### PR TITLE
- PXC#489: GTID holes created on cluster peers of async slave node (C…

### DIFF
--- a/mysql-test/suite/galera/galera_2nodes_as_master_slave.cnf
+++ b/mysql-test/suite/galera/galera_2nodes_as_master_slave.cnf
@@ -1,0 +1,83 @@
+
+#
+# Let's understand the topology.
+# * Independent Master with server-id = 1
+# * Galera cluster with 2 nodes: node#1 and node#2 with server-id = 2, 3
+#   node#1 act as slave to Independent Master with server-id = 1
+# * Independent Slave with server-id = 4 replicating from galera node#2
+#
+
+# Use default setting for mysqld processes
+!include include/default_mysqld.cnf
+
+[mysqld]
+log-slave-updates
+log-bin=mysqld-bin
+binlog-format=row
+gtid-mode=on
+enforce-gtid-consistency=true
+
+[mysqld.1]
+server-id=1
+
+[mysqld.2]
+server-id=2
+
+wsrep_provider=@ENV.WSREP_PROVIDER
+wsrep_cluster_address='gcomm://'
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;evs.install_timeout = PT15S; evs.max_install_timeouts=1;'
+
+# enforce read-committed characteristics across the cluster
+wsrep_causal_reads=ON
+wsrep_sync_wait = 7
+
+wsrep_node_address=127.0.0.1
+wsrep_sst_receive_address=127.0.0.2:@mysqld.2.#sst_port
+wsrep_node_incoming_address=127.0.0.1:@mysqld.2.port
+
+# Required for Galera
+innodb_autoinc_lock_mode=2
+
+innodb_flush_log_at_trx_commit=2
+
+[mysqld.3]
+server-id=3
+
+wsrep_provider=@ENV.WSREP_PROVIDER
+wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.2.#galera_port'
+wsrep_provider_options='base_port=@mysqld.3.#galera_port;evs.install_timeout = PT15S; evs.max_install_timeouts = 1;'
+
+# enforce read-committed characteristics across the cluster
+wsrep_causal_reads=ON
+wsrep_sync_wait = 7
+
+wsrep_node_address=127.0.0.1
+wsrep_sst_receive_address=127.0.0.2:@mysqld.3.#sst_port
+wsrep_node_incoming_address=127.0.0.1:@mysqld.3.port
+
+# Required for Galera
+innodb_autoinc_lock_mode=2
+
+innodb_flush_log_at_trx_commit=2
+
+[mysqld.4]
+server-id=4
+
+[ENV]
+NODE_MYPORT_1= @mysqld.1.port
+NODE_MYSOCK_1= @mysqld.1.socket
+
+NODE_MYPORT_2= @mysqld.2.port
+NODE_MYSOCK_2= @mysqld.2.socket
+
+NODE_MYPORT_3= @mysqld.3.port
+NODE_MYSOCK_3= @mysqld.3.socket
+
+NODE_MYPORT_4= @mysqld.4.port
+NODE_MYSOCK_4= @mysqld.4.socket
+
+NODE_GALERAPORT_2= @mysqld.2.#galera_port
+NODE_GALERAPORT_3= @mysqld.3.#galera_port
+
+NODE_SSTPORT_2= @mysqld.2.#sst_port
+NODE_SSTPORT_3= @mysqld.3.#sst_port

--- a/mysql-test/suite/galera/r/galera_as_master_and_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_master_and_slave.result
@@ -1,0 +1,147 @@
+#node-2 (galera-cluster-node acting as slave to an independent master)
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+#node-4 (independent slave replicating from galera-node-2)
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+#node-1 (independent master)
+use test;
+create table t (i int, c char(10), primary key pk(i)) engine=innodb;
+insert into t values (1, 'aaaaaa'), (2, 'bbbbbb'), (3, 'cccccc'),
+(4, 'dddddd'), (5, 'eeeeee');
+select right(@@global.gtid_executed, 3);
+right(@@global.gtid_executed, 3)
+1-2
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+#node-2 (galera-cluster-node acting as slave to an independent master)
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+#node-3 (galera-cluster-node-2 that act as master to independent slave)
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+#node-4 (independent slave replicating from galera-node-2)
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+#node-2 (galera-cluster-node acting as slave to an independent master)
+delete from t where i = 2;
+update t set c = 'zzzzzz' where i = 4;
+update t set c = 'pppppp', i = 50 where i = 5;
+select * from t;
+i	c
+1	aaaaaa
+3	cccccc
+4	zzzzzz
+50	pppppp
+select locate('1-3', @@global.gtid_executed);
+locate('1-3', @@global.gtid_executed)
+VALID_POS
+#node-4 (independent slave replicating from galera-node-2)
+select * from t;
+i	c
+1	aaaaaa
+3	cccccc
+4	zzzzzz
+50	pppppp
+select locate('1-3', @@global.gtid_executed);
+locate('1-3', @@global.gtid_executed)
+VALID_POS
+#node-1 (independent master)
+delete from t where i = 2;
+update t set c = 'zzzzzz' where i = 4;
+update t set c = 'pppppp', i = 50 where i = 5;
+select * from t;
+i	c
+1	aaaaaa
+3	cccccc
+4	zzzzzz
+50	pppppp
+select right(@@global.gtid_executed, 3);
+right(@@global.gtid_executed, 3)
+1-5
+#node-2 (galera-cluster-node acting as slave to an independent master)
+select * from t;
+i	c
+1	aaaaaa
+3	cccccc
+4	zzzzzz
+50	pppppp
+select locate('1-5', @@global.gtid_executed);
+locate('1-5', @@global.gtid_executed)
+VALID_POS
+#node-3 (galera-cluster-node-2 that act as master to independent slave)
+select * from t;
+i	c
+1	aaaaaa
+3	cccccc
+4	zzzzzz
+50	pppppp
+select locate('1-5', @@global.gtid_executed);
+locate('1-5', @@global.gtid_executed)
+VALID_POS
+#node-4 (independent slave replicating from galera-node-2)
+select * from t;
+i	c
+1	aaaaaa
+3	cccccc
+4	zzzzzz
+50	pppppp
+select locate('1-5', @@global.gtid_executed);
+locate('1-5', @@global.gtid_executed)
+VALID_POS
+#node-1 (independent master)
+update t set c = 'kkkkk' where i = 1;
+update t set c = 'k2', i = 100 where i = 1;
+select * from t;
+i	c
+3	cccccc
+4	zzzzzz
+50	pppppp
+100	k2
+select right(@@global.gtid_executed, 3);
+right(@@global.gtid_executed, 3)
+1-7
+#node-3 (galera-cluster-node-2 that act as master to independent slave)
+select * from t;
+i	c
+3	cccccc
+4	zzzzzz
+50	pppppp
+100	k2
+select locate('1-7', @@global.gtid_executed);
+locate('1-7', @@global.gtid_executed)
+VALID_POS
+#node-1 (independent master)
+drop table t;
+#node-2 (galera-cluster-node acting as slave to an independent master)
+STOP SLAVE;
+RESET SLAVE ALL;
+#node-1 (independent master)
+RESET MASTER;
+#node-4 (independent slave replicating from galera-node-2)
+STOP SLAVE;
+RESET SLAVE ALL;
+#node-3 (galera-cluster-node-2 that act as master to independent slave)
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_master_and_slave.cnf
+++ b/mysql-test/suite/galera/t/galera_as_master_and_slave.cnf
@@ -1,0 +1,7 @@
+!include ../galera_2nodes_as_master_slave.cnf
+
+[mysqld.2]
+slave_skip_errors=1032
+
+[mysqld.4]
+slave_skip_errors=1032

--- a/mysql-test/suite/galera/t/galera_as_master_and_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_master_and_slave.test
@@ -1,0 +1,165 @@
+#
+# Check for Topological description in galera_2nodes_as_master_slave.cnf
+# TC will try to fire events on different layers
+# (MASTER, INTERMEDIATE SLAVE, SLAVE) and see if all events are properly
+# replicated with no missing GTID.
+#
+
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+
+#
+# Starting galera cluster
+# As node #1 is not a Galera node, we connect to node#2 in order to run include/galera_cluster.inc
+#
+
+#
+# Step-1: Try to establish needed replication links.
+#
+--connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2
+--echo #node-2 (galera-cluster-node acting as slave to an independent master)
+--disable_query_log
+--eval CHANGE MASTER TO  MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START SLAVE USER='root';
+
+--connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4
+--connection node_4
+--echo #node-4 (independent slave replicating from galera-node-2)
+--disable_query_log
+--eval CHANGE MASTER TO  MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_3;
+--enable_query_log
+START SLAVE USER='root';
+
+#
+# Step-2: Initiate some seed workload on independent master.
+#
+--connect node_1, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1
+--echo #node-1 (independent master)
+use test;
+create table t (i int, c char(10), primary key pk(i)) engine=innodb;
+insert into t values (1, 'aaaaaa'), (2, 'bbbbbb'), (3, 'cccccc'),
+                     (4, 'dddddd'), (5, 'eeeeee');
+select right(@@global.gtid_executed, 3);
+select * from t;
+# replication lag
+--sleep 1
+
+#
+# ensure remaining nodes has the needed data.
+--connection node_2
+--echo #node-2 (galera-cluster-node acting as slave to an independent master)
+select * from t;
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_3
+--echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+select * from t;
+
+--connection node_4
+--echo #node-4 (independent slave replicating from galera-node-2)
+select * from t;
+
+
+#
+# Step-3: Try to perform some DML directly on galera-node-1 which is slave
+# This is not recommended action as SLAVEs are read-only but we have
+# setup where-in data is directly modified on SLAVE.
+#
+--connection node_2
+--echo #node-2 (galera-cluster-node acting as slave to an independent master)
+delete from t where i = 2;
+update t set c = 'zzzzzz' where i = 4;
+update t set c = 'pppppp', i = 50 where i = 5;
+select * from t;
+--replace_regex /[1-9][0-9]+/VALID_POS/
+select locate('1-3', @@global.gtid_executed);
+# replication lag
+sleep 1;
+
+--connection node_4
+--echo #node-4 (independent slave replicating from galera-node-2)
+select * from t;
+--replace_regex /[1-9][0-9]+/VALID_POS/
+select locate('1-3', @@global.gtid_executed);
+
+# repeat same workload on independent master now.
+# replication will cause the re-execution of action on slave but slave
+# will raise an error as action is already executed.
+# given that we have slave_skip_errors enabled replication link will not break.
+--connection node_1
+--echo #node-1 (independent master)
+delete from t where i = 2;
+update t set c = 'zzzzzz' where i = 4;
+update t set c = 'pppppp', i = 50 where i = 5;
+select * from t;
+select right(@@global.gtid_executed, 3);
+# replication lag
+sleep 1;
+
+
+--connection node_2
+--echo #node-2 (galera-cluster-node acting as slave to an independent master)
+select * from t;
+--replace_regex /[1-9][0-9]+/VALID_POS/
+select locate('1-5', @@global.gtid_executed);
+
+--connection node_3
+--echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+select * from t;
+--replace_regex /[1-9][0-9]+/VALID_POS/
+select locate('1-5', @@global.gtid_executed);
+
+--connection node_4
+--echo #node-4 (independent slave replicating from galera-node-2)
+select * from t;
+--replace_regex /[1-9][0-9]+/VALID_POS/
+select locate('1-5', @@global.gtid_executed);
+
+#
+# do some more transaction to rule-out existence of GTID gaps.
+#
+--connection node_1
+--echo #node-1 (independent master)
+update t set c = 'kkkkk' where i = 1;
+update t set c = 'k2', i = 100 where i = 1;
+select * from t;
+select right(@@global.gtid_executed, 3);
+# replication lag
+--sleep 1
+
+--connection node_3
+--echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+select * from t;
+--replace_regex /[1-9][0-9]+/VALID_POS/
+select locate('1-7', @@global.gtid_executed);
+
+#
+# Step-n: Remove seed table and break all replication links as part of cleanup.
+#
+--connection node_1
+--echo #node-1 (independent master)
+drop table t;
+# replication lag
+--sleep 1
+
+--connection node_2
+--echo #node-2 (galera-cluster-node acting as slave to an independent master)
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--connection node_1
+--echo #node-1 (independent master)
+RESET MASTER;
+
+--connection node_4
+--echo #node-4 (independent slave replicating from galera-node-2)
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--connection node_3
+--echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+RESET MASTER;
+

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -36,6 +36,7 @@
 
 #ifdef WITH_WSREP
 #include "wsrep_xid.h"
+extern handlerton* wsrep_hton;
 #endif /* WITH_WSREP */
 
 using std::max;
@@ -7382,6 +7383,12 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit)
       cache_mngr->stmt_cache.reset();
     }
     DBUG_RETURN(rcode);
+  }
+
+  if (thd->wsrep_certify_empty_trx)
+  {
+    wsrep_run_wsrep_commit(thd, wsrep_hton, true);
+    wsrep_post_commit(thd, true);
   }
 #endif /* WITH_WSREP */
 

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1196,6 +1196,7 @@ THD::THD(bool enable_plugins)
    wsrep_po_in_trans(FALSE),
    wsrep_apply_format(0),
    wsrep_apply_toi(false),
+   wsrep_certify_empty_trx(false),
 #endif
    m_parser_state(NULL),
 #if defined(ENABLED_DEBUG_SYNC)
@@ -1733,6 +1734,7 @@ void THD::init(void)
   wsrep_mysql_replicated  = 0;
   wsrep_TOI_pre_queries.clear();
   wsrep_sync_wait_gtid= WSREP_GTID_UNDEFINED;
+  wsrep_certify_empty_trx= false;
 #endif
   binlog_row_event_extra_data= 0;
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3492,6 +3492,7 @@ public:
   void*                     wsrep_apply_format;
   bool                      wsrep_apply_toi; /* applier processing in TOI */
   wsrep_gtid_t              wsrep_sync_wait_gtid;
+  bool                      wsrep_certify_empty_trx;
 #endif /* WITH_WSREP */
   /**
     Internal parser state.

--- a/sql/wsrep_hton.cc
+++ b/sql/wsrep_hton.cc
@@ -42,6 +42,7 @@ void wsrep_cleanup_transaction(THD *thd)
   thd->wsrep_trx_meta.gtid= WSREP_GTID_UNDEFINED;
   thd->wsrep_trx_meta.depends_on= WSREP_SEQNO_UNDEFINED;
   thd->wsrep_exec_mode= LOCAL_STATE;
+  thd->wsrep_certify_empty_trx= false;
   return;
 }
 


### PR DESCRIPTION
…ID#62236)

  Issue:

---

  Let's understand the issue using a topology.
- Independent Master
- Galera Nodes (node#1 and node#2).
- Node#1 is acting as async-slave to Independent Master.
  
  Let's say user execute some action on node#1 these action will get replicated
  in galera-eco-system but at same time it is data is being modified directly
  on slave putting slave out of sync from master.
  
  Now same action is executed on master. This action is replicated to slave
  but given that slave already has executed the action slave would raise and
  error. This is can be handled by installed error handler that would allow
  slave to suppress such errors.
  
  There are other use-cases where-in "UPDATE" can cause same record to update
  to same value in which case UPDATE simply doesn't execute the action on slave.
  
  In all such cases even though action is suppressed GTID sequence update
  still needs to get replicated in galera-eco-system as it is done in
  Master-Slave eco-system.
  
  (There could be different views on whether event in master-slave eco-system
  should be propogated to galera-eco-system but let's for now assume
  this is needed).
  ## Solution:
  
  When such a situation arise in Master-Slave eco-system, Slave will create
  an empty GTID event that is then replicated if Slave is acting as Master
  to some other Slave.
  
  Galera will follow the same. Such empty GTID event will now also be replicated
  in Galera eco-system.
