### PR TITLE
- #PXC-541: WSREP_SST_AUTH_ENV variable is not transmitted into SST scripts after PXC-502

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -466,18 +466,10 @@ static void* sst_joiner_thread (void* a)
         // Print error message if SST is not cancelled:
         if (!sst_cancelled)
         {
-          if (tmp)
-          {
-             WSREP_ERROR("Failed to read '%s <addr>' from: %s\n\tRead: '%s'",
-                         magic, arg->cmd, tmp);
-          }
-          else
-          {
-            // Null-pointer is not valid argument for %s formatting (even
-            // though it is supported by many compilers):
-            WSREP_ERROR("Failed to read '%s <addr>' from: %s\n\tRead: '(null)'",
-                        magic, arg->cmd);
-          }
+          // Null-pointer is not valid argument for %s formatting (even
+          // though it is supported by many compilers):
+           WSREP_ERROR("Failed to read '%s <addr>' from: %s\n\tRead: '%s'",
+                       magic, arg->cmd, tmp ? tmp : "(null)");
         }
         // Clear the pointer to SST process:
         sst_process = NULL;
@@ -562,13 +554,6 @@ static void* sst_joiner_thread (void* a)
 
 static int sst_append_auth_env(wsp::env& env, const char* sst_auth)
 {
-#ifndef HAVE_EXECVPE
-  if (setenv(WSREP_SST_AUTH_ENV, sst_auth ? sst_auth : "", 1)) 
-  {
-      return -errno;
-  }
-  return 0;
-#else
   int const sst_auth_size= strlen(WSREP_SST_AUTH_ENV) + 1 /* = */
     + (sst_auth ? strlen(sst_auth) : 0) + 1 /* \0 */;
 
@@ -586,7 +571,6 @@ static int sst_append_auth_env(wsp::env& env, const char* sst_auth)
 
   env.append(sst_auth_str());
   return -env.error();
-#endif
 }
 
 static ssize_t sst_prepare_other (const char*  method,
@@ -1152,7 +1136,6 @@ wait_signal:
     mysql_mutex_unlock (&LOCK_wsrep_sst);
 
 skip_clear_pointer:
-    sst_process = NULL;
     if (!err && proc.error()) err= proc.error();
   }
   else


### PR DESCRIPTION
The code in sst_append_auth_env() and in the sst_prepare_other() functions violates the principle of the "black box". These functions know how the implementation of wsp::process() works and they transmit parameters for this implementation implicitly, through the environment of the parent process. But they continue to pass the cloned environment (without WSREP_SST_AUTH_ENV variable) to wsp::process() via explicit parameter – relying on the fact that the implementation of this function will ignore this parameter and the cloned environment will not be transferred to the child process. But they do so only for very old versions of Linux that do not have the execvpe() call (glibc prior to 2.11). Therefore, the PXC-502 patch works well on all systems except very old versions of Linux - we found this bug only on CentOS 5.

To correct this flaw, I removed implicit parameter passing from the wsrep_sst.cс code, and added emulation of execvpe() (made on the basis of the implementation of execvpe in glibc) to the code, which does not use posix_spawn().

I also made a small improvement in the treatment of errors in the new implementation of the wsp::process() function, which allow to avoid a small memory leak if SST failed. It is not essential for the current implementation, because SST failure stops node working, but it makes the code more clean.

Jenkins build: http://jenkins.percona.com/job/pxc56.test.mtr.mini/17/
