### PR TITLE
- PXC#497: Warning: "BF applier failed to open_and_lock_tables"

### DIFF
--- a/mysql-test/suite/galera/r/galera_transaction_replay.result
+++ b/mysql-test/suite/galera/r/galera_transaction_replay.result
@@ -30,3 +30,43 @@ SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'c';
 COUNT(*) = 1
 1
 DROP TABLE t1;
+#node_1
+create table t1 (i int primary key, c char(1)) engine=innodb;
+insert into t1 values (1, 'a'), (2, 'a'), (5, 'a'), (6, 'a');
+select * from t1;
+i	c
+1	a
+2	a
+5	a
+6	a
+prepare stmt1 from "update t1 set c = 'b' where i > 2 and i < 6";
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_enter_sync';
+execute stmt1;;
+#node_1a
+set session wsrep_sync_wait = 0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+#node_2
+insert into t1 values (3, 'a');
+#node_1a
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_enter_sync';
+#node_1
+select * from t1;
+i	c
+1	a
+2	a
+3	a
+5	b
+6	a
+#node_2
+select * from t1;
+i	c
+1	a
+2	a
+3	a
+5	b
+6	a
+#node_1
+deallocate prepare stmt1;
+drop table t1;

--- a/mysql-test/suite/galera/t/galera_transaction_replay.test
+++ b/mysql-test/suite/galera/t/galera_transaction_replay.test
@@ -70,3 +70,60 @@ SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'b';
 SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'c';
 
 DROP TABLE t1;
+
+
+#
+# If 2 conflicting trx are executed then local trx is rolled back.
+# If the local trx is through exectuion of prepared statement it use
+# re-execution/replay of it use to fail.
+#
+--connection node_1
+--echo #node_1
+create table t1 (i int primary key, c char(1)) engine=innodb;
+insert into t1 values (1, 'a'), (2, 'a'), (5, 'a'), (6, 'a');
+select * from t1;
+
+prepare stmt1 from "update t1 set c = 'b' where i > 2 and i < 6";
+--let $galera_sync_point = commit_monitor_enter_sync
+--source include/galera_set_sync_point.inc
+--send execute stmt1;
+
+# Wait until commit is blocked
+--connection node_1a
+--echo #node_1a
+set session wsrep_sync_wait = 0;
+--source include/galera_wait_sync_point.inc
+
+# Issue a conflicting update on node #2
+--connection node_2
+--echo #node_2
+insert into t1 values (3, 'a');
+
+# Wait for both transactions to be blocked
+--connection node_1a
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'wsrep in pre-commit stage';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Write_rows_log_event::write_row%';
+--source include/wait_condition.inc
+
+# Unblock the commit
+--connection node_1a
+--echo #node_1a
+--source include/galera_clear_sync_point.inc
+--source include/galera_signal_sync_point.inc
+
+# Commit succeeds
+--connection node_1
+--echo #node_1
+--reap
+select * from t1;
+
+--connection node_2
+--echo #node_2
+select * from t1;
+
+--connection node_1
+--echo #node_1
+deallocate prepare stmt1;
+drop table t1;

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -4018,6 +4018,7 @@ reexecute:
 
   error= execute(expanded_query, open_cursor) || thd->is_error();
 #ifdef WITH_WSREP
+  bool observer_popped= false;
   mysql_mutex_lock(&thd->LOCK_wsrep_thd);
   switch (thd->wsrep_conflict_state)
   {
@@ -4028,12 +4029,20 @@ reexecute:
     break;
 
   case MUST_REPLAY:
+    /* We don't need reprepare observer as the table will not be
+    open and locked when running in replay mode.
+    Replay mode will apply write-set directly there-by taking
+    a quicker and consistent path. */
+    thd->pop_reprepare_observer();
+    observer_popped= true;
     (void)wsrep_replay_transaction(thd);
+
   default: break;
   }
   mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
-#endif /* WITH_WSREP */
 
+  if (!observer_popped)
+#endif /* WITH_WSREP */
   thd->pop_reprepare_observer();
 
   if ((sql_command_flags[lex->sql_command] & CF_REEXECUTION_FRAGILE) &&


### PR DESCRIPTION
  Issue:

---

  Let me explain it with an example. Would be simpler.

  Let's assume there are 2 pxc nodes and each node and following
  workload is being

  node-1: executes already prepare stmt and about to commit
  (update i > 2 and i < 5)

  node-2: executes some stmt that would conflict with node-1 (insert (3))
  inserting in gap.

  As per the protocol local trx is selected for rollback and so
  when node-1 get node-2 trx which is applier trx node-1 local trx that
  is prepare stmt execution is rolled back and re-tried using replay trx.

  Note: retried using replay trx effectively means only write-set
  is applied this makes it bit faster.
  Application of write-set uses the apply-log-event path which
  open and locks table so there is no need to keep track of
  table versioning change which is normally done (in normal path)
  by installing a reprepare observer.

  Solution:

---
- Avoid installing observer when prepare trx is being replayed
  as trx will open and lock the tables.
