### PR TITLE
- PXC#490: crash-safe slaves: relay_log_recovery breaks replication (…

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_crash_safe.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_crash_safe.result
@@ -1,0 +1,24 @@
+#node-3 (async slave)
+call mtr.add_suppression("Recovery from master pos");
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+#node-1 (master)
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+#node-3 (async slave)
+#Restarting node-3 (async slave) ...
+STOP SLAVE;
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+#node-1 (master)
+INSERT INTO t1 VALUES (2);
+#node-3 (async slave)
+#node-2 (galera replicated node non-slave)
+INSERT INTO t1 VALUES (3);
+#node-3 (async slave)
+DROP TABLE t1;
+STOP SLAVE;
+RESET SLAVE ALL;
+RESET MASTER;

--- a/mysql-test/suite/galera/r/galera_sbr.result
+++ b/mysql-test/suite/galera/r/galera_sbr.result
@@ -5,8 +5,9 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET SESSION binlog_format = 'MIXED';
 INSERT INTO t1 VALUES (2);
-SELECT COUNT(*) = 2 FROM t1;
-COUNT(*) = 2
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT COUNT(*) = 1 FROM t1;
+COUNT(*) = 1
 1
 DROP TABLE t1;
 SET GLOBAL binlog_format = 'ROW';

--- a/mysql-test/suite/galera/r/galera_sbr_binlog.result
+++ b/mysql-test/suite/galera/r/galera_sbr_binlog.result
@@ -5,8 +5,9 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET SESSION binlog_format = 'MIXED';
 INSERT INTO t1 VALUES (2);
-SELECT COUNT(*) = 2 FROM t1;
-COUNT(*) = 2
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT COUNT(*) = 1 FROM t1;
+COUNT(*) = 1
 1
 DROP TABLE t1;
 SET SESSION binlog_format = 'ROW';

--- a/mysql-test/suite/galera/t/galera_as_slave_crash_safe.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_crash_safe.cnf
@@ -1,0 +1,14 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld.2]
+relay_log_info_repository = TABLE
+master_info_repository = TABLE
+relay_log_recovery = 1
+relay-log=mysqld2-relay-bin
+
+[mysqld.3]
+relay_log_info_repository = TABLE
+master_info_repository = TABLE
+relay_log_recovery = 1
+relay-log=mysqld3-relay-bin
+

--- a/mysql-test/suite/galera/t/galera_as_slave_crash_safe.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_crash_safe.test
@@ -1,0 +1,79 @@
+#
+# Test Galera as a slave to a MySQL master
+#
+# The galera/galera_2node_slave.cnf describes the setup of the nodes
+#
+
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+
+# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--source include/galera_cluster.inc
+
+--connection node_3
+--echo #node-3 (async slave)
+call mtr.add_suppression("Recovery from master pos");
+--disable_query_log
+--eval CHANGE MASTER TO  MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START SLAVE USER='root';
+
+#
+# test if replication is working fine.
+--connection node_1
+--echo #node-1 (master)
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+
+--connection node_3
+--echo #node-3 (async slave)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
+#
+# restart node-3
+--echo #Restarting node-3 (async slave) ...
+--source include/restart_mysqld.inc
+# sleep for some time before checkin if replication is up and running.
+--sleep 10
+STOP SLAVE;
+START SLAVE USER='root';
+--sleep 10
+
+#
+# re-test if replication is working fine.
+--connection node_1
+--echo #node-1 (master)
+INSERT INTO t1 VALUES (2);
+
+--connection node_3
+--echo #node-3 (async slave)
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_2
+--echo #node-2 (galera replicated node non-slave)
+INSERT INTO t1 VALUES (3);
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_3
+--echo #node-3 (async slave)
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_1
+DROP TABLE t1;
+
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--connection node_1
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_sbr.test
+++ b/mysql-test/suite/galera/t/galera_sbr.test
@@ -9,7 +9,7 @@
 
 --connection node_1
 # Not allowed in PXC
---error 1231
+--error ER_WRONG_VALUE_FOR_VAR
 SET GLOBAL binlog_format = 'STATEMENT';
 --disable_warnings
 SET SESSION binlog_format = 'STATEMENT';
@@ -22,10 +22,11 @@ INSERT INTO t1 VALUES (1);
 SET SESSION binlog_format = 'MIXED';
 --enable_warnings
 
+--error ER_LOCK_DEADLOCK
 INSERT INTO t1 VALUES (2);
 
 --connection node_2
-SELECT COUNT(*) = 2 FROM t1;
+SELECT COUNT(*) = 1 FROM t1;
 
 DROP TABLE t1;
 

--- a/mysql-test/suite/galera/t/galera_sbr_binlog.test
+++ b/mysql-test/suite/galera/t/galera_sbr_binlog.test
@@ -10,7 +10,7 @@
 
 --connection node_1
 # Not allowed in PXC
---error 1231
+--error ER_WRONG_VALUE_FOR_VAR
 SET GLOBAL binlog_format = 'STATEMENT';
 # Allowed only with warning
 --disable_warnings
@@ -24,10 +24,11 @@ INSERT INTO t1 VALUES (1);
 SET SESSION binlog_format = 'MIXED';
 --enable_warnings
 
+--error ER_LOCK_DEADLOCK
 INSERT INTO t1 VALUES (2);
 
 --connection node_2
-SELECT COUNT(*) = 2 FROM t1;
+SELECT COUNT(*) = 1 FROM t1;
 
 DROP TABLE t1;
 


### PR DESCRIPTION
…CID#62894)

  Issue:

---

  Replication info table like slave_master_info, slave_relay_log_info are
  created in InnoDB to support crash-safe replication that was introduce in
  MySQL-5.6

  Being a innodb tables they default qualify for galera replication but they
  shouldn't as per the protocol as they are meant to be kept on active
  ASYNC slave only.

  MySQL flow does block bin-logging of events performed on these tables but
  WSREP replication missed blocking its replication.
  This causes start of trx in galera cluster which was not needed.

  Infact, the condition to append_key that starts trx in the galera eco-system
  was not adequated to handle case where-in bin-logging is turned-off for
  a specific flow like update performed to replication info table.

  Solution:

---

  Corrected condition that trigger start of replication in galera cluster.
  If bin-logging is turned-off then we avoid starting trx in galera eco-system.

  Note: We also explicitly allows replication when binlog-format = STATEMENT.
  This is an existing semantics so nothing new here but we made is explict
  and there-by kept the hook open only for STATEMENT and not for MIXED.
  It is interesting to learn that this hook is needed only for pt-table-checksum
  to operate that unfortunately relied on so called non-supported functionality
  of PXC cluster (replication under SBR is not supported).
