### PR TITLE
PXC-509 : wsrep_node_name not defaulting to computer's node name

### DIFF
--- a/mysql-test/include/galera_actual_node_name.inc
+++ b/mysql-test/include/galera_actual_node_name.inc
@@ -1,0 +1,16 @@
+#
+# Gets the node name for the server
+# This will return the variable in $galera_actual_node_name
+#
+-- echo # Extracting server node name
+--perl
+	use_strict;
+		my $galera_actual_node_name = `uname -n`;
+		chomp($galera_actual_node_name);
+
+	open(FILE, ">", "$ENV{MYSQL_TMP_DIR}/galera_actual_node_name.inc") or die;
+		print FILE "--let \$galera_actual_node_name = $galera_actual_node_name\n";
+		close FILE;
+EOF
+--source $MYSQL_TMP_DIR/galera_actual_node_name.inc
+--remove_file $MYSQL_TMP_DIR/galera_actual_node_name.inc

--- a/mysql-test/suite/galera/r/galera_var_node_address.result
+++ b/mysql-test/suite/galera/r/galera_var_node_address.result
@@ -1,9 +1,18 @@
-SELECT VARIABLE_VALUE = 4 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-VARIABLE_VALUE = 4
-1
 CREATE TABLE t1 (f1 INTEGER);
 INSERT INTO t1 VALUES (1);
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
 DROP TABLE t1;
+# Extracting server node name
+# connection node_1
+node_name_check
+1
+# connection node_2
+SELECT @@global.wsrep_node_name = '';
+@@global.wsrep_node_name = ''
+1
+# connection node_3
+SELECT @@global.wsrep_node_name = 'my_host_3';
+@@global.wsrep_node_name = 'my_host_3'
+1

--- a/mysql-test/suite/galera/t/galera_var_node_address.cnf
+++ b/mysql-test/suite/galera/t/galera_var_node_address.cnf
@@ -2,9 +2,11 @@
 
 [mysqld.2]
 wsrep_node_address=127.0.0.1
+wsrep_node_name=
 
 [mysqld.3]
 wsrep_node_address=localhost
+wsrep_node_name=my_host_3
 
 [mysqld.4]
 wsrep_node_address=lo

--- a/mysql-test/suite/galera/t/galera_var_node_address.test
+++ b/mysql-test/suite/galera/t/galera_var_node_address.test
@@ -2,11 +2,16 @@
 # Test wsrep_node_address . The galera_var_node_address.cnf contains various settings for
 # wsrep_node_address, so in this test we simply confirm that the cluster has started up correctly.
 #
+# This will also test the configuration behavior of wsrep_node_name:
+# 	Node 1: wsrep_node_name not specified, using default
+#	Node 2: In .cnf, wsrep_node_name = ''
+#	Node 3: In .cnf, wsrep_node_name = 'my_host_3'
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
-SELECT VARIABLE_VALUE = 4 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--let $wait_condition = SELECT VARIABLE_VALUE = 4 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
 
 --connection node_1
 CREATE TABLE t1 (f1 INTEGER);
@@ -20,3 +25,24 @@ SELECT COUNT(*) = 1 FROM t1;
 
 --connection node_1
 DROP TABLE t1;
+
+# Test the wsrep_node_name behavior
+--source include/galera_actual_node_name.inc
+
+#
+# Test that the node names were picked up from the configuration file
+#
+--connection node_1
+--echo # connection node_1
+--disable_query_log
+--eval SELECT @@global.wsrep_node_name = '$galera_actual_node_name' AS node_name_check;
+--enable_query_log
+
+--connection node_2
+--echo # connection node_2
+SELECT @@global.wsrep_node_name = '';
+
+--connection node_3
+--echo # connection node_3
+SELECT @@global.wsrep_node_name = 'my_host_3';
+

--- a/mysql-test/suite/sys_vars/r/wsrep_node_name_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_node_name_basic.result
@@ -2,12 +2,12 @@
 # wsrep_node_name
 #
 call mtr.add_suppression("WSREP: Failed to get provider options");
+# Extracting server node name
 # save the initial value
 SET @wsrep_node_name_global_saved = @@global.wsrep_node_name;
-# default
-SELECT @@global.wsrep_node_name;
-@@global.wsrep_node_name
-
+# check for proper default
+node_name_check
+1
 
 # scope
 SELECT @@session.wsrep_node_name;
@@ -26,7 +26,7 @@ SET @@global.wsrep_node_name='hyphenated-node-name';
 SELECT @@global.wsrep_node_name;
 @@global.wsrep_node_name
 hyphenated-node-name
-SET @@global.wsrep_node_name=default;
+SET @@global.wsrep_node_name='';
 SELECT @@global.wsrep_node_name;
 @@global.wsrep_node_name
 

--- a/mysql-test/suite/sys_vars/t/wsrep_node_name_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_node_name_basic.test
@@ -6,11 +6,16 @@
 
 call mtr.add_suppression("WSREP: Failed to get provider options");
 
+# Find the actual server node name
+--source include/galera_actual_node_name.inc
+
 --echo # save the initial value
 SET @wsrep_node_name_global_saved = @@global.wsrep_node_name;
 
---echo # default
-SELECT @@global.wsrep_node_name;
+--echo # check for proper default
+--disable_query_log
+--eval SELECT @@global.wsrep_node_name = '$galera_actual_node_name' AS 'node_name_check';
+--enable_query_log
 
 --echo
 --echo # scope
@@ -25,7 +30,7 @@ SET @@global.wsrep_node_name='my_node';
 SELECT @@global.wsrep_node_name;
 SET @@global.wsrep_node_name='hyphenated-node-name';
 SELECT @@global.wsrep_node_name;
-SET @@global.wsrep_node_name=default;
+SET @@global.wsrep_node_name='';
 SELECT @@global.wsrep_node_name;
 
 --echo

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4856,7 +4856,7 @@ static Sys_var_charptr Sys_wsrep_cluster_address (
 static Sys_var_charptr Sys_wsrep_node_name (
        "wsrep_node_name", "Node name",
        PREALLOCATED GLOBAL_VAR(wsrep_node_name), CMD_LINE(REQUIRED_ARG),
-       IN_FS_CHARSET, DEFAULT(""),
+       IN_FS_CHARSET, DEFAULT(0),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(wsrep_node_name_check),
        ON_UPDATE(wsrep_node_name_update));


### PR DESCRIPTION
Issue: The system does not pick up the computer's node to use as
a default for WSREP_NODE_NAME (which it should according to the
documentation).

Solution:
The system is already trying to get the local node name, however
the value is getting overwritten when initialization the variables.
Change the settings for wsrep_node_name so that the default value
is not overwritten.
