### PR TITLE
- PXC#479: Setting wsrep_desync=1 after FTWRL blocks a node

### DIFF
--- a/mysql-test/suite/galera/r/galera_flush.result
+++ b/mysql-test/suite/galera/r/galera_flush.result
@@ -1,4 +1,7 @@
 DROP TABLE IF EXISTS t1, t2;
+call mtr.add_suppression("InnoDB: Resizing redo log from .*");
+call mtr.add_suppression("InnoDB: Starting to delete and rewrite log files");
+call mtr.add_suppression("InnoDB: New log files created.*");
 FLUSH DES_KEY_FILE;
 FLUSH HOSTS;
 SET SESSION wsrep_replicate_myisam = TRUE;
@@ -35,3 +38,18 @@ RESET CHANGED_PAGE_BITMAPS;
 RESET QUERY CACHE;
 DROP TABLE t1;
 DROP TABLE t2;
+call mtr.add_suppression("WSREP: Trying to desync a node that is already paused");
+#node-1
+select @@wsrep_desync;
+@@wsrep_desync
+0
+set global wsrep_desync = 1;
+set global wsrep_desync = 0;
+flush table with read lock;
+set global wsrep_desync = 1;
+ERROR 42000: Variable 'wsrep_desync' can't be set to the value of 'ON'
+set global wsrep_desync = 0;
+ERROR 42000: Variable 'wsrep_desync' can't be set to the value of 'OFF'
+unlock tables;
+set global wsrep_desync = 1;
+set global wsrep_desync = 0;;

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -10,6 +10,12 @@
 --disable_warnings
 DROP TABLE IF EXISTS t1, t2; 
 --enable_warnings
+
+--connection node_2
+call mtr.add_suppression("InnoDB: Resizing redo log from .*");
+call mtr.add_suppression("InnoDB: Starting to delete and rewrite log files");
+call mtr.add_suppression("InnoDB: New log files created.*");
+
 #
 # The following FLUSH statements should be replicated
 #
@@ -297,8 +303,26 @@ let $wait_timeout= 90;
 #--source include/wait_condition.inc
 #--enable_query_log
 
-
-
 --connection node_1
 DROP TABLE t1;
 DROP TABLE t2;
+
+#
+# If FTWRL has paused the node then avoid toggling desync.
+#
+--connection node_1
+call mtr.add_suppression("WSREP: Trying to desync a node that is already paused");
+--echo #node-1
+--let $wsrep_desync_saved = `select @@wsrep_desync`
+#
+select @@wsrep_desync;
+set global wsrep_desync = 1;
+set global wsrep_desync = 0;
+flush table with read lock;
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_desync = 1;
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_desync = 0;
+unlock tables;
+set global wsrep_desync = 1;
+--eval set global wsrep_desync = $wsrep_desync_saved;

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -586,7 +586,20 @@ bool wsrep_slave_threads_update (sys_var *self, THD* thd, enum_var_type type)
 
 bool wsrep_desync_check (sys_var *self, THD* thd, set_var* var)
 {
+  /* Setting desync to on/off signals participation of node in flow control.
+  It doesn't turn-off recieval of write-sets.
+  If the node is already in paused state due to some previous action like FTWRL
+  then avoid desync as superset action of pausing the node is already active. */
   bool new_wsrep_desync = var->save_result.ulonglong_value;
+  if (!thd->global_read_lock.provider_resumed())
+  {
+    WSREP_WARN ("Trying to desync a node that is already paused.");
+    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0),
+             var->var->name.str,
+             new_wsrep_desync ? "ON" : "OFF");
+    return true;
+  }
+
   mysql_mutex_lock(&LOCK_wsrep_desync_count);
   if (new_wsrep_desync)
   {


### PR DESCRIPTION
  FTWRL pauses cluster which is node specific action and wsrep_desync
  try to turn-off flow control for the said node which too is node specific
  action.

  FTWRL action is complete only after user executed UNLOCK TABLES.
  So if end-user try to toggle wsrep_desync while FTWRL is active (till unlock
  is executed) then it would cause galera plugin to halt/deadlock.

  Let's now understand the semantics a bit.

  a. FTWRL is mean to pause the cluster-node even though write-sets are recieved
     by cluster-node they are not applied.

  b. desync=1 suggest that this node will participate in flow-control.

  If node is paused then of-course the write-queue is bound to grow
  and will hit flow-control so if end-users can explicitly disable
  flow-control before triggerring FTWRL but once the cluster is paused
  then cluster node can't be desynced or re-synced till the FTWRL action is
  complete as both of the line would then act contraditory.
