### PR TITLE
PXC-522 : wsrep_last_committed race conditions in several test cases

### DIFF
--- a/mysql-test/suite/galera/t/galera_transaction_read_only.test
+++ b/mysql-test/suite/galera/t/galera_transaction_read_only.test
@@ -11,6 +11,9 @@
 CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
 --connection node_1
@@ -20,6 +23,7 @@ START TRANSACTION;
 COMMIT;
 
 --connection node_2
+--sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
@@ -36,6 +40,7 @@ SELECT COUNT(*) = 0 FROM t1;
 COMMIT;
 
 --connection node_2
+--sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
@@ -49,6 +54,7 @@ SELECT COUNT(*) = 0 FROM t1;
 COMMIT;
 
 --connection node_2
+--sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;

--- a/mysql-test/suite/galera/t/galera_var_load_data_splitting.test
+++ b/mysql-test/suite/galera/t/galera_var_load_data_splitting.test
@@ -16,6 +16,9 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 # Record wsrep_last_committed as it was before LOAD DATA
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
 SET GLOBAL wsrep_load_data_splitting = TRUE;

--- a/mysql-test/suite/galera/t/mysql-wsrep#31.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#31.test
@@ -8,6 +8,9 @@ INSERT INTO t1 VALUES('test');
 CREATE DATABASE db;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'db';
+--source include/wait_condition.inc
+
 --let $expected_position_uuid = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_state_uuid'`
 --let $expected_position_seqno = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 


### PR DESCRIPTION
Issue:
These test cases were unreliable (occasionally failing) due to timing
issues when retreiving the value of wsrep_last_committed.

Solution:
Make sure the tests wait (if possible) for changes to be replicated
to the nodes before getting the value of wsrep_last_committed.
In some cases, this is not possible, since there is no change in value,
in those cases a sleep was added.
