### PR TITLE
- PXC#458: DELAYED_INSERT on MYISAM table causes TOI state in-consist…

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
+++ b/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
@@ -115,3 +115,53 @@ drop table is1;
 drop table is2;
 drop table is3;
 drop table is4;
+#node-1
+set @@global.wsrep_replicate_myisam = 1;
+set @@global.wsrep_OSU_method="TOI";
+use test;
+create table is1 (i int) engine=myisam;
+insert into is1 values (1), (2);
+#node-2
+select * from is1;
+i
+1
+2
+#node-1
+insert delayed is1 values (3), (4);
+Warnings:
+Warning	1287	'INSERT DELAYED' is deprecated and will be removed in a future release. Please use INSERT instead
+alter table is1 add column j int;
+#node-2
+select * from is1;
+i	j
+1	NULL
+2	NULL
+3	NULL
+4	NULL
+drop table is1;
+#node-1
+set @@global.wsrep_OSU_method="RSU";
+set @@session.wsrep_OSU_method="RSU";
+select @@global.wsrep_OSU_method;
+@@global.wsrep_OSU_method
+RSU
+select @@session.wsrep_OSU_method;
+@@session.wsrep_OSU_method
+RSU
+use test;
+create table is1 (i int) engine=myisam;
+insert into is1 values (11), (12);
+insert delayed is1 values (13), (14);
+Warnings:
+Warning	1287	'INSERT DELAYED' is deprecated and will be removed in a future release. Please use INSERT instead
+rename table is1 to is2;
+select * from is2;
+i
+11
+12
+13
+14
+drop table is2;
+#node-1
+set global wsrep_replicate_myisam = 0;
+set global wsrep_OSU_method = TOI;

--- a/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
+++ b/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
@@ -169,3 +169,56 @@ drop table is1;
 drop table is2;
 drop table is3;
 drop table is4;
+
+#
+# In INSERT DELAYED statement DELAYED clause is ignored.
+# (Why ? DELAYED clause is execute in async fashion which interfere with
+# sync replication from galera)
+#
+--connection node_1
+--echo #node-1
+#
+--let $wsrep_replicate_myisam_cached = `select @@global.wsrep_replicate_myisam`
+--let $wsrep_OSU_method_cached = `select @@global.wsrep_OSU_method`
+#
+set @@global.wsrep_replicate_myisam = 1;
+set @@global.wsrep_OSU_method="TOI";
+#
+use test;
+create table is1 (i int) engine=myisam;
+insert into is1 values (1), (2);
+#
+--connection node_2
+--echo #node-2
+select * from is1;
+#
+--connection node_1
+--echo #node-1
+insert delayed is1 values (3), (4);
+alter table is1 add column j int;
+#
+--connection node_2
+--echo #node-2
+select * from is1;
+drop table is1;
+
+#
+# with OSU method = RSU
+--connection node_1
+--echo #node-1
+set @@global.wsrep_OSU_method="RSU";
+set @@session.wsrep_OSU_method="RSU";
+select @@global.wsrep_OSU_method;
+select @@session.wsrep_OSU_method;
+use test;
+create table is1 (i int) engine=myisam;
+insert into is1 values (11), (12);
+insert delayed is1 values (13), (14);
+rename table is1 to is2;
+select * from is2;
+drop table is2;
+
+--connection node_1
+--echo #node-1
+--eval set global wsrep_replicate_myisam = $wsrep_replicate_myisam_cached
+--eval set global wsrep_OSU_method = $wsrep_OSU_method_cached

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -423,6 +423,17 @@ void upgrade_lock_type(THD *thd, thr_lock_type *lock_type,
     return;
   }
 
+#if WITH_WSREP
+  /* DELAYED clause is ignored while operating node as a cluster node.
+  DELAYED clause causes async insertion which doesn't go well with sync cluster
+  replication semantics. */
+  if (WSREP(thd) && *lock_type == TL_WRITE_DELAYED)
+  {
+    *lock_type= TL_WRITE;
+     return;
+  }
+#endif
+
   if (*lock_type == TL_WRITE_DELAYED)
   {
     /*


### PR DESCRIPTION
…ency

```
       (TOI_END is not called)
```

  PXC#459: DELAYED_INSERT on MYISAM table causes WSREP-MDL conflict due even
           when wsrep is not enabled.

  INSERT DELAYED is executed in asynchronous fashion as in a separate handler
  thread is created and it executes the INSERT statement.

  This asynchronous replication doeesn't go well with galera's synchronous
  replication for following reasons:
  a. ID is supported by MyISAM (not by InnoDB) and galera doesn't by default
     support MyISAM replication
  b. Existing semantics is broken as ID is replicated using TOI/RSU.
     Code starts TOI but fail to close it. (Well this can be fixed but
     that is like allowing ID to execute using TOI model in asynchronous
     and till it is done it will cause all the other TOI enabled statement
     to wait even though client has reported success).

  In general DELAYED clause is ignored on asynchronous slave too to avoid
  in-consistency with master.

  Also, there are MDL level conflict that arises when RSU mode is used.
  ID handler trying to execute INSERT statement when parallely another
  DDL statement requesting the same MDL lock which again doesn't go
  well with galera MDL check semantics.

  With all those shortcoming we decided to ignore DELAYED clause to
  avoid in-consistency. (We could have fixed the pointed issues
  but semantics in-consistency would continue)
