### PR TITLE
Fix service-startup-timeout for systemd

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -169,7 +169,7 @@ export PATH
 
 pid_path=$(parse_cnf pid-file "" server mysqld mysqld_safe)
 datadir=$(parse_cnf datadir "" server mysqld mysqld_safe)
-service_startup_timeout=$(parse_cnf service-startup-timeout $service_startup_timeout server mysqld)
+service_startup_timeout=$(parse_cnf service-startup-timeout $service_startup_timeout server mysqld mysqld_safe)
 
 if [[ -z ${datadir:-} ]];then
     datadir="/var/lib/mysql"


### PR DESCRIPTION
PXC won't start if found service-startup-timeout under [server] or [mysqld]
so parse_cnf should search for service-startup-timeout under [mysqld_safe].
