### PR TITLE
- PXC#466: GET_LOCK + drupal_workaround can crash server

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
@@ -10,3 +10,21 @@ ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 wsrep_local_aborts_increment
 1
 DROP TABLE t1;
+#node-1
+use test;
+set @@sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
+set @@session.sql_log_bin = 0;
+set @@global.wsrep_drupal_282555_workaround = 1;
+select get_lock("lock-1", 100000);
+get_lock("lock-1", 100000)
+1
+create table t1 (c1 int auto_increment unique key) engine=innodb;
+insert into t1 values ('a');
+Warnings:
+Warning	1366	Incorrect integer value: 'a' for column 'c1' at row 1
+insert into t1 values ('a');
+ERROR 23000: Duplicate entry '0' for key 'c1'
+set @@global.wsrep_drupal_282555_workaround = 0;;
+set @@session.sql_log_bin = 1;;
+set @@sql_mode = NO_ENGINE_SUBSTITUTION;;
+drop table t1;

--- a/mysql-test/suite/galera/t/galera_bf_abort_get_lock.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_get_lock.test
@@ -34,3 +34,38 @@ INSERT INTO t1 VALUES (1);
 --enable_query_log
 
 DROP TABLE t1;
+
+#
+# GET_LOCK is still not fully supported by Galera and listed as limitation
+# part of it works part of it may not work.
+# One such case is when error occurs while INSERTing duplicate data
+# to auto-incremented column.
+#
+--connection node_1
+--echo #node-1
+
+connect(con_node_1a, localhost, root,,);
+#
+use test;
+--let $existing_sql_mode = `SELECT @@sql_mode`
+--let $existing_sql_log_bin = `SELECT @@session.sql_log_bin`
+--let $existing_drupal_workaround = `SELECT @@wsrep_drupal_282555_workaround`
+
+set @@sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
+set @@session.sql_log_bin = 0;
+set @@global.wsrep_drupal_282555_workaround = 1;
+
+select get_lock("lock-1", 100000);
+create table t1 (c1 int auto_increment unique key) engine=innodb;
+insert into t1 values ('a');
+--error ER_DUP_ENTRY
+insert into t1 values ('a');
+
+--eval set @@global.wsrep_drupal_282555_workaround = $existing_drupal_workaround;
+--eval set @@session.sql_log_bin = $existing_sql_log_bin;
+--eval set @@sql_mode = $existing_sql_mode;
+#
+disconnect con_node_1a;
+
+--connection node_1
+drop table t1;

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -61,6 +61,9 @@ void wsrep_client_rollback(THD *thd)
   /* Release transactional metadata locks. */
   thd->mdl_context.release_transactional_locks();
 
+  /* Release all user-locks. */
+  mysql_ull_cleanup(thd);
+
   /* release explicit MDL locks */
   thd->mdl_context.release_explicit_locks();
 


### PR DESCRIPTION
  GET_LOCK is not supported by Galera/PXC and this is an existing documented
  limitation.

  Despite of this, use of GET_LOCK in workload shouldn't cause server to crash.

  Issue:

---
- get_lock + drupal_workaround + insert to auto-increment
  causes failed insert to be re-tried.
- As per the existing galera semantics/protocol before automatically
  re-trying such failed instance it would release all locks associated with
  given thd (including explicit locks that are set by get_lock/lock-tables)
- After PXC refreshed from PS it got the changes related to
  multiple-user-locks patch (6b7f3e6). BTW this patch is part of mysql-5.7
  
  This patch cached user level lock in thd->ull_hash besides registering
  them as part of thd->mdl_context->m_tickets.
  
  Cleanup code failed to consider cleaning up of additional reference that
  is thd->ull_hash and so while the session is closed session-cleanup
  routine discovered an in-consistency causing crash or assert.
  ## Solution:
- Ensure that that cleanup code removes all possible references of locks.
  ## Open Question:
- Failing to insert a row in an auto-increment column with drupal_workaround
  causes automated re-try but this re-try cleanup routine shouldn't remove
  explicit user level lock.
  Given that wsrep explicitly calls removal of explicit locks there may be
  a reason why this was done.
  Either way GET_LOCK is not supported and so expect the semantics to be
  broken/undefined.
  
  PXC will ensure that semantics are as far possible inline with Codership
  (unless there is reason to diverge) but there is no crash if unsupported
  statement is used in workload.
