### PR TITLE
- PXC#454: Stopping/Resetting wsrep_provider in middle of trx causes …

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_provider_unset_set.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_provider_unset_set.result
@@ -1,13 +1,35 @@
+#node-1
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
+#node-2
+#node-2a
+begin;
+insert into t1 values (101);
+select * from t1;
+f1
+1
+101
+#node-2
+call mtr.add_suppression('WSREP: Cannot modify wsrep_provider inside a transaction');
+BEGIN;
+INSERT INTO t1 VALUES (100);
+SET GLOBAL wsrep_provider='none';
+ERROR 42000: Variable 'wsrep_provider' can't be set to the value of 'none'
+COMMIT;
 SET GLOBAL wsrep_provider='none';
 INSERT INTO t1 VALUES (2);
+#node-1
 INSERT INTO t1 VALUES (3);
+#node-2a
+select * from t1;
+ERROR HY000: Lost connection to MySQL server during query
+#node-2
 INSERT INTO t1 VALUES (4);
+SELECT COUNT(*) = 5 FROM t1;
+COUNT(*) = 5
+1
+#node-1
 SELECT COUNT(*) = 4 FROM t1;
 COUNT(*) = 4
-1
-SELECT COUNT(*) = 3 FROM t1;
-COUNT(*) = 3
 1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -1,4 +1,4 @@
-galera_wsrep_provider_unset_set : lp1379204 'Unsupported protocol downgrade: incremental data collection disabled. Expect abort.'
+#galera_wsrep_provider_unset_set : lp1379204 'Unsupported protocol downgrade: incremental data collection disabled. Expect abort.'
 galera_kill_nochanges : mysql-wsrep#24 Galera server does not restart properly if killed
 galera_bf_abort_for_update : mysql-wsrep#26 SELECT FOR UPDATE sometimes allowed to proceed in the face of a concurrent update
 galera_toi_ddl_fk_insert : qa#39 galera_toi_ddl_fk_insert fails sporadically

--- a/mysql-test/suite/galera/t/galera_wsrep_provider_unset_set.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_provider_unset_set.test
@@ -7,20 +7,50 @@
 --source include/have_innodb.inc
 
 --connection node_1
+--echo #node-1
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
+--echo #node-2
 --let $wsrep_provider_orig = `SELECT @@wsrep_provider`
 --let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+--echo #node-2a
+begin;
+insert into t1 values (101);
+select * from t1;
+# don't commit. let's see what happen when the clusterness of the node is disabled.
+
+--connection node_2
+--echo #node-2
+#
+# Test the sceanrio where-in we try to set wsrep_provider in middle of
+# an active transaction.
+#
+call mtr.add_suppression('WSREP: Cannot modify wsrep_provider inside a transaction');
+BEGIN;
+INSERT INTO t1 VALUES (100);
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_provider='none';
+COMMIT;
 
 SET GLOBAL wsrep_provider='none';
 INSERT INTO t1 VALUES (2);
 
 --connection node_1
+--echo #node-1
 INSERT INTO t1 VALUES (3);
 
+--connection node_2a
+--echo #node-2a
+--error 2013
+select * from t1;
+
 --connection node_2
+--echo #node-2
 --disable_query_log
 --eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
 --eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
@@ -32,10 +62,11 @@ INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 
 # Node #2 has all the inserts
-SELECT COUNT(*) = 4 FROM t1;
+SELECT COUNT(*) = 5 FROM t1;
 
 --connection node_1
+--echo #node-1
 # Node #1 is missing the insert made while Node #2 was not replicated
-SELECT COUNT(*) = 3 FROM t1;
+SELECT COUNT(*) = 4 FROM t1;
 
 DROP TABLE t1;


### PR DESCRIPTION
…assert as

  cleanup is not done

  wsrep_provider points to the galera-plugin library. This variable is dynamic
  and can be set on the fly to either to point to a different version of
  galera-plugin or none.

  Generally user use it to point to none to get a specific node out of cluster
  and still continue using it as a normal standalone Percona Server node.

  Changing this variable will cause all connections (except the connection that
  triggered the change) to the given node to disconnect.

  If this change in setting is trigger while a transaction is active it
  can leave the server in an inconsistent state.

  To avoid this behavior changing this value in middle of transaction
  or as part of procedure or trigger is now blocked.
