### PR TITLE
- PXC#485: handle_fatal_signal (sig=11) in get_quote_char_for_identif…

### DIFF
--- a/mysql-test/suite/galera/r/galera_prepared_statement.result
+++ b/mysql-test/suite/galera/r/galera_prepared_statement.result
@@ -31,3 +31,13 @@ DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
+call mtr.add_suppression("Slave SQL: Error 'Table 'v1' already exists' on .*");
+call mtr.add_suppression("Slave SQL: Error 'Table 'v1' already exists' on .*");
+use test;
+create table t1 (i int key, j blob) engine=innodb;
+prepare stmt from "create view v1 as SELECT 1 b";
+execute stmt;
+execute stmt;
+ERROR 42S01: Table 'v1' already exists
+drop view v1;
+drop table t1;

--- a/mysql-test/suite/galera/t/galera_prepared_statement.test
+++ b/mysql-test/suite/galera/t/galera_prepared_statement.test
@@ -42,3 +42,21 @@ DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
+
+#
+# Re-executing of same prepare statement multiple times with DDL involved
+# causing TOI invocation.
+#
+--connection node_2
+call mtr.add_suppression("Slave SQL: Error 'Table 'v1' already exists' on .*");
+--connection node_1
+call mtr.add_suppression("Slave SQL: Error 'Table 'v1' already exists' on .*");
+#
+use test;
+create table t1 (i int key, j blob) engine=innodb;
+prepare stmt from "create view v1 as SELECT 1 b";
+execute stmt;
+--error ER_TABLE_EXISTS_ERROR
+execute stmt;
+drop view v1;
+drop table t1;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1137,6 +1137,7 @@ create_view_query(THD *thd, uchar** buf, size_t* buf_len)
         If this is an ALTER VIEW then the current user should be set as
         the definer.
       */
+      Prepared_stmt_arena_holder ps_arena_holder(thd);
 
       if (!(lex->definer= create_default_definer(thd)))
       {


### PR DESCRIPTION
…ier |

  sql/sql_show.cc:1209

  If prepare statement involves DDL galera replicate it using TOI.
  During this replication it creates a lex->definer that has needed
  details about host and user-name.

  This lex->definer should be created in persistent memory arena as
  it would be re-used when the prepare statement is re-executed.
  Galera TOI logic missed putting it to persistent memory arena
  which eventually lead to stale pointer pointing to freed memory
  if the same prepare statement is re-executed.
