### PR TITLE
- PXC#453: Hitting assert when myisam table is being loaded

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
+++ b/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
@@ -83,6 +83,7 @@ use test;
 create table is1 (i int) engine=myisam;
 create table is2 (i int) engine=myisam;
 create table is3 (i int) engine=innodb;
+create table is4 (i int) engine=myisam;
 insert into is1 select 1;
 insert into is1 (i) select i from is1;
 insert into is1 values (2), (3);
@@ -100,6 +101,7 @@ i
 insert into is2 (i) select i from is1;
 insert into is3 (i) select i from is1;
 insert into is1 (i) select i from is3;
+insert into is4 (i) select 1 from information_schema.tables;
 select count(*) from is1;
 count(*)
 16
@@ -112,3 +114,4 @@ count(*)
 drop table is1;
 drop table is2;
 drop table is3;
+drop table is4;

--- a/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
+++ b/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
@@ -147,6 +147,7 @@ use test;
 create table is1 (i int) engine=myisam;
 create table is2 (i int) engine=myisam;
 create table is3 (i int) engine=innodb;
+create table is4 (i int) engine=myisam;
 insert into is1 select 1;
 insert into is1 (i) select i from is1;
 insert into is1 values (2), (3);
@@ -157,6 +158,8 @@ insert into is2 (i) select i from is1;
 #
 insert into is3 (i) select i from is1;
 insert into is1 (i) select i from is3;
+#
+insert into is4 (i) select 1 from information_schema.tables;
 
 --connection node_2
 select count(*) from is1;
@@ -165,3 +168,4 @@ select count(*) from is3;
 drop table is1;
 drop table is2;
 drop table is3;
+drop table is4;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -324,8 +324,10 @@ uint get_table_def_key(const TABLE_LIST *table_list, const char **key)
   */
   DBUG_ASSERT(!strcmp(table_list->get_db_name(),
                       table_list->mdl_request.key.db_name()) &&
-              !strcmp(table_list->get_table_name(),
-                      table_list->mdl_request.key.name()));
+              (!strcmp(table_list->get_table_name(),
+                      table_list->mdl_request.key.name()) ||
+               !strcmp(table_list->get_table_alias(),
+                       table_list->mdl_request.key.name())));
 
   *key= (const char*)table_list->mdl_request.key.ptr() + 1;
   return table_list->mdl_request.key.length() - 1;

--- a/sql/table.h
+++ b/sql/table.h
@@ -2016,6 +2016,17 @@ public:
      respectively.
    */
   char *get_table_name() const { return view != NULL ? view_name.str : table_name; }
+
+  /**
+     @brief Returns the table alias that this TABLE_LIST represents.
+     This is needed to get the real name of the temporary table as the normal
+     table name is temporary generated string.
+
+
+     @details The unqualified table alias
+   */
+  char *get_table_alias() const { return alias; }
+
   int fetch_number_of_rows();
   bool update_derived_keys(Field*, Item**, uint);
   bool generate_keys();


### PR DESCRIPTION
  (with replicate-myisam) from schema based temporary table.

  If wsrep_replicate_myisam is turned ON it will try to replicate
  MyISAM table using TOI. But this replication is not applicable
  to temporary tables as it doesn't make sense to replicate session
  specific tables like temporary tables.

  Code snippet that processes prepare keys for isolation has check to
  identify and skip temporary tables.

  This check for temporary table retrieves table_cache key using
  "get_table_def_key" which in turns validates table key attributes
  by comparing db_name/table_name with mdl_request registered
  db_name/table_name.

  If table is temporary schema table (information_schema) then name of
  table is generally set to path of the table and original name is
  cached in alias.

  Validation check was only considering table_name which would not match
  with MDL key which is created before the table_name is set to path
  by open_and_process_table -> mysql_scheme_table function.
