### PR TITLE
- PXC#480: xtrabackup-v2 SST fails with multiple log_bin directives i…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -240,7 +240,11 @@ parse_cnf()
 {
     local group=$1
     local var=$2
-    reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2-)
+    # print the default settings for given group using my_print_default.
+    # normalize the variable names specified in cnf file (user can use _ or - for example log-bin or log_bin)
+    # then grep for needed variable
+    # finally get the variable value (if variables has been specified multiple time use the last value only)
+    reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
     if [[ -z $reval ]];then 
         [[ -n $3 ]] && reval=$3
     fi


### PR DESCRIPTION
…n my.cnf

  If any given variable the xtrabackup-v2 sst script looks for is specified
  multiple times in cnf file then it tend to pick both of them causing
  some of the follow-up command to fail.

  Avoid this programatic mistake by honoring only the last variable assigned
  setting as done by mysqld too.

  Check https://bugs.launchpad.net/percona-xtradb-cluster/+bug/1362830
