### PR TITLE
- #PXC-502: Silent abort (crash) at gcs/src/gcs_core.cpp:1152

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5302,12 +5302,18 @@ a file name for --log-bin-index option", opt_binlog_index_name);
     else // full wsrep initialization
     {
       // add basedir/bin to PATH to resolve wsrep script names
-      char* const tmp_path((char*)alloca(strlen(mysql_home) +
-                                           strlen("/bin") + 1));
+      int mysql_home_len= strlen(mysql_home);
+      char* const tmp_path((char*)alloca(mysql_home_len +
+                                         strlen("/bin") + 1));
       if (tmp_path)
       {
         strcpy(tmp_path, mysql_home);
-        strcat(tmp_path, "/bin");
+        /*
+          mysql_home may already contain a trailing slash:
+        */
+        strcat(tmp_path, (mysql_home_len == 0 ||
+                          mysql_home[mysql_home_len - 1] != '/') ? "/bin" :
+                                                                    "bin");
         wsrep_prepend_PATH(tmp_path);
       }
       else


### PR DESCRIPTION
The new node cannot join the cluster when the user reserves a very large amount of memory for the work buffers, for example, if she/he reserves 18GB for InnoDB buffer pool. In today's world, this is no surprise, but it is still a very large buffer. Because of this the user later receives "insufficient memory" (ENOMEM) error when calling fork() - when another node is trying to join the cluster and has requested the SST from this node. We do not need a lot of memory for SST, but the fork() function failed because the operating system tends to reserve in advance the such amount of memory that may be changed in future - after the fork() call (even if it uses copy-on-write semantics for memory operations).

The actual memory copying does not happen, but the operating system allocates memory pages in advance - because it fears that the whole memory of the process can be changed and all pages will be copied. It depends on the settings of the operating system and is especially important when swapping is off. Details here: https://www.kernel.org/doc/Documentation/vm/overcommit-accounting

Therefore on many configurations (especially when swapping is off) we cannot make a fork() if the amount of free memory is less than the amount of memory used by our process. And, in any case, when we run xtrabackup or mysqldump during the SST, a fork() function does a huge amount of unnecessary work related to bifurcation of the address space, which in a few microseconds is eliminated with the help of execvpe().

We can solve this issue (and win the performance) if we use posix_spawn[p] function instead of fork(). In addition, it will significantly increase the performance when we run SST in PXC on a heavily loaded system.

This patch replaces the creation of a new process (eg, SST) via fork() to creation of exactly the same process through posix_spawnp(), on all the systems where we have this feature.

Jenkins build: http://jenkins.percona.com/job/pxc56.clone/1896/
