### PR TITLE
PXC-525 : galera_as_slave_nonprim fails due to wrong size in error me…

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
@@ -14,7 +14,7 @@ STOP SLAVE;
 RESET SLAVE ALL;
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown command' on query");
 CALL mtr.add_suppression("Slave: Unknown command Error_code: 1047");
-CALL mtr.add_suppression("Send action {\\(nil\\), 328, TORDERED} returned -107 \\(Transport endpoint is not connected\\)");
+CALL mtr.add_suppression("Send action {\\(nil\\), 323, TORDERED} returned -107 \\(Transport endpoint is not connected\\)");
 CALL mtr.add_suppression("Slave SQL: Error in Xid_log_event: Commit could not be completed, 'Deadlock found when trying to get lock; try restarting transaction', Error_code: 1213");
 CALL mtr.add_suppression("Slave SQL: Node has dropped from cluster, Error_code: 1047");
 RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
@@ -88,7 +88,7 @@ RESET SLAVE ALL;
 
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown command' on query");
 CALL mtr.add_suppression("Slave: Unknown command Error_code: 1047");
-CALL mtr.add_suppression("Send action {\\(nil\\), 328, TORDERED} returned -107 \\(Transport endpoint is not connected\\)");
+CALL mtr.add_suppression("Send action {\\(nil\\), 323, TORDERED} returned -107 \\(Transport endpoint is not connected\\)");
 CALL mtr.add_suppression("Slave SQL: Error in Xid_log_event: Commit could not be completed, 'Deadlock found when trying to get lock; try restarting transaction', Error_code: 1213");
 CALL mtr.add_suppression("Slave SQL: Node has dropped from cluster, Error_code: 1047");
 


### PR DESCRIPTION
…ssage

Issue:
Occasional test failure, this error messge is sent because another node
has shutdown (expected shutdown).  Due to the timing, we may get this
error message, thus the occasional test failure.

Solution:
Correct the expected error message. The parameter that changed is
the size of the message in bytes.
