### PR TITLE
Fix for PXC-518 : galera_admin test case fails occasionally

### DIFF
--- a/mysql-test/suite/galera/r/galera_admin.result
+++ b/mysql-test/suite/galera/r/galera_admin.result
@@ -9,16 +9,19 @@ INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 INSERT INTO x1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 INSERT INTO t2 (f2) SELECT 1 FROM t1 AS a1, t1 AS a2, t1 AS a3, t1 AS a4;
 INSERT INTO x2 (f2) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+# ANALYZE test
 ANALYZE TABLE t1, t2;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
 test.t2	analyze	status	OK
+# OPTIMIZE test
 OPTIMIZE TABLE t1, t2;
 Table	Op	Msg_type	Msg_text
 test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
 test.t1	optimize	status	OK
 test.t2	optimize	note	Table does not support optimize, doing recreate + analyze instead
 test.t2	optimize	status	OK
+# REPAIR test
 REPAIR TABLE x1, x2;
 Table	Op	Msg_type	Msg_text
 test.x1	repair	status	OK

--- a/mysql-test/suite/galera/t/galera_admin.test
+++ b/mysql-test/suite/galera/t/galera_admin.test
@@ -23,46 +23,55 @@ INSERT INTO x1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 INSERT INTO t2 (f2) SELECT 1 FROM t1 AS a1, t1 AS a2, t1 AS a3, t1 AS a4;
 INSERT INTO x2 (f2) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 
+# Wait until all the data from t2 has been replicated
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 10 FROM x1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 10 FROM x2;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 10000 FROM t2;
+--source include/wait_condition.inc
+
+
+--echo # ANALYZE test
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
 --connection node_1
 ANALYZE TABLE t1, t2;
+
 --connection node_2
---sleep 1
---let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
---disable_query_log
-let $wait_timeout= 300;
---let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
 --source include/wait_condition.inc
---enable_query_log
 
 
+
+--echo # OPTIMIZE test
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
 --connection node_1
 OPTIMIZE TABLE t1, t2;
+
 --connection node_2
---sleep 1
---let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
---disable_query_log
-let $wait_timeout= 300;
---let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
 --source include/wait_condition.inc
---enable_query_log
 
 
+
+--echo # REPAIR test
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
 --connection node_1
 REPAIR TABLE x1, x2;
+
 --connection node_2
---sleep 1
---let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
---disable_query_log
-let $wait_timeout= 300;
---let $wait_condition = SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 1 AS wsrep_last_committed_diff;
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
 --source include/wait_condition.inc
---enable_query_log
+
 
 
 --connection node_2


### PR DESCRIPTION
Issue:
These tests were unreliable and would fail occasionally.
We were not checking to see that the tables replicated before
starting the tests. Depending on the timing, we would see wsrep_last_committed
incremented by 1 or 2.

Solution:
Before starting the test proper, check that all tables have been replicated.
