### PR TITLE
- #PXC-474: Async replication + auto-increment + log-format (STMT) = inconsistent cluster node

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
@@ -1,0 +1,61 @@
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+SET SESSION binlog_format='STATEMENT';
+CREATE TABLE t1 (
+i int(11) NOT NULL AUTO_INCREMENT,
+c char(32) DEFAULT 'dummy_text',
+PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+insert into t1(i) values(null);
+select * from t1;
+i	c
+1	dummy_text
+insert into t1(i) values(null), (null), (null);
+select * from t1;
+i	c
+1	dummy_text
+2	dummy_text
+3	dummy_text
+4	dummy_text
+show variables like 'binlog_format';
+Variable_name	Value
+binlog_format	STATEMENT
+show variables like '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	1
+auto_increment_offset	1
+wsrep_auto_increment_control	ON
+select * from t1;
+i	c
+1	dummy_text
+2	dummy_text
+3	dummy_text
+4	dummy_text
+show variables like 'binlog_format';
+Variable_name	Value
+binlog_format	ROW
+show variables like '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	2
+auto_increment_offset	1
+wsrep_auto_increment_control	ON
+select * from t1;
+i	c
+1	dummy_text
+2	dummy_text
+3	dummy_text
+4	dummy_text
+show variables like 'binlog_format';
+Variable_name	Value
+binlog_format	ROW
+show variables like '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	2
+auto_increment_offset	2
+wsrep_auto_increment_control	ON
+DROP TABLE t1;
+STOP SLAVE;
+RESET SLAVE ALL;
+SET GLOBAL binlog_format='ROW';
+RESET MASTER;

--- a/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
@@ -1,0 +1,74 @@
+SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
+SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
+CREATE TABLE t1 (
+i int(11) NOT NULL AUTO_INCREMENT,
+c char(32) DEFAULT 'dummy_text',
+PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+insert into t1(i) values(null);
+select * from t1;
+i	c
+1	dummy_text
+insert into t1(i) values(null), (null), (null);
+select * from t1;
+i	c
+1	dummy_text
+3	dummy_text
+5	dummy_text
+7	dummy_text
+select * from t1;
+i	c
+1	dummy_text
+3	dummy_text
+5	dummy_text
+7	dummy_text
+SET GLOBAL wsrep_forced_binlog_format='none';
+SET GLOBAL wsrep_forced_binlog_format='none';
+drop table t1;
+SET SESSION binlog_format='STATEMENT';
+show variables like 'binlog_format';
+Variable_name	Value
+binlog_format	STATEMENT
+SET GLOBAL wsrep_auto_increment_control='OFF';
+SET SESSION auto_increment_increment = 3;
+SET SESSION auto_increment_offset = 1;
+CREATE TABLE t1 (
+i int(11) NOT NULL AUTO_INCREMENT,
+c char(32) DEFAULT 'dummy_text',
+PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+insert into t1(i) values(null);
+select * from t1;
+i	c
+1	dummy_text
+insert into t1(i) values(null), (null), (null);
+select * from t1;
+i	c
+1	dummy_text
+4	dummy_text
+7	dummy_text
+10	dummy_text
+select * from t1;
+i	c
+1	dummy_text
+4	dummy_text
+7	dummy_text
+10	dummy_text
+SET GLOBAL wsrep_auto_increment_control='ON';
+SET SESSION binlog_format='ROW';
+show variables like 'binlog_format';
+Variable_name	Value
+binlog_format	ROW
+show variables like '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	2
+auto_increment_offset	1
+wsrep_auto_increment_control	ON
+SET GLOBAL wsrep_auto_increment_control='OFF';
+show variables like '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	3
+auto_increment_offset	1
+wsrep_auto_increment_control	OFF
+SET GLOBAL wsrep_auto_increment_control='ON';
+drop table t1;

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.cnf
@@ -1,0 +1,1 @@
+!include ../galera_2nodes_as_slave.cnf

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
@@ -1,0 +1,79 @@
+#
+# Test Galera as a slave to a MySQL master
+#
+# The galera/galera_2node_slave.cnf describes the setup of the nodes
+#
+
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+
+# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster.inc
+
+--connection node_2
+--disable_query_log
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START SLAVE USER='root';
+
+--connection node_1
+
+##
+## Verify the correct operation of the auto-increment when
+## the binlog format set to the 'STATEMENT' on the master node:
+##
+
+SET SESSION binlog_format='STATEMENT';
+
+CREATE TABLE t1 (
+     i int(11) NOT NULL AUTO_INCREMENT,
+     c char(32) DEFAULT 'dummy_text',
+     PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+insert into t1(i) values(null);
+
+select * from t1;
+
+insert into t1(i) values(null), (null), (null);
+
+select * from t1;
+
+show variables like 'binlog_format';
+show variables like '%auto_increment%';
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 4 FROM t1;
+--source include/wait_condition.inc
+
+select * from t1;
+
+show variables like 'binlog_format';
+show variables like '%auto_increment%';
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+select * from t1;
+
+show variables like 'binlog_format';
+show variables like '%auto_increment%';
+
+--connection node_1
+DROP TABLE t1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--connection node_1
+
+SET GLOBAL binlog_format='ROW';
+
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.test
@@ -1,0 +1,114 @@
+##
+## Tests the auto-increment with binlog in STATEMENT mode.
+##
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+##
+## Verify the correct operation of the auto-increment when the binlog
+## format artificially set to the 'STATEMENT' (although this mode is
+## not recommended in the current version):
+##
+
+--connection node_2
+SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
+
+--connection node_1
+SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
+
+CREATE TABLE t1 (
+     i int(11) NOT NULL AUTO_INCREMENT,
+     c char(32) DEFAULT 'dummy_text',
+     PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+insert into t1(i) values(null);
+
+select * from t1;
+
+insert into t1(i) values(null), (null), (null);
+
+select * from t1;
+
+--connection node_2
+
+select * from t1;
+
+SET GLOBAL wsrep_forced_binlog_format='none';
+
+--connection node_1
+
+SET GLOBAL wsrep_forced_binlog_format='none';
+
+drop table t1;
+
+##
+## Check the operation when the automatic control over the auto-increment
+## settings is switched off, that is, when we use the increment step and
+## the offset specified by the user. In the current session, the binlog
+## format is set to 'STATEMENT'. It is important that the values of the
+## auto-increment options does not changed on other node - it allows us
+## to check the correct transmission of the auto-increment options to
+## other nodes:
+##
+
+--disable_warnings
+SET SESSION binlog_format='STATEMENT';
+--enable_warnings
+
+show variables like 'binlog_format';
+
+SET GLOBAL wsrep_auto_increment_control='OFF';
+
+SET SESSION auto_increment_increment = 3;
+SET SESSION auto_increment_offset = 1;
+
+CREATE TABLE t1 (
+     i int(11) NOT NULL AUTO_INCREMENT,
+     c char(32) DEFAULT 'dummy_text',
+     PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+insert into t1(i) values(null);
+
+select * from t1;
+
+insert into t1(i) values(null), (null), (null);
+
+select * from t1;
+
+--connection node_2
+
+select * from t1;
+
+--connection node_1
+
+##
+## Verify the return to automatic calculation of the step
+## and offset of the auto-increment:
+##
+
+SET GLOBAL wsrep_auto_increment_control='ON';
+
+SET SESSION binlog_format='ROW';
+
+show variables like 'binlog_format';
+show variables like '%auto_increment%';
+
+##
+## Verify the recovery of original user-defined values after
+## stopping the automatic control over auto-increment:
+##
+
+SET GLOBAL wsrep_auto_increment_control='OFF';
+
+show variables like '%auto_increment%';
+
+##
+## Restore original options and drop test table:
+##
+
+SET GLOBAL wsrep_auto_increment_control='ON';
+
+drop table t1;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4172,6 +4172,20 @@ int init_common_variables()
   */
   global_system_variables.time_zone= my_tz_SYSTEM;
 
+#ifdef WITH_WSREP
+  /*
+    We need to initialize auxiliary variables, that will be
+    further keep the original values of auto-increment options
+    as they set by the user. These variables used to restore
+    user-defined values of the auto-increment options after
+    setting of the wsrep_auto_increment_control to 'OFF'.
+  */
+  global_system_variables.saved_auto_increment_increment=
+    global_system_variables.auto_increment_increment;
+  global_system_variables.saved_auto_increment_offset=
+    global_system_variables.auto_increment_offset;
+#endif
+
 #ifdef HAVE_PSI_INTERFACE
   /*
     Complete the mysql_bin_log initialization.

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -503,6 +503,16 @@ typedef struct system_variables
   ha_rows select_limit;
   ha_rows max_join_size;
   ulong auto_increment_increment, auto_increment_offset;
+#ifdef WITH_WSREP
+  /*
+    Stored values of the auto_increment_increment and auto_increment_offset
+    that are will be needed when wsrep_auto_increment_control will be set to
+    'OFF', because the setting it to 'ON' leads to overwriting of the original
+    values (which are set by the user) by calculated values (which are based
+    on the cluster's size):
+  */
+  ulong saved_auto_increment_increment, saved_auto_increment_offset;
+#endif
   ulong bulk_insert_buff_size;
   uint  eq_range_index_dive_limit;
   ulong join_buff_size;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7264,7 +7264,7 @@ void THD::reset_for_next_command()
     transactions. Appliers and replayers are either processing ROW
     events or get autoinc variable values from Query_log_event.
   */
-  if (WSREP(thd) && thd->wsrep_exec_mode == LOCAL_STATE) {
+  if (WSREP(thd) && thd->wsrep_exec_mode == LOCAL_STATE && !thd->slave_thread) {
     if (wsrep_auto_increment_control)
     {
       if (thd->variables.auto_increment_offset !=

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -543,13 +543,56 @@ static Sys_var_long Sys_pfs_connect_attrs_size(
 #endif /* EMBEDDED_LIBRARY */
 #endif /* WITH_PERFSCHEMA_STORAGE_ENGINE */
 
+#ifdef WITH_WSREP
+
+/*
+  We need to keep the original values set by the user, as they will
+  be lost if wsrep_auto_increment_control set to 'ON':
+*/
+static bool update_auto_increment_increment (sys_var *self, THD *thd, enum_var_type type)
+{
+  if (type == OPT_GLOBAL)
+    global_system_variables.saved_auto_increment_increment=
+      global_system_variables.auto_increment_increment;
+  else
+    thd->variables.saved_auto_increment_increment=
+      thd->variables.auto_increment_increment;
+  return false;
+}
+
+#endif
+
 static Sys_var_ulong Sys_auto_increment_increment(
        "auto_increment_increment",
        "Auto-increment columns are incremented by this",
        SESSION_VAR(auto_increment_increment),
        CMD_LINE(OPT_ARG),
        VALID_RANGE(1, 65535), DEFAULT(1), BLOCK_SIZE(1),
+#ifdef WITH_WSREP
+       NO_MUTEX_GUARD, IN_BINLOG, ON_CHECK(0),
+       ON_UPDATE(update_auto_increment_increment));
+#else
        NO_MUTEX_GUARD, IN_BINLOG);
+#endif
+
+#ifdef WITH_WSREP
+
+/*
+  We need to keep the original values set by the user, as they will
+  be lost if wsrep_auto_increment_control set to 'ON':
+*/
+static bool update_auto_increment_offset (sys_var *self, THD *thd, enum_var_type type)
+{
+  if (type == OPT_GLOBAL)
+    global_system_variables.saved_auto_increment_offset=
+      global_system_variables.auto_increment_offset;
+  else
+    thd->variables.saved_auto_increment_offset=
+      thd->variables.auto_increment_offset;
+  return false;
+}
+
+#endif
 
 static Sys_var_ulong Sys_auto_increment_offset(
        "auto_increment_offset",
@@ -558,7 +601,12 @@ static Sys_var_ulong Sys_auto_increment_offset(
        SESSION_VAR(auto_increment_offset),
        CMD_LINE(OPT_ARG),
        VALID_RANGE(1, 65535), DEFAULT(1), BLOCK_SIZE(1),
+#ifdef WITH_WSREP
+       NO_MUTEX_GUARD, IN_BINLOG, ON_CHECK(0),
+       ON_UPDATE(update_auto_increment_offset));
+#else
        NO_MUTEX_GUARD, IN_BINLOG);
+#endif
 
 static Sys_var_mybool Sys_automatic_sp_privileges(
        "automatic_sp_privileges",
@@ -4857,11 +4905,54 @@ static Sys_var_ulong Sys_wsrep_retry_autocommit(
        SESSION_VAR(wsrep_retry_autocommit), CMD_LINE(REQUIRED_ARG),
        VALID_RANGE(0, 10000), DEFAULT(1), BLOCK_SIZE(1));
 
+static bool update_wsrep_auto_increment_control (sys_var *self, THD *thd, enum_var_type type)
+{
+  if (wsrep_auto_increment_control)
+  {
+    /*
+      The variables that control auto increment shall be calculated
+      automaticaly based on the size of the cluster. This usually done
+      within the wsrep_view_handler_cb callback. However, if the user
+      manually sets the value of wsrep_auto_increment_control to 'ON',
+      then we should to re-calculate these variables again (because
+      these values may be required before wsrep_view_handler_cb will
+      be re-invoked, which is rarely invoked if the cluster stays in
+      the stable state):
+    */
+    global_system_variables.auto_increment_increment=
+       wsrep_cluster_size ? wsrep_cluster_size : 1;
+    global_system_variables.auto_increment_offset=
+       wsrep_local_index >= 0 ? wsrep_local_index + 1 : 1;
+    thd->variables.auto_increment_increment=
+      global_system_variables.auto_increment_increment;
+    thd->variables.auto_increment_offset=
+      global_system_variables.auto_increment_offset;
+  }
+  else
+  {
+    /*
+      We must restore the last values of the variables that
+      are explicitly specified by the user:
+    */
+    global_system_variables.auto_increment_increment=
+      global_system_variables.saved_auto_increment_increment;
+    global_system_variables.auto_increment_offset=
+      global_system_variables.saved_auto_increment_offset;
+    thd->variables.auto_increment_increment=
+      thd->variables.saved_auto_increment_increment;
+    thd->variables.auto_increment_offset=
+      thd->variables.saved_auto_increment_offset;
+  }
+  return false;
+}
+
 static Sys_var_mybool Sys_wsrep_auto_increment_control(
        "wsrep_auto_increment_control", "To automatically control the "
        "assignment of autoincrement variables",
        GLOBAL_VAR(wsrep_auto_increment_control), 
-       CMD_LINE(OPT_ARG), DEFAULT(TRUE));
+       CMD_LINE(OPT_ARG), DEFAULT(TRUE),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
+       ON_UPDATE(update_wsrep_auto_increment_control));
 
 static Sys_var_mybool Sys_wsrep_drupal_282555_workaround(
        "wsrep_drupal_282555_workaround", "To use a workaround for"


### PR DESCRIPTION
This is patch for the PXC-474 issue: suppose we have a PXC 2+ node cluster which is replicating from an async master. Now if the binlog_format is STATEMENT and multi-row inserts are executed on a table with an auto_increment column such that values are automatically generated by MySQL, then the PXC node generates wrong auto_increment values which are different from what was generated on the async master.

Jenkins build: http://jenkins.percona.com/job/pxc56.clone/1847/
