### PR TITLE
Fix PXC-552 : mysql-wsrep#198 test case timing issue, fails on slower…

### DIFF
--- a/mysql-test/suite/galera/t/mysql-wsrep#198.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#198.test
@@ -6,6 +6,8 @@ CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 CREATE TABLE t2 (id INT PRIMARY KEY) ENGINE=InnoDB;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
 LOCK TABLE t2 WRITE;
 
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2


### PR DESCRIPTION
… nodes

Issue:
This test case will fail occasionally because the "CREATE TABLE t2" operation
will not have propagated to node 2 before the "LOCK TABLE t2".

Solution:
Have node 2 wait for the create table to propagate before continuing
with the test.
