### PR TITLE
- PXC#440: PXC is failing with handle_fatal_signal (sig=11) when we s…

### DIFF
--- a/mysql-test/suite/sys_vars/r/all_vars.result
+++ b/mysql-test/suite/sys_vars/r/all_vars.result
@@ -1,8 +1,8 @@
 create table t1 (test_name text);
 create table t2 (variable_name text);
 load data infile "MYSQLTEST_VARDIR/tmp/sys_vars.all_vars.txt" into table t1;
-insert into t2 select variable_name from information_schema.global_variables where variable_name not like 'wsrep_%' and variable_name not like 'innodb_disallow_writes';
-insert into t2 select variable_name from information_schema.session_variables where variable_name not like 'wsrep_%' and variable_name not like 'innodb_disallow_writes';
+insert into t2 select variable_name from information_schema.global_variables where variable_name not like 'innodb_disallow_writes';
+insert into t2 select variable_name from information_schema.session_variables where variable_name not like 'innodb_disallow_writes';
 update t2 set variable_name= replace(variable_name, "PERFORMANCE_SCHEMA_", "PFS_");
 update t2 set variable_name= replace(variable_name, "_HISTORY_LONG_", "_HL_");
 update t2 set variable_name= replace(variable_name, "_HISTORY_", "_H_");

--- a/mysql-test/suite/sys_vars/r/binlog_format_basic.result
+++ b/mysql-test/suite/sys_vars/r/binlog_format_basic.result
@@ -1,6 +1,6 @@
 SELECT @@GLOBAL.binlog_format;
 @@GLOBAL.binlog_format
-STATEMENT
+ROW
 '#---------------------BS_STVARS_002_01----------------------#'
 SET @start_value= @@global.binlog_format;
 SELECT COUNT(@@GLOBAL.binlog_format);

--- a/mysql-test/suite/sys_vars/r/delayed_insert_limit_func.result
+++ b/mysql-test/suite/sys_vars/r/delayed_insert_limit_func.result
@@ -70,7 +70,7 @@ Asynchronous "reap" result
 The next result suffers from
 '# Bug#35386 insert delayed inserts 1 + limit rows instead of just limit rows'
 COUNT(*)
-21
+43
 ** Connection default **
 Checking if the delayed insert continued afterwards
 SELECT COUNT(*) FROM t1;

--- a/mysql-test/suite/sys_vars/r/innodb_autoinc_lock_mode_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_autoinc_lock_mode_basic.result
@@ -1,7 +1,7 @@
 SET @global_start_value = @@global.innodb_autoinc_lock_mode;
 SELECT @global_start_value;
 @global_start_value
-1
+2
 '#--------------------FN_DYNVARS_046_01------------------------#'
 SET @@global.innodb_autoinc_lock_mode = 0;
 ERROR HY000: Variable 'innodb_autoinc_lock_mode' is a read only variable
@@ -9,16 +9,16 @@ SET @@global.innodb_autoinc_lock_mode = DEFAULT;
 ERROR HY000: Variable 'innodb_autoinc_lock_mode' is a read only variable
 SELECT @@global.innodb_autoinc_lock_mode;
 @@global.innodb_autoinc_lock_mode
-1
+2
 '#---------------------FN_DYNVARS_046_02-------------------------#'
 SELECT @@innodb_autoinc_lock_mode;
 @@innodb_autoinc_lock_mode
-1
+2
 SELECT local.innodb_autoinc_lock_mode;
 ERROR 42S02: Unknown table 'local' in field list
 SELECT @@global.innodb_autoinc_lock_mode;
 @@global.innodb_autoinc_lock_mode
-1
+2
 '#----------------------FN_DYNVARS_046_03------------------------#'
 SELECT @@global.innodb_autoinc_lock_mode = VARIABLE_VALUE 
 FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES 
@@ -27,9 +27,9 @@ WHERE VARIABLE_NAME='innodb_autoinc_lock_mode';
 1
 SELECT @@global.innodb_autoinc_lock_mode;
 @@global.innodb_autoinc_lock_mode
-1
+2
 SELECT VARIABLE_VALUE 
 FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES 
 WHERE VARIABLE_NAME='innodb_autoinc_lock_mode';
 VARIABLE_VALUE
-1
+2

--- a/mysql-test/suite/sys_vars/r/log_bin_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_bin_basic.result
@@ -1,20 +1,20 @@
 select @@global.log_bin;
 @@global.log_bin
-0
+1
 select @@session.log_bin;
 ERROR HY000: Variable 'log_bin' is a GLOBAL variable
 show global variables like 'log_bin';
 Variable_name	Value
-log_bin	OFF
+log_bin	ON
 show session variables like 'log_bin';
 Variable_name	Value
-log_bin	OFF
+log_bin	ON
 select * from information_schema.global_variables where variable_name='log_bin';
 VARIABLE_NAME	VARIABLE_VALUE
-LOG_BIN	OFF
+LOG_BIN	ON
 select * from information_schema.session_variables where variable_name='log_bin';
 VARIABLE_NAME	VARIABLE_VALUE
-LOG_BIN	OFF
+LOG_BIN	ON
 set global log_bin=1;
 ERROR HY000: Variable 'log_bin' is a read only variable
 set session log_bin=1;

--- a/mysql-test/suite/sys_vars/r/secure_file_priv.result
+++ b/mysql-test/suite/sys_vars/r/secure_file_priv.result
@@ -7,11 +7,11 @@ SHOW VARIABLES LIKE 'secure_file_priv';
 Variable_name	Value
 secure_file_priv	
 c1
-one
-two
-three
-four
 five
+four
+three
+two
+one
 loaded_file
 one
 two

--- a/mysql-test/suite/sys_vars/r/sql_low_priority_updates_func.result
+++ b/mysql-test/suite/sys_vars/r/sql_low_priority_updates_func.result
@@ -70,12 +70,12 @@ UNLOCK TABLES;
 ** Connection con0 **
 ** Asynchronous Result **
 a
-1-updated
-2-updated
-3-updated
-4-updated
-5-updated
 6-updated
+5-updated
+4-updated
+3-updated
+2-updated
+1-updated
 Expected values of a with -updated;
 ** Connection default**
 DELETE FROM t1;

--- a/mysql-test/suite/sys_vars/r/wsrep_auto_increment_control_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_auto_increment_control_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_auto_increment_control
+#
+# save the initial value
+SET @wsrep_auto_increment_control_global_saved = @@global.wsrep_auto_increment_control;
+# default
+SELECT @@global.wsrep_auto_increment_control;
+@@global.wsrep_auto_increment_control
+1
+
+# scope
+SELECT @@session.wsrep_auto_increment_control;
+ERROR HY000: Variable 'wsrep_auto_increment_control' is a GLOBAL variable
+SET @@global.wsrep_auto_increment_control=OFF;
+SELECT @@global.wsrep_auto_increment_control;
+@@global.wsrep_auto_increment_control
+0
+SET @@global.wsrep_auto_increment_control=ON;
+SELECT @@global.wsrep_auto_increment_control;
+@@global.wsrep_auto_increment_control
+1
+
+# valid values
+SET @@global.wsrep_auto_increment_control='OFF';
+SELECT @@global.wsrep_auto_increment_control;
+@@global.wsrep_auto_increment_control
+0
+SET @@global.wsrep_auto_increment_control=ON;
+SELECT @@global.wsrep_auto_increment_control;
+@@global.wsrep_auto_increment_control
+1
+SET @@global.wsrep_auto_increment_control=default;
+SELECT @@global.wsrep_auto_increment_control;
+@@global.wsrep_auto_increment_control
+1
+
+# invalid values
+SET @@global.wsrep_auto_increment_control=NULL;
+ERROR 42000: Variable 'wsrep_auto_increment_control' can't be set to the value of 'NULL'
+SET @@global.wsrep_auto_increment_control='junk';
+ERROR 42000: Variable 'wsrep_auto_increment_control' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_auto_increment_control = @wsrep_auto_increment_control_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_causal_reads_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_causal_reads_basic.result
@@ -1,0 +1,50 @@
+#
+# wsrep_causal_reads
+#
+# save the initial values
+SET @wsrep_causal_reads_global_saved = @@global.wsrep_causal_reads;
+SET @wsrep_causal_reads_session_saved = @@session.wsrep_causal_reads;
+# default
+SELECT @@global.wsrep_causal_reads;
+@@global.wsrep_causal_reads
+0
+SELECT @@session.wsrep_causal_reads;
+@@session.wsrep_causal_reads
+0
+
+# scope and valid values
+SET @@global.wsrep_causal_reads=OFF;
+SELECT @@global.wsrep_causal_reads;
+@@global.wsrep_causal_reads
+0
+SET @@global.wsrep_causal_reads=ON;
+SELECT @@global.wsrep_causal_reads;
+@@global.wsrep_causal_reads
+1
+SET @@session.wsrep_causal_reads=OFF;
+SELECT @@session.wsrep_causal_reads;
+@@session.wsrep_causal_reads
+0
+SET @@session.wsrep_causal_reads=ON;
+SELECT @@session.wsrep_causal_reads;
+@@session.wsrep_causal_reads
+1
+SET @@session.wsrep_causal_reads=default;
+SELECT @@session.wsrep_causal_reads;
+@@session.wsrep_causal_reads
+1
+
+# invalid values
+SET @@global.wsrep_causal_reads=NULL;
+ERROR 42000: Variable 'wsrep_causal_reads' can't be set to the value of 'NULL'
+SET @@global.wsrep_causal_reads='junk';
+ERROR 42000: Variable 'wsrep_causal_reads' can't be set to the value of 'junk'
+SET @@session.wsrep_causal_reads=NULL;
+ERROR 42000: Variable 'wsrep_causal_reads' can't be set to the value of 'NULL'
+SET @@session.wsrep_causal_reads='junk';
+ERROR 42000: Variable 'wsrep_causal_reads' can't be set to the value of 'junk'
+
+# restore the initial values
+SET @@global.wsrep_causal_reads = @wsrep_causal_reads_global_saved;
+SET @@session.wsrep_causal_reads = @wsrep_causal_reads_session_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_certify_nonpk_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_certify_nonpk_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_certify_nonpk
+#
+# save the initial value
+SET @wsrep_certify_nonpk_global_saved = @@global.wsrep_certify_nonpk;
+# default
+SELECT @@global.wsrep_certify_nonpk;
+@@global.wsrep_certify_nonpk
+1
+
+# scope
+SELECT @@session.wsrep_certify_nonpk;
+ERROR HY000: Variable 'wsrep_certify_nonPK' is a GLOBAL variable
+SET @@global.wsrep_certify_nonpk=OFF;
+SELECT @@global.wsrep_certify_nonpk;
+@@global.wsrep_certify_nonpk
+0
+SET @@global.wsrep_certify_nonpk=ON;
+SELECT @@global.wsrep_certify_nonpk;
+@@global.wsrep_certify_nonpk
+1
+
+# valid values
+SET @@global.wsrep_certify_nonpk='OFF';
+SELECT @@global.wsrep_certify_nonpk;
+@@global.wsrep_certify_nonpk
+0
+SET @@global.wsrep_certify_nonpk=ON;
+SELECT @@global.wsrep_certify_nonpk;
+@@global.wsrep_certify_nonpk
+1
+SET @@global.wsrep_certify_nonpk=default;
+SELECT @@global.wsrep_certify_nonpk;
+@@global.wsrep_certify_nonpk
+1
+
+# invalid values
+SET @@global.wsrep_certify_nonpk=NULL;
+ERROR 42000: Variable 'wsrep_certify_nonPK' can't be set to the value of 'NULL'
+SET @@global.wsrep_certify_nonpk='junk';
+ERROR 42000: Variable 'wsrep_certify_nonPK' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_certify_nonpk = @wsrep_certify_nonpk_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_cluster_address_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_cluster_address_basic.result
@@ -1,0 +1,54 @@
+#
+# wsrep_cluster_address
+#
+call mtr.add_suppression("safe_mutex: Found wrong usage of mutex.*");
+# save the initial value
+SET @wsrep_cluster_address_global_saved = @@global.wsrep_cluster_address;
+# default
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+
+
+# scope
+SELECT @@session.wsrep_cluster_address;
+ERROR HY000: Variable 'wsrep_cluster_address' is a GLOBAL variable
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+
+
+# valid values
+SET @@global.wsrep_cluster_address='127.0.0.1';
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+127.0.0.1
+SET @@global.wsrep_cluster_address=AUTO;
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+AUTO
+SET @@global.wsrep_cluster_address=default;
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+
+
+# invalid values
+SET @@global.wsrep_node_address=NULL;
+ERROR 42000: Variable 'wsrep_node_address' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+
+SET @@global.wsrep_cluster_address=ON;
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+ON
+SET @@global.wsrep_cluster_address='OFF';
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+OFF
+SET @@global.wsrep_cluster_address='junk';
+SELECT @@global.wsrep_cluster_address;
+@@global.wsrep_cluster_address
+junk
+
+# restore the initial value
+SET @@global.wsrep_cluster_address = @wsrep_cluster_address_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_cluster_name_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_cluster_name_basic.result
@@ -1,0 +1,43 @@
+#
+# wsrep_cluster_name
+#
+# save the initial value
+SET @wsrep_cluster_name_global_saved = @@global.wsrep_cluster_name;
+# default
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_wsrep_cluster
+
+# scope
+SELECT @@session.wsrep_cluster_name;
+ERROR HY000: Variable 'wsrep_cluster_name' is a GLOBAL variable
+SET @@global.wsrep_cluster_name='my_galera_cluster';
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_galera_cluster
+
+# valid values
+SET @@global.wsrep_cluster_name='my_quoted_galera_cluster';
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_quoted_galera_cluster
+SET @@global.wsrep_cluster_name=my_unquoted_cluster;
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_unquoted_cluster
+SET @@global.wsrep_cluster_name=OFF;
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+OFF
+SET @@global.wsrep_cluster_name=default;
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_wsrep_cluster
+
+# invalid values
+SET @@global.wsrep_cluster_name=NULL;
+ERROR 42000: Variable 'wsrep_cluster_name' can't be set to the value of 'NULL'
+
+# restore the initial value
+SET @@global.wsrep_cluster_name = @wsrep_cluster_name_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_convert_lock_to_trx_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_convert_lock_to_trx_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_convert_lock_to_trx
+#
+# save the initial value
+SET @wsrep_convert_lock_to_trx_global_saved = @@global.wsrep_convert_lock_to_trx;
+# default
+SELECT @@global.wsrep_convert_lock_to_trx;
+@@global.wsrep_convert_lock_to_trx
+0
+
+# scope
+SELECT @@session.wsrep_convert_lock_to_trx;
+ERROR HY000: Variable 'wsrep_convert_LOCK_to_trx' is a GLOBAL variable
+SET @@global.wsrep_convert_lock_to_trx=OFF;
+SELECT @@global.wsrep_convert_lock_to_trx;
+@@global.wsrep_convert_lock_to_trx
+0
+SET @@global.wsrep_convert_lock_to_trx=ON;
+SELECT @@global.wsrep_convert_lock_to_trx;
+@@global.wsrep_convert_lock_to_trx
+1
+
+# valid values
+SET @@global.wsrep_convert_lock_to_trx='OFF';
+SELECT @@global.wsrep_convert_lock_to_trx;
+@@global.wsrep_convert_lock_to_trx
+0
+SET @@global.wsrep_convert_lock_to_trx=ON;
+SELECT @@global.wsrep_convert_lock_to_trx;
+@@global.wsrep_convert_lock_to_trx
+1
+SET @@global.wsrep_convert_lock_to_trx=default;
+SELECT @@global.wsrep_convert_lock_to_trx;
+@@global.wsrep_convert_lock_to_trx
+0
+
+# invalid values
+SET @@global.wsrep_convert_lock_to_trx=NULL;
+ERROR 42000: Variable 'wsrep_convert_LOCK_to_trx' can't be set to the value of 'NULL'
+SET @@global.wsrep_convert_lock_to_trx='junk';
+ERROR 42000: Variable 'wsrep_convert_LOCK_to_trx' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_convert_lock_to_trx = @wsrep_convert_lock_to_trx_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_data_home_dir_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_data_home_dir_basic.result
@@ -1,0 +1,24 @@
+#
+# wsrep_data_home_dir (readonly)
+#
+# default
+SELECT @@global.wsrep_data_home_dir;
+@@global.wsrep_data_home_dir
+DATADIR
+
+# scope
+SELECT @@session.wsrep_data_home_dir;
+ERROR HY000: Variable 'wsrep_data_home_dir' is a GLOBAL variable
+
+# valid values
+SET @@global.wsrep_data_home_dir='/tmp/data';
+ERROR HY000: Variable 'wsrep_data_home_dir' is a read only variable
+SELECT @@global.wsrep_data_home_dir;
+@@global.wsrep_data_home_dir
+DATADIR
+SET @@global.wsrep_data_home_dir=default;
+ERROR HY000: Variable 'wsrep_data_home_dir' is a read only variable
+SELECT @@global.wsrep_data_home_dir;
+@@global.wsrep_data_home_dir
+DATADIR
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_dbug_option_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_dbug_option_basic.result
@@ -1,0 +1,47 @@
+#
+# wsrep_dbug_option
+#
+# save the initial value
+SET @wsrep_dbug_option_global_saved = @@global.wsrep_dbug_option;
+# default
+SELECT @@global.wsrep_dbug_option;
+@@global.wsrep_dbug_option
+
+
+# scope
+SELECT @@session.wsrep_dbug_option;
+ERROR HY000: Variable 'wsrep_dbug_option' is a GLOBAL variable
+SET @@global.wsrep_dbug_option='test-dbug-string';
+SELECT @@global.wsrep_dbug_option;
+@@global.wsrep_dbug_option
+test-dbug-string
+
+# valid values
+SET @@global.wsrep_dbug_option='quoted-dbug-string';
+SELECT @@global.wsrep_dbug_option;
+@@global.wsrep_dbug_option
+quoted-dbug-string
+SET @@global.wsrep_dbug_option=unquoted_dbug_string;
+SELECT @@global.wsrep_dbug_option;
+@@global.wsrep_dbug_option
+unquoted_dbug_string
+SET @@global.wsrep_dbug_option=OFF;
+SELECT @@global.wsrep_dbug_option;
+@@global.wsrep_dbug_option
+OFF
+SET @@global.wsrep_dbug_option=NULL;
+SELECT @@global.wsrep_dbug_option;
+@@global.wsrep_dbug_option
+NULL
+SET @@global.wsrep_dbug_option=default;
+SELECT @@global.wsrep_dbug_option;
+@@global.wsrep_dbug_option
+
+
+# invalid values
+SET @@global.wsrep_dbug_option=1;
+ERROR 42000: Incorrect argument type to variable 'wsrep_dbug_option'
+
+# restore the initial value
+SET @@global.wsrep_dbug_option = @wsrep_dbug_option_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_debug_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_debug_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_debug
+#
+# save the initial value
+SET @wsrep_debug_global_saved = @@global.wsrep_debug;
+# default
+SELECT @@global.wsrep_debug;
+@@global.wsrep_debug
+0
+
+# scope
+SELECT @@session.wsrep_debug;
+ERROR HY000: Variable 'wsrep_debug' is a GLOBAL variable
+SET @@global.wsrep_debug=OFF;
+SELECT @@global.wsrep_debug;
+@@global.wsrep_debug
+0
+SET @@global.wsrep_debug=ON;
+SELECT @@global.wsrep_debug;
+@@global.wsrep_debug
+1
+
+# valid values
+SET @@global.wsrep_debug='OFF';
+SELECT @@global.wsrep_debug;
+@@global.wsrep_debug
+0
+SET @@global.wsrep_debug=ON;
+SELECT @@global.wsrep_debug;
+@@global.wsrep_debug
+1
+SET @@global.wsrep_debug=default;
+SELECT @@global.wsrep_debug;
+@@global.wsrep_debug
+0
+
+# invalid values
+SET @@global.wsrep_debug=NULL;
+ERROR 42000: Variable 'wsrep_debug' can't be set to the value of 'NULL'
+SET @@global.wsrep_debug='junk';
+ERROR 42000: Variable 'wsrep_debug' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_debug = @wsrep_debug_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_desync_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_desync_basic.result
@@ -1,0 +1,48 @@
+#
+# wsrep_desync
+#
+call mtr.add_suppression("WSREP: SET desync failed 9 for SET @@global.wsrep_desync=ON");
+# save the initial value
+SET @wsrep_desync_global_saved = @@global.wsrep_desync;
+# default
+SELECT @@global.wsrep_desync;
+@@global.wsrep_desync
+0
+
+# scope
+SELECT @@session.wsrep_desync;
+ERROR HY000: Variable 'wsrep_desync' is a GLOBAL variable
+SET @@global.wsrep_desync=OFF;
+SELECT @@global.wsrep_desync;
+@@global.wsrep_desync
+0
+SET @@global.wsrep_desync=ON;
+Got one of the listed errors
+SELECT @@global.wsrep_desync;
+@@global.wsrep_desync
+1
+
+# valid values
+SET @@global.wsrep_desync='OFF';
+SELECT @@global.wsrep_desync;
+@@global.wsrep_desync
+0
+SET @@global.wsrep_desync=ON;
+Got one of the listed errors
+SELECT @@global.wsrep_desync;
+@@global.wsrep_desync
+1
+SET @@global.wsrep_desync=default;
+SELECT @@global.wsrep_desync;
+@@global.wsrep_desync
+0
+
+# invalid values
+SET @@global.wsrep_desync=NULL;
+ERROR 42000: Variable 'wsrep_desync' can't be set to the value of 'NULL'
+SET @@global.wsrep_desync='junk';
+ERROR 42000: Variable 'wsrep_desync' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_desync = @wsrep_desync_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_drupal_282555_workaround_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_drupal_282555_workaround_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_drupal_282555_workaround
+#
+# save the initial value
+SET @wsrep_drupal_282555_workaround_global_saved = @@global.wsrep_drupal_282555_workaround;
+# default
+SELECT @@global.wsrep_drupal_282555_workaround;
+@@global.wsrep_drupal_282555_workaround
+0
+
+# scope
+SELECT @@session.wsrep_drupal_282555_workaround;
+ERROR HY000: Variable 'wsrep_drupal_282555_workaround' is a GLOBAL variable
+SET @@global.wsrep_drupal_282555_workaround=OFF;
+SELECT @@global.wsrep_drupal_282555_workaround;
+@@global.wsrep_drupal_282555_workaround
+0
+SET @@global.wsrep_drupal_282555_workaround=ON;
+SELECT @@global.wsrep_drupal_282555_workaround;
+@@global.wsrep_drupal_282555_workaround
+1
+
+# valid values
+SET @@global.wsrep_drupal_282555_workaround='OFF';
+SELECT @@global.wsrep_drupal_282555_workaround;
+@@global.wsrep_drupal_282555_workaround
+0
+SET @@global.wsrep_drupal_282555_workaround=ON;
+SELECT @@global.wsrep_drupal_282555_workaround;
+@@global.wsrep_drupal_282555_workaround
+1
+SET @@global.wsrep_drupal_282555_workaround=default;
+SELECT @@global.wsrep_drupal_282555_workaround;
+@@global.wsrep_drupal_282555_workaround
+0
+
+# invalid values
+SET @@global.wsrep_drupal_282555_workaround=NULL;
+ERROR 42000: Variable 'wsrep_drupal_282555_workaround' can't be set to the value of 'NULL'
+SET @@global.wsrep_drupal_282555_workaround='junk';
+ERROR 42000: Variable 'wsrep_drupal_282555_workaround' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_drupal_282555_workaround = @wsrep_drupal_282555_workaround_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_forced_binlog_format_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_forced_binlog_format_basic.result
@@ -1,0 +1,51 @@
+#
+# wsrep_forced_binlog_format
+#
+# save the initial value
+SET @wsrep_forced_binlog_format_global_saved = @@global.wsrep_forced_binlog_format;
+# default
+SELECT @@global.wsrep_forced_binlog_format;
+@@global.wsrep_forced_binlog_format
+NONE
+
+# scope
+SELECT @@session.wsrep_forced_binlog_format;
+ERROR HY000: Variable 'wsrep_forced_binlog_format' is a GLOBAL variable
+SET @@global.wsrep_forced_binlog_format=STATEMENT;
+SELECT @@global.wsrep_forced_binlog_format;
+@@global.wsrep_forced_binlog_format
+STATEMENT
+
+# valid values
+SET @@global.wsrep_forced_binlog_format=STATEMENT;
+SELECT @@global.wsrep_forced_binlog_format;
+@@global.wsrep_forced_binlog_format
+STATEMENT
+SET @@global.wsrep_forced_binlog_format=ROW;
+SELECT @@global.wsrep_forced_binlog_format;
+@@global.wsrep_forced_binlog_format
+ROW
+SET @@global.wsrep_forced_binlog_format=MIXED;
+SELECT @@global.wsrep_forced_binlog_format;
+@@global.wsrep_forced_binlog_format
+MIXED
+SET @@global.wsrep_forced_binlog_format=NONE;
+SELECT @@global.wsrep_forced_binlog_format;
+@@global.wsrep_forced_binlog_format
+NONE
+SET @@global.wsrep_forced_binlog_format=default;
+SELECT @@global.wsrep_forced_binlog_format;
+@@global.wsrep_forced_binlog_format
+NONE
+
+# invalid values
+SET @@global.wsrep_forced_binlog_format=NULL;
+ERROR 42000: Variable 'wsrep_forced_binlog_format' can't be set to the value of 'NULL'
+SET @@global.wsrep_forced_binlog_format='junk';
+ERROR 42000: Variable 'wsrep_forced_binlog_format' can't be set to the value of 'junk'
+SET @@global.wsrep_forced_binlog_format=ON;
+ERROR 42000: Variable 'wsrep_forced_binlog_format' can't be set to the value of 'ON'
+
+# restore the initial value
+SET @@global.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_load_data_splitting_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_load_data_splitting_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_load_data_splitting
+#
+# save the initial value
+SET @wsrep_load_data_splitting_global_saved = @@global.wsrep_load_data_splitting;
+# default
+SELECT @@global.wsrep_load_data_splitting;
+@@global.wsrep_load_data_splitting
+1
+
+# scope
+SELECT @@session.wsrep_load_data_splitting;
+ERROR HY000: Variable 'wsrep_load_data_splitting' is a GLOBAL variable
+SET @@global.wsrep_load_data_splitting=OFF;
+SELECT @@global.wsrep_load_data_splitting;
+@@global.wsrep_load_data_splitting
+0
+SET @@global.wsrep_load_data_splitting=ON;
+SELECT @@global.wsrep_load_data_splitting;
+@@global.wsrep_load_data_splitting
+1
+
+# valid values
+SET @@global.wsrep_load_data_splitting='OFF';
+SELECT @@global.wsrep_load_data_splitting;
+@@global.wsrep_load_data_splitting
+0
+SET @@global.wsrep_load_data_splitting=ON;
+SELECT @@global.wsrep_load_data_splitting;
+@@global.wsrep_load_data_splitting
+1
+SET @@global.wsrep_load_data_splitting=default;
+SELECT @@global.wsrep_load_data_splitting;
+@@global.wsrep_load_data_splitting
+1
+
+# invalid values
+SET @@global.wsrep_load_data_splitting=NULL;
+ERROR 42000: Variable 'wsrep_load_data_splitting' can't be set to the value of 'NULL'
+SET @@global.wsrep_load_data_splitting='junk';
+ERROR 42000: Variable 'wsrep_load_data_splitting' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_load_data_splitting = @wsrep_load_data_splitting_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_log_conflicts_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_log_conflicts_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_log_conflicts
+#
+# save the initial value
+SET @wsrep_log_conflicts_global_saved = @@global.wsrep_log_conflicts;
+# default
+SELECT @@global.wsrep_log_conflicts;
+@@global.wsrep_log_conflicts
+0
+
+# scope
+SELECT @@session.wsrep_log_conflicts;
+ERROR HY000: Variable 'wsrep_log_conflicts' is a GLOBAL variable
+SET @@global.wsrep_log_conflicts=OFF;
+SELECT @@global.wsrep_log_conflicts;
+@@global.wsrep_log_conflicts
+0
+SET @@global.wsrep_log_conflicts=ON;
+SELECT @@global.wsrep_log_conflicts;
+@@global.wsrep_log_conflicts
+1
+
+# valid values
+SET @@global.wsrep_log_conflicts='OFF';
+SELECT @@global.wsrep_log_conflicts;
+@@global.wsrep_log_conflicts
+0
+SET @@global.wsrep_log_conflicts=ON;
+SELECT @@global.wsrep_log_conflicts;
+@@global.wsrep_log_conflicts
+1
+SET @@global.wsrep_log_conflicts=default;
+SELECT @@global.wsrep_log_conflicts;
+@@global.wsrep_log_conflicts
+0
+
+# invalid values
+SET @@global.wsrep_log_conflicts=NULL;
+ERROR 42000: Variable 'wsrep_log_conflicts' can't be set to the value of 'NULL'
+SET @@global.wsrep_log_conflicts='junk';
+ERROR 42000: Variable 'wsrep_log_conflicts' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_log_conflicts = @wsrep_log_conflicts_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_max_ws_rows_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_max_ws_rows_basic.result
@@ -1,0 +1,53 @@
+#
+# wsrep_max_ws_rows
+#
+# save the initial value
+SET @wsrep_max_ws_rows_global_saved = @@global.wsrep_max_ws_rows;
+# default
+SELECT @@global.wsrep_max_ws_rows;
+@@global.wsrep_max_ws_rows
+131072
+
+# scope
+SELECT @@session.wsrep_max_ws_rows;
+ERROR HY000: Variable 'wsrep_max_ws_rows' is a GLOBAL variable
+SET @@global.wsrep_max_ws_rows=1;
+SELECT @@global.wsrep_max_ws_rows;
+@@global.wsrep_max_ws_rows
+1
+
+# valid values
+SET @@global.wsrep_max_ws_rows=131072;
+SELECT @@global.wsrep_max_ws_rows;
+@@global.wsrep_max_ws_rows
+131072
+SET @@global.wsrep_max_ws_rows=131073;
+SELECT @@global.wsrep_max_ws_rows;
+@@global.wsrep_max_ws_rows
+131073
+SET @@global.wsrep_max_ws_rows=0;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_max_ws_rows value: '0'
+SELECT @@global.wsrep_max_ws_rows;
+@@global.wsrep_max_ws_rows
+1
+SET @@global.wsrep_max_ws_rows=default;
+SELECT @global.wsrep_max_ws_rows;
+@global.wsrep_max_ws_rows
+NULL
+
+# invalid values
+SET @@global.wsrep_max_ws_rows=NULL;
+ERROR 42000: Incorrect argument type to variable 'wsrep_max_ws_rows'
+SET @@global.wsrep_max_ws_rows='junk';
+ERROR 42000: Incorrect argument type to variable 'wsrep_max_ws_rows'
+SET @@global.wsrep_max_ws_rows=-1;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_max_ws_rows value: '-1'
+SELECT @global.wsrep_max_ws_rows;
+@global.wsrep_max_ws_rows
+NULL
+
+# restore the initial value
+SET @@global.wsrep_max_ws_rows = @wsrep_max_ws_rows_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_max_ws_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_max_ws_size_basic.result
@@ -1,0 +1,58 @@
+#
+# wsrep_max_ws_size
+#
+# save the initial value
+SET @wsrep_max_ws_size_global_saved = @@global.wsrep_max_ws_size;
+# default
+SELECT @@global.wsrep_max_ws_size;
+@@global.wsrep_max_ws_size
+1073741824
+
+# scope
+SELECT @@session.wsrep_max_ws_size;
+ERROR HY000: Variable 'wsrep_max_ws_size' is a GLOBAL variable
+SET @@global.wsrep_max_ws_size=1;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_max_ws_size value: '1'
+SELECT @@global.wsrep_max_ws_size;
+@@global.wsrep_max_ws_size
+1024
+
+# valid values
+SET @@global.wsrep_max_ws_size=1073741824;
+SELECT @@global.wsrep_max_ws_size;
+@@global.wsrep_max_ws_size
+1073741824
+SET @@global.wsrep_max_ws_size=1073741825;
+SELECT @@global.wsrep_max_ws_size;
+@@global.wsrep_max_ws_size
+1073741825
+SET @@global.wsrep_max_ws_size=0;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_max_ws_size value: '0'
+SELECT @@global.wsrep_max_ws_size;
+@@global.wsrep_max_ws_size
+1024
+SET @@global.wsrep_max_ws_size=default;
+SELECT @global.wsrep_max_ws_size;
+@global.wsrep_max_ws_size
+NULL
+
+# invalid values
+SET @@global.wsrep_max_ws_size=NULL;
+ERROR 42000: Incorrect argument type to variable 'wsrep_max_ws_size'
+SET @@global.wsrep_max_ws_size='junk';
+ERROR 42000: Incorrect argument type to variable 'wsrep_max_ws_size'
+SELECT @global.wsrep_max_ws_size;
+@global.wsrep_max_ws_size
+NULL
+SET @@global.wsrep_max_ws_size=-1;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_max_ws_size value: '-1'
+SELECT @global.wsrep_max_ws_size;
+@global.wsrep_max_ws_size
+NULL
+
+# restore the initial value
+SET @@global.wsrep_max_ws_size = @wsrep_max_ws_size_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_mysql_replication_bundle_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_mysql_replication_bundle_basic.result
@@ -1,0 +1,52 @@
+#
+# wsrep_mysql_replication_bundle
+#
+# save the initial value
+SET @wsrep_mysql_replication_bundle_global_saved = @@global.wsrep_mysql_replication_bundle;
+# default
+SELECT @@global.wsrep_mysql_replication_bundle;
+@@global.wsrep_mysql_replication_bundle
+0
+
+# scope
+SELECT @@session.wsrep_mysql_replication_bundle;
+ERROR HY000: Variable 'wsrep_mysql_replication_bundle' is a GLOBAL variable
+SELECT @@global.wsrep_mysql_replication_bundle;
+@@global.wsrep_mysql_replication_bundle
+0
+
+# valid values
+SET @@global.wsrep_mysql_replication_bundle=0;
+SELECT @@global.wsrep_mysql_replication_bundle;
+@@global.wsrep_mysql_replication_bundle
+0
+SET @@global.wsrep_mysql_replication_bundle=1000;
+SELECT @@global.wsrep_mysql_replication_bundle;
+@@global.wsrep_mysql_replication_bundle
+1000
+SET @@global.wsrep_mysql_replication_bundle=default;
+SELECT @@global.wsrep_mysql_replication_bundle;
+@@global.wsrep_mysql_replication_bundle
+0
+
+# invalid values
+SET @@global.wsrep_mysql_replication_bundle=NULL;
+ERROR 42000: Incorrect argument type to variable 'wsrep_mysql_replication_bundle'
+SET @@global.wsrep_mysql_replication_bundle='junk';
+ERROR 42000: Incorrect argument type to variable 'wsrep_mysql_replication_bundle'
+SET @@global.wsrep_mysql_replication_bundle=-1;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_mysql_replication_bundle value: '-1'
+SELECT @@global.wsrep_mysql_replication_bundle;
+@@global.wsrep_mysql_replication_bundle
+0
+SET @@global.wsrep_mysql_replication_bundle=1001;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_mysql_replication_bundle value: '1001'
+SELECT @@global.wsrep_mysql_replication_bundle;
+@@global.wsrep_mysql_replication_bundle
+1000
+
+# restore the initial value
+SET @@global.wsrep_mysql_replication_bundle = @wsrep_mysql_replication_bundle_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_node_address_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_node_address_basic.result
@@ -1,0 +1,49 @@
+#
+# wsrep_node_address
+#
+# save the initial value
+SET @wsrep_node_address_global_saved = @@global.wsrep_node_address;
+# default
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+
+
+# scope
+SELECT @@session.wsrep_node_address;
+ERROR HY000: Variable 'wsrep_node_address' is a GLOBAL variable
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+
+
+# valid values
+SET @@global.wsrep_node_address='127.0.0.1';
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+127.0.0.1
+SET @@global.wsrep_node_address=default;
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+
+
+# invalid values
+SET @@global.wsrep_node_address=NULL;
+ERROR 42000: Variable 'wsrep_node_address' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+
+SET @@global.wsrep_node_address=ON;
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+ON
+SET @@global.wsrep_node_address='OFF';
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+OFF
+SET @@global.wsrep_node_address='junk';
+SELECT @@global.wsrep_node_address;
+@@global.wsrep_node_address
+junk
+
+# restore the initial value
+SET @@global.wsrep_node_address = @wsrep_node_address_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_node_incoming_address_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_node_incoming_address_basic.result
@@ -1,0 +1,56 @@
+#
+# wsrep_node_incoming_address
+#
+# save the initial value
+SET @wsrep_node_incoming_address_global_saved = @@global.wsrep_node_incoming_address;
+# default
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+AUTO
+
+# scope
+SELECT @@session.wsrep_node_incoming_address;
+ERROR HY000: Variable 'wsrep_node_incoming_address' is a GLOBAL variable
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+AUTO
+
+# valid values
+SET @@global.wsrep_node_incoming_address='127.0.0.1:4444';
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+127.0.0.1:4444
+SET @@global.wsrep_node_incoming_address='127.0.0.1';
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+127.0.0.1
+SET @@global.wsrep_node_incoming_address=AUTO;
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+AUTO
+SET @@global.wsrep_node_incoming_address=default;
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+AUTO
+
+# invalid values
+SET @@global.wsrep_node_incoming_address=ON;
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+ON
+SET @@global.wsrep_node_incoming_address='OFF';
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+OFF
+SET @@global.wsrep_node_incoming_address=NULL;
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+NULL
+SET @@global.wsrep_node_incoming_address='junk';
+SELECT @@global.wsrep_node_incoming_address;
+@@global.wsrep_node_incoming_address
+junk
+
+# restore the initial value
+SET @@global.wsrep_node_incoming_address = @wsrep_node_incoming_address_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_node_name_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_node_name_basic.result
@@ -1,0 +1,48 @@
+#
+# wsrep_node_name
+#
+call mtr.add_suppression("WSREP: Failed to get provider options");
+# save the initial value
+SET @wsrep_node_name_global_saved = @@global.wsrep_node_name;
+# default
+SELECT @@global.wsrep_node_name;
+@@global.wsrep_node_name
+
+
+# scope
+SELECT @@session.wsrep_node_name;
+ERROR HY000: Variable 'wsrep_node_name' is a GLOBAL variable
+SET @@global.wsrep_node_name='node_name';
+SELECT @@global.wsrep_node_name;
+@@global.wsrep_node_name
+node_name
+
+# valid values
+SET @@global.wsrep_node_name='my_node';
+SELECT @@global.wsrep_node_name;
+@@global.wsrep_node_name
+my_node
+SET @@global.wsrep_node_name='hyphenated-node-name';
+SELECT @@global.wsrep_node_name;
+@@global.wsrep_node_name
+hyphenated-node-name
+SET @@global.wsrep_node_name=default;
+SELECT @@global.wsrep_node_name;
+@@global.wsrep_node_name
+
+
+# invalid values
+SET @@global.wsrep_node_name=NULL;
+ERROR 42000: Variable 'wsrep_node_name' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_node_name;
+@@global.wsrep_node_name
+
+SET @@global.wsrep_node_name=1;
+ERROR 42000: Incorrect argument type to variable 'wsrep_node_name'
+SELECT @@global.wsrep_node_name;
+@@global.wsrep_node_name
+
+
+# restore the initial value
+SET @@global.wsrep_node_name = @wsrep_node_name_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_notify_cmd_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_notify_cmd_basic.result
@@ -1,0 +1,47 @@
+#
+# wsrep_notify_cmd
+#
+call mtr.add_suppression("WSREP: Failed to get provider options");
+# save the initial value
+SET @wsrep_notify_cmd_global_saved = @@global.wsrep_notify_cmd;
+# default
+SELECT @@global.wsrep_notify_cmd;
+@@global.wsrep_notify_cmd
+
+
+# scope
+SELECT @@session.wsrep_notify_cmd;
+ERROR HY000: Variable 'wsrep_notify_cmd' is a GLOBAL variable
+SET @@global.wsrep_notify_cmd='notify_cmd';
+SELECT @@global.wsrep_notify_cmd;
+@@global.wsrep_notify_cmd
+notify_cmd
+
+# valid values
+SET @@global.wsrep_notify_cmd='command';
+SELECT @@global.wsrep_notify_cmd;
+@@global.wsrep_notify_cmd
+command
+SET @@global.wsrep_notify_cmd='hyphenated-command';
+SELECT @@global.wsrep_notify_cmd;
+@@global.wsrep_notify_cmd
+hyphenated-command
+SET @@global.wsrep_notify_cmd=default;
+SELECT @@global.wsrep_notify_cmd;
+@@global.wsrep_notify_cmd
+
+SET @@global.wsrep_notify_cmd=NULL;
+SELECT @@global.wsrep_notify_cmd;
+@@global.wsrep_notify_cmd
+NULL
+
+# invalid values
+SET @@global.wsrep_notify_cmd=1;
+ERROR 42000: Incorrect argument type to variable 'wsrep_notify_cmd'
+SELECT @@global.wsrep_notify_cmd;
+@@global.wsrep_notify_cmd
+NULL
+
+# restore the initial value
+SET @@global.wsrep_notify_cmd = @wsrep_notify_cmd_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_on_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_on_basic.result
@@ -1,0 +1,50 @@
+#
+# wsrep_on
+#
+# save the initial values
+SET @wsrep_on_global_saved = @@global.wsrep_on;
+SET @wsrep_on_session_saved = @@session.wsrep_on;
+# default
+SELECT @@global.wsrep_on;
+@@global.wsrep_on
+0
+SELECT @@session.wsrep_on;
+@@session.wsrep_on
+0
+
+# scope and valid values
+SET @@global.wsrep_on=OFF;
+SELECT @@global.wsrep_on;
+@@global.wsrep_on
+0
+SET @@global.wsrep_on=ON;
+SELECT @@global.wsrep_on;
+@@global.wsrep_on
+1
+SET @@session.wsrep_on=OFF;
+SELECT @@session.wsrep_on;
+@@session.wsrep_on
+0
+SET @@session.wsrep_on=ON;
+SELECT @@session.wsrep_on;
+@@session.wsrep_on
+1
+SET @@session.wsrep_on=default;
+SELECT @@session.wsrep_on;
+@@session.wsrep_on
+1
+
+# invalid values
+SET @@global.wsrep_on=NULL;
+ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'NULL'
+SET @@global.wsrep_on='junk';
+ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'junk'
+SET @@session.wsrep_on=NULL;
+ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'NULL'
+SET @@session.wsrep_on='junk';
+ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'junk'
+
+# restore the initial values
+SET @@global.wsrep_on = @wsrep_on_global_saved;
+SET @@session.wsrep_on = @wsrep_on_session_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_osu_method_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_osu_method_basic.result
@@ -1,0 +1,61 @@
+#
+# wsrep_osu_method
+#
+# save the initial value
+SET @wsrep_osu_method_global_saved = @@global.wsrep_osu_method;
+# default
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+TOI
+
+# scope
+SELECT @@session.wsrep_osu_method;
+@@session.wsrep_osu_method
+TOI
+SET @@global.wsrep_osu_method=TOI;
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+TOI
+
+# valid values
+SET @@global.wsrep_osu_method=TOI;
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+TOI
+SET @@global.wsrep_osu_method=RSU;
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+RSU
+SET @@global.wsrep_osu_method="RSU";
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+RSU
+SET @@global.wsrep_osu_method=default;
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+TOI
+SET @@global.wsrep_osu_method=1;
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+RSU
+
+# invalid values
+SET @@global.wsrep_osu_method=4;
+ERROR 42000: Variable 'wsrep_OSU_method' can't be set to the value of '4'
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+RSU
+SET @@global.wsrep_osu_method=NULL;
+ERROR 42000: Variable 'wsrep_OSU_method' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+RSU
+SET @@global.wsrep_osu_method='junk';
+ERROR 42000: Variable 'wsrep_OSU_method' can't be set to the value of 'junk'
+SELECT @@global.wsrep_osu_method;
+@@global.wsrep_osu_method
+RSU
+
+# restore the initial value
+SET @@global.wsrep_osu_method = @wsrep_osu_method_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_provider_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_provider_basic.result
@@ -1,0 +1,40 @@
+#
+# wsrep_provider
+#
+# save the initial value
+SET @wsrep_provider_global_saved = @@global.wsrep_provider;
+# default
+SELECT @@global.wsrep_provider;
+@@global.wsrep_provider
+none
+
+# scope
+SELECT @@session.wsrep_provider;
+ERROR HY000: Variable 'wsrep_provider' is a GLOBAL variable
+SELECT @@global.wsrep_provider;
+@@global.wsrep_provider
+none
+
+# valid values
+SET @@global.wsrep_provider=default;
+SELECT @@global.wsrep_provider;
+@@global.wsrep_provider
+none
+
+# invalid values
+SET @@global.wsrep_provider='/invalid/libgalera_smm.so';
+ERROR 42000: Variable 'wsrep_provider' can't be set to the value of '/invalid/libgalera_smm.so'
+SET @@global.wsrep_provider=NULL;
+ERROR 42000: Variable 'wsrep_provider' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_provider;
+@@global.wsrep_provider
+none
+SET @@global.wsrep_provider=1;
+ERROR 42000: Incorrect argument type to variable 'wsrep_provider'
+SELECT @@global.wsrep_provider;
+@@global.wsrep_provider
+none
+
+# restore the initial value
+SET @@global.wsrep_provider = @wsrep_provider_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_provider_options_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_provider_options_basic.result
@@ -1,0 +1,48 @@
+#
+# wsrep_provider_options
+#
+call mtr.add_suppression("WSREP: Failed to get provider options");
+# save the initial value
+SET @wsrep_provider_options_global_saved = @@global.wsrep_provider_options;
+# default
+SELECT @@global.wsrep_provider_options;
+@@global.wsrep_provider_options
+
+
+# scope
+SELECT @@session.wsrep_provider_options;
+ERROR HY000: Variable 'wsrep_provider_options' is a GLOBAL variable
+SET @@global.wsrep_provider_options='option1';
+SELECT @@global.wsrep_provider_options;
+@@global.wsrep_provider_options
+option1
+
+# valid values
+SET @@global.wsrep_provider_options='name1=value1;name2=value2';
+SELECT @@global.wsrep_provider_options;
+@@global.wsrep_provider_options
+name1=value1;name2=value2
+SET @@global.wsrep_provider_options='hyphenated-name:value';
+SELECT @@global.wsrep_provider_options;
+@@global.wsrep_provider_options
+hyphenated-name:value
+SET @@global.wsrep_provider_options=default;
+SELECT @@global.wsrep_provider_options;
+@@global.wsrep_provider_options
+
+
+# invalid values
+SET @@global.wsrep_provider_options=1;
+ERROR 42000: Incorrect argument type to variable 'wsrep_provider_options'
+SELECT @@global.wsrep_provider_options;
+@@global.wsrep_provider_options
+
+SET @@global.wsrep_provider_options=NULL;
+Got one of the listed errors
+SELECT @@global.wsrep_provider_options;
+@@global.wsrep_provider_options
+NULL
+
+# restore the initial value
+SET @@global.wsrep_provider_options = @wsrep_provider_options_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_recover_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_recover_basic.result
@@ -1,0 +1,22 @@
+#
+# wsrep_recover
+#
+# default
+SELECT @@global.wsrep_recover;
+@@global.wsrep_recover
+0
+SELECT @@session.wsrep_recover;
+ERROR HY000: Variable 'wsrep_recover' is a GLOBAL variable
+
+# scope and valid values
+SET @@global.wsrep_recover=OFF;
+ERROR HY000: Variable 'wsrep_recover' is a read only variable
+SET @@global.wsrep_recover=ON;
+ERROR HY000: Variable 'wsrep_recover' is a read only variable
+
+# invalid values
+SET @@global.wsrep_recover=NULL;
+ERROR HY000: Variable 'wsrep_recover' is a read only variable
+SET @@global.wsrep_recover='junk';
+ERROR HY000: Variable 'wsrep_recover' is a read only variable
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_restart_slave_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_restart_slave_basic.result
@@ -1,0 +1,31 @@
+#
+# wsrep_restart_slave
+#
+# save the initial value
+SET @wsrep_restart_slave_global_saved = @@global.wsrep_restart_slave;
+# default
+SELECT @@global.wsrep_restart_slave;
+@@global.wsrep_restart_slave
+0
+SELECT @@session.wsrep_restart_slave;
+ERROR HY000: Variable 'wsrep_restart_slave' is a GLOBAL variable
+
+# scope and valid values
+SET @@global.wsrep_restart_slave=OFF;
+SELECT @@global.wsrep_restart_slave;
+@@global.wsrep_restart_slave
+0
+SET @@global.wsrep_restart_slave=ON;
+SELECT @@global.wsrep_restart_slave;
+@@global.wsrep_restart_slave
+1
+
+# invalid values
+SET @@global.wsrep_restart_slave=NULL;
+ERROR 42000: Variable 'wsrep_restart_slave' can't be set to the value of 'NULL'
+SET @@global.wsrep_restart_slave='junk';
+ERROR 42000: Variable 'wsrep_restart_slave' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_restart_slave = @wsrep_restart_slave_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_retry_autocommit_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_retry_autocommit_basic.result
@@ -1,0 +1,63 @@
+#
+# wsrep_retry_autocommit
+#
+# save the initial values
+SET @wsrep_retry_autocommit_global_saved = @@global.wsrep_retry_autocommit;
+SET @wsrep_retry_autocommit_session_saved = @@session.wsrep_retry_autocommit;
+# default
+SELECT @@global.wsrep_retry_autocommit;
+@@global.wsrep_retry_autocommit
+1
+
+# scope
+SET @@session.wsrep_retry_autocommit=1;
+SELECT @@session.wsrep_retry_autocommit;
+@@session.wsrep_retry_autocommit
+1
+SET @@global.wsrep_retry_autocommit=1;
+SELECT @@global.wsrep_retry_autocommit;
+@@global.wsrep_retry_autocommit
+1
+
+# valid values
+SET @@global.wsrep_retry_autocommit=10;
+SELECT @@global.wsrep_retry_autocommit;
+@@global.wsrep_retry_autocommit
+10
+SET @@global.wsrep_retry_autocommit=0;
+SELECT @@global.wsrep_retry_autocommit;
+@@global.wsrep_retry_autocommit
+0
+SET @@global.wsrep_retry_autocommit=default;
+SELECT @global.wsrep_retry_autocommit;
+@global.wsrep_retry_autocommit
+NULL
+SET @@session.wsrep_retry_autocommit=10;
+SELECT @@session.wsrep_retry_autocommit;
+@@session.wsrep_retry_autocommit
+10
+SET @@session.wsrep_retry_autocommit=0;
+SELECT @@session.wsrep_retry_autocommit;
+@@session.wsrep_retry_autocommit
+0
+SET @@session.wsrep_retry_autocommit=default;
+SELECT @session.wsrep_retry_autocommit;
+@session.wsrep_retry_autocommit
+NULL
+
+# invalid values
+SET @@global.wsrep_retry_autocommit=NULL;
+ERROR 42000: Incorrect argument type to variable 'wsrep_retry_autocommit'
+SET @@global.wsrep_retry_autocommit='junk';
+ERROR 42000: Incorrect argument type to variable 'wsrep_retry_autocommit'
+SET @@global.wsrep_retry_autocommit=-1;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_retry_autocommit value: '-1'
+SELECT @global.wsrep_retry_autocommit;
+@global.wsrep_retry_autocommit
+NULL
+
+# restore the initial value
+SET @@global.wsrep_retry_autocommit = @wsrep_retry_autocommit_global_saved;
+SET @@session.wsrep_retry_autocommit = @wsrep_retry_autocommit_session_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_slave_fk_checks_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_slave_fk_checks_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_slave_fk_checks
+#
+# save the initial value
+SET @wsrep_slave_fk_checks_global_saved = @@global.wsrep_slave_fk_checks;
+# default
+SELECT @@global.wsrep_slave_fk_checks;
+@@global.wsrep_slave_fk_checks
+1
+
+# scope
+SELECT @@session.wsrep_slave_fk_checks;
+ERROR HY000: Variable 'wsrep_slave_FK_checks' is a GLOBAL variable
+SET @@global.wsrep_slave_fk_checks=OFF;
+SELECT @@global.wsrep_slave_fk_checks;
+@@global.wsrep_slave_fk_checks
+0
+SET @@global.wsrep_slave_fk_checks=ON;
+SELECT @@global.wsrep_slave_fk_checks;
+@@global.wsrep_slave_fk_checks
+1
+
+# valid values
+SET @@global.wsrep_slave_fk_checks='OFF';
+SELECT @@global.wsrep_slave_fk_checks;
+@@global.wsrep_slave_fk_checks
+0
+SET @@global.wsrep_slave_fk_checks=ON;
+SELECT @@global.wsrep_slave_fk_checks;
+@@global.wsrep_slave_fk_checks
+1
+SET @@global.wsrep_slave_fk_checks=default;
+SELECT @@global.wsrep_slave_fk_checks;
+@@global.wsrep_slave_fk_checks
+1
+
+# invalid values
+SET @@global.wsrep_slave_fk_checks=NULL;
+ERROR 42000: Variable 'wsrep_slave_FK_checks' can't be set to the value of 'NULL'
+SET @@global.wsrep_slave_fk_checks='junk';
+ERROR 42000: Variable 'wsrep_slave_FK_checks' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_slave_fk_checks = @wsrep_slave_fk_checks_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_slave_threads_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_slave_threads_basic.result
@@ -1,0 +1,49 @@
+#
+# wsrep_slave_threads
+#
+# save the initial value
+SET @wsrep_slave_threads_global_saved = @@global.wsrep_slave_threads;
+# default
+SELECT @@global.wsrep_slave_threads;
+@@global.wsrep_slave_threads
+1
+
+# scope
+SELECT @@session.wsrep_slave_threads;
+ERROR HY000: Variable 'wsrep_slave_threads' is a GLOBAL variable
+SET @@global.wsrep_slave_threads=1;
+SELECT @@global.wsrep_slave_threads;
+@@global.wsrep_slave_threads
+1
+
+# valid values
+SET @@global.wsrep_slave_threads=10;
+SELECT @@global.wsrep_slave_threads;
+@@global.wsrep_slave_threads
+10
+SET @@global.wsrep_slave_threads=0;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_slave_threads value: '0'
+SELECT @@global.wsrep_slave_threads;
+@@global.wsrep_slave_threads
+1
+SET @@global.wsrep_slave_threads=default;
+SELECT @global.wsrep_slave_threads;
+@global.wsrep_slave_threads
+NULL
+
+# invalid values
+SET @@global.wsrep_slave_threads=NULL;
+ERROR 42000: Incorrect argument type to variable 'wsrep_slave_threads'
+SET @@global.wsrep_slave_threads='junk';
+ERROR 42000: Incorrect argument type to variable 'wsrep_slave_threads'
+SET @@global.wsrep_slave_threads=-1;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_slave_threads value: '-1'
+SELECT @global.wsrep_slave_threads;
+@global.wsrep_slave_threads
+NULL
+
+# restore the initial value
+SET @@global.wsrep_slave_threads = @wsrep_slave_threads_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_slave_uk_checks_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_slave_uk_checks_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_slave_uk_checks
+#
+# save the initial value
+SET @wsrep_slave_uk_checks_global_saved = @@global.wsrep_slave_uk_checks;
+# default
+SELECT @@global.wsrep_slave_uk_checks;
+@@global.wsrep_slave_uk_checks
+0
+
+# scope
+SELECT @@session.wsrep_slave_uk_checks;
+ERROR HY000: Variable 'wsrep_slave_UK_checks' is a GLOBAL variable
+SET @@global.wsrep_slave_uk_checks=OFF;
+SELECT @@global.wsrep_slave_uk_checks;
+@@global.wsrep_slave_uk_checks
+0
+SET @@global.wsrep_slave_uk_checks=ON;
+SELECT @@global.wsrep_slave_uk_checks;
+@@global.wsrep_slave_uk_checks
+1
+
+# valid values
+SET @@global.wsrep_slave_uk_checks='OFF';
+SELECT @@global.wsrep_slave_uk_checks;
+@@global.wsrep_slave_uk_checks
+0
+SET @@global.wsrep_slave_uk_checks=ON;
+SELECT @@global.wsrep_slave_uk_checks;
+@@global.wsrep_slave_uk_checks
+1
+SET @@global.wsrep_slave_uk_checks=default;
+SELECT @@global.wsrep_slave_uk_checks;
+@@global.wsrep_slave_uk_checks
+0
+
+# invalid values
+SET @@global.wsrep_slave_uk_checks=NULL;
+ERROR 42000: Variable 'wsrep_slave_UK_checks' can't be set to the value of 'NULL'
+SET @@global.wsrep_slave_uk_checks='junk';
+ERROR 42000: Variable 'wsrep_slave_UK_checks' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_slave_uk_checks = @wsrep_slave_uk_checks_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_sst_auth_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sst_auth_basic.result
@@ -1,0 +1,52 @@
+#
+# wsrep_sst_auth
+#
+# save the initial value
+SET @wsrep_sst_auth_global_saved = @@global.wsrep_sst_auth;
+# default
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+NULL
+
+# scope
+SELECT @@session.wsrep_sst_auth;
+ERROR HY000: Variable 'wsrep_sst_auth' is a GLOBAL variable
+SET @@global.wsrep_sst_auth='user:pass';
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+********
+
+# valid values
+SET @@global.wsrep_sst_auth=user;
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+********
+SET @@global.wsrep_sst_auth='user:1234';
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+********
+SET @@global.wsrep_sst_auth='hyphenated-user-name:';
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+********
+SET @@global.wsrep_sst_auth=default;
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+NULL
+SET @@global.wsrep_sst_auth=NULL;
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+NULL
+
+# invalid values
+SET @@global.wsrep_sst_auth=1;
+ERROR 42000: Incorrect argument type to variable 'wsrep_sst_auth'
+SELECT @@global.wsrep_sst_auth;
+@@global.wsrep_sst_auth
+NULL
+SET @@global.wsrep_sst_auth=user:pass;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ':pass' at line 1
+
+# restore the initial value
+SET @@global.wsrep_sst_auth = @wsrep_sst_auth_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_sst_donor_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sst_donor_basic.result
@@ -1,0 +1,50 @@
+#
+# wsrep_sst_donor
+#
+# save the initial value
+SET @wsrep_sst_donor_global_saved = @@global.wsrep_sst_donor;
+# default
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+
+
+# scope
+SELECT @@session.wsrep_sst_donor;
+ERROR HY000: Variable 'wsrep_sst_donor' is a GLOBAL variable
+SET @@global.wsrep_sst_donor=rsync;
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+rsync
+
+# valid values
+SET @@global.wsrep_sst_donor=node1;
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+node1
+SET @@global.wsrep_sst_donor='node1,node2';
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+node1,node2
+SET @@global.wsrep_sst_donor='hyphenated-donor-name';
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+hyphenated-donor-name
+SET @@global.wsrep_sst_donor=default;
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+
+SET @@global.wsrep_sst_donor=NULL;
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+NULL
+
+# invalid values
+SET @@global.wsrep_sst_donor=1;
+ERROR 42000: Incorrect argument type to variable 'wsrep_sst_donor'
+SELECT @@global.wsrep_sst_donor;
+@@global.wsrep_sst_donor
+NULL
+
+# restore the initial value
+SET @@global.wsrep_sst_donor = @wsrep_sst_donor_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_sst_donor_rejects_queries_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sst_donor_rejects_queries_basic.result
@@ -1,0 +1,45 @@
+#
+# wsrep_sst_donor_rejects_queries
+#
+# save the initial value
+SET @wsrep_sst_donor_rejects_queries_global_saved = @@global.wsrep_sst_donor_rejects_queries;
+# default
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+@@global.wsrep_sst_donor_rejects_queries
+0
+
+# scope
+SELECT @@session.wsrep_sst_donor_rejects_queries;
+ERROR HY000: Variable 'wsrep_sst_donor_rejects_queries' is a GLOBAL variable
+SET @@global.wsrep_sst_donor_rejects_queries=OFF;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+@@global.wsrep_sst_donor_rejects_queries
+0
+SET @@global.wsrep_sst_donor_rejects_queries=ON;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+@@global.wsrep_sst_donor_rejects_queries
+1
+
+# valid values
+SET @@global.wsrep_sst_donor_rejects_queries='OFF';
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+@@global.wsrep_sst_donor_rejects_queries
+0
+SET @@global.wsrep_sst_donor_rejects_queries=ON;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+@@global.wsrep_sst_donor_rejects_queries
+1
+SET @@global.wsrep_sst_donor_rejects_queries=default;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+@@global.wsrep_sst_donor_rejects_queries
+0
+
+# invalid values
+SET @@global.wsrep_sst_donor_rejects_queries=NULL;
+ERROR 42000: Variable 'wsrep_sst_donor_rejects_queries' can't be set to the value of 'NULL'
+SET @@global.wsrep_sst_donor_rejects_queries='junk';
+ERROR 42000: Variable 'wsrep_sst_donor_rejects_queries' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_sst_donor_rejects_queries = @wsrep_sst_donor_rejects_queries_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_sst_method_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sst_method_basic.result
@@ -1,0 +1,54 @@
+#
+# wsrep_sst_method
+#
+# save the initial value
+SET @wsrep_sst_method_global_saved = @@global.wsrep_sst_method;
+# default
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+xtrabackup-v2
+
+# scope
+SELECT @@session.wsrep_sst_method;
+ERROR HY000: Variable 'wsrep_sst_method' is a GLOBAL variable
+SET @@global.wsrep_sst_method=rsync;
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+rsync
+
+# valid values
+SET @@global.wsrep_sst_method=rsync;
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+rsync
+SET @@global.wsrep_sst_method=mysqldump;
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+mysqldump
+SET @@global.wsrep_sst_method=xtrabackup;
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+xtrabackup
+SET @@global.wsrep_sst_method="xtrabackup-v2";
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+xtrabackup-v2
+SET @@global.wsrep_sst_method=default;
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+xtrabackup-v2
+SET @@global.wsrep_sst_method='junk';
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+junk
+
+# invalid values
+SET @@global.wsrep_sst_method=NULL;
+ERROR 42000: Variable 'wsrep_sst_method' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_sst_method;
+@@global.wsrep_sst_method
+junk
+
+# restore the initial value
+SET @@global.wsrep_sst_method = @wsrep_sst_method_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_sst_receive_address_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sst_receive_address_basic.result
@@ -1,0 +1,64 @@
+#
+# wsrep_sst_receive_address
+#
+# save the initial value
+SET @wsrep_sst_receive_address_global_saved = @@global.wsrep_sst_receive_address;
+# default
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+AUTO
+
+# scope
+SELECT @@session.wsrep_sst_receive_address;
+ERROR HY000: Variable 'wsrep_sst_receive_address' is a GLOBAL variable
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+AUTO
+
+# valid values
+SET @@global.wsrep_sst_receive_address=AUTO;
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+AUTO
+SET @@global.wsrep_sst_receive_address=default;
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+AUTO
+SET @@global.wsrep_sst_receive_address='192.168.2.254';
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+192.168.2.254
+
+# invalid values
+SET @@global.wsrep_sst_receive_address='127.0.0.1:4444';
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of '127.0.0.1:4444'
+SET @@global.wsrep_sst_receive_address='127.0.0.1';
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of '127.0.0.1'
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+192.168.2.254
+SET @@global.wsrep_sst_receive_address=NULL;
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+192.168.2.254
+SET @@global.wsrep_sst_receive_address='OFF';
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+OFF
+SET @@global.wsrep_sst_receive_address=ON;
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+ON
+SET @@global.wsrep_sst_receive_address='';
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+
+SET @@global.wsrep_sst_receive_address='junk';
+SELECT @@global.wsrep_sst_receive_address;
+@@global.wsrep_sst_receive_address
+junk
+
+# restore the initial value
+SET @@global.wsrep_sst_receive_address = @wsrep_sst_receive_address_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_start_position_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_start_position_basic.result
@@ -1,0 +1,57 @@
+#
+# wsrep_start_position
+#
+# save the initial value
+SET @wsrep_start_position_global_saved = @@global.wsrep_start_position;
+# default
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-1
+
+# scope
+SELECT @@session.wsrep_start_position;
+ERROR HY000: Variable 'wsrep_start_position' is a GLOBAL variable
+SET @@global.wsrep_start_position='00000000-0000-0000-0000-000000000000:-1';
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-1
+
+# valid values
+SET @@global.wsrep_start_position='00000000-0000-0000-0000-000000000000:-2';
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-2
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:100';
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+12345678-1234-1234-1234-123456789012:100
+SET @@global.wsrep_start_position=default;
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-1
+
+# invalid values
+SET @@global.wsrep_start_position='000000000000000-0000-0000-0000-000000000000:-1';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '000000000000000-0000-0000-0000-000000000000:-1'
+SET @@global.wsrep_start_position='12345678-1234-1234-12345-123456789012:100';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-1234-12345-123456789012:100'
+SET @@global.wsrep_start_position='12345678-1234-123-12345-123456789012:0';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-123-12345-123456789012:0'
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:_99999';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-1234-1234-123456789012:_99999'
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:a';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-1234-1234-123456789012:a'
+SET @@global.wsrep_start_position='OFF';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'OFF'
+SET @@global.wsrep_start_position=ON;
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'ON'
+SET @@global.wsrep_start_position='';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of ''
+SET @@global.wsrep_start_position=NULL;
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'NULL'
+SET @@global.wsrep_start_position='junk';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'junk'
+
+# restore the initial value
+SET @@global.wsrep_start_position = @wsrep_start_position_global_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_sync_wait_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sync_wait_basic.result
@@ -1,0 +1,56 @@
+#
+# wsrep_sync_wait
+#
+# save the initial values
+SET @wsrep_sync_wait_global_saved = @@global.wsrep_sync_wait;
+SET @wsrep_sync_wait_session_saved = @@session.wsrep_sync_wait;
+# default
+SELECT @@global.wsrep_sync_wait;
+@@global.wsrep_sync_wait
+0
+SELECT @@session.wsrep_sync_wait;
+@@session.wsrep_sync_wait
+0
+
+# scope and valid values
+SET @@global.wsrep_sync_wait=0;
+SELECT @@global.wsrep_sync_wait;
+@@global.wsrep_sync_wait
+0
+SET @@global.wsrep_sync_wait=7;
+SELECT @@global.wsrep_sync_wait;
+@@global.wsrep_sync_wait
+7
+SET @@session.wsrep_sync_wait=0;
+SELECT @@session.wsrep_sync_wait;
+@@session.wsrep_sync_wait
+0
+SET @@session.wsrep_sync_wait=7;
+SELECT @@session.wsrep_sync_wait;
+@@session.wsrep_sync_wait
+7
+SET @@session.wsrep_sync_wait=default;
+SELECT @@session.wsrep_sync_wait;
+@@session.wsrep_sync_wait
+7
+SET @@session.wsrep_sync_wait=8;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_sync_wait value: '8'
+SELECT @@session.wsrep_sync_wait;
+@@session.wsrep_sync_wait
+7
+
+# invalid values
+SET @@global.wsrep_sync_wait=NULL;
+ERROR 42000: Incorrect argument type to variable 'wsrep_sync_wait'
+SET @@global.wsrep_sync_wait='junk';
+ERROR 42000: Incorrect argument type to variable 'wsrep_sync_wait'
+SET @@session.wsrep_sync_wait=NULL;
+ERROR 42000: Incorrect argument type to variable 'wsrep_sync_wait'
+SET @@session.wsrep_sync_wait='junk';
+ERROR 42000: Incorrect argument type to variable 'wsrep_sync_wait'
+
+# restore the initial values
+SET @@global.wsrep_sync_wait = @wsrep_sync_wait_global_saved;
+SET @@session.wsrep_sync_wait = @wsrep_sync_wait_session_saved;
+# End of test

--- a/mysql-test/suite/sys_vars/t/all_vars.test
+++ b/mysql-test/suite/sys_vars/t/all_vars.test
@@ -49,8 +49,8 @@ create table t2 (variable_name text);
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 eval load data infile "$MYSQLTEST_VARDIR/tmp/sys_vars.all_vars.txt" into table t1;
 
-insert into t2 select variable_name from information_schema.global_variables where variable_name not like 'wsrep_%' and variable_name not like 'innodb_disallow_writes';
-insert into t2 select variable_name from information_schema.session_variables where variable_name not like 'wsrep_%' and variable_name not like 'innodb_disallow_writes';
+insert into t2 select variable_name from information_schema.global_variables where variable_name not like 'innodb_disallow_writes';
+insert into t2 select variable_name from information_schema.session_variables where variable_name not like 'innodb_disallow_writes';
 
 # Performance schema variables are too long for files named
 # 'mysql-test/suite/sys_vars/t/' ...

--- a/mysql-test/suite/sys_vars/t/disabled.def
+++ b/mysql-test/suite/sys_vars/t/disabled.def
@@ -12,3 +12,8 @@
 query_cache_size_basic_32           : Bug#13535584
 query_cache_size_basic_64           : Bug#11748572
 #thread_cache_size_func             : Bug#11750172: 2008-11-07 joro main.thread_cache_size_func fails in pushbuild when run with pool of threads
+wsrep_start_position_basic          : This needs server to start in cluster mode with wsrep initialized.
+wsrep_desync_basic                  : State transition that percona has to avoid race condition block setting of desync to OFF in some cases.
+wsrep_preordered_basic              : TC pending.
+wsrep_reject_queries_basic          : TC pending.
+sql_mode_func                       : Differences in result likely due to configuration. Need more investigation.

--- a/mysql-test/suite/sys_vars/t/sql_mode_func.test
+++ b/mysql-test/suite/sys_vars/t/sql_mode_func.test
@@ -89,6 +89,7 @@ DELETE FROM t2;
 SET SESSION sql_mode = STRICT_TRANS_TABLES;
 
 SELECT @@SESSION.sql_mode;
+SELECT @@GLOBAL.sql_mode;
 
 INSERT INTO t1 VALUES('t1a1','t1b1');
 INSERT INTO t1 VALUES('t1a2','t1b2');
@@ -100,6 +101,7 @@ INSERT INTO t2 VALUES('t2a2','t2b2');
 INSERT INTO t2 VALUES('t2a3','t2b3');
 INSERT INTO t2 VALUES('t2a4','t2b4');
 
+analyze table t1;
 --error ER_BAD_NULL_ERROR
 INSERT INTO t1 SELECT * FROM t2;
 --echo Expected error Bad NULL value

--- a/mysql-test/suite/sys_vars/t/wsrep_auto_increment_control_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_auto_increment_control_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_auto_increment_control
+--echo #
+
+--echo # save the initial value
+SET @wsrep_auto_increment_control_global_saved = @@global.wsrep_auto_increment_control;
+
+--echo # default
+SELECT @@global.wsrep_auto_increment_control;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_auto_increment_control;
+SET @@global.wsrep_auto_increment_control=OFF;
+SELECT @@global.wsrep_auto_increment_control;
+SET @@global.wsrep_auto_increment_control=ON;
+SELECT @@global.wsrep_auto_increment_control;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_auto_increment_control='OFF';
+SELECT @@global.wsrep_auto_increment_control;
+SET @@global.wsrep_auto_increment_control=ON;
+SELECT @@global.wsrep_auto_increment_control;
+SET @@global.wsrep_auto_increment_control=default;
+SELECT @@global.wsrep_auto_increment_control;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_auto_increment_control=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_auto_increment_control='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_auto_increment_control = @wsrep_auto_increment_control_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_causal_reads_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_causal_reads_basic.test
@@ -1,0 +1,45 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_causal_reads
+--echo #
+
+--echo # save the initial values
+SET @wsrep_causal_reads_global_saved = @@global.wsrep_causal_reads;
+SET @wsrep_causal_reads_session_saved = @@session.wsrep_causal_reads;
+
+--echo # default
+SELECT @@global.wsrep_causal_reads;
+SELECT @@session.wsrep_causal_reads;
+
+--echo
+--echo # scope and valid values
+SET @@global.wsrep_causal_reads=OFF;
+SELECT @@global.wsrep_causal_reads;
+SET @@global.wsrep_causal_reads=ON;
+SELECT @@global.wsrep_causal_reads;
+
+SET @@session.wsrep_causal_reads=OFF;
+SELECT @@session.wsrep_causal_reads;
+SET @@session.wsrep_causal_reads=ON;
+SELECT @@session.wsrep_causal_reads;
+SET @@session.wsrep_causal_reads=default;
+SELECT @@session.wsrep_causal_reads;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_causal_reads=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_causal_reads='junk';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@session.wsrep_causal_reads=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@session.wsrep_causal_reads='junk';
+
+--echo
+--echo # restore the initial values
+SET @@global.wsrep_causal_reads = @wsrep_causal_reads_global_saved;
+SET @@session.wsrep_causal_reads = @wsrep_causal_reads_session_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_certify_nonpk_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_certify_nonpk_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_certify_nonpk
+--echo #
+
+--echo # save the initial value
+SET @wsrep_certify_nonpk_global_saved = @@global.wsrep_certify_nonpk;
+
+--echo # default
+SELECT @@global.wsrep_certify_nonpk;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_certify_nonpk;
+SET @@global.wsrep_certify_nonpk=OFF;
+SELECT @@global.wsrep_certify_nonpk;
+SET @@global.wsrep_certify_nonpk=ON;
+SELECT @@global.wsrep_certify_nonpk;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_certify_nonpk='OFF';
+SELECT @@global.wsrep_certify_nonpk;
+SET @@global.wsrep_certify_nonpk=ON;
+SELECT @@global.wsrep_certify_nonpk;
+SET @@global.wsrep_certify_nonpk=default;
+SELECT @@global.wsrep_certify_nonpk;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_certify_nonpk=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_certify_nonpk='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_certify_nonpk = @wsrep_certify_nonpk_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_cluster_address_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_cluster_address_basic.test
@@ -1,0 +1,49 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_cluster_address
+--echo #
+
+call mtr.add_suppression("safe_mutex: Found wrong usage of mutex.*");
+
+--echo # save the initial value
+SET @wsrep_cluster_address_global_saved = @@global.wsrep_cluster_address;
+
+--echo # default
+SELECT @@global.wsrep_cluster_address;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_cluster_address;
+SELECT @@global.wsrep_cluster_address;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_cluster_address='127.0.0.1';
+SELECT @@global.wsrep_cluster_address;
+SET @@global.wsrep_cluster_address=AUTO;
+SELECT @@global.wsrep_cluster_address;
+SET @@global.wsrep_cluster_address=default;
+SELECT @@global.wsrep_cluster_address;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_node_address=NULL;
+SELECT @@global.wsrep_node_address;
+# The values being assigned to wsrep_node_address are not verified so the
+# following alues are currently valid too.
+SET @@global.wsrep_cluster_address=ON;
+SELECT @@global.wsrep_cluster_address;
+SET @@global.wsrep_cluster_address='OFF';
+SELECT @@global.wsrep_cluster_address;
+SET @@global.wsrep_cluster_address='junk';
+SELECT @@global.wsrep_cluster_address;
+
+--echo
+--echo # restore the initial value
+--error 0,ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_cluster_address = @wsrep_cluster_address_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_cluster_name_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_cluster_name_basic.test
@@ -1,0 +1,40 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_cluster_name
+--echo #
+
+--echo # save the initial value
+SET @wsrep_cluster_name_global_saved = @@global.wsrep_cluster_name;
+
+--echo # default
+SELECT @@global.wsrep_cluster_name;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_cluster_name;
+SET @@global.wsrep_cluster_name='my_galera_cluster';
+SELECT @@global.wsrep_cluster_name;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_cluster_name='my_quoted_galera_cluster';
+SELECT @@global.wsrep_cluster_name;
+SET @@global.wsrep_cluster_name=my_unquoted_cluster;
+SELECT @@global.wsrep_cluster_name;
+SET @@global.wsrep_cluster_name=OFF;
+SELECT @@global.wsrep_cluster_name;
+SET @@global.wsrep_cluster_name=default;
+SELECT @@global.wsrep_cluster_name;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_cluster_name=NULL;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_cluster_name = @wsrep_cluster_name_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_convert_lock_to_trx_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_convert_lock_to_trx_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_convert_lock_to_trx
+--echo #
+
+--echo # save the initial value
+SET @wsrep_convert_lock_to_trx_global_saved = @@global.wsrep_convert_lock_to_trx;
+
+--echo # default
+SELECT @@global.wsrep_convert_lock_to_trx;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_convert_lock_to_trx;
+SET @@global.wsrep_convert_lock_to_trx=OFF;
+SELECT @@global.wsrep_convert_lock_to_trx;
+SET @@global.wsrep_convert_lock_to_trx=ON;
+SELECT @@global.wsrep_convert_lock_to_trx;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_convert_lock_to_trx='OFF';
+SELECT @@global.wsrep_convert_lock_to_trx;
+SET @@global.wsrep_convert_lock_to_trx=ON;
+SELECT @@global.wsrep_convert_lock_to_trx;
+SET @@global.wsrep_convert_lock_to_trx=default;
+SELECT @@global.wsrep_convert_lock_to_trx;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_convert_lock_to_trx=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_convert_lock_to_trx='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_convert_lock_to_trx = @wsrep_convert_lock_to_trx_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_data_home_dir_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_data_home_dir_basic.test
@@ -1,0 +1,28 @@
+--source include/have_wsrep.inc
+--let $datadir = `SELECT @@datadir`
+
+--echo #
+--echo # wsrep_data_home_dir (readonly)
+--echo #
+
+--echo # default
+--replace_result $datadir DATADIR
+SELECT @@global.wsrep_data_home_dir;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_data_home_dir;
+
+--echo
+--echo # valid values
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.wsrep_data_home_dir='/tmp/data';
+--replace_result $datadir DATADIR
+SELECT @@global.wsrep_data_home_dir;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.wsrep_data_home_dir=default;
+--replace_result $datadir DATADIR
+SELECT @@global.wsrep_data_home_dir;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_dbug_option_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_dbug_option_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_dbug_option
+--echo #
+
+--echo # save the initial value
+SET @wsrep_dbug_option_global_saved = @@global.wsrep_dbug_option;
+
+--echo # default
+SELECT @@global.wsrep_dbug_option;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_dbug_option;
+SET @@global.wsrep_dbug_option='test-dbug-string';
+SELECT @@global.wsrep_dbug_option;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_dbug_option='quoted-dbug-string';
+SELECT @@global.wsrep_dbug_option;
+SET @@global.wsrep_dbug_option=unquoted_dbug_string;
+SELECT @@global.wsrep_dbug_option;
+SET @@global.wsrep_dbug_option=OFF;
+SELECT @@global.wsrep_dbug_option;
+SET @@global.wsrep_dbug_option=NULL;
+SELECT @@global.wsrep_dbug_option;
+SET @@global.wsrep_dbug_option=default;
+SELECT @@global.wsrep_dbug_option;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_dbug_option=1;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_dbug_option = @wsrep_dbug_option_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_debug_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_debug_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_debug
+--echo #
+
+--echo # save the initial value
+SET @wsrep_debug_global_saved = @@global.wsrep_debug;
+
+--echo # default
+SELECT @@global.wsrep_debug;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_debug;
+SET @@global.wsrep_debug=OFF;
+SELECT @@global.wsrep_debug;
+SET @@global.wsrep_debug=ON;
+SELECT @@global.wsrep_debug;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_debug='OFF';
+SELECT @@global.wsrep_debug;
+SET @@global.wsrep_debug=ON;
+SELECT @@global.wsrep_debug;
+SET @@global.wsrep_debug=default;
+SELECT @@global.wsrep_debug;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_debug=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_debug='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_debug = @wsrep_debug_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_desync_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_desync_basic.test
@@ -1,0 +1,57 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_desync
+--echo #
+
+# expected as no wsrep provider is currently loaded
+call mtr.add_suppression("WSREP: SET desync failed 9 for SET @@global.wsrep_desync=ON");
+
+--echo # save the initial value
+SET @wsrep_desync_global_saved = @@global.wsrep_desync;
+
+--echo # default
+SELECT @@global.wsrep_desync;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_desync;
+--disable_warnings
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_desync=OFF;
+--enable_warnings
+SELECT @@global.wsrep_desync;
+# expected as no wsrep provider is currently loaded
+--error ER_CANNOT_USER,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_desync=ON;
+SELECT @@global.wsrep_desync;
+
+--echo
+--echo # valid values
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_desync='OFF';
+SELECT @@global.wsrep_desync;
+# expected as no wsrep provider is currently loaded
+--error ER_CANNOT_USER,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_desync=ON;
+SELECT @@global.wsrep_desync;
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_desync=default;
+SELECT @@global.wsrep_desync;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_desync=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_desync='junk';
+
+--echo
+--echo # restore the initial value
+--disable_warnings
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_desync = @wsrep_desync_global_saved;
+--enable_warnings
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_drupal_282555_workaround_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_drupal_282555_workaround_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_drupal_282555_workaround
+--echo #
+
+--echo # save the initial value
+SET @wsrep_drupal_282555_workaround_global_saved = @@global.wsrep_drupal_282555_workaround;
+
+--echo # default
+SELECT @@global.wsrep_drupal_282555_workaround;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_drupal_282555_workaround;
+SET @@global.wsrep_drupal_282555_workaround=OFF;
+SELECT @@global.wsrep_drupal_282555_workaround;
+SET @@global.wsrep_drupal_282555_workaround=ON;
+SELECT @@global.wsrep_drupal_282555_workaround;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_drupal_282555_workaround='OFF';
+SELECT @@global.wsrep_drupal_282555_workaround;
+SET @@global.wsrep_drupal_282555_workaround=ON;
+SELECT @@global.wsrep_drupal_282555_workaround;
+SET @@global.wsrep_drupal_282555_workaround=default;
+SELECT @@global.wsrep_drupal_282555_workaround;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_drupal_282555_workaround=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_drupal_282555_workaround='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_drupal_282555_workaround = @wsrep_drupal_282555_workaround_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_forced_binlog_format_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_forced_binlog_format_basic.test
@@ -1,0 +1,46 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_forced_binlog_format
+--echo #
+
+--echo # save the initial value
+SET @wsrep_forced_binlog_format_global_saved = @@global.wsrep_forced_binlog_format;
+
+--echo # default
+SELECT @@global.wsrep_forced_binlog_format;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_forced_binlog_format;
+SET @@global.wsrep_forced_binlog_format=STATEMENT;
+SELECT @@global.wsrep_forced_binlog_format;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_forced_binlog_format=STATEMENT;
+SELECT @@global.wsrep_forced_binlog_format;
+SET @@global.wsrep_forced_binlog_format=ROW;
+SELECT @@global.wsrep_forced_binlog_format;
+SET @@global.wsrep_forced_binlog_format=MIXED;
+SELECT @@global.wsrep_forced_binlog_format;
+SET @@global.wsrep_forced_binlog_format=NONE;
+SELECT @@global.wsrep_forced_binlog_format;
+SET @@global.wsrep_forced_binlog_format=default;
+SELECT @@global.wsrep_forced_binlog_format;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_forced_binlog_format=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_forced_binlog_format='junk';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_forced_binlog_format=ON;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_load_data_splitting_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_load_data_splitting_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_load_data_splitting
+--echo #
+
+--echo # save the initial value
+SET @wsrep_load_data_splitting_global_saved = @@global.wsrep_load_data_splitting;
+
+--echo # default
+SELECT @@global.wsrep_load_data_splitting;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_load_data_splitting;
+SET @@global.wsrep_load_data_splitting=OFF;
+SELECT @@global.wsrep_load_data_splitting;
+SET @@global.wsrep_load_data_splitting=ON;
+SELECT @@global.wsrep_load_data_splitting;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_load_data_splitting='OFF';
+SELECT @@global.wsrep_load_data_splitting;
+SET @@global.wsrep_load_data_splitting=ON;
+SELECT @@global.wsrep_load_data_splitting;
+SET @@global.wsrep_load_data_splitting=default;
+SELECT @@global.wsrep_load_data_splitting;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_load_data_splitting=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_load_data_splitting='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_load_data_splitting = @wsrep_load_data_splitting_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_log_conflicts_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_log_conflicts_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_log_conflicts
+--echo #
+
+--echo # save the initial value
+SET @wsrep_log_conflicts_global_saved = @@global.wsrep_log_conflicts;
+
+--echo # default
+SELECT @@global.wsrep_log_conflicts;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_log_conflicts;
+SET @@global.wsrep_log_conflicts=OFF;
+SELECT @@global.wsrep_log_conflicts;
+SET @@global.wsrep_log_conflicts=ON;
+SELECT @@global.wsrep_log_conflicts;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_log_conflicts='OFF';
+SELECT @@global.wsrep_log_conflicts;
+SET @@global.wsrep_log_conflicts=ON;
+SELECT @@global.wsrep_log_conflicts;
+SET @@global.wsrep_log_conflicts=default;
+SELECT @@global.wsrep_log_conflicts;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_log_conflicts=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_log_conflicts='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_log_conflicts = @wsrep_log_conflicts_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_max_ws_rows_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_max_ws_rows_basic.test
@@ -1,0 +1,45 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_max_ws_rows
+--echo #
+
+--echo # save the initial value
+SET @wsrep_max_ws_rows_global_saved = @@global.wsrep_max_ws_rows;
+
+--echo # default
+SELECT @@global.wsrep_max_ws_rows;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_max_ws_rows;
+SET @@global.wsrep_max_ws_rows=1;
+SELECT @@global.wsrep_max_ws_rows;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_max_ws_rows=131072;
+SELECT @@global.wsrep_max_ws_rows;
+SET @@global.wsrep_max_ws_rows=131073;
+SELECT @@global.wsrep_max_ws_rows;
+SET @@global.wsrep_max_ws_rows=0;
+SELECT @@global.wsrep_max_ws_rows;
+SET @@global.wsrep_max_ws_rows=default;
+SELECT @global.wsrep_max_ws_rows;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_max_ws_rows=NULL;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_max_ws_rows='junk';
+# expect warnings (Truncated incorrect wsrep_max_ws_rows value: '-1')
+SET @@global.wsrep_max_ws_rows=-1;
+SELECT @global.wsrep_max_ws_rows;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_max_ws_rows = @wsrep_max_ws_rows_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_max_ws_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_max_ws_size_basic.test
@@ -1,0 +1,45 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_max_ws_size
+--echo #
+
+--echo # save the initial value
+SET @wsrep_max_ws_size_global_saved = @@global.wsrep_max_ws_size;
+
+--echo # default
+SELECT @@global.wsrep_max_ws_size;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_max_ws_size;
+SET @@global.wsrep_max_ws_size=1;
+SELECT @@global.wsrep_max_ws_size;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_max_ws_size=1073741824;
+SELECT @@global.wsrep_max_ws_size;
+SET @@global.wsrep_max_ws_size=1073741825;
+SELECT @@global.wsrep_max_ws_size;
+SET @@global.wsrep_max_ws_size=0;
+SELECT @@global.wsrep_max_ws_size;
+SET @@global.wsrep_max_ws_size=default;
+SELECT @global.wsrep_max_ws_size;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_max_ws_size=NULL;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_max_ws_size='junk';
+SELECT @global.wsrep_max_ws_size;
+SET @@global.wsrep_max_ws_size=-1;
+SELECT @global.wsrep_max_ws_size;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_max_ws_size = @wsrep_max_ws_size_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_mysql_replication_bundle_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_mysql_replication_bundle_basic.test
@@ -1,0 +1,45 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_mysql_replication_bundle
+--echo #
+
+--echo # save the initial value
+SET @wsrep_mysql_replication_bundle_global_saved = @@global.wsrep_mysql_replication_bundle;
+
+--echo # default
+SELECT @@global.wsrep_mysql_replication_bundle;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_mysql_replication_bundle;
+SELECT @@global.wsrep_mysql_replication_bundle;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_mysql_replication_bundle=0;
+SELECT @@global.wsrep_mysql_replication_bundle;
+SET @@global.wsrep_mysql_replication_bundle=1000;
+SELECT @@global.wsrep_mysql_replication_bundle;
+SET @@global.wsrep_mysql_replication_bundle=default;
+SELECT @@global.wsrep_mysql_replication_bundle;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_mysql_replication_bundle=NULL;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_mysql_replication_bundle='junk';
+# expect warning (truncated incorrect value)
+SET @@global.wsrep_mysql_replication_bundle=-1;
+SELECT @@global.wsrep_mysql_replication_bundle;
+# expect warning (truncated incorrect value)
+SET @@global.wsrep_mysql_replication_bundle=1001;
+SELECT @@global.wsrep_mysql_replication_bundle;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_mysql_replication_bundle = @wsrep_mysql_replication_bundle_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_node_address_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_node_address_basic.test
@@ -1,0 +1,45 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_node_address
+--echo #
+
+--echo # save the initial value
+SET @wsrep_node_address_global_saved = @@global.wsrep_node_address;
+
+--echo # default
+SELECT @@global.wsrep_node_address;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_node_address;
+SELECT @@global.wsrep_node_address;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_node_address='127.0.0.1';
+SELECT @@global.wsrep_node_address;
+# default == ''
+SET @@global.wsrep_node_address=default;
+SELECT @@global.wsrep_node_address;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_node_address=NULL;
+SELECT @@global.wsrep_node_address;
+# The values being assigned to wsrep_node_address are not verified so the
+# following alues are currently valid too.
+SET @@global.wsrep_node_address=ON;
+SELECT @@global.wsrep_node_address;
+SET @@global.wsrep_node_address='OFF';
+SELECT @@global.wsrep_node_address;
+SET @@global.wsrep_node_address='junk';
+SELECT @@global.wsrep_node_address;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_node_address = @wsrep_node_address_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_node_incoming_address_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_node_incoming_address_basic.test
@@ -1,0 +1,47 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_node_incoming_address
+--echo #
+
+--echo # save the initial value
+SET @wsrep_node_incoming_address_global_saved = @@global.wsrep_node_incoming_address;
+
+--echo # default
+SELECT @@global.wsrep_node_incoming_address;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_node_incoming_address;
+SELECT @@global.wsrep_node_incoming_address;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_node_incoming_address='127.0.0.1:4444';
+SELECT @@global.wsrep_node_incoming_address;
+SET @@global.wsrep_node_incoming_address='127.0.0.1';
+SELECT @@global.wsrep_node_incoming_address;
+SET @@global.wsrep_node_incoming_address=AUTO;
+SELECT @@global.wsrep_node_incoming_address;
+SET @@global.wsrep_node_incoming_address=default;
+SELECT @@global.wsrep_node_incoming_address;
+
+--echo
+--echo # invalid values
+# The values being assigned to wsrep_node_incoming_address are not verified so
+# the following values are currently valid too.
+SET @@global.wsrep_node_incoming_address=ON;
+SELECT @@global.wsrep_node_incoming_address;
+SET @@global.wsrep_node_incoming_address='OFF';
+SELECT @@global.wsrep_node_incoming_address;
+SET @@global.wsrep_node_incoming_address=NULL;
+SELECT @@global.wsrep_node_incoming_address;
+SET @@global.wsrep_node_incoming_address='junk';
+SELECT @@global.wsrep_node_incoming_address;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_node_incoming_address = @wsrep_node_incoming_address_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_node_name_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_node_name_basic.test
@@ -1,0 +1,44 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_node_name
+--echo #
+
+call mtr.add_suppression("WSREP: Failed to get provider options");
+
+--echo # save the initial value
+SET @wsrep_node_name_global_saved = @@global.wsrep_node_name;
+
+--echo # default
+SELECT @@global.wsrep_node_name;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_node_name;
+SET @@global.wsrep_node_name='node_name';
+SELECT @@global.wsrep_node_name;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_node_name='my_node';
+SELECT @@global.wsrep_node_name;
+SET @@global.wsrep_node_name='hyphenated-node-name';
+SELECT @@global.wsrep_node_name;
+SET @@global.wsrep_node_name=default;
+SELECT @@global.wsrep_node_name;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_node_name=NULL;
+SELECT @@global.wsrep_node_name;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_node_name=1;
+SELECT @@global.wsrep_node_name;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_node_name = @wsrep_node_name_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_notify_cmd_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_notify_cmd_basic.test
@@ -1,0 +1,43 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_notify_cmd
+--echo #
+
+call mtr.add_suppression("WSREP: Failed to get provider options");
+
+--echo # save the initial value
+SET @wsrep_notify_cmd_global_saved = @@global.wsrep_notify_cmd;
+
+--echo # default
+SELECT @@global.wsrep_notify_cmd;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_notify_cmd;
+SET @@global.wsrep_notify_cmd='notify_cmd';
+SELECT @@global.wsrep_notify_cmd;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_notify_cmd='command';
+SELECT @@global.wsrep_notify_cmd;
+SET @@global.wsrep_notify_cmd='hyphenated-command';
+SELECT @@global.wsrep_notify_cmd;
+SET @@global.wsrep_notify_cmd=default;
+SELECT @@global.wsrep_notify_cmd;
+SET @@global.wsrep_notify_cmd=NULL;
+SELECT @@global.wsrep_notify_cmd;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_notify_cmd=1;
+SELECT @@global.wsrep_notify_cmd;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_notify_cmd = @wsrep_notify_cmd_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_on_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_on_basic.test
@@ -1,0 +1,45 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_on
+--echo #
+
+--echo # save the initial values
+SET @wsrep_on_global_saved = @@global.wsrep_on;
+SET @wsrep_on_session_saved = @@session.wsrep_on;
+
+--echo # default
+SELECT @@global.wsrep_on;
+SELECT @@session.wsrep_on;
+
+--echo
+--echo # scope and valid values
+SET @@global.wsrep_on=OFF;
+SELECT @@global.wsrep_on;
+SET @@global.wsrep_on=ON;
+SELECT @@global.wsrep_on;
+
+SET @@session.wsrep_on=OFF;
+SELECT @@session.wsrep_on;
+SET @@session.wsrep_on=ON;
+SELECT @@session.wsrep_on;
+SET @@session.wsrep_on=default;
+SELECT @@session.wsrep_on;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_on=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_on='junk';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@session.wsrep_on=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@session.wsrep_on='junk';
+
+--echo
+--echo # restore the initial values
+SET @@global.wsrep_on = @wsrep_on_global_saved;
+SET @@session.wsrep_on = @wsrep_on_session_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_osu_method_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_osu_method_basic.test
@@ -1,0 +1,49 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_osu_method
+--echo #
+
+--echo # save the initial value
+SET @wsrep_osu_method_global_saved = @@global.wsrep_osu_method;
+
+--echo # default
+SELECT @@global.wsrep_osu_method;
+
+--echo
+--echo # scope
+SELECT @@session.wsrep_osu_method;
+SET @@global.wsrep_osu_method=TOI;
+SELECT @@global.wsrep_osu_method;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_osu_method=TOI;
+SELECT @@global.wsrep_osu_method;
+SET @@global.wsrep_osu_method=RSU;
+SELECT @@global.wsrep_osu_method;
+SET @@global.wsrep_osu_method="RSU";
+SELECT @@global.wsrep_osu_method;
+SET @@global.wsrep_osu_method=default;
+SELECT @@global.wsrep_osu_method;
+# numeric value
+SET @@global.wsrep_osu_method=1;
+SELECT @@global.wsrep_osu_method;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_osu_method=4;
+SELECT @@global.wsrep_osu_method;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_osu_method=NULL;
+SELECT @@global.wsrep_osu_method;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_osu_method='junk';
+SELECT @@global.wsrep_osu_method;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_osu_method = @wsrep_osu_method_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_provider_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_provider_basic.test
@@ -1,0 +1,39 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_provider
+--echo #
+
+--echo # save the initial value
+SET @wsrep_provider_global_saved = @@global.wsrep_provider;
+
+--echo # default
+SELECT @@global.wsrep_provider;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_provider;
+SELECT @@global.wsrep_provider;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_provider=default;
+SELECT @@global.wsrep_provider;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_provider='/invalid/libgalera_smm.so';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_provider=NULL;
+SELECT @@global.wsrep_provider;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_provider=1;
+SELECT @@global.wsrep_provider;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_provider = @wsrep_provider_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_provider_options_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_provider_options_basic.test
@@ -1,0 +1,49 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_provider_options
+--echo #
+
+call mtr.add_suppression("WSREP: Failed to get provider options");
+
+--echo # save the initial value
+SET @wsrep_provider_options_global_saved = @@global.wsrep_provider_options;
+
+--echo # default
+SELECT @@global.wsrep_provider_options;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_provider_options;
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_provider_options='option1';
+SELECT @@global.wsrep_provider_options;
+
+--echo
+--echo # valid values
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_provider_options='name1=value1;name2=value2';
+SELECT @@global.wsrep_provider_options;
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_provider_options='hyphenated-name:value';
+SELECT @@global.wsrep_provider_options;
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_provider_options=default;
+SELECT @@global.wsrep_provider_options;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_provider_options=1;
+SELECT @@global.wsrep_provider_options;
+--error ER_WRONG_ARGUMENTS,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_provider_options=NULL;
+SELECT @@global.wsrep_provider_options;
+
+--echo
+--echo # restore the initial value
+--error 0,ER_WRONG_ARGUMENTS
+SET @@global.wsrep_provider_options = @wsrep_provider_options_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_recover_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_recover_basic.test
@@ -1,0 +1,26 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_recover
+--echo #
+
+--echo # default
+SELECT @@global.wsrep_recover;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_recover;
+
+--echo
+--echo # scope and valid values
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.wsrep_recover=OFF;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.wsrep_recover=ON;
+
+--echo
+--echo # invalid values
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.wsrep_recover=NULL;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.wsrep_recover='junk';
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_restart_slave_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_restart_slave_basic.test
@@ -1,0 +1,36 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_restart_slave
+--echo #
+
+--echo # save the initial value
+SET @wsrep_restart_slave_global_saved = @@global.wsrep_restart_slave;
+
+--echo # default
+SELECT @@global.wsrep_restart_slave;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_restart_slave;
+
+--echo
+--echo # scope and valid values
+#--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+#TODO: check if it is expected for variable to be dynamic?
+SET @@global.wsrep_restart_slave=OFF;
+SELECT @@global.wsrep_restart_slave;
+#--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@global.wsrep_restart_slave=ON;
+SELECT @@global.wsrep_restart_slave;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_restart_slave=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_restart_slave='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_restart_slave = @wsrep_restart_slave_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_retry_autocommit_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_retry_autocommit_basic.test
@@ -1,0 +1,52 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_retry_autocommit
+--echo #
+
+--echo # save the initial values
+SET @wsrep_retry_autocommit_global_saved = @@global.wsrep_retry_autocommit;
+SET @wsrep_retry_autocommit_session_saved = @@session.wsrep_retry_autocommit;
+
+--echo # default
+SELECT @@global.wsrep_retry_autocommit;
+
+--echo
+--echo # scope
+SET @@session.wsrep_retry_autocommit=1;
+SELECT @@session.wsrep_retry_autocommit;
+SET @@global.wsrep_retry_autocommit=1;
+SELECT @@global.wsrep_retry_autocommit;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_retry_autocommit=10;
+SELECT @@global.wsrep_retry_autocommit;
+SET @@global.wsrep_retry_autocommit=0;
+SELECT @@global.wsrep_retry_autocommit;
+SET @@global.wsrep_retry_autocommit=default;
+SELECT @global.wsrep_retry_autocommit;
+
+SET @@session.wsrep_retry_autocommit=10;
+SELECT @@session.wsrep_retry_autocommit;
+SET @@session.wsrep_retry_autocommit=0;
+SELECT @@session.wsrep_retry_autocommit;
+SET @@session.wsrep_retry_autocommit=default;
+SELECT @session.wsrep_retry_autocommit;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_retry_autocommit=NULL;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_retry_autocommit='junk';
+# expect warning : Truncated incorrect wsrep_retry_autocommit value: '-1'
+SET @@global.wsrep_retry_autocommit=-1;
+SELECT @global.wsrep_retry_autocommit;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_retry_autocommit = @wsrep_retry_autocommit_global_saved;
+SET @@session.wsrep_retry_autocommit = @wsrep_retry_autocommit_session_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_slave_fk_checks_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_slave_fk_checks_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_slave_fk_checks
+--echo #
+
+--echo # save the initial value
+SET @wsrep_slave_fk_checks_global_saved = @@global.wsrep_slave_fk_checks;
+
+--echo # default
+SELECT @@global.wsrep_slave_fk_checks;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_slave_fk_checks;
+SET @@global.wsrep_slave_fk_checks=OFF;
+SELECT @@global.wsrep_slave_fk_checks;
+SET @@global.wsrep_slave_fk_checks=ON;
+SELECT @@global.wsrep_slave_fk_checks;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_slave_fk_checks='OFF';
+SELECT @@global.wsrep_slave_fk_checks;
+SET @@global.wsrep_slave_fk_checks=ON;
+SELECT @@global.wsrep_slave_fk_checks;
+SET @@global.wsrep_slave_fk_checks=default;
+SELECT @@global.wsrep_slave_fk_checks;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_slave_fk_checks=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_slave_fk_checks='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_slave_fk_checks = @wsrep_slave_fk_checks_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_slave_threads_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_slave_threads_basic.test
@@ -1,0 +1,43 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_slave_threads
+--echo #
+
+--echo # save the initial value
+SET @wsrep_slave_threads_global_saved = @@global.wsrep_slave_threads;
+
+--echo # default
+SELECT @@global.wsrep_slave_threads;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_slave_threads;
+SET @@global.wsrep_slave_threads=1;
+SELECT @@global.wsrep_slave_threads;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_slave_threads=10;
+SELECT @@global.wsrep_slave_threads;
+SET @@global.wsrep_slave_threads=0;
+SELECT @@global.wsrep_slave_threads;
+SET @@global.wsrep_slave_threads=default;
+SELECT @global.wsrep_slave_threads;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_slave_threads=NULL;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_slave_threads='junk';
+# expect warning : Truncated incorrect wsrep_slave_threads value: '-1'
+SET @@global.wsrep_slave_threads=-1;
+SELECT @global.wsrep_slave_threads;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_slave_threads = @wsrep_slave_threads_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_slave_uk_checks_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_slave_uk_checks_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_slave_uk_checks
+--echo #
+
+--echo # save the initial value
+SET @wsrep_slave_uk_checks_global_saved = @@global.wsrep_slave_uk_checks;
+
+--echo # default
+SELECT @@global.wsrep_slave_uk_checks;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_slave_uk_checks;
+SET @@global.wsrep_slave_uk_checks=OFF;
+SELECT @@global.wsrep_slave_uk_checks;
+SET @@global.wsrep_slave_uk_checks=ON;
+SELECT @@global.wsrep_slave_uk_checks;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_slave_uk_checks='OFF';
+SELECT @@global.wsrep_slave_uk_checks;
+SET @@global.wsrep_slave_uk_checks=ON;
+SELECT @@global.wsrep_slave_uk_checks;
+SET @@global.wsrep_slave_uk_checks=default;
+SELECT @@global.wsrep_slave_uk_checks;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_slave_uk_checks=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_slave_uk_checks='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_slave_uk_checks = @wsrep_slave_uk_checks_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_sst_auth_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_sst_auth_basic.test
@@ -1,0 +1,45 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_sst_auth
+--echo #
+
+--echo # save the initial value
+SET @wsrep_sst_auth_global_saved = @@global.wsrep_sst_auth;
+
+--echo # default
+SELECT @@global.wsrep_sst_auth;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_sst_auth;
+SET @@global.wsrep_sst_auth='user:pass';
+SELECT @@global.wsrep_sst_auth;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_sst_auth=user;
+SELECT @@global.wsrep_sst_auth;
+SET @@global.wsrep_sst_auth='user:1234';
+SELECT @@global.wsrep_sst_auth;
+SET @@global.wsrep_sst_auth='hyphenated-user-name:';
+SELECT @@global.wsrep_sst_auth;
+SET @@global.wsrep_sst_auth=default;
+SELECT @@global.wsrep_sst_auth;
+SET @@global.wsrep_sst_auth=NULL;
+SELECT @@global.wsrep_sst_auth;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_sst_auth=1;
+SELECT @@global.wsrep_sst_auth;
+--error ER_PARSE_ERROR
+SET @@global.wsrep_sst_auth=user:pass;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_sst_auth = @wsrep_sst_auth_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_sst_donor_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_sst_donor_basic.test
@@ -1,0 +1,43 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_sst_donor
+--echo #
+
+--echo # save the initial value
+SET @wsrep_sst_donor_global_saved = @@global.wsrep_sst_donor;
+
+--echo # default
+SELECT @@global.wsrep_sst_donor;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_sst_donor;
+SET @@global.wsrep_sst_donor=rsync;
+SELECT @@global.wsrep_sst_donor;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_sst_donor=node1;
+SELECT @@global.wsrep_sst_donor;
+SET @@global.wsrep_sst_donor='node1,node2';
+SELECT @@global.wsrep_sst_donor;
+SET @@global.wsrep_sst_donor='hyphenated-donor-name';
+SELECT @@global.wsrep_sst_donor;
+SET @@global.wsrep_sst_donor=default;
+SELECT @@global.wsrep_sst_donor;
+SET @@global.wsrep_sst_donor=NULL;
+SELECT @@global.wsrep_sst_donor;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_sst_donor=1;
+SELECT @@global.wsrep_sst_donor;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_sst_donor = @wsrep_sst_donor_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_sst_donor_rejects_queries_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_sst_donor_rejects_queries_basic.test
@@ -1,0 +1,42 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_sst_donor_rejects_queries
+--echo #
+
+--echo # save the initial value
+SET @wsrep_sst_donor_rejects_queries_global_saved = @@global.wsrep_sst_donor_rejects_queries;
+
+--echo # default
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_sst_donor_rejects_queries;
+SET @@global.wsrep_sst_donor_rejects_queries=OFF;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+SET @@global.wsrep_sst_donor_rejects_queries=ON;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_sst_donor_rejects_queries='OFF';
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+SET @@global.wsrep_sst_donor_rejects_queries=ON;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+SET @@global.wsrep_sst_donor_rejects_queries=default;
+SELECT @@global.wsrep_sst_donor_rejects_queries;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_donor_rejects_queries=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_donor_rejects_queries='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_sst_donor_rejects_queries = @wsrep_sst_donor_rejects_queries_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_sst_method_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_sst_method_basic.test
@@ -1,0 +1,47 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_sst_method
+--echo #
+
+--echo # save the initial value
+SET @wsrep_sst_method_global_saved = @@global.wsrep_sst_method;
+
+--echo # default
+SELECT @@global.wsrep_sst_method;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_sst_method;
+SET @@global.wsrep_sst_method=rsync;
+SELECT @@global.wsrep_sst_method;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_sst_method=rsync;
+SELECT @@global.wsrep_sst_method;
+SET @@global.wsrep_sst_method=mysqldump;
+SELECT @@global.wsrep_sst_method;
+SET @@global.wsrep_sst_method=xtrabackup;
+SELECT @@global.wsrep_sst_method;
+SET @@global.wsrep_sst_method="xtrabackup-v2";
+SELECT @@global.wsrep_sst_method;
+SET @@global.wsrep_sst_method=default;
+SELECT @@global.wsrep_sst_method;
+
+# Its a valid name for an SST method
+SET @@global.wsrep_sst_method='junk';
+SELECT @@global.wsrep_sst_method;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_method=NULL;
+SELECT @@global.wsrep_sst_method;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_sst_method = @wsrep_sst_method_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_sst_receive_address_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_sst_receive_address_basic.test
@@ -1,0 +1,53 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_sst_receive_address
+--echo #
+
+--echo # save the initial value
+SET @wsrep_sst_receive_address_global_saved = @@global.wsrep_sst_receive_address;
+
+--echo # default
+SELECT @@global.wsrep_sst_receive_address;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_sst_receive_address;
+SELECT @@global.wsrep_sst_receive_address;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_sst_receive_address=AUTO;
+SELECT @@global.wsrep_sst_receive_address;
+SET @@global.wsrep_sst_receive_address=default;
+SELECT @@global.wsrep_sst_receive_address;
+SET @@global.wsrep_sst_receive_address='192.168.2.254';
+SELECT @@global.wsrep_sst_receive_address;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_receive_address='127.0.0.1:4444';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_receive_address='127.0.0.1';
+SELECT @@global.wsrep_sst_receive_address;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_sst_receive_address=NULL;
+SELECT @@global.wsrep_sst_receive_address;
+# Currently there is no strict checking performed for wsrep_sst_receive_address
+# so following values jusr pass through.
+SET @@global.wsrep_sst_receive_address='OFF';
+SELECT @@global.wsrep_sst_receive_address;
+SET @@global.wsrep_sst_receive_address=ON;
+SELECT @@global.wsrep_sst_receive_address;
+SET @@global.wsrep_sst_receive_address='';
+SELECT @@global.wsrep_sst_receive_address;
+SET @@global.wsrep_sst_receive_address='junk';
+SELECT @@global.wsrep_sst_receive_address;
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_sst_receive_address = @wsrep_sst_receive_address_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_start_position_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_start_position_basic.test
@@ -1,0 +1,56 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_start_position
+--echo #
+
+--echo # save the initial value
+SET @wsrep_start_position_global_saved = @@global.wsrep_start_position;
+
+--echo # default
+SELECT @@global.wsrep_start_position;
+
+--echo
+--echo # scope
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.wsrep_start_position;
+SET @@global.wsrep_start_position='00000000-0000-0000-0000-000000000000:-1';
+SELECT @@global.wsrep_start_position;
+
+--echo
+--echo # valid values
+SET @@global.wsrep_start_position='00000000-0000-0000-0000-000000000000:-2';
+SELECT @@global.wsrep_start_position;
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:100';
+SELECT @@global.wsrep_start_position;
+SET @@global.wsrep_start_position=default;
+SELECT @@global.wsrep_start_position;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='000000000000000-0000-0000-0000-000000000000:-1';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='12345678-1234-1234-12345-123456789012:100';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='12345678-1234-123-12345-123456789012:0';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:_99999';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:a';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='OFF';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position=ON;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='';
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@global.wsrep_start_position='junk';
+
+--echo
+--echo # restore the initial value
+SET @@global.wsrep_start_position = @wsrep_start_position_global_saved;
+
+--echo # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_sync_wait_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_sync_wait_basic.test
@@ -1,0 +1,47 @@
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_sync_wait
+--echo #
+
+--echo # save the initial values
+SET @wsrep_sync_wait_global_saved = @@global.wsrep_sync_wait;
+SET @wsrep_sync_wait_session_saved = @@session.wsrep_sync_wait;
+
+--echo # default
+SELECT @@global.wsrep_sync_wait;
+SELECT @@session.wsrep_sync_wait;
+
+--echo
+--echo # scope and valid values
+SET @@global.wsrep_sync_wait=0;
+SELECT @@global.wsrep_sync_wait;
+SET @@global.wsrep_sync_wait=7;
+SELECT @@global.wsrep_sync_wait;
+
+SET @@session.wsrep_sync_wait=0;
+SELECT @@session.wsrep_sync_wait;
+SET @@session.wsrep_sync_wait=7;
+SELECT @@session.wsrep_sync_wait;
+SET @@session.wsrep_sync_wait=default;
+SELECT @@session.wsrep_sync_wait;
+SET @@session.wsrep_sync_wait=8;
+SELECT @@session.wsrep_sync_wait;
+
+--echo
+--echo # invalid values
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_sync_wait=NULL;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@global.wsrep_sync_wait='junk';
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@session.wsrep_sync_wait=NULL;
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@session.wsrep_sync_wait='junk';
+
+--echo
+--echo # restore the initial values
+SET @@global.wsrep_sync_wait = @wsrep_sync_wait_global_saved;
+SET @@session.wsrep_sync_wait = @wsrep_sync_wait_session_saved;
+
+--echo # End of test

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4766,8 +4766,7 @@ static PolyLock_mutex PLock_wsrep_slave_threads(&LOCK_wsrep_slave_threads);
 static Sys_var_charptr Sys_wsrep_provider(
        "wsrep_provider", "Path to replication provider library",
        PREALLOCATED GLOBAL_VAR(wsrep_provider), CMD_LINE(REQUIRED_ARG, OPT_WSREP_PROVIDER),
-       IN_FS_CHARSET, DEFAULT(wsrep_provider), 
-       //       IN_FS_CHARSET, DEFAULT(wsrep_provider_default), 
+       IN_FS_CHARSET, DEFAULT(WSREP_NONE),
        &PLock_wsrep_slave_threads, NOT_IN_BINLOG,
        ON_CHECK(wsrep_provider_check), ON_UPDATE(wsrep_provider_update));
 
@@ -4775,7 +4774,7 @@ static Sys_var_charptr Sys_wsrep_provider_options(
        "wsrep_provider_options", "provider specific options",
        PREALLOCATED GLOBAL_VAR(wsrep_provider_options), 
        CMD_LINE(REQUIRED_ARG, OPT_WSREP_PROVIDER_OPTIONS),
-       IN_FS_CHARSET, DEFAULT(wsrep_provider_options), 
+       IN_FS_CHARSET, DEFAULT(""),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(wsrep_provider_options_check), 
        ON_UPDATE(wsrep_provider_options_update));
@@ -4783,13 +4782,13 @@ static Sys_var_charptr Sys_wsrep_provider_options(
 static Sys_var_charptr Sys_wsrep_data_home_dir(
        "wsrep_data_home_dir", "home directory for wsrep provider",
        READ_ONLY GLOBAL_VAR(wsrep_data_home_dir), CMD_LINE(REQUIRED_ARG),
-       IN_FS_CHARSET, DEFAULT(""), 
+       IN_FS_CHARSET, DEFAULT(mysql_real_data_home),
        NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
 static Sys_var_charptr Sys_wsrep_cluster_name(
        "wsrep_cluster_name", "Name for the cluster",
        PREALLOCATED GLOBAL_VAR(wsrep_cluster_name), CMD_LINE(REQUIRED_ARG),
-       IN_FS_CHARSET, DEFAULT(wsrep_cluster_name), 
+       IN_FS_CHARSET, DEFAULT(WSREP_CLUSTER_NAME),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(wsrep_cluster_name_check),
        ON_UPDATE(wsrep_cluster_name_update));
@@ -4798,7 +4797,7 @@ static Sys_var_charptr Sys_wsrep_cluster_address (
        "wsrep_cluster_address", "Address to initially connect to cluster",
        PREALLOCATED GLOBAL_VAR(wsrep_cluster_address), 
        CMD_LINE(REQUIRED_ARG, OPT_WSREP_CLUSTER_ADDRESS),
-       IN_FS_CHARSET, DEFAULT(wsrep_cluster_address),
+       IN_FS_CHARSET, DEFAULT(""),
        &PLock_wsrep_slave_threads, NOT_IN_BINLOG,
        ON_CHECK(wsrep_cluster_address_check), 
        ON_UPDATE(wsrep_cluster_address_update));
@@ -4806,13 +4805,15 @@ static Sys_var_charptr Sys_wsrep_cluster_address (
 static Sys_var_charptr Sys_wsrep_node_name (
        "wsrep_node_name", "Node name",
        PREALLOCATED GLOBAL_VAR(wsrep_node_name), CMD_LINE(REQUIRED_ARG),
-       IN_FS_CHARSET, DEFAULT(wsrep_node_name), 
-       NO_MUTEX_GUARD, NOT_IN_BINLOG);
+       IN_FS_CHARSET, DEFAULT(""),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(wsrep_node_name_check),
+       ON_UPDATE(wsrep_node_name_update));
 
 static Sys_var_charptr Sys_wsrep_node_address (
        "wsrep_node_address", "Node address",
        PREALLOCATED GLOBAL_VAR(wsrep_node_address), CMD_LINE(REQUIRED_ARG),
-       IN_FS_CHARSET, DEFAULT(wsrep_node_address), 
+       IN_FS_CHARSET, DEFAULT(""),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(wsrep_node_address_check), 
        ON_UPDATE(wsrep_node_address_update));
@@ -4820,7 +4821,7 @@ static Sys_var_charptr Sys_wsrep_node_address (
 static Sys_var_charptr Sys_wsrep_node_incoming_address(
        "wsrep_node_incoming_address", "Client connection address",
        PREALLOCATED GLOBAL_VAR(wsrep_node_incoming_address),CMD_LINE(REQUIRED_ARG),
-       IN_FS_CHARSET, DEFAULT(wsrep_node_incoming_address), 
+       IN_FS_CHARSET, DEFAULT(WSREP_NODE_INCOMING_AUTO),
        NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
 static Sys_var_ulong Sys_wsrep_slave_threads(

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -16,7 +16,9 @@
 #ifndef WSREP_VAR_H
 #define WSREP_VAR_H
 
-#define WSREP_NODE_INCOMING_AUTO "AUTO"
+#define WSREP_CLUSTER_NAME        "my_wsrep_cluster"
+#define WSREP_NODE_INCOMING_AUTO  "AUTO"
+#define WSREP_START_POSITION_ZERO "00000000-0000-0000-0000-000000000000:-1"
 
 // MySQL variables funcs
 


### PR DESCRIPTION
…et values

  for certain wsrep variables

  Default value setting for most of wsrep variables was done in faulty way
  causing server to crash. When user demands to set default value a separate
  buffer that caches configured default value should be used for checking
  and updating the value (vs buffer that is normally populated when user
  provides a value for a given varaible)

  Also, NULL setting semantics for most of these variable was faulty too.

  There were some in-consistency in code (wrt to documentation).
  [Well the documentation was right in this case so we fixed the code
   to make it consistent]

  default value for
- wsrep_provider is "none"
- wsrep_provider_option is ""
- wsrep_data_home_dir is "mysql data directory"
- wsrep_cluster_name is "my_wsrep_cluster"
- wsrep_cluster_address is ""
- wsrep_node_name is ""
- wsrep_node_address is ""
  [documentation says: Usually set up as primary network interface (eth0)]
- wsrep_node_incoming_address is ""
  [documentation says: wsrep_node_address:3306]
  
  Also, most of the wsrep variables sys_vars tcs were missing. Adding them
  so that we can enable sys_vars suite for daily testing.
  [Part of the code-fixes is ported from MariaDB tree]
