### PR TITLE
- PXC#547: Cannot set wsrep_desync to OFF dynamically when set in my.cnf

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_desync_wsrep_on.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_desync_wsrep_on.result
@@ -31,3 +31,11 @@ INSERT INTO t1 (f1) VALUES (100);
 ERROR 23000: Duplicate entry '100' for key 'PRIMARY'
 DROP TABLE t1;
 DROP TABLE ten;
+call mtr.add_suppression("Can't desync a node even before it is synced with cluster");
+call mtr.add_suppression("Aborting");
+#node-2
+"Shutdown node-2 gracefully"
+"Restart with wsrep_desync=1"
+"Restart with default options"
+"grep --count "Can't desync a node even before it is synced with cluster""
+1

--- a/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
@@ -55,3 +55,36 @@ INSERT INTO t1 (f1) VALUES (100);
 
 DROP TABLE t1;
 DROP TABLE ten;
+
+#
+# Try to set the wsrep_desync=1 as part of initial configuration.
+# Server should refuse to start.
+#
+
+--connection node_2
+
+call mtr.add_suppression("Can't desync a node even before it is synced with cluster");
+call mtr.add_suppression("Aborting");
+
+--echo #node-2
+--echo "Shutdown node-2 gracefully"
+--source include/shutdown_mysqld.inc
+
+--echo "Restart with wsrep_desync=1"
+--let $start_mysqld_params="--wsrep_desync=1"
+--enable_reconnect
+--exec echo "restart:$start_mysqld_params" > $_expect_file_name
+--disable_reconnect
+# Wait for node failure
+--source include/wait_until_disconnected.inc
+
+--echo "Restart with default options"
+--let $start_mysqld_params=
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--echo "grep --count \"Can't desync a node even before it is synced with cluster\""
+--exec grep --count "Can't desync a node even before it is synced with cluster" $MYSQLTEST_VARDIR/log/mysqld.2.err
+

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5185,6 +5185,14 @@ static int init_server_components()
     unireg_abort(1);
   }
 
+#ifdef WITH_WSREP
+  if (WSREP_ON && wsrep_desync)
+  {
+    sql_print_error("Can't desync a node even before it is synced with cluster");
+    unireg_abort(1);
+  }
+#endif /* WITH_WSREP */
+
   /*
     initialize delegates for extension observers, errors have already
     been reported in the function


### PR DESCRIPTION
  Issue:

---
- wsrep_desync is used to indicate that node will not participate in
  flow control decision of the cluster.
- Setting it to ON will disable node participation in flow control.
  It can be toggled back to OFF.
  
  This action of desync can be done manually or even internally
  as part of RSU or SST.
- It being a configuration variable what if user try to set this
  as part of initial configuration (in my.cnf).
  It suggest user is requesting node to be desync even before it is
  synced with cluster which logically doesn't make any sense.
  
  With that background all such use-case should be blocked.
  ## Solution:
- Emit error if wsrep_desync is set during server initialization.
  User is free to desync a node after it has been successfully
  synced with the cluster.
  
  Node doesn't participate in flow control during initialization
  when it act as JOINER to recieve the state from DONOR.
