### PR TITLE
- PXC#418: wsrep_cluster_name over 32 characters causes gmcast messag…

### DIFF
--- a/mysql-test/suite/sys_vars/r/wsrep_cluster_name_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_cluster_name_basic.result
@@ -37,6 +37,22 @@ my_wsrep_cluster
 # invalid values
 SET @@global.wsrep_cluster_name=NULL;
 ERROR 42000: Variable 'wsrep_cluster_name' can't be set to the value of 'NULL'
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_wsrep_cluster
+set @@global.wsrep_cluster_name="1234567890123456789012345678901234567890";
+ERROR 42000: Variable 'wsrep_cluster_name' can't be set to the value of '1234567890123456789012345678901234567890'
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_wsrep_cluster
+set @@global.wsrep_cluster_name="12345678901234567890123456789012";
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+12345678901234567890123456789012
+SET @@global.wsrep_cluster_name=default;
+SELECT @@global.wsrep_cluster_name;
+@@global.wsrep_cluster_name
+my_wsrep_cluster
 
 # restore the initial value
 SET @@global.wsrep_cluster_name = @wsrep_cluster_name_global_saved;

--- a/mysql-test/suite/sys_vars/t/wsrep_cluster_name_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_cluster_name_basic.test
@@ -32,6 +32,15 @@ SELECT @@global.wsrep_cluster_name;
 --echo # invalid values
 --error ER_WRONG_VALUE_FOR_VAR
 SET @@global.wsrep_cluster_name=NULL;
+# trying to set the cluster-name of size > 32 bytes.
+SELECT @@global.wsrep_cluster_name;
+--error ER_WRONG_VALUE_FOR_VAR
+set @@global.wsrep_cluster_name="1234567890123456789012345678901234567890";
+SELECT @@global.wsrep_cluster_name;
+set @@global.wsrep_cluster_name="12345678901234567890123456789012";
+SELECT @@global.wsrep_cluster_name;
+SET @@global.wsrep_cluster_name=default;
+SELECT @@global.wsrep_cluster_name;
 
 --echo
 --echo # restore the initial value

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -502,6 +502,22 @@ int wsrep_init()
             wsrep->provider_vendor,  sizeof(provider_vendor) - 1);
   }
 
+  /* wsrep_cluster_name is restricted to WSREP_CLUSTER_NAME_MAX_LEN characters
+  only. For now galera supports only UTF-8 so WSREP_CLUSTER_NAME_MAX_LEN is ok
+  on that front too. This limitation is indirectly enforced by limitation of
+  gcomm */
+  size_t const wsrep_len = strlen (wsrep_cluster_name);
+  if (wsrep_len > WSREP_CLUSTER_NAME_MAX_LEN)
+  {
+    rcode = 1;
+    WSREP_ERROR("wsrep_cluster_name too long (%zu)", wsrep_len);
+    WSREP_ERROR("wsrep::init() failed: %d, must shutdown", rcode);
+    wsrep->free(wsrep);
+    free(wsrep);
+    wsrep = NULL;
+    return rcode;
+  }
+
   if (!wsrep_data_home_dir || strlen(wsrep_data_home_dir) == 0)
     wsrep_data_home_dir = mysql_real_data_home;
 

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -445,7 +445,8 @@ void wsrep_cluster_address_init (const char* value)
 bool wsrep_cluster_name_check (sys_var *self, THD* thd, set_var* var)
 {
   if (!var->save_result.string_value.str ||
-      (var->save_result.string_value.length == 0))
+      (var->save_result.string_value.length == 0) ||
+      (var->save_result.string_value.length > WSREP_CLUSTER_NAME_MAX_LEN))
   {
     my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), var->var->name.str,
              (var->save_result.string_value.str ?

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -19,6 +19,7 @@
 #define WSREP_CLUSTER_NAME        "my_wsrep_cluster"
 #define WSREP_NODE_INCOMING_AUTO  "AUTO"
 #define WSREP_START_POSITION_ZERO "00000000-0000-0000-0000-000000000000:-1"
+#define WSREP_CLUSTER_NAME_MAX_LEN 32
 
 // MySQL variables funcs
 


### PR DESCRIPTION
…e max

  length overrun

  wsrep_cluster_name is used by joining node to join the cluster group started
  by the bootstrapping cluster node.

  This communication for handshake is done using gcomm protocol which enforces
  a static limit on buffer than holds group_name (technically very much needed
  to avoid memory bloat).

  This static limit for group_name is 32 bytes and so if cluster_name is
  greater than this static limit gcomm handshake will fail.

  In order to avoid this failure at handshake stage it is better to enforce
  such limit at wsrep_cluster_name validation step.

  From now on wsrep_cluster_name will have a hardlimit of 32 bytes.
  Trying to configure a cluster with cluster_name of size > 32 will result in
  server start failure. Trying to set cluster_name of size > 32 using SET
  command will return error without changing the cluster_name.

  [Note: We cautiously avoid auto-truncation as that would confuse user and
   may break a monitoring tool that may be using cluster-name for montioring]
