### PR TITLE
    PXC-507 - Trying to create slave thread end up in assert if

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_cluster_address.result
+++ b/mysql-test/suite/galera/r/galera_var_cluster_address.result
@@ -49,6 +49,20 @@ VARIABLE_VALUE = 'Primary'
 SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 VARIABLE_VALUE = 2
 1
+SET GLOBAL wsrep_cluster_address = 'gcomm://192.0.2.1';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_STATUS;
+SHOW STATUS LIKE 'wsrep_connected';
+Variable_name	Value
+wsrep_connected	OFF
+SET GLOBAL wsrep_slave_threads = 1 + 16;;
+SET GLOBAL wsrep_slave_threads = 1;;
+SET GLOBAL wsrep_cluster_address = @@wsrep_cluster_address;
+SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+VARIABLE_VALUE = 'Primary'
+1
+SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+VARIABLE_VALUE = 2
+1
 CALL mtr.add_suppression("Backend not supported: foo");
 CALL mtr.add_suppression("Failed to initialize backend using 'foo");
 CALL mtr.add_suppression("Failed to open channel 'my_wsrep_cluster' at 'foo");
@@ -61,3 +75,4 @@ CALL mtr.add_suppression("Failed to open channel 'my_wsrep_cluster' at 'gcomm://
 CALL mtr.add_suppression("gcs connect failed: Connection timed out");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(foo://\\) failed: 7");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(gcomm://192.0.2.1\\) failed: 7");
+CALL mtr.add_suppression("WSREP: Trying to launch slave threads before creating connection at 'gcomm://192.0.2.1'");

--- a/mysql-test/suite/galera/t/galera_var_cluster_address.test
+++ b/mysql-test/suite/galera/t/galera_var_cluster_address.test
@@ -99,6 +99,43 @@ SET GLOBAL wsrep_cluster_address = @@wsrep_cluster_address;
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 
+#
+# Set to an invalid host and change the number of slave threads
+#
+
+--connection node_1
+--let $wsrep_slave_threads = `SELECT @@wsrep_slave_threads`
+SET GLOBAL wsrep_cluster_address = 'gcomm://192.0.2.1';
+
+# This should work even with wsrep_ready OFF in PXC
+--disable_result_log
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_STATUS;
+--enable_result_log
+
+# Must return 'OFF'
+SHOW STATUS LIKE 'wsrep_connected';
+
+# Should see a warning message, but not a crash
+--eval SET GLOBAL wsrep_slave_threads = $wsrep_slave_threads + 16;
+
+#
+# Reset everything as it was
+#
+
+--connection node_1
+--eval SET GLOBAL wsrep_slave_threads = $wsrep_slave_threads;
+--disable_query_log
+--eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_node1';
+--enable_query_log
+
+--connection node_2
+SET GLOBAL wsrep_cluster_address = @@wsrep_cluster_address;
+--sleep 1
+
+--connection node_1
+SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+
 CALL mtr.add_suppression("Backend not supported: foo");
 CALL mtr.add_suppression("Failed to initialize backend using 'foo");
 CALL mtr.add_suppression("Failed to open channel 'my_wsrep_cluster' at 'foo");
@@ -111,4 +148,4 @@ CALL mtr.add_suppression("Failed to open channel 'my_wsrep_cluster' at 'gcomm://
 CALL mtr.add_suppression("gcs connect failed: Connection timed out");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(foo://\\) failed: 7");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(gcomm://192.0.2.1\\) failed: 7");
-
+CALL mtr.add_suppression("WSREP: Trying to launch slave threads before creating connection at 'gcomm://192.0.2.1'");

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -375,9 +375,8 @@ void wsrep_create_appliers(long threads)
     if (wsrep_cluster_address && strlen(wsrep_cluster_address) &&
         wsrep_provider && strcasecmp(wsrep_provider, "none"))
     {
-      WSREP_ERROR("Trying to launch slave threads before creating "
+      WSREP_WARN("Trying to launch slave threads before creating "
                   "connection at '%s'", wsrep_cluster_address);
-      assert(0);
     }
     return;
   }


### PR DESCRIPTION
PXC#507: Trying to create slave thread end up in assert if cluster address is INVALID.
## Issue:

Trying to create extra applier thread(s) with cluster address set to INVALID (wsrep_connected = false) result in an assert. While the scenario is valid as it doesn't make sense to create applier thread(s) with wsrep disconnected asserting and getting server down is bit too strict.
## Solution:

Raise a warning (vs error before) in such scenario and avoid creation of thread(s).
Expanded test-case to cover this test-scenario.
