### PR TITLE
    Fix PXC-529 : Tests fail on Centos7 with "[Warning] Hostname 'XXX…

### DIFF
--- a/mysql-test/suite/galera/include/galera_sst_restore.inc
+++ b/mysql-test/suite/galera/include/galera_sst_restore.inc
@@ -22,6 +22,7 @@ CALL mtr.add_suppression("Can't open and lock time zone table");
 CALL mtr.add_suppression("Can't open and lock privilege tables");
 CALL mtr.add_suppression("Info table is not ready to be used");
 CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");
 
 --disable_query_log
 --eval SET GLOBAL wsrep_sst_method = '$wsrep_sst_method_orig';

--- a/mysql-test/suite/galera/r/galera_ist_mysqldump.result
+++ b/mysql-test/suite/galera/r/galera_ist_mysqldump.result
@@ -282,3 +282,4 @@ CALL mtr.add_suppression("Can't open and lock time zone table");
 CALL mtr.add_suppression("Can't open and lock privilege tables");
 CALL mtr.add_suppression("Info table is not ready to be used");
 CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");

--- a/mysql-test/suite/galera/r/galera_migrate.result
+++ b/mysql-test/suite/galera/r/galera_migrate.result
@@ -77,3 +77,4 @@ SET GLOBAL wsrep_sst_receive_address = 'AUTO';
 DROP TABLE t1;
 DROP USER sst;
 CALL mtr.add_suppression("InnoDB: Error: Table \"mysql\"\\.\"innodb_index_stats\" not found");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");

--- a/mysql-test/suite/galera/r/galera_sst_mysqldump.result
+++ b/mysql-test/suite/galera/r/galera_sst_mysqldump.result
@@ -457,3 +457,4 @@ CALL mtr.add_suppression("Can't open and lock time zone table");
 CALL mtr.add_suppression("Can't open and lock privilege tables");
 CALL mtr.add_suppression("Info table is not ready to be used");
 CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");

--- a/mysql-test/suite/galera/r/galera_sst_mysqldump_with_key.result
+++ b/mysql-test/suite/galera/r/galera_sst_mysqldump_with_key.result
@@ -103,6 +103,7 @@ CALL mtr.add_suppression("Can't open and lock time zone table");
 CALL mtr.add_suppression("Can't open and lock privilege tables");
 CALL mtr.add_suppression("Info table is not ready to be used");
 CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");
 DROP USER sslsst;
 SET GLOBAL general_log = ON;
 SET GLOBAL slow_query_log = ON;

--- a/mysql-test/suite/galera/r/mysql-wsrep#33.result
+++ b/mysql-test/suite/galera/r/mysql-wsrep#33.result
@@ -99,5 +99,6 @@ CALL mtr.add_suppression("Can't open and lock time zone table");
 CALL mtr.add_suppression("Can't open and lock privilege tables");
 CALL mtr.add_suppression("Info table is not ready to be used");
 CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");
 SET GLOBAL general_log = ON;
 SET GLOBAL slow_query_log = ON;

--- a/mysql-test/suite/galera/t/galera_migrate.test
+++ b/mysql-test/suite/galera/t/galera_migrate.test
@@ -203,3 +203,4 @@ DROP TABLE t1;
 DROP USER sst;
 
 CALL mtr.add_suppression("InnoDB: Error: Table \"mysql\"\\.\"innodb_index_stats\" not found");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");


### PR DESCRIPTION
…' does not resolve to '127.0.0.2'

```
Issue:
Some tests are failing on Centos7 due to this warning message popping up:
"[Warning] Hostname 'XXX' does not resolve to '127.0.0.2'"

tests involved: galera.galera_ist_mysqldump, galera.galera_migrate,
galera.galera_sst_mysqldump, galera.galera_sst_mysqldump_with_key,
galera.mysql-wsrep#33

Solution:
Suppress this warning message for these tests.
```
