### PR TITLE
- #PXC-468: Some of the galera mtr suite tcs are failing intermittently

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -5225,7 +5225,7 @@ sub mysqld_arguments ($$$) {
   # to start unless we specify what user to run as, see BUG#30630
   my $euid= $>;
   if (!IS_WINDOWS and $euid == 0 and
-      (grep(/^--user/, @$extra_opts)) == 0) {
+      (grep(/^--user=/, @$extra_opts)) == 0) {
     mtr_add_arg($args, "--user=root");
   }
 

--- a/mysql-test/suite/galera/r/galera_flush_gtid.result
+++ b/mysql-test/suite/galera/r/galera_flush_gtid.result
@@ -45,3 +45,18 @@ UNLOCK TABLES;
 FLUSH TABLES t1;
 DROP TABLE t1;
 DROP TABLE t2;
+call mtr.add_suppression("WSREP: Trying to desync a node that is already paused");
+#node-1
+select @@wsrep_desync;
+@@wsrep_desync
+0
+set global wsrep_desync = 1;
+set global wsrep_desync = 0;
+flush table with read lock;
+set global wsrep_desync = 1;
+ERROR 42000: Variable 'wsrep_desync' can't be set to the value of 'ON'
+set global wsrep_desync = 0;
+ERROR 42000: Variable 'wsrep_desync' can't be set to the value of 'OFF'
+unlock tables;
+set global wsrep_desync = 1;
+set global wsrep_desync = 0;;

--- a/mysql-test/suite/galera/r/galera_kill_nochanges.result
+++ b/mysql-test/suite/galera/r/galera_kill_nochanges.result
@@ -1,5 +1,6 @@
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
+Killing server ...
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1

--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -1,10 +1,5 @@
 galera_wsrep_provider_unset_set : lp1379204 'Unsupported protocol downgrade: incremental data collection disabled. Expect abort.'
 pxc-421 : lp1379204 'Unsupported protocol downgrade: incremental data collection disabled. Expect abort.'
-galera_kill_nochanges : mysql-wsrep#24 Galera server does not restart properly if killed
 galera_bf_abort_for_update : mysql-wsrep#26 SELECT FOR UPDATE sometimes allowed to proceed in the face of a concurrent update
 galera_toi_ddl_fk_insert : qa#39 galera_toi_ddl_fk_insert fails sporadically
 galera_toi_ddl_online : fails randomly with "deadlock error" as sequence of action is causing an issue.
-galera_split_brain : fails with an assert on cent-os for while now. needs to be investigated.
-galera_flush_local : timeout failure
-galera_flush_gtid : timeout failure
-galera_admin : timeout failure

--- a/mysql-test/suite/galera/t/galera_admin.test
+++ b/mysql-test/suite/galera/t/galera_admin.test
@@ -31,7 +31,7 @@ ANALYZE TABLE t1, t2;
 --sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 180;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -45,7 +45,7 @@ OPTIMIZE TABLE t1, t2;
 --sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 180;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -59,7 +59,7 @@ REPAIR TABLE x1, x2;
 --sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 180;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -22,7 +22,7 @@ FLUSH DES_KEY_FILE;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -35,7 +35,7 @@ FLUSH HOSTS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -58,7 +58,7 @@ FLUSH QUERY CACHE;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -72,7 +72,7 @@ FLUSH STATUS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -85,7 +85,7 @@ FLUSH USER_RESOURCES;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -98,7 +98,7 @@ FLUSH TABLES;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -113,7 +113,7 @@ FLUSH TABLES t2;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -126,7 +126,7 @@ FLUSH ERROR LOGS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -138,7 +138,7 @@ FLUSH SLOW LOGS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -150,7 +150,7 @@ FLUSH GENERAL LOGS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -162,7 +162,7 @@ FLUSH ENGINE LOGS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -174,7 +174,7 @@ FLUSH RELAY LOGS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -189,7 +189,7 @@ FLUSH USER_STATISTICS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 4 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -201,7 +201,7 @@ FLUSH THREAD_STATISTICS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -214,7 +214,7 @@ FLUSH CHANGED_PAGE_BITMAPS;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -245,7 +245,7 @@ RESET QUERY CACHE;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -265,7 +265,7 @@ UNLOCK TABLES;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -281,7 +281,7 @@ UNLOCK TABLES;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log
@@ -290,7 +290,7 @@ FLUSH TABLES t1;
 --connection node_2
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
-let $wait_timeout= 90;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 --enable_query_log

--- a/mysql-test/suite/galera/t/galera_flush_local.test
+++ b/mysql-test/suite/galera/t/galera_flush_local.test
@@ -140,11 +140,11 @@ REPAIR TABLE x1, x2;
 
 --disable_query_log
 
-let $wait_timeout= 180;
+let $wait_timeout= 300;
 --let $wait_condition =  SELECT $wsrep_last_committed_after2 = $wsrep_last_committed_before2 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 
-let $wait_timeout= 180;
+let $wait_timeout= 300;
 --let $wait_condition = SELECT $wsrep_last_committed_after2 = $wsrep_last_committed_before + 9 AS wsrep_last_committed_diff2;
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/galera/t/galera_split_brain.test
+++ b/mysql-test/suite/galera/t/galera_split_brain.test
@@ -26,9 +26,10 @@ SET GLOBAL wsrep_cluster_address = '';
 --enable_query_log
 
 --source include/start_mysqld.inc
---sleep 5
+--sleep 10
 --source include/wait_until_connected_again.inc
 
+let $wait_timeout= 300;
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
 --source include/wait_condition.inc
 


### PR DESCRIPTION
Some of the galera mtr suite testcases are failing intermittently: galera_admin, galera_flush_local, galera_flush_gtid, galera_split_brain and galera_kill_nochanges.

In most cases, this is due to insufficient timeouts, which we need to increase in order to pass tests even when running in the virtual machine, and not only on the dedicated server.

In addition, we need to adjust the output file for galera_flush_gtid.test. It does not reflect the recent changes in the galera_flush.test (which is indirectly included from the galera_flush_gtid.test).

In addition, we need to change one regexp in the main mtr script (mysql-test-run.pl) to ensure that it did not consider all the options that begin with the word "user" as the "user=<name>" and do not forget to add "--user=root" when it is required.

We also need to add a forgotten line (with notification that the server was killed) to the galera_kill_nochange results file.

Then we need to remove the corrected tests from the list of disabled tests.

Jenkins build: http://jenkins.percona.com/job/pxc56.clone/1855/
