### PR TITLE
- PXC#451: INSERT .... SELECT for MYISAM table with myisam replicate …

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
+++ b/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
@@ -50,6 +50,8 @@ COUNT(*) = 1
 SELECT COUNT(*) = 1 FROM t2;
 COUNT(*) = 1
 1
+SET AUTOCOMMIT=ON;
+SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES (2);
 INSERT INTO t2 VALUES (2);
@@ -64,13 +66,49 @@ COUNT(*) = 1
 1
 DROP TABLE t1;
 DROP TABLE t2;
+SET AUTOCOMMIT=ON;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=MyISAM;
 CREATE TABLE t2 (f2 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t2 VALUES (1);
 INSERT INTO t1 VALUES (1);
 ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
 COMMIT;
+SET AUTOCOMMIT=ON;
 DROP TABLE t1;
 DROP TABLE t2;
+use test;
+create table is1 (i int) engine=myisam;
+create table is2 (i int) engine=myisam;
+create table is3 (i int) engine=innodb;
+insert into is1 select 1;
+insert into is1 (i) select i from is1;
+insert into is1 values (2), (3);
+insert into is1 (i) select i from is1;
+select * from is1;
+i
+1
+1
+2
+3
+1
+1
+2
+3
+insert into is2 (i) select i from is1;
+insert into is3 (i) select i from is1;
+insert into is1 (i) select i from is3;
+select count(*) from is1;
+count(*)
+16
+select count(*) from is2;
+count(*)
+8
+select count(*) from is3;
+count(*)
+8
+drop table is1;
+drop table is2;
+drop table is3;

--- a/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
+++ b/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
@@ -90,11 +90,15 @@ COMMIT;
 SELECT COUNT(*) = 1 FROM t1;
 SELECT COUNT(*) = 1 FROM t2;
 
+--connection node_1
+SET AUTOCOMMIT=ON;
+
 #
 # Transaction rollback
 #
 
 --connection node_1
+SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES (2);
 INSERT INTO t2 VALUES (2);
@@ -107,6 +111,9 @@ SELECT COUNT(*) = 1 FROM t2;
 DROP TABLE t1;
 DROP TABLE t2;
 
+--connection node_1
+SET AUTOCOMMIT=ON;
+
 #
 # Transaction conflict
 #
@@ -115,6 +122,7 @@ DROP TABLE t2;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=MyISAM;
 CREATE TABLE t2 (f2 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
+SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t2 VALUES (1);
@@ -126,7 +134,34 @@ INSERT INTO t1 VALUES (1);
 
 --connection node_1
 COMMIT;
+SET AUTOCOMMIT=ON;
 
 DROP TABLE t1;
 DROP TABLE t2;
 
+#
+# INSERT .... SELECT
+#
+--connection node_1
+use test;
+create table is1 (i int) engine=myisam;
+create table is2 (i int) engine=myisam;
+create table is3 (i int) engine=innodb;
+insert into is1 select 1;
+insert into is1 (i) select i from is1;
+insert into is1 values (2), (3);
+insert into is1 (i) select i from is1;
+select * from is1;
+#
+insert into is2 (i) select i from is1;
+#
+insert into is3 (i) select i from is1;
+insert into is1 (i) select i from is3;
+
+--connection node_2
+select count(*) from is1;
+select count(*) from is2;
+select count(*) from is3;
+drop table is1;
+drop table is2;
+drop table is3;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5439,6 +5439,12 @@ restart:
       }
     }
 #ifdef WITH_WSREP
+  /* It is not recommended to replicate MyISAM as it lacks rollback feature
+  but if user demands then actions are replicated using TOI.
+  Following code will kick-start the TOI but this has to be done only once
+  per statement.
+  Note: kick-start will take-care of creating isolation key for all tables
+  involved in the list (provided all of them are MYISAM tables). */
   if ((thd->lex->sql_command== SQLCOM_INSERT         ||
        thd->lex->sql_command== SQLCOM_INSERT_SELECT  ||
        thd->lex->sql_command== SQLCOM_REPLACE        ||
@@ -5448,7 +5454,8 @@ restart:
        thd->lex->sql_command== SQLCOM_LOAD           ||
        thd->lex->sql_command== SQLCOM_DELETE)        &&
       thd->variables.wsrep_replicate_myisam          &&
-      (*start)->table && (*start)->table->file->ht->db_type == DB_TYPE_MYISAM)
+      (*start)->table && (*start)->table->file->ht->db_type == DB_TYPE_MYISAM &&
+      thd->wsrep_exec_mode== LOCAL_STATE)
     {
       WSREP_TO_ISOLATION_BEGIN(NULL, NULL, (*start));
     }


### PR DESCRIPTION
…= on crashes.

  Best practice recommend not to replicate myisam using galera as myisam doesn't
  support rollback but if user demands it by setting the variable
  wsrep_replicate_myisam = on/1 (default = off/0) then framework will execute
  these actions using TOI.

  TOI initialization is suppose to be done only once per statement also the
  initialization takes care of all tables involved in the statement.

  Test-Scenario exercised a INSERT .... SELECT case that involved 2 tables
  (destination and source table can be same as done in bug test-case)
  which in turn-casued TOI to get invoked twice which is not needed
  as first invocation has taken care of all tables involved in statement.
