### PR TITLE
use minherit(INHERIT_NONE) on FreeBSD to speed up process spawning for Galera SST

### DIFF
--- a/storage/innobase/os/os0proc.cc
+++ b/storage/innobase/os/os0proc.cc
@@ -182,15 +182,22 @@ skip:
 	}
 #endif
 
-#if defined(WITH_WSREP) && defined(UNIV_LINUX)
+#if defined(WITH_WSREP)
 	/* Do not make the pages from this block available to the child after a
-	fork(). This is required to speed up process spawning for Galera SST. */
-
+	 fork(). This is required to speed up process spawning for Galera SST. */
+# if defined(UNIV_LINUX)
 	if (madvise(ptr, size, MADV_DONTFORK)) {
 		fprintf(stderr, "InnoDB: Warning: madvise(MADV_DONTFORK) is "
 			"not supported by the kernel. Spawning SST processes "
 			"can be slow.\n");
 	}
+# elif defined(__FreeBSD__)
+	if (minherit(ptr, size, INHERIT_NONE)) {
+		fprintf(stderr, "InnoDB: Warning: minherit(INHERIT_NONE) is "
+				"not supported by the kernel. Spawning SST processes "
+				"can be slow.\n");
+	}
+# endif
 #endif
 	return(ptr);
 }


### PR DESCRIPTION
On Linux, the buffer pool is marked as `MADV_DONTFORK` to speed up Galera's usage of fork(). On FreeBSD, `MADV_DONTFORK` doesn't exists, so we should use the equivalent `minherit(ptr, size, INHERIT_NONE)`.

This fixes an issue on FreeBSD where forking() for SST by a donor can take a long time (up to 30s) and stop the donor from responding to keepalives with a sufficiently big buffer pool size. The cluster could get partitioned and stop responding while the IST was running or the IST could fail. By ensuring that the buffer pools are not forked() along, fork() is no longer slow and the donor stays reachable.

A similar pull request has been sent to codership/galera, for the gu_cache, which is marked as `MADV_DONTFORK` on Linux as well.
