### PR TITLE
PXC-523 : test case galera.mysql-wsrep#216 often fails on Jenkins

### DIFF
--- a/mysql-test/suite/galera/r/mysql-wsrep#216.result
+++ b/mysql-test/suite/galera/r/mysql-wsrep#216.result
@@ -2,9 +2,9 @@ SET GLOBAL wsrep_debug = ON;
 CREATE USER u1 IDENTIFIED BY 'plaintext_password';
 CREATE USER u1 IDENTIFIED BY 'plaintext_password';
 ERROR HY000: Operation CREATE USER failed for 'u1'@'%'
+DROP USER u1;
 0
 0
 4
 1
-DROP USER u1;
 CALL mtr.add_suppression('Operation CREATE USER failed');

--- a/mysql-test/suite/galera/t/mysql-wsrep#216.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#216.test
@@ -12,9 +12,20 @@ SET GLOBAL wsrep_debug = ON;
 
 CREATE USER u1 IDENTIFIED BY 'plaintext_password';
 
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE USER = 'u1';
+--source include/wait_condition.inc
+
+--connection node_1
 --error ER_CANNOT_USER
 CREATE USER u1 IDENTIFIED BY 'plaintext_password';
+DROP USER u1;
 
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.user WHERE USER = 'u1';
+--source include/wait_condition.inc
+
+--connection node_1
 # Check that the plaintext password does not appear in the logs
 --exec grep --count plaintext_password $MYSQLTEST_VARDIR/log/mysqld.1.err || true
 --exec grep --count plaintext_password $MYSQLTEST_VARDIR/log/mysqld.2.err || true
@@ -26,8 +37,6 @@ CREATE USER u1 IDENTIFIED BY 'plaintext_password';
 
 # Once for the second node, in the 'Slave SQL' error
 --exec grep --count 9CAB2BAE176801E82ABA9E55CCCDDBF388E0301D $MYSQLTEST_VARDIR/log/mysqld.2.err
-
-DROP USER u1;
 
 --disable_query_log
 --eval SET GLOBAL wsrep_debug = $wsrep_debug_orig


### PR DESCRIPTION
Issue:
There is a timing issue with how this test runs. The test looks at
the node_2 log, but due to timing that log may not have been created
yet.

Solution:
Modify the test so that we can check to see if node_2 has received
the data before checking its log.
