### PR TITLE
Fix PXC-524 : test case galera.galera_var_cluster_address should wait…

### DIFF
--- a/mysql-test/suite/galera/t/galera_var_cluster_address.test
+++ b/mysql-test/suite/galera/t/galera_var_cluster_address.test
@@ -53,7 +53,6 @@ SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VA
 
 --connection node_2
 SET GLOBAL wsrep_cluster_address = @@wsrep_cluster_address;
-
 --source include/wait_until_connected_again.inc
 
 --connection node_1
@@ -93,7 +92,7 @@ SHOW STATUS LIKE 'wsrep_local_state_comment';
 
 --connection node_2
 SET GLOBAL wsrep_cluster_address = @@wsrep_cluster_address;
---sleep 1
+--source include/wait_until_connected_again.inc
 
 --connection node_1
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
@@ -130,7 +129,7 @@ SHOW STATUS LIKE 'wsrep_connected';
 
 --connection node_2
 SET GLOBAL wsrep_cluster_address = @@wsrep_cluster_address;
---sleep 1
+--source include/wait_until_connected_again.inc
 
 --connection node_1
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';


### PR DESCRIPTION
… for cluster reconnect

Issue:
The test can sometimes fail on Jenkins.  The test will wait a second to reconnect
to the cluster, however this may not be enough time, especially on Jenkins.
This causes the test to occasionally fail on Jenkins while succeeding when
run locally.

Solution:
Change the sleep to an include/wait_until_connected_again.inc
