### PR TITLE
- #PXC-496: Tests that use 'galera_wsrep_recover.inc' have failed under root privileges

### DIFF
--- a/mysql-test/suite/galera/include/galera_wsrep_recover.inc
+++ b/mysql-test/suite/galera/include/galera_wsrep_recover.inc
@@ -1,5 +1,14 @@
 --echo Performing --wsrep-recover ...
+#
+# When mysqld is run by a root user it will fail to start unless
+# we specify what user is ran it (using "--user root" option):
+#
+if ($MYSQL_TEST_ROOT == 'YES') {
+--exec $MYSQLD --defaults-group-suffix=.$galera_wsrep_recover_server_id --defaults-file=$MYSQLTEST_VARDIR/my.cnf --wsrep-recover --user root > $MYSQL_TMP_DIR/galera_wsrep_recover.log 2>&1
+}
+if ($MYSQL_TEST_ROOT != 'YES') {
 --exec $MYSQLD --defaults-group-suffix=.$galera_wsrep_recover_server_id --defaults-file=$MYSQLTEST_VARDIR/my.cnf --wsrep-recover > $MYSQL_TMP_DIR/galera_wsrep_recover.log 2>&1
+}
 
 --perl
 	use strict;


### PR DESCRIPTION
When mysqld is run by a root user it will fail to start unless we specify what user is ran it (using “--user root” option). It is done in the mtr script, but one of the include files does not take into account this requirement. We need to add some changes to the galera_wsrep_recover.inc, because without it the galera_ist_restart_joiner.test and other IST/SST tests have failed.

To solve this problem I added a check of the MYSQL_TEST_ROOT variable to the galera_wsrep_recover.inc file.

Jenkins build: http://jenkins.percona.com/job/pxc56.clone/1849/
