### PR TITLE
- PXC#404: PXC node failure when drop table command share with tempor…

### DIFF
--- a/mysql-test/suite/galera/r/galera_create_table_like.result
+++ b/mysql-test/suite/galera/r/galera_create_table_like.result
@@ -46,3 +46,25 @@ DROP TABLE schema2.real_table2;
 DROP TABLE schema2.real_table3;
 DROP SCHEMA schema1;
 DROP SCHEMA schema2;
+#node-1
+use test;
+create table t1 (c1 int) engine=innodb;
+create table t2 (c1 int) engine=innodb;
+create temporary table t1 (c1 int) engine=innodb;
+insert into t1 values (1);
+insert into t2 values (2);
+#node-2
+use test;
+select * from t1;
+c1
+select * from t2;
+c1
+2
+#node-1
+drop table t2, t1;
+insert into t1 values (11);
+#node-2
+select * from t1;
+c1
+11
+drop table t1;

--- a/mysql-test/suite/galera/t/galera_create_table_like.test
+++ b/mysql-test/suite/galera/t/galera_create_table_like.test
@@ -49,3 +49,37 @@ DROP TABLE schema2.real_table3;
 
 DROP SCHEMA schema1;
 DROP SCHEMA schema2;
+
+#
+# Scenario that involves mix of temporary and non-temporary as part of single
+# drop statement.
+#
+
+--connection node_1
+--echo #node-1
+use test;
+create table t1 (c1 int) engine=innodb;
+create table t2 (c1 int) engine=innodb;
+create temporary table t1 (c1 int) engine=innodb;
+insert into t1 values (1);
+insert into t2 values (2);
+
+--connection node_2
+--echo #node-2
+use test;
+select * from t1;
+select * from t2;
+
+--connection node_1
+--echo #node-1
+# this statement create a mix of temporary and non-temporary object.
+# temporary objects are not replicated but statement is replicated
+# completely w/o stripping off temporary objects and so we create
+# a dummy temporary object for statement to pass on slave.
+drop table t2, t1;
+insert into t1 values (11);
+
+--connection node_2
+--echo #node-2
+select * from t1;
+drop table t1;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1190,6 +1190,7 @@ THD::THD(bool enable_plugins)
    wsrep_applier(is_applier),
    wsrep_applier_closing(FALSE),
    wsrep_client_thread(0),
+   wsrep_TOI_pre_queries(),
    wsrep_po_handle(WSREP_PO_INITIALIZER),
    wsrep_po_cnt(0),
    wsrep_po_in_trans(FALSE),
@@ -1314,8 +1315,6 @@ THD::THD(bool enable_plugins)
   wsrep_consistency_check = NO_CONSISTENCY_CHECK;
   wsrep_status_vars       = 0;
   wsrep_mysql_replicated  = 0;
-  wsrep_TOI_pre_query     = NULL;
-  wsrep_TOI_pre_query_len = 0;
 #endif
   /* Call to init() below requires fully initialized Open_tables_state. */
   reset_open_tables_state();
@@ -1730,8 +1729,7 @@ void THD::init(void)
   wsrep_PA_safe= true;
   wsrep_consistency_check = NO_CONSISTENCY_CHECK;
   wsrep_mysql_replicated  = 0;
-  wsrep_TOI_pre_query     = NULL;
-  wsrep_TOI_pre_query_len = 0;
+  wsrep_TOI_pre_queries.clear();
 #endif
   binlog_row_event_extra_data= 0;
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -19,6 +19,9 @@
 
 /* Classes in mysql */
 
+#include <vector>
+using std::vector;
+
 #include "my_global.h"                          /* NO_EMBEDDED_ACCESS_CHECKS */
 #ifdef MYSQL_SERVER
 #include "unireg.h"                    // REQUIRED: for other includes
@@ -3475,9 +3478,12 @@ public:
                             wsrep_consistency_check;
   wsrep_stats_var*          wsrep_status_vars;
   int                       wsrep_mysql_replicated;
-  const char*               wsrep_TOI_pre_query; /* a query to apply before 
-                                                    the actual TOI query */
-  size_t                    wsrep_TOI_pre_query_len;
+
+  /* query to apply before actual TOI query. Needed in case of
+  CREATE LIKE or DROP TABLE (with mix of temp/non-temp) */
+  typedef vector<String*>   wsrep_queries;
+  wsrep_queries             wsrep_TOI_pre_queries;
+
   wsrep_po_handle_t         wsrep_po_handle;
   size_t                    wsrep_po_cnt;
   my_bool                   wsrep_po_in_trans;

--- a/sql/sql_string.h
+++ b/sql/sql_string.h
@@ -174,6 +174,10 @@ public:
     Alloced_length=str.Alloced_length; alloced=0; 
     str_charset=str.str_charset;
   }
+#ifdef WITH_WSREP
+  static void *operator new(size_t size)
+  { return ::operator new(size); }
+#endif
   static void *operator new(size_t size, MEM_ROOT *mem_root) throw ()
   { return (void*) alloc_root(mem_root, (uint) size); }
   static void operator delete(void *ptr_arg, size_t size)

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1095,10 +1095,10 @@ int wsrep_to_buf_helper(
   }
 
   /* if there is prepare query, add event for it */
-  if (!ret && thd->wsrep_TOI_pre_query)
+  for (uint i = 0; i < thd->wsrep_TOI_pre_queries.size() && !ret; ++i)
   {
-    Query_log_event ev(thd, thd->wsrep_TOI_pre_query,
-		       thd->wsrep_TOI_pre_query_len,
+    Query_log_event ev(thd, thd->wsrep_TOI_pre_queries[i]->ptr(),
+                       thd->wsrep_TOI_pre_queries[i]->length(),
 		       FALSE, FALSE, FALSE, 0);
     if (ev.write(&tmp_io_cache)) ret= 1;
   }


### PR DESCRIPTION
…ary table

  DROP TABLE is ambiguous if there exist 2 objects with same name but
  different type TEMPORARY and NON_TEMPORARY.

  drop table t1;
  there could be 2 objects (temporary and non-temporary) with same name t1.

  It is like local and global scope in C programming language.

  MySQL semantics resolves such ambiguity by referening local (in this case
  temporary object).

---

  Galera replication doesn't replicate TEMPORARY object as their scope
  is localized to the thread that created it and that in case of replication
  would be applier thread making it in-accessible to end-user.

---

  DROP TABLE statement with mix of temporary and non-temporary object
  such that there exist a non-temporary object with same name as temporary
  object specified in DROP TABLE confuses replication.

  Replication algorithm detects presence of non-temporary object and replicate
  the event in form of query as is there-by carrying removal of temporary object
  too which is not part of replicated nodes.

  This means on replicated node drop table references non-temporary objects
  and get rid of it making it in-consistent with workload executor node.

  Algorithm now detect such case (mix of temporary and non-temporary)
  and creates a fake temporary object (as part of DROP workload) for
  replicated node to remove.
