### PR TITLE
Fixed the git revision in version comment in rpm packages (BLD-382)

### DIFF
--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -29,6 +29,7 @@ Prefix: %{_sysconfdir}
 %define mysql_version @@MYSQL_VERSION@@
 %define redhatversion %(lsb_release -rs | awk -F. '{ print $1}')
 %define percona_server_version @@PERCONA_VERSION@@
+%define revision @@REVISION@@
 %define distribution  rhel%{redhatversion}
 
 #
@@ -51,15 +52,15 @@ Prefix: %{_sysconfdir}
 #
 %{!?wsrep_version:%global wsrep_version @@WSREP_VERSION@@}
 #
-%if %{undefined revision}
-%define revision	1
+%if %{undefined rpm_version}
+%define rpm_version	1
 %endif
 
 %define release_tag	%{nil}
 %if %{undefined dist}
-    %define release         %{release_tag}%{wsrep_version}.%{revision}.%{distribution}
+    %define release         %{release_tag}%{wsrep_version}.%{rpm_version}.%{distribution}
 %else
-    %define release         %{release_tag}%{wsrep_version}.%{revision}.%{dist}
+    %define release         %{release_tag}%{wsrep_version}.%{rpm_version}.%{dist}
 %endif
 
 #


### PR DESCRIPTION
**BUG:** BLD-382 - Different version comment for PXC between deb and rpm packages

**TEST BUILD:**
http://jenkins.percona.com/job/percona-xtradb-cluster-5.6-redhat-binary-new/24/

It looked like this before (git revision was always 1 in rpm):

```
+---------------------------------------------------------------------------------------------+
| @@VERSION_COMMENT                                                                           |
+---------------------------------------------------------------------------------------------+
| Percona XtraDB Cluster (GPL), Release rel76.0, Revision 1, WSREP version 25.13, wsrep_25.13 |
+---------------------------------------------------------------------------------------------+
```

Now it looks like this (normal git revision is visible):

```
+---------------------------------------------------------------------------------------------------+
| @@VERSION_COMMENT                                                                                 |
+---------------------------------------------------------------------------------------------------+
| Percona XtraDB Cluster (GPL), Release rel74.0, Revision 087774c, WSREP version 25.12, wsrep_25.12 |
+---------------------------------------------------------------------------------------------------+
```
