### PR TITLE
PXC-304 “wsrep_desync issues - SST” / PXC-335 “wsrep_desync issues - RSU”

### DIFF
--- a/mysql-test/suite/galera/r/galera_desync_overlapped.result
+++ b/mysql-test/suite/galera/r/galera_desync_overlapped.result
@@ -1,0 +1,25 @@
+CREATE TABLE ten (f1 INTEGER);
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+CREATE TABLE t1 (f1 INTEGER, PRIMARY KEY (f1)) Engine=InnoDB;
+CREATE TABLE t2 (f1 INTEGER, PRIMARY KEY (f1)) Engine=InnoDB;
+SET GLOBAL wsrep_desync = "ON";
+SET DEBUG_SYNC='before_execute_sql_command SIGNAL alter1 WAIT_FOR alter2';
+INSERT INTO t1 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+SET GLOBAL wsrep_desync = "ON";
+SET DEBUG_SYNC='now WAIT_FOR alter1';
+SET DEBUG_SYNC='before_execute_sql_command SIGNAL alter2';
+INSERT INTO t2 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+SET DEBUG_SYNC='RESET';
+SET GLOBAL wsrep_desync = "OFF";
+SET GLOBAL wsrep_desync = "OFF";
+SET GLOBAL wsrep_desync = "OFF";
+ERROR 42000: Variable 'wsrep_desync' can't be set to the value of 'OFF'
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1000
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+1000
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE ten;

--- a/mysql-test/suite/galera/r/galera_rsu_overlapped.result
+++ b/mysql-test/suite/galera/r/galera_rsu_overlapped.result
@@ -1,0 +1,23 @@
+CREATE TABLE ten (f1 INTEGER);
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
+CREATE TABLE t2 (f1 INTEGER) Engine=InnoDB;
+INSERT INTO t1 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+INSERT INTO t2 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+SET GLOBAL wsrep_OSU_method = "RSU";
+SET DEBUG_SYNC='wsrep_RSU_begin_after_lock SIGNAL alter1 WAIT_FOR alter2';
+ALTER TABLE t1 ADD PRIMARY KEY (f1);
+SET DEBUG_SYNC='now WAIT_FOR alter1';
+SET DEBUG_SYNC='wsrep_RSU_begin_enter SIGNAL alter2';
+ALTER TABLE t2 ADD PRIMARY KEY (f1);
+SET DEBUG_SYNC='RESET';
+SET GLOBAL wsrep_OSU_method = "TOI";
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1000
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+1000
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE ten;

--- a/mysql-test/suite/galera/t/galera_desync_overlapped.test
+++ b/mysql-test/suite/galera/t/galera_desync_overlapped.test
@@ -1,0 +1,55 @@
+#
+# Test for overlapped transactions under manual desync.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+--let $galera_connection_name = node_1a
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+
+--connection node_1
+
+CREATE TABLE ten (f1 INTEGER);
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+CREATE TABLE t1 (f1 INTEGER, PRIMARY KEY (f1)) Engine=InnoDB;
+CREATE TABLE t2 (f1 INTEGER, PRIMARY KEY (f1)) Engine=InnoDB;
+
+SET GLOBAL wsrep_desync = "ON";
+SET DEBUG_SYNC='before_execute_sql_command SIGNAL alter1 WAIT_FOR alter2';
+send INSERT INTO t1 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+
+--connection node_1a
+
+SET GLOBAL wsrep_desync = "ON";
+SET DEBUG_SYNC='now WAIT_FOR alter1';
+SET DEBUG_SYNC='before_execute_sql_command SIGNAL alter2';
+send INSERT INTO t2 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+
+--connection node_1
+reap;
+
+--connection node_1a
+reap;
+
+--connection node_1
+
+SET DEBUG_SYNC='RESET';
+
+SET GLOBAL wsrep_desync = "OFF";
+SET GLOBAL wsrep_desync = "OFF";
+
+--disable_query_log
+call mtr.add_suppression("Trying to make wsrep_desync = OFF on the node that is already synchronized.");
+--enable_query_log
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_desync = "OFF";
+
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM t2;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE ten;

--- a/mysql-test/suite/galera/t/galera_rsu_overlapped.test
+++ b/mysql-test/suite/galera/t/galera_rsu_overlapped.test
@@ -1,0 +1,52 @@
+#
+# Test for overlapped RSU transactions.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+--let $galera_connection_name = node_1a
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+
+--connection node_1
+
+CREATE TABLE ten (f1 INTEGER);
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
+CREATE TABLE t2 (f1 INTEGER) Engine=InnoDB;
+
+# Insert some values before the ALTER
+INSERT INTO t1 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+INSERT INTO t2 (f1) SELECT 0000 + (100 * a1.f1) + (10 * a2.f1) + a3.f1 FROM ten AS a1, ten AS a2, ten AS a3;
+
+SET GLOBAL wsrep_OSU_method = "RSU";
+
+SET DEBUG_SYNC='wsrep_RSU_begin_after_lock SIGNAL alter1 WAIT_FOR alter2';
+send ALTER TABLE t1 ADD PRIMARY KEY (f1);
+
+--connection node_1a
+
+SET DEBUG_SYNC='now WAIT_FOR alter1';
+SET DEBUG_SYNC='wsrep_RSU_begin_enter SIGNAL alter2';
+send ALTER TABLE t2 ADD PRIMARY KEY (f1);
+
+--connection node_1
+reap;
+
+--connection node_1a
+reap;
+
+--connection node_1
+
+SET DEBUG_SYNC='RESET';
+
+SET GLOBAL wsrep_OSU_method = "TOI";
+
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM t2;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE ten;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -806,7 +806,10 @@ mysql_mutex_t LOCK_wsrep_replaying;
 mysql_cond_t  COND_wsrep_replaying;
 mysql_mutex_t LOCK_wsrep_slave_threads;
 mysql_mutex_t LOCK_wsrep_desync;
+mysql_mutex_t LOCK_wsrep_desync_count;
 int wsrep_replaying= 0;
+int wsrep_desync_count= 0;
+int wsrep_desync_count_manual= 0;
 static void wsrep_close_threads(THD* thd);
 #endif /* WITH_WSREP */
 mysql_rwlock_t LOCK_consistent_snapshot;
@@ -2179,6 +2182,7 @@ static void clean_up_mutexes()
   (void) mysql_cond_destroy(&COND_wsrep_replaying);
   (void) mysql_mutex_destroy(&LOCK_wsrep_slave_threads);
   (void) mysql_mutex_destroy(&LOCK_wsrep_desync);
+  (void) mysql_mutex_destroy(&LOCK_wsrep_desync_count);
 #endif
   mysql_rwlock_destroy(&LOCK_consistent_snapshot);
 }
@@ -4520,6 +4524,8 @@ static int init_thread_environment()
                    &LOCK_wsrep_slave_threads, MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_wsrep_desync,
                    &LOCK_wsrep_desync, MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(key_LOCK_wsrep_desync_count,
+                   &LOCK_wsrep_desync_count, MY_MUTEX_INIT_FAST);
 #endif
   return 0;
 }
@@ -10424,7 +10430,7 @@ PSI_mutex_key
 PSI_mutex_key key_LOCK_wsrep_rollback, key_LOCK_wsrep_thd, 
   key_LOCK_wsrep_replaying, key_LOCK_wsrep_ready, key_LOCK_wsrep_sst, 
   key_LOCK_wsrep_sst_thread, key_LOCK_wsrep_sst_init, 
-  key_LOCK_wsrep_slave_threads, key_LOCK_wsrep_desync;
+  key_LOCK_wsrep_slave_threads, key_LOCK_wsrep_desync, key_LOCK_wsrep_desync_count;
 #endif
 PSI_mutex_key key_LOCK_thd_remove;
 PSI_mutex_key key_RELAYLOG_LOCK_commit;
@@ -10530,6 +10536,7 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_LOCK_wsrep_replaying, "LOCK_wsrep_replaying", PSI_FLAG_GLOBAL},
   { &key_LOCK_wsrep_slave_threads, "LOCK_wsrep_slave_threads", PSI_FLAG_GLOBAL},
   { &key_LOCK_wsrep_desync, "LOCK_wsrep_desync", PSI_FLAG_GLOBAL},
+  { &key_LOCK_wsrep_desync_count, "LOCK_wsrep_desync_count", PSI_FLAG_GLOBAL},
 #endif
   { &key_LOCK_thd_remove, "LOCK_thd_remove", PSI_FLAG_GLOBAL},
   { &key_LOCK_log_throttle_qni, "LOCK_log_throttle_qni", PSI_FLAG_GLOBAL},

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -277,6 +277,9 @@ extern mysql_mutex_t LOCK_wsrep_replaying;
 extern mysql_cond_t  COND_wsrep_replaying;
 extern mysql_mutex_t LOCK_wsrep_slave_threads;
 extern mysql_mutex_t LOCK_wsrep_desync;
+extern int wsrep_desync_count;
+extern int wsrep_desync_count_manual;
+extern mysql_mutex_t LOCK_wsrep_desync_count;
 extern wsrep_aborting_thd_t wsrep_aborting_thd;
 extern my_bool       wsrep_emulate_bin_log;
 extern int           wsrep_to_isolation;
@@ -298,6 +301,7 @@ extern PSI_mutex_key key_LOCK_wsrep_replaying;
 extern PSI_cond_key  key_COND_wsrep_replaying;
 extern PSI_mutex_key key_LOCK_wsrep_slave_threads;
 extern PSI_mutex_key key_LOCK_wsrep_desync;
+extern PSI_mutex_key key_LOCK_wsrep_desync_count;
 #endif /* HAVE_PSI_INTERFACE */
 struct TABLE_LIST;
 int wsrep_to_isolation_begin(THD *thd, char *db_, char *table_,


### PR DESCRIPTION
Make setting wsrep_desync in multiple concurrent sessions independent
from other sessions and/or implicit desync operations from RSU/SST to
avoid race conditions.
