### PR TITLE
PXC-375: Add compatibility option to init script for Debian Jessie an…

### DIFF
--- a/build-ps/debian/percona-xtradb-cluster-server-5.6.mysql.init
+++ b/build-ps/debian/percona-xtradb-cluster-server-5.6.mysql.init
@@ -210,7 +210,7 @@ case "${1:-''}" in
 	fi
 	;;
 
-  'stop')
+  'stop'|'bootstrap-stop')
 	# * As a passwordless mysqladmin (e.g. via ~/.my.cnf) must be possible
 	# at least for cron, we can rely on it here, too. (although we have 
 	# to specify it explicit as e.g. sudo environments points to the normal
@@ -256,7 +256,7 @@ case "${1:-''}" in
 	$SELF bootstrap-pxc 
 	;;
 
-  'reload'|'force-reload')
+  'reload'|'force-reload'|'reload-bootstrap')
   	log_daemon_msg "Reloading MySQL (Percona XtraDB Cluster)" "mysqld"
         mysqld_pid=$(cat $pid_file 2>/dev/null)
 
@@ -276,7 +276,7 @@ case "${1:-''}" in
         fi
 	;;
 
-  'status')
+  'status'|'status-bootstrap')
 	if mysqld_status check_alive nowarn; then
 	  log_action_msg "Percona XtraDB Cluster up and running"
 	else


### PR DESCRIPTION
…d Ubuntu Vivid for bootstrapping a PXC node.

The issue is that, without systemd units in place, systemctl overrides
options in /etc/init.d/mysql.

The issue is that, with systemd being default init system, non-default
options like bootstrap-pxc are not recognized by it, but instead
passed-through to the init script itself.

ie. service mysql start works with systemctl. However, for
non-standard options like bootstrap-pxc this can be a problem.

So, what happens is, for bootstrapping:

a) service mysql bootstrap-pxc flies right by systemd. It doesn't know
about this!

b) service mysql stop will fail because systemd sees nothing was
started. This won't apply to service mysql start because systemd knows
about that.

Hence, adding a bootstrap-stop sysv-compatibility option which can stop
a PXC node which was bootstrapped.

Note that, restart-bootstrap has been there before too, which restarts a
normal (either bootstrapped or non-bootstapped) node bootstrapped. So,
it should be used to restart a bootstrapped node in same state.

Also, added reload-bootstrap and status-bootstrap.
