### PR TITLE
- PXC#486: Correcting the DDL/DML replication semantics for MyISAM ta…

### DIFF
--- a/mysql-test/suite/galera/r/galera_create_table_like.result
+++ b/mysql-test/suite/galera/r/galera_create_table_like.result
@@ -69,13 +69,13 @@ c1
 11
 drop table t1;
 #node-1
+use test;
+create table src_i (i int, primary key pk(i)) engine=innodb;
+create table src_m (j int, primary key pk(j)) engine=myisam;
 set wsrep_replicate_myisam = 1;
 select @@wsrep_replicate_myisam;
 @@wsrep_replicate_myisam
 1
-use test;
-create table src_i (i int, primary key pk(i)) engine=innodb;
-create table src_m (i int, primary key pk(i)) engine=myisam;
 create table t1 engine=innodb as select * from src_i;
 create table t2 engine=innodb as select * from src_m;
 create table t3 engine=innodb as select 1;
@@ -86,15 +86,65 @@ create table t7 engine=myisam as select * from src_m;
 create table t8 engine=myisam as select 1;
 create table t9 engine=myisam as select 1 from src_i;
 create table t10 engine=myisam as select 1 from src_m;
+create table t101 engine=innodb as select * from src_i, src_m;
+create table t102 engine=myisam as select * from src_i, src_m;
+create table t103 like src_i;
+create table t104 like src_m;
+set default_storage_engine = 'MyISAM';
+create table t105 like src_i;
+create table t106 like src_m;
+set default_storage_engine = 'InnoDB';
+set wsrep_replicate_myisam = 0;
+select @@wsrep_replicate_myisam;
+@@wsrep_replicate_myisam
+0
+create table t11 engine=innodb as select * from src_i;
+create table t12 engine=innodb as select * from src_m;
+create table t13 engine=innodb as select 1;
+create table t14 engine=innodb as select 1 from src_i;
+create table t15 engine=innodb as select 1 from src_m;
+create table t16 engine=myisam as select * from src_i;
+create table t17 engine=myisam as select * from src_m;
+create table t18 engine=myisam as select 1;
+create table t19 engine=myisam as select 1 from src_i;
+create table t20 engine=myisam as select 1 from src_m;
+create table t201 engine=innodb as select * from src_i, src_m;
+create table t202 engine=myisam as select * from src_i, src_m;
+create table t203 like src_i;
+create table t204 like src_m;
+set default_storage_engine = 'MyISAM';
+create table t205 like src_i;
+create table t206 like src_m;
+set default_storage_engine = 'InnoDB';
 #node-2
 call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t7,test.t8,test.t10''.*");
+call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t17,test.t18,test.t20''.*");
 use test;
 show tables;
 Tables_in_test
 src_i
 src_m
 t1
+t101
+t102
+t103
+t104
+t105
+t106
+t11
+t12
+t13
+t14
+t15
+t16
+t19
 t2
+t201
+t202
+t203
+t204
+t205
+t206
 t3
 t4
 t5
@@ -103,8 +153,18 @@ t9
 #node-1
 drop table t1, t2, t3, t4, t5;
 drop table t6, t7, t8, t9, t10;
+drop table t11, t12, t13, t14, t15;
+drop table t16, t17, t18, t19, t20;
+drop table t101, t102;
+drop table t201, t202;
+drop table t103, t104, t105, t106;
+drop table t203, t204, t205, t206;
 insert into src_i values (1), (2);
 insert into src_m values (1), (2);
+set wsrep_replicate_myisam = 1;
+select @@wsrep_replicate_myisam;
+@@wsrep_replicate_myisam
+1
 create table t1 engine=innodb as select * from src_i;
 create table t2 engine=innodb as select * from src_m;
 create table t3 engine=innodb as select 1;
@@ -115,6 +175,24 @@ create table t7 engine=myisam as select * from src_m;
 create table t8 engine=myisam as select 1;
 create table t9 engine=myisam as select 1 from src_i;
 create table t10 engine=myisam as select 1 from src_m;
+create table t101 engine=innodb as select * from src_i, src_m;
+create table t102 engine=myisam as select * from src_i, src_m;
+set wsrep_replicate_myisam = 0;
+select @@wsrep_replicate_myisam;
+@@wsrep_replicate_myisam
+0
+create table t11 engine=innodb as select * from src_i;
+create table t12 engine=innodb as select * from src_m;
+create table t13 engine=innodb as select 1;
+create table t14 engine=innodb as select 1 from src_i;
+create table t15 engine=innodb as select 1 from src_m;
+create table t16 engine=myisam as select * from src_i;
+create table t17 engine=myisam as select * from src_m;
+create table t18 engine=myisam as select 1;
+create table t19 engine=myisam as select 1 from src_i;
+create table t20 engine=myisam as select 1 from src_m;
+create table t201 engine=innodb as select * from src_i, src_m;
+create table t202 engine=myisam as select * from src_i, src_m;
 #node-2
 use test;
 show tables;
@@ -122,7 +200,18 @@ Tables_in_test
 src_i
 src_m
 t1
+t101
+t102
+t11
+t12
+t13
+t14
+t15
+t16
+t19
 t2
+t201
+t202
 t3
 t4
 t5
@@ -131,5 +220,9 @@ t9
 #node-1
 drop table t1, t2, t3, t4, t5;
 drop table t6, t7, t8, t9, t10;
+drop table t11, t12, t13, t14, t15;
+drop table t16, t17, t18, t19, t20;
+drop table t101, t102, t201, t202;
 drop table src_i, src_m;
+set @@default_storage_engine = InnoDB;;
 set wsrep_replicate_myisam = 1;;

--- a/mysql-test/suite/galera/r/galera_ddl_dml.result
+++ b/mysql-test/suite/galera/r/galera_ddl_dml.result
@@ -1,0 +1,50 @@
+#node-1
+create table t1 (i int) engine=innodb;
+insert into t1 values (1), (2), (3);
+set wsrep_replicate_myisam = 0;
+create table t2 (j int) engine=myisam;
+insert into t2 values (10), (20), (30);
+set wsrep_replicate_myisam = 0;
+set wsrep_replicate_myisam = 1;
+create table t3 (j int) engine=myisam;
+insert into t3 values (100), (200), (300);
+set wsrep_replicate_myisam = 0;
+#node-2
+show tables;
+Tables_in_test
+t1
+t2
+t3
+select * from t1;
+i
+1
+2
+3
+select * from t2;
+j
+select * from t3;
+j
+100
+200
+300
+#node-1
+truncate table t1;
+truncate table t2;
+truncate table t3;
+#node-2
+show tables;
+Tables_in_test
+t1
+t2
+t3
+select * from t1;
+i
+select * from t2;
+j
+select * from t3;
+j
+#node-1
+drop table t1;
+drop table t2;
+drop table t3;
+set @@wsrep_replicate_myisam = 0;;

--- a/mysql-test/suite/galera/r/galera_var_replicate_myisam_off.result
+++ b/mysql-test/suite/galera/r/galera_var_replicate_myisam_off.result
@@ -1,7 +1,6 @@
 SET SESSION wsrep_replicate_myisam = FALSE;
 CREATE TABLE t1 (f1 INT PRIMARY KEY) Engine=MyISAM;
 INSERT INTO t1 VALUES (1);
-call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query. Default database: 'test'. Query: 'DROP TABLE t1', Error_code: 1051");
 SELECT * FROM t1;
-ERROR 42S02: Table 'test.t1' doesn't exist
+f1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_create_table_like.test
+++ b/mysql-test/suite/galera/t/galera_create_table_like.test
@@ -91,14 +91,15 @@ drop table t1;
 --connection node_1
 --echo #node-1
 --let $wsrep_replicate_myisam_orig = `SELECT @@wsrep_replicate_myisam`
-set wsrep_replicate_myisam = 1;
-select @@wsrep_replicate_myisam;
+--let $default_se = `SELECT @@default_storage_engine`
 
 #
 use test;
 create table src_i (i int, primary key pk(i)) engine=innodb;
-create table src_m (i int, primary key pk(i)) engine=myisam;
+create table src_m (j int, primary key pk(j)) engine=myisam;
 #
+set wsrep_replicate_myisam = 1;
+select @@wsrep_replicate_myisam;
 create table t1 engine=innodb as select * from src_i;
 create table t2 engine=innodb as select * from src_m;
 create table t3 engine=innodb as select 1;
@@ -109,10 +110,47 @@ create table t7 engine=myisam as select * from src_m;
 create table t8 engine=myisam as select 1;
 create table t9 engine=myisam as select 1 from src_i;
 create table t10 engine=myisam as select 1 from src_m;
+#
+create table t101 engine=innodb as select * from src_i, src_m;
+create table t102 engine=myisam as select * from src_i, src_m;
+#
+create table t103 like src_i;
+create table t104 like src_m;
+set default_storage_engine = 'MyISAM';
+create table t105 like src_i;
+create table t106 like src_m;
+set default_storage_engine = 'InnoDB';
+#
+#
+set wsrep_replicate_myisam = 0;
+select @@wsrep_replicate_myisam;
+create table t11 engine=innodb as select * from src_i;
+create table t12 engine=innodb as select * from src_m;
+create table t13 engine=innodb as select 1;
+create table t14 engine=innodb as select 1 from src_i;
+create table t15 engine=innodb as select 1 from src_m;
+create table t16 engine=myisam as select * from src_i;
+create table t17 engine=myisam as select * from src_m;
+create table t18 engine=myisam as select 1;
+create table t19 engine=myisam as select 1 from src_i;
+create table t20 engine=myisam as select 1 from src_m;
+#
+create table t201 engine=innodb as select * from src_i, src_m;
+create table t202 engine=myisam as select * from src_i, src_m;
+#
+#
+create table t203 like src_i;
+create table t204 like src_m;
+set default_storage_engine = 'MyISAM';
+create table t205 like src_i;
+create table t206 like src_m;
+set default_storage_engine = 'InnoDB';
+#
 
 --connection node_2
 --echo #node-2
 call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t7,test.t8,test.t10''.*");
+call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t17,test.t18,test.t20''.*");
 # with dest = myisam only few of the tables are replicated
 # this issue exist in upstream too (but they are hitting
 # a bug before). Upstream may not fix it given that it is
@@ -124,9 +162,18 @@ show tables;
 --echo #node-1
 drop table t1, t2, t3, t4, t5;
 drop table t6, t7, t8, t9, t10;
+drop table t11, t12, t13, t14, t15;
+drop table t16, t17, t18, t19, t20;
+drop table t101, t102;
+drop table t201, t202;
+drop table t103, t104, t105, t106;
+drop table t203, t204, t205, t206;
+#
 insert into src_i values (1), (2);
 insert into src_m values (1), (2);
 #
+set wsrep_replicate_myisam = 1;
+select @@wsrep_replicate_myisam;
 create table t1 engine=innodb as select * from src_i;
 create table t2 engine=innodb as select * from src_m;
 create table t3 engine=innodb as select 1;
@@ -137,6 +184,23 @@ create table t7 engine=myisam as select * from src_m;
 create table t8 engine=myisam as select 1;
 create table t9 engine=myisam as select 1 from src_i;
 create table t10 engine=myisam as select 1 from src_m;
+create table t101 engine=innodb as select * from src_i, src_m;
+create table t102 engine=myisam as select * from src_i, src_m;
+#
+set wsrep_replicate_myisam = 0;
+select @@wsrep_replicate_myisam;
+create table t11 engine=innodb as select * from src_i;
+create table t12 engine=innodb as select * from src_m;
+create table t13 engine=innodb as select 1;
+create table t14 engine=innodb as select 1 from src_i;
+create table t15 engine=innodb as select 1 from src_m;
+create table t16 engine=myisam as select * from src_i;
+create table t17 engine=myisam as select * from src_m;
+create table t18 engine=myisam as select 1;
+create table t19 engine=myisam as select 1 from src_i;
+create table t20 engine=myisam as select 1 from src_m;
+create table t201 engine=innodb as select * from src_i, src_m;
+create table t202 engine=myisam as select * from src_i, src_m;
 
 --connection node_2
 --echo #node-2
@@ -151,5 +215,12 @@ show tables;
 --echo #node-1
 drop table t1, t2, t3, t4, t5;
 drop table t6, t7, t8, t9, t10;
+drop table t11, t12, t13, t14, t15;
+drop table t16, t17, t18, t19, t20;
+drop table t101, t102, t201, t202;
 drop table src_i, src_m;
+
+#
+#
+--eval set @@default_storage_engine = $default_se;
 --eval set wsrep_replicate_myisam = $wsrep_replicate_myisam_orig;

--- a/mysql-test/suite/galera/t/galera_ddl_dml.test
+++ b/mysql-test/suite/galera/t/galera_ddl_dml.test
@@ -1,0 +1,78 @@
+
+#
+# This test exercises multiple scenario that involves testing
+# different DDL + DML statement for innodb and myisam engine
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+
+#-------------------------------------------------------------------------------
+#
+# Test-Scenarios
+#
+# 1. DDL/DML statement and their replication
+# 2. DDL/DML statement and their replication with enforce_storage_engine
+#
+#
+
+#-------------------------------------------------------------------------------
+#
+# create test-bed
+#
+--let $wsrep_replicate_myisam_saved = `select @@wsrep_replicate_myisam`
+
+
+
+#-------------------------------------------------------------------------------
+#
+# 1. DDL/DML statement and their replication
+#
+--connection node_1
+--echo #node-1
+
+create table t1 (i int) engine=innodb;
+insert into t1 values (1), (2), (3);
+
+set wsrep_replicate_myisam = 0;
+create table t2 (j int) engine=myisam;
+insert into t2 values (10), (20), (30);
+set wsrep_replicate_myisam = 0;
+
+set wsrep_replicate_myisam = 1;
+create table t3 (j int) engine=myisam;
+insert into t3 values (100), (200), (300);
+set wsrep_replicate_myisam = 0;
+
+--connection node_2
+--echo #node-2
+show tables;
+select * from t1;
+select * from t2;
+select * from t3;
+
+--connection node_1
+--echo #node-1
+truncate table t1;
+truncate table t2;
+truncate table t3;
+
+--connection node_2
+--echo #node-2
+show tables;
+select * from t1;
+select * from t2;
+select * from t3;
+
+--connection node_1
+--echo #node-1
+drop table t1;
+drop table t2;
+drop table t3;
+
+#-------------------------------------------------------------------------------
+#
+# remove test-bed
+#
+--eval set @@wsrep_replicate_myisam = $wsrep_replicate_myisam_saved;

--- a/mysql-test/suite/galera/t/galera_var_replicate_myisam_off.test
+++ b/mysql-test/suite/galera/t/galera_var_replicate_myisam_off.test
@@ -11,8 +11,6 @@ CREATE TABLE t1 (f1 INT PRIMARY KEY) Engine=MyISAM;
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
-call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query. Default database: 'test'. Query: 'DROP TABLE t1', Error_code: 1051");
---error ER_NO_SUCH_TABLE
 SELECT * FROM t1;
 
 --connection node_1

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1404,68 +1404,12 @@ static void wsrep_RSU_end(THD *thd)
 int wsrep_to_isolation_begin(THD *thd, char *db_, char *table_,
                              const TABLE_LIST* table_list)
 {
-  int ret= 0;
-  LEX *lex;
   /*
     No isolation for applier or replaying threads.
    */
   if (thd->wsrep_exec_mode == REPL_RECV) return 0;
 
-
-  lex= thd->lex;
-  /*
-    Note: We don't check if enforce_storage_engine succeeds or not
-    We check only the replication requirements here.
-   */
-  if (!thd->variables.wsrep_replicate_myisam && (!enforce_storage_engine ||
-					       (enforce_storage_engine
-						&&
-						strcasecmp
-						(enforce_storage_engine,
-						 "InnoDB")))
-    && lex->sql_command == SQLCOM_CREATE_TABLE)
-  {
-    if (table_ && lex->create_info.db_type &&
-	lex->create_info.db_type->db_type == DB_TYPE_MYISAM)
-      {
-	if (db_)
-	  {
-	    WSREP_INFO
-	      ("Cannot replicate MyISAM DDL for %s.%s with wsrep_replicate_myisam OFF",
-	       db_, table_);
-	  }
-	else
-	  {
-	    WSREP_INFO
-	      ("Cannot replicate MyISAM DDL for %s with wsrep_replicate_myisam OFF",
-	       table_);
-	  }
-	return ret;
-      }
-    else if (table_list)
-      {
-	for (const TABLE_LIST * table = table_list; table;
-	     table = table->next_global)
-	  {
-	    /*
-	     * First condition is required for IF EXISTS queries
-	     */
-	    if (table->table
-		&& table->table->file->ht->db_type == DB_TYPE_MYISAM)
-	      {
-		WSREP_INFO
-		  ("Cannot replicate MyISAM DDL for %s.%s with wsrep_replicate_myisam OFF",
-		   table->db, table->table_name);
-		/* 
-		 * Break even if one table is MyISAM
-		 * Note: This may not work well with CREATE TABLE .. SELECT (CTAS)
-		 * but CTAS is not executed as TOI currently.
-		 */
-		return ret;
-	      }
-	  }
-      }
-  }
+  int ret= 0;
   mysql_mutex_lock(&thd->LOCK_wsrep_thd);
 
   if (thd->wsrep_conflict_state == MUST_ABORT)


### PR DESCRIPTION
…ble with

  wsrep_replicate_myisam=off

  Existing or Updated Semantics:

  a. DDL statement: CREATE/DROP/TRUNCATE/.... for engine=myisam
     Will be replicated ir-respective of wsrep_replicate_myisam settings.
     This is done to ensure that name of the object is blocked so that user
     can't create another object with same name on replicated node (with or
     without different schema structure).
     [No change in innodb semantics]

  b. DML statement: INSERT/UPDATE/DELETE/SELECT .... for engine=myisam
     Will be replicated only if wsrep_replicate_myisam = 1.
     Expect node in-consistency if user try to run part of workload with
     wsrep_replicate_myisam = 0 and rest of the part with
     wsrep_replicate_myisam = 1

  c. SST xfer:
     A newly booted cluster node that get full SST will also get MyISAM table
     (schema + data) ir-respective of wsrep_replicate_myisam setting.

  d. enforce_storage_engine (options specific to PXC)
     If this option is set and sql_mode doesn't conflict with the setting
     (set sql_mode = "") then even if user request creation of MyISAM table it
     will be auto-converted to SE dictated by enforce_storage_engine option.
     Replication status is captured even before enforce storage engine variable
     modifies the table execution path and so for replication original statement
     as issued by user is used. If this option is set for #node-1 and not for
     #node-2 then expect in-consistency in cluster operation as #node-1 would
     end up auto-updating SE for the table to "InnoDB" but #node-2 may continue
     to create the same table with original user specified engine.
     (This limitation should be documented)

  e. CTAS statement: This is executed and handled differently as it involves
     DML + DDL. CTAS semantics are already confusing in upstream.
     PXC ensures that if the CTAS "select" has myisam table only
     (or no table select 1) such queries are not replicated.

```
 Why is this so ?
 - If there is involvement of innodb table then trx context has to be setup
   and wsrep-plugin is design to work only if trx context is setup.

 Then how come other myisam stmt replicated ?
 - Using TOI and CTAS doesn't use TOI.
```
