### PR TITLE
PXC-373: Allow wsrep_dirty_reads to have a global scope

### DIFF
--- a/mysql-test/suite/sys_vars/r/wsrep_dirty_reads_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_dirty_reads_basic.result
@@ -3,14 +3,36 @@
 #
 # save the initial value
 SET @wsrep_dirty_reads_session_saved = @@session.wsrep_dirty_reads;
+SET @wsrep_dirty_reads_global_saved = @@global.wsrep_dirty_reads;
 # default
 SELECT @@global.wsrep_dirty_reads;
-ERROR HY000: Variable 'wsrep_dirty_reads' is a SESSION variable
+@@global.wsrep_dirty_reads
+0
 SELECT @@session.wsrep_dirty_reads;
 @@session.wsrep_dirty_reads
 0
 
-# scope and valid values
+# global scope and valid values
+SET @@global.wsrep_dirty_reads=OFF;
+SELECT @@global.wsrep_dirty_reads;
+@@global.wsrep_dirty_reads
+0
+SET @@global.wsrep_dirty_reads=ON;
+SELECT @@global.wsrep_dirty_reads;
+@@global.wsrep_dirty_reads
+1
+SELECT @@session.wsrep_dirty_reads;
+@@session.wsrep_dirty_reads
+0
+SET @@global.wsrep_dirty_reads=default;
+SELECT @@global.wsrep_dirty_reads;
+@@global.wsrep_dirty_reads
+0
+SELECT @@session.wsrep_dirty_reads;
+@@session.wsrep_dirty_reads
+0
+
+# local (session) scope and valid values
 SET @@session.wsrep_dirty_reads=OFF;
 SELECT @@session.wsrep_dirty_reads;
 @@session.wsrep_dirty_reads
@@ -32,4 +54,5 @@ ERROR 42000: Variable 'wsrep_dirty_reads' can't be set to the value of 'junk'
 
 # restore the initial values
 SET @@session.wsrep_dirty_reads = @wsrep_dirty_reads_session_saved;
+SET @@global.wsrep_dirty_reads = @wsrep_dirty_reads_global_saved;
 # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_dirty_reads_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_dirty_reads_basic.test
@@ -6,14 +6,25 @@
 
 --echo # save the initial value
 SET @wsrep_dirty_reads_session_saved = @@session.wsrep_dirty_reads;
+SET @wsrep_dirty_reads_global_saved = @@global.wsrep_dirty_reads;
 
 --echo # default
---error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SELECT @@global.wsrep_dirty_reads;
 SELECT @@session.wsrep_dirty_reads;
 
 --echo
---echo # scope and valid values
+--echo # global scope and valid values
+SET @@global.wsrep_dirty_reads=OFF;
+SELECT @@global.wsrep_dirty_reads;
+SET @@global.wsrep_dirty_reads=ON;
+SELECT @@global.wsrep_dirty_reads;
+SELECT @@session.wsrep_dirty_reads;
+SET @@global.wsrep_dirty_reads=default;
+SELECT @@global.wsrep_dirty_reads;
+SELECT @@session.wsrep_dirty_reads;
+
+--echo
+--echo # local (session) scope and valid values
 SET @@session.wsrep_dirty_reads=OFF;
 SELECT @@session.wsrep_dirty_reads;
 SET @@session.wsrep_dirty_reads=ON;
@@ -31,5 +42,6 @@ SET @@session.wsrep_dirty_reads='junk';
 --echo
 --echo # restore the initial values
 SET @@session.wsrep_dirty_reads = @wsrep_dirty_reads_session_saved;
+SET @@global.wsrep_dirty_reads = @wsrep_dirty_reads_global_saved;
 
 --echo # End of test

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5517,8 +5517,8 @@ static Sys_var_enum Sys_block_encryption_mode(
 static Sys_var_mybool Sys_wsrep_dirty_reads(
        "wsrep_dirty_reads",
        "Allow dirty reads when the node is not ready.",
-       SESSION_ONLY(wsrep_dirty_reads),
-       NO_CMD_LINE, DEFAULT(FALSE), NO_MUTEX_GUARD, NOT_IN_BINLOG);
+       SESSION_VAR(wsrep_dirty_reads),
+       CMD_LINE(OPT_ARG), DEFAULT(FALSE), NO_MUTEX_GUARD, NOT_IN_BINLOG);
 #endif
 static Sys_var_mybool Sys_avoid_temporal_upgrade(
        "avoid_temporal_upgrade",


### PR DESCRIPTION
Changed wsrep_dirty_reads type from session-only to a session variable,
so that it can be assigned a global value now.
