### PR TITLE
- #PXC-473: Error during cluster start shouldn't immediately zero-out grastate

### DIFF
--- a/mysql-test/suite/galera/r/galera_ist_try_again.result
+++ b/mysql-test/suite/galera/r/galera_ist_try_again.result
@@ -1,0 +1,43 @@
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+INSERT INTO t1 VALUES (1, 'a'), (2, 'a'), (3, 'a'), (4, 'a'), (5, 'a'),(6, 'a');
+Unloading wsrep provider ...
+SET GLOBAL wsrep_provider = 'none';
+UPDATE t1 SET f2 = 'b' WHERE f1 > 1;
+UPDATE t1 SET f2 = 'c' WHERE f1 > 2;
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_send_state_request';
+SET SESSION wsrep_sync_wait = 0;
+Loading wsrep_provider ...
+SHOW STATUS LIKE 'wsrep_debug_sync_waiters';
+Variable_name	Value
+wsrep_debug_sync_waiters	after_send_state_request
+UPDATE t1 SET f2 = 'd' WHERE f1 > 3;
+CREATE TABLE t2 (f1 INTEGER);
+UPDATE t1 SET f2 = 'e' WHERE f1 > 4;
+CREATE TABLE t3 (f1 INTEGER);
+Performing --wsrep-recover ...
+Starting server ...
+Using --wsrep-start-position when starting mysqld ...
+UPDATE t1 SET f2 = 'f' WHERE f1 > 5;
+SELECT * FROM t1;
+f1	f2
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+SELECT * FROM t1;
+f1	f2
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+SELECT COUNT(*) = 0 FROM t2;
+COUNT(*) = 0
+1
+SELECT COUNT(*) = 0 FROM t3;
+COUNT(*) = 0
+1
+DROP TABLE t1, t2, t3;

--- a/mysql-test/suite/galera/t/galera_flush_local.test
+++ b/mysql-test/suite/galera/t/galera_flush_local.test
@@ -140,11 +140,11 @@ REPAIR TABLE x1, x2;
 
 --disable_query_log
 
-let $wait_timeout= 300;
+let $wait_timeout= 600;
 --let $wait_condition =  SELECT $wsrep_last_committed_after2 = $wsrep_last_committed_before2 AS wsrep_last_committed_diff;
 --source include/wait_condition.inc
 
-let $wait_timeout= 300;
+let $wait_timeout= 600;
 --let $wait_condition = SELECT $wsrep_last_committed_after2 = $wsrep_last_committed_before + 9 AS wsrep_last_committed_diff2;
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/galera/t/galera_ist_try_again.cnf
+++ b/mysql-test/suite/galera/t/galera_ist_try_again.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'

--- a/mysql-test/suite/galera/t/galera_ist_try_again.test
+++ b/mysql-test/suite/galera/t/galera_ist_try_again.test
@@ -1,0 +1,147 @@
+#
+# Test that a joiner performing IST can be killed before first transaction
+# was applied and restarted with no adverse consequences. This is achieved
+# by using the 'after_send_state_request' Galera debug sync point to block
+# node after send state request. When node blocks, we kill and restart the
+# joiner.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+--source suite/galera/include/galera_have_debug_sync.inc
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+INSERT INTO t1 VALUES (1, 'a'), (2, 'a'), (3, 'a'), (4, 'a'), (5, 'a'),(6, 'a');
+
+# Disconnect node #2
+--connection node_2
+--source suite/galera/include/galera_unload_provider.inc
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer' warnings in the log file before and after testing.
+# To do this we need to save original log file before testing:
+#
+--let TEST_LOG=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   if (-e $test_log_copy) {
+      unlink $test_log_copy;
+   }
+EOF
+--copy_file $TEST_LOG $TEST_LOG.copy
+
+--connection node_1
+UPDATE t1 SET f2 = 'b' WHERE f1 > 1;
+
+# Wait until node #2 has left
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+UPDATE t1 SET f2 = 'c' WHERE f1 > 2;
+
+--connection node_2
+# Make sure IST will block ...
+--let $galera_sync_point = after_send_state_request
+--source include/galera_set_sync_point.inc
+
+SET SESSION wsrep_sync_wait = 0;
+
+# Write file to make mysql-test-run.pl expect the crash, but don't start it
+--let $_server_id= `SELECT @@server_id`
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
+--exec echo "wait" > $_expect_file_name
+
+--let KILL_NODE_PIDFILE = `SELECT @@pid_file`
+
+# ... and restart provider to force IST
+--echo Loading wsrep_provider ...
+--disable_query_log
+--eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
+--eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
+--enable_query_log
+
+# We can not use a wait_condition on SELECT * FROM INFORMATION_SCHEMA.GLOBAL_STATUS as such queries are blocked during IST
+# so we perform a simple sleep and SHOW instead
+
+--sleep 5
+SHOW STATUS LIKE 'wsrep_debug_sync_waiters';
+
+--connection node_1
+# Perform DML and DDL while IST is in progress
+--connection node_1
+UPDATE t1 SET f2 = 'd' WHERE f1 > 3;
+CREATE TABLE t2 (f1 INTEGER);
+
+# Kill node #2 while IST is in progress
+--connection node_2
+
+# Kill the connected server
+--disable_reconnect
+
+--perl
+	my $pid_filename = $ENV{'KILL_NODE_PIDFILE'};
+	my $mysqld_pid = `cat $pid_filename`;
+	chomp($mysqld_pid);
+	system("kill -9 $mysqld_pid");
+	exit(0);
+EOF
+
+--source include/wait_until_disconnected.inc
+
+--connection node_1
+--source include/wait_until_connected_again.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Perform DML and DDL while node #2 is down
+UPDATE t1 SET f2 = 'e' WHERE f1 > 4;
+CREATE TABLE t3 (f1 INTEGER);
+
+--connection node_2
+
+--let $galera_wsrep_recover_server_id=2
+--source suite/galera/include/galera_wsrep_recover.inc
+
+--echo Starting server ...
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_1
+UPDATE t1 SET f2 = 'f' WHERE f1 > 5;
+SELECT * FROM t1;
+
+--connection node_2
+SELECT * FROM t1;
+SELECT COUNT(*) = 0 FROM t2;
+SELECT COUNT(*) = 0 FROM t3;
+
+--connection node_1
+DROP TABLE t1, t2, t3;
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer' warnings in the log file during test phase - to print
+# the error message if quantity of such warnings in log file increased
+# at the end of the test:
+#
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   open(FILE, $test_log_copy) or die("Unable to open $test_log_copy: $!\n");
+   my $initial=grep(/\[Warning\] WSREP\: Failed to prepare for incremental state transfer/gi,<FILE>);
+   close(FILE);
+   open(FILE, $test_log) or die("Unable to open $test_log: $!\n");
+   my $count_warnings=grep(/\[Warning\] WSREP\: Failed to prepare for incremental state transfer/gi,<FILE>);
+   close(FILE);
+   if ($count_warnings != $initial) {
+      my $diff=$count_warnings-$initial;
+      print "Failed to prepare for incremental state transfer $diff times.\n";
+   }
+EOF
+--remove_file $TEST_LOG.copy

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -226,6 +226,8 @@ void wsrep_sst_grab ()
 // Wait for end of SST
 bool wsrep_sst_wait ()
 {
+  wsrep_seqno_t seqno;
+
   if (mysql_mutex_lock (&LOCK_wsrep_sst)) abort();
   while (!sst_complete)
   {
@@ -233,19 +235,26 @@ bool wsrep_sst_wait ()
     mysql_cond_wait (&COND_wsrep_sst, &LOCK_wsrep_sst);
   }
 
-  if (local_seqno >= 0)
+  // Save a local copy of a global variable prior to release
+  // of the mutex - to ensure that the return code from this
+  // function and a diagnostic message in the log will always
+  // be consistent with each other:
+
+  seqno = local_seqno;
+
+  mysql_mutex_unlock (&LOCK_wsrep_sst);
+
+  if (seqno >= 0)
   {
-    WSREP_INFO("SST complete, seqno: %lld", (long long) local_seqno);
+    WSREP_INFO("SST complete, seqno: %lld", (long long) seqno);
   }
   else
   {
     WSREP_ERROR("SST failed: %d (%s)",
-                int(-local_seqno), strerror(-local_seqno));
+                int(-seqno), strerror(-seqno));
   }
 
-  mysql_mutex_unlock (&LOCK_wsrep_sst);
-
-  return (local_seqno >= 0);
+  return (seqno >= 0);
 }
 
 // Signal end of SST


### PR DESCRIPTION
This patch contains three fixes, as they partially affect the same lines of code. All three are associated with the processing of errors during SST/IST, immediately after or before SST/IST. Two of them are described as PXC-473 and PXC-329, the third error is most evident after correcting the previous two, but it has been repeatedly observed as a side effect of other errors - its symptom is hanging of the thread that waits for completion of the SST, which occurs when changing state with S_JOINING any other.
# PART ONE (PXC-473)

In many cases, grastate.dat zeroed if we encounter an error at the node startup. For example, grastate.dat zeroed on misconfiguration in the my.cnf. As a result, we have to perform a full SST after the node restart, although we could only do IST.

This is because the function ReplicatorSMM::request_state_transfer() always marks the state as "unsafe" fearing that current state will be broken in the process of execution of the SST. Since one general function is responsible for the SST and IST, it happens even when the SST is not required or when the SST is trivial.

We must mark the state as the "unsafe" before SST because the current state may be changed during execution of the SST and it will no longer match the stored seqno (state becomes "unsafe" after the first modification of data during the SST, but unfortunately, we do not have callback or wsrep API to notify about the first data modification).

On the other hand, in cases where the full SST is not required and we want to use IST, we need to save the current state - to prevent unnecessary SST after node restart (if IST will be failed).

Therefore, to correct this error we need to check whether the full state transfer (SST) is required or not, before marking state as unsafe.
# PART TWO (PXC-329)

Even when node is evicted from the cluster in middle of SST, the SST may completes normally (and InnoDB starts). After this, the node calls the gcs_join function (from gcs/src/gcs.cpp) and tries to join the cluster. However, this is impossible, because the node is already evicted. Therefore, the _join() function (which called from gcs_join) fails. Then node does IST (which also fails), after/during which it is aborted.

To fix this, we should avoid joining the cluster through gcs_join if node is evicted. To do this, we should check the current connection state in the gcs_join() function to return from it immediately if the node's communication channel was closed.

And we should not do the IST when we left S_JOINING state (for example, if we have lost the connection to the network or we were evicted from the cluster).
# PART THREE

If SST is completed after the connection lost or when the state changed from the S_JOINING to some other, the ReplicatorSMM::request_state_transfer function hangs forever, because the associated ReplicatorSMM::sst_received function not calls the signal() for the sst_cond_ conditional variable. This is due to a premature return from the sst_received function in case of state change.

Ti fix this, we should to check the state only after we signalized about completion of the SST - otherwise the request_state_transfer() function will be infinitely wait on the sst_cond_ condition variable, for which no one will call the signal() function.

Related Galera pull request here: https://github.com/percona/galera/pull/47

Jenkins builds:
http://jenkins.percona.com/job/pxc56.clone.galera3.testgalera/4/ (Galera)
http://jenkins.percona.com/job/pxc56.clone/1879/ (PXC)
http://jenkins.percona.com/job/pxc56.test.mtr/188/ (mtr tests)
