### PR TITLE
Fix for centos7 systemd script for multiple same options occuring (#1490897)

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -9,9 +9,9 @@ parse_cnf()
     local def=$2
     shift
     local groups=$*
-    reval=$(my_print_defaults $groups | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2-)
+    reval=$(my_print_defaults $groups | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -n 1)
     if [[ -z ${reval:-} ]];then 
-        val=$(tr ' ' '\n' <<< "$env_args" | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2-)
+        val=$(tr ' ' '\n' <<< "$env_args" | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -n 1)
         if [[ -n ${val:-} ]];then
             reval=$val
         else 


### PR DESCRIPTION
BUG:
mysql-systemd start-post never returns when pid_file specified in multiple sections of the my.cnf
https://bugs.launchpad.net/percona-xtradb-cluster/+bug/1490897

Small change just to add a "tail -n 1" so that only the last option is used. We already have this in some other places.
