### PR TITLE
- PXC#450: Assertion `key_coun t > 0' failed in galera/src/certificat…

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_certify_nonPK_off.result
+++ b/mysql-test/suite/galera/r/galera_var_certify_nonPK_off.result
@@ -4,6 +4,8 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB /* Table has no primary key */;
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1), (2);
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+CREATE TABLE T3 SELECT 1 c;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 INSERT INTO t2 VALUES (1), (2);
 UPDATE t2 SET f1 = 3 WHERE f1 = 1;
 SELECT COUNT(*) = 0 FROM t1;

--- a/mysql-test/suite/galera/t/galera_var_certify_nonPK_off.test
+++ b/mysql-test/suite/galera/t/galera_var_certify_nonPK_off.test
@@ -19,6 +19,12 @@ CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 --error ER_LOCK_DEADLOCK
 INSERT INTO t1 VALUES (1), (2);
 
+# Following statement will try to create table and will also insert
+# data into the table but insert should be blocked as table is without
+# PK and certification of table without PK is blocked.
+--error ER_LOCK_DEADLOCK
+CREATE TABLE T3 SELECT 1 c;
+
 # DML with a PK is allowed to proceed
 INSERT INTO t2 VALUES (1), (2);
 UPDATE t2 SET f1 = 3 WHERE f1 = 1;
@@ -36,4 +42,3 @@ SELECT COUNT(*) = 1 FROM t2 WHERE f1 = 3;
 
 DROP TABLE t1;
 DROP TABLE t2;
-

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -10261,6 +10261,18 @@ ha_innobase::wsrep_append_keys(
 		DBUG_RETURN(0);
 	}
 
+	/* If certification of table with non-PK is blocked by setting
+	relevant configuration option wsrep_certify_nonPK = OFF/0 then
+	ensure that thd->wsrep_ws_handle->trx_id = WSREP_UNDEFINED_TRX_ID.
+	If not then make sure you set it to WSREP_UNDEFINED_TRX_ID.
+	But what may cause trx_id to set if append-key is blocked ?
+	CREATE TABLE ... SELECT statement will cause a fake_trx_id to set
+	while processing SELECT statement. */
+	if (!key_appended && !wsrep_certify_nonPK) {
+		wsrep_ws_handle_for_trx(
+			wsrep_thd_ws_handle(thd), WSREP_UNDEFINED_TRX_ID);
+	}
+
 	DBUG_RETURN(0);
 }
 #endif


### PR DESCRIPTION
…ion.cpp:590

  SEMANTICS:

---

  What is the issues.
- If wsrep_certify_nonPK is set to 1 (default = 1) it will allow certification
  of table w/o PK by appending a unique key to the write-set.
  (though it is not recommended to create table w/o PK as part of
   best practices)
- If user configures cluster to avoid certification of table w/o pk by setting
  wsrep_certify_nonPK=0 then attempt to perform any such action will result in
  DEADLOCK error.
  ## ISSUE:
  
  SQL TC mentioned in the bug report failed to generate the deadlock error and
  went ahead with certification which then failed (assert). Why ?
- In normal flow, attempt to create table w/o pk with append_key disabled
  skips setting of trx_id which is an indication for caller to avoid
  certification and instead generate an error.
- Test-Scenario involved CREATE...SELECT (which in turn is
  create->select->insert selected data). SELECT processing caused the trx_id
  to set but this trx_id was not resetted before INSERT execution as both the
  actions SELECT and INSERT are part of same statement.
  
  This eventually led to an inconsistency where-in append_key routine is not
  executed as configuration has disabled it but trx_id is set to valid value
  confusing caller to proceed with certification.
  ## SOLUTION:
  
  If append_key for table w/o pk is disabled then wsrep_ws_handle->trx_id
  should be initialized to UNDEFINED. If not, then make sure it is set
  accordingly.
