### PR TITLE
Addendum to fix for bug #1382797

### DIFF
--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -174,6 +174,17 @@ process::process (const char* cmd, const char* type)
     }
 #endif
 
+    /* Reset the process signal mask to unblock signals blocked by the server */
+
+    sigset_t set;
+    (void) sigemptyset(&set);
+
+    if (sigprocmask(SIG_SETMASK, &set, NULL))
+    {
+      sql_perror("sigprocmask() failed");
+      _exit(EXIT_FAILURE);
+    }
+
     /* Reset all ignored signals to SIG_DFL */
 
     memset(&sa, 0, sizeof(sa));


### PR DESCRIPTION
Addendum to fix for bug #1382797 "Modify SST code to use fork()/exec()
to allow cleanup on fatal signals"

In addition to resetting ignored signals, also reset the process signal
mask for the child process.
