### PR TITLE
Relax innobackup logs removal to not fail an SST

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -981,9 +981,7 @@ then
         fi
 
         MAGIC_FILE="${TDATA}/${INFO_FILE}"
-        set +e
-        rm $TDATA/innobackup.prepare.log $TDATA/innobackup.move.log
-        set -e
+        rm -f {$TDATA,$DATA}/innobackup.prepare.log {$TDATA,$DATA}/innobackup.move.log
         wsrep_log_info "Moving the backup to ${TDATA}"
         timeit "Xtrabackup move stage" "$INNOMOVE"
         if [[ $? -eq 0 ]];then 


### PR DESCRIPTION
There is a misuse of DATA/TDATA paths for
innobackup.prepare.log and innobackup.move.log, which
may fail an SST.

Make those to be removed from both paths and do not
fail.

Related-bug: bug/1573159

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com
