### PR TITLE
- PXC#452: Caching write-set data beyond configured limit result in c…

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_max_ws_size.result
+++ b/mysql-test/suite/galera/r/galera_var_max_ws_size.result
@@ -2,6 +2,8 @@ call mtr.add_suppression('WSREP: transaction size limit.*');
 call mtr.add_suppression('WSREP: rbr write fail.*');
 call mtr.add_suppression('WSREP: Maximum writeset size exceeded by.*');
 call mtr.add_suppression('WSREP: transaction size exceeded.*');
+call mtr.add_suppression('WSREP: .* isolation failure');
+call mtr.add_suppression('WSREP: Append/Write to writeset buffer failed.*');
 CREATE TABLE t1 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY, f2 VARCHAR(1024)) Engine=InnoDB;
 SET GLOBAL wsrep_max_ws_size = 1024;
 INSERT INTO t1 VALUES (DEFAULT, REPEAT('X', 1024));
@@ -9,4 +11,8 @@ ERROR HY000: Got error 5 during COMMIT
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
+CREATE TABLE t2 (name char) engine=innodb;
+ALTER TABLE t2 ADD COLUMN address INT COMMENT 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+ERROR HY000: Got error 5 during COMMIT
+DROP TABLE t2;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_var_max_ws_size.test
+++ b/mysql-test/suite/galera/t/galera_var_max_ws_size.test
@@ -9,6 +9,8 @@ call mtr.add_suppression('WSREP: transaction size limit.*');
 call mtr.add_suppression('WSREP: rbr write fail.*');
 call mtr.add_suppression('WSREP: Maximum writeset size exceeded by.*');
 call mtr.add_suppression('WSREP: transaction size exceeded.*');
+call mtr.add_suppression('WSREP: .* isolation failure');
+call mtr.add_suppression('WSREP: Append/Write to writeset buffer failed.*');
 
 CREATE TABLE t1 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY, f2 VARCHAR(1024)) Engine=InnoDB;
 
@@ -19,8 +21,13 @@ SET GLOBAL wsrep_max_ws_size = 1024;
 INSERT INTO t1 VALUES (DEFAULT, REPEAT('X', 1024));
 SELECT COUNT(*) = 0 FROM t1;
 
+CREATE TABLE t2 (name char) engine=innodb;
+--error ER_ERROR_DURING_COMMIT
+ALTER TABLE t2 ADD COLUMN address INT COMMENT 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
 --disable_query_log
 --eval SET GLOBAL wsrep_max_ws_size = $wsrep_max_ws_size_orig
 --enable_query_log
 
+DROP TABLE t2;
 DROP TABLE t1;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1225,6 +1225,17 @@ static int wsrep_TOI_begin(THD *thd, char *db_, char *table_,
     break;
   }
 
+  if (buf_err == 1) {
+    /* Given the existing error handling setup, all errors with write-set
+    are classified under single error code. It would be good to have a proper
+    error code reporting mechanism. */
+    WSREP_WARN("Append/Write to writeset buffer failed (either due to IO "
+		"issues (including memory allocation) or hitting a configured "
+                "limit viz. write set size, etc.");
+    my_error(ER_ERROR_DURING_COMMIT, MYF(0), WSREP_SIZE_EXCEEDED);
+    return -1;
+  }
+
   wsrep_key_arr_t key_arr= {0, 0};
   struct wsrep_buf buff = { buf, buf_len };
   if (WSREP(thd))


### PR DESCRIPTION
…rash.

  DML/DDL action result in caching of write-set needed for replication.
  Write-set buffer limit is governed by --wsrep-max-ws-size.

  If DML/DDL action result in write-set string that exceed configured limit
  an error is generated to notify caller about the same.

  TOI workflow failed to handle this error and went ahead with certification
  causing failure.
