### PR TITLE
- PXC#462: Turning off wsrep provider in middle of trx leaves trx in an

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_wsrep_on_off.result
+++ b/mysql-test/suite/galera/r/galera_var_wsrep_on_off.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("Cannot modify @@session.wsrep_on");
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET SESSION wsrep_on = FALSE;
@@ -5,7 +6,7 @@ INSERT INTO t1 VALUES (2);
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
-SET GLOBAL wsrep_on = TRUE;
+SET SESSION wsrep_on = TRUE;
 INSERT INTO t1 VALUES (3);
 SELECT COUNT(*) = 2 FROM t1;
 COUNT(*) = 2
@@ -17,3 +18,104 @@ SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 3;
 COUNT(*) = 1
 1
 DROP TABLE t1;
+#node-1
+set session wsrep_on = TRUE;
+create table t1 (i int) engine=innodb;
+insert into t1 values (1), (2);
+#node-2
+select * from t1;
+i
+1
+2
+#node-1
+set session wsrep_on = TRUE;
+begin;
+insert into t1 values (3), (4);
+commit;
+#node-2
+select * from t1;
+i
+1
+2
+3
+4
+#node-1
+set session wsrep_on = TRUE;
+begin;
+insert into t1 values (5), (6);
+set session wsrep_on = FALSE;
+ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'OFF'
+select * from t1;
+i
+1
+2
+3
+4
+5
+6
+commit;
+#node-2
+select * from t1;
+i
+1
+2
+3
+4
+5
+6
+#node-1
+set session wsrep_on = TRUE;
+begin;
+insert into t1 values (7), (8);
+set session wsrep_on = FALSE;
+ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'OFF'
+select * from t1;
+i
+1
+2
+3
+4
+5
+6
+7
+8
+rollback;
+#node-2
+select * from t1;
+i
+1
+2
+3
+4
+5
+6
+#node-1
+set session wsrep_on = FALSE;
+begin;
+insert into t1 values (9), (10);
+set session wsrep_on = TRUE;
+ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'ON'
+commit;
+select * from t1;
+i
+1
+2
+3
+4
+5
+6
+9
+10
+insert into t1 values (11), (12);
+#node-2
+select * from t1;
+i
+1
+2
+3
+4
+5
+6
+#node-1
+set session wsrep_on = TRUE;
+drop table t1;

--- a/mysql-test/suite/galera/t/galera_var_wsrep_on_off.test
+++ b/mysql-test/suite/galera/t/galera_var_wsrep_on_off.test
@@ -5,6 +5,8 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
+call mtr.add_suppression("Cannot modify @@session.wsrep_on");
+
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET SESSION wsrep_on = FALSE;
@@ -16,7 +18,7 @@ INSERT INTO t1 VALUES (2);
 SELECT COUNT(*) = 1 FROM t1;
 
 --connection node_1
-SET GLOBAL wsrep_on = TRUE;
+SET SESSION wsrep_on = TRUE;
 INSERT INTO t1 VALUES (3);
 
 --connection node_2
@@ -30,3 +32,78 @@ SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 3;
 
 DROP TABLE t1;
 
+#
+# Use-case that try to switch-off wsrep in middle of active transaction.
+#
+
+--connection node_1
+--echo #node-1
+set session wsrep_on = TRUE;
+create table t1 (i int) engine=innodb;
+insert into t1 values (1), (2);
+
+--connection node_2
+--echo #node-2
+select * from t1;
+
+# This will be replicated as wsrep_on = true
+--connection node_1
+--echo #node-1
+set session wsrep_on = TRUE;
+begin;
+insert into t1 values (3), (4);
+commit;
+
+--connection node_2
+--echo #node-2
+select * from t1;
+
+# Setting wsrep_on to false in middle of trx is not allowed.
+--connection node_1
+--echo #node-1
+set session wsrep_on = TRUE;
+begin;
+insert into t1 values (5), (6);
+--error ER_WRONG_VALUE_FOR_VAR
+set session wsrep_on = FALSE;
+select * from t1;
+commit;
+
+--connection node_2
+--echo #node-2
+select * from t1;
+
+--connection node_1
+--echo #node-1
+set session wsrep_on = TRUE;
+begin;
+insert into t1 values (7), (8);
+--error ER_WRONG_VALUE_FOR_VAR
+set session wsrep_on = FALSE;
+select * from t1;
+rollback;
+
+--connection node_2
+--echo #node-2
+select * from t1;
+
+# Let's try opposite. Switching the replication back to ON from OFF.
+--connection node_1
+--echo #node-1
+set session wsrep_on = FALSE;
+begin;
+insert into t1 values (9), (10);
+--error ER_WRONG_VALUE_FOR_VAR
+set session wsrep_on = TRUE;
+commit;
+select * from t1;
+insert into t1 values (11), (12);
+
+--connection node_2
+--echo #node-2
+select * from t1;
+
+--connection node_1
+--echo #node-1
+set session wsrep_on = TRUE;
+drop table t1;

--- a/mysql-test/suite/sys_vars/r/wsrep_on_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_on_basic.result
@@ -2,25 +2,12 @@
 # wsrep_on
 #
 # save the initial values
-SET @wsrep_on_global_saved = @@global.wsrep_on;
 SET @wsrep_on_session_saved = @@session.wsrep_on;
 # default
-SELECT @@global.wsrep_on;
-@@global.wsrep_on
-0
 SELECT @@session.wsrep_on;
 @@session.wsrep_on
 0
 
-# scope and valid values
-SET @@global.wsrep_on=OFF;
-SELECT @@global.wsrep_on;
-@@global.wsrep_on
-0
-SET @@global.wsrep_on=ON;
-SELECT @@global.wsrep_on;
-@@global.wsrep_on
-1
 SET @@session.wsrep_on=OFF;
 SELECT @@session.wsrep_on;
 @@session.wsrep_on
@@ -32,19 +19,14 @@ SELECT @@session.wsrep_on;
 SET @@session.wsrep_on=default;
 SELECT @@session.wsrep_on;
 @@session.wsrep_on
-1
+0
 
 # invalid values
-SET @@global.wsrep_on=NULL;
-ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'NULL'
-SET @@global.wsrep_on='junk';
-ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'junk'
 SET @@session.wsrep_on=NULL;
 ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'NULL'
 SET @@session.wsrep_on='junk';
 ERROR 42000: Variable 'wsrep_on' can't be set to the value of 'junk'
 
 # restore the initial values
-SET @@global.wsrep_on = @wsrep_on_global_saved;
 SET @@session.wsrep_on = @wsrep_on_session_saved;
 # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_on_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_on_basic.test
@@ -5,20 +5,12 @@
 --echo #
 
 --echo # save the initial values
-SET @wsrep_on_global_saved = @@global.wsrep_on;
 SET @wsrep_on_session_saved = @@session.wsrep_on;
 
 --echo # default
-SELECT @@global.wsrep_on;
 SELECT @@session.wsrep_on;
 
 --echo
---echo # scope and valid values
-SET @@global.wsrep_on=OFF;
-SELECT @@global.wsrep_on;
-SET @@global.wsrep_on=ON;
-SELECT @@global.wsrep_on;
-
 SET @@session.wsrep_on=OFF;
 SELECT @@session.wsrep_on;
 SET @@session.wsrep_on=ON;
@@ -29,17 +21,12 @@ SELECT @@session.wsrep_on;
 --echo
 --echo # invalid values
 --error ER_WRONG_VALUE_FOR_VAR
-SET @@global.wsrep_on=NULL;
---error ER_WRONG_VALUE_FOR_VAR
-SET @@global.wsrep_on='junk';
---error ER_WRONG_VALUE_FOR_VAR
 SET @@session.wsrep_on=NULL;
 --error ER_WRONG_VALUE_FOR_VAR
 SET @@session.wsrep_on='junk';
 
 --echo
 --echo # restore the initial values
-SET @@global.wsrep_on = @wsrep_on_global_saved;
 SET @@session.wsrep_on = @wsrep_on_session_saved;
 
 --echo # End of test

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4909,9 +4909,10 @@ static Sys_var_mybool Sys_wsrep_sst_donor_rejects_queries(
 
 static Sys_var_mybool Sys_wsrep_on (
        "wsrep_on", "To enable wsrep replication ",
-       SESSION_VAR(wsrep_on), 
+       SESSION_ONLY(wsrep_on),
        CMD_LINE(OPT_ARG), DEFAULT(TRUE), 
-       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(wsrep_on_check),
        ON_UPDATE(wsrep_on_update));
 
 static Sys_var_charptr Sys_wsrep_start_position (

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -35,6 +35,7 @@ int wsrep_init_vars();
 #define DEFAULT_ARGS (THD* thd, enum_var_type var_type)
 #define INIT_ARGS    (const char* opt)
 
+extern bool wsrep_on_check                   CHECK_ARGS;
 extern bool wsrep_on_update                  UPDATE_ARGS;
 extern bool wsrep_causal_reads_update        UPDATE_ARGS;
 extern bool wsrep_sync_wait_update           UPDATE_ARGS;


### PR DESCRIPTION
  inconsistent state.

  wsrep_on can be use to temporarily turn-off replication.

  Current scope of wsrep_on is global/local which means if some client
  connection turns it off then other client connections (connected to
  same node) will start experiencing the effect of it all of sudden
  unknowingly.
  If the value get toggled in middle of transaction then it would
  cause in-consistent state with part of transaction executed with
  replication on and other part without replication on.

  In order to solve all of these issues following solution has been
  implemented:
  a. wsrep_on will be session_only (local) variable moving forward.
  b. Trying to toggle its value in middle of transaction would
     result in error. Given the scope is local only other active
     transactions started by parallely connected client is not affected.

  Well sql_log_bin can help achieve the same effect.
  In theory yes but sql_log_bin stops bin-logging which means async
  replication slaves also doesn't see the events.
  wsrep_on effects only galera based setup by stopping replication
  to galera replicated cluster node only.
