### PR TITLE
LP bug #1290526: wsrep_start_replication wsrep->connect rcode matching

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -824,19 +824,10 @@ bool wsrep_start_replication()
                               wsrep_sst_donor,
                               bootstrap)))
   {
-    if (-ESOCKTNOSUPPORT == rcode)
-    {
-      DBUG_PRINT("wsrep",("unrecognized cluster address: '%s', rcode: %d",
-                          wsrep_cluster_address, rcode));
-      WSREP_ERROR("unrecognized cluster address: '%s', rcode: %d",
-                  wsrep_cluster_address, rcode);
-    }
-    else
-    {
-      DBUG_PRINT("wsrep",("wsrep->connect() failed: %d", rcode));
-      WSREP_ERROR("wsrep::connect() failed: %d", rcode);
-    }
-
+    DBUG_PRINT("wsrep",("wsrep->connect(%s) failed: %d",
+                        wsrep_cluster_address, rcode));
+    WSREP_ERROR("wsrep::connect(%s) failed: %d",
+                wsrep_cluster_address, rcode);
     return false;
   }
   else


### PR DESCRIPTION
Removed a -Wtautological-constant-out-of-range-compare compiler warning.
