### PR TITLE
Fix PXC-556 : Restarting a cluster with innodb_page_size=4096 segfaults

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1350,9 +1350,17 @@ innodb_page_size_validate(
 /*======================*/
 	ulong	page_size)		/*!< in: Page Size to evaluate */
 {
-	ulong		n;
-
 	DBUG_ENTER("innodb_page_size_validate");
+
+#ifdef WITH_WSREP
+	/* With a 4K page_size, Galera triggers an assert upon restart.
+	 * Until that gets resolved, require using the default page size (16K).
+	*/
+	if (page_size == UNIV_PAGE_SIZE_ORIG) {
+		DBUG_RETURN(UNIV_PAGE_SIZE_SHIFT_ORIG);
+	}
+#else
+	ulong		n;
 
 	for (n = UNIV_PAGE_SIZE_SHIFT_MIN;
 	     n <= UNIV_PAGE_SIZE_SHIFT_MAX;
@@ -1361,7 +1369,7 @@ innodb_page_size_validate(
 			DBUG_RETURN(n);
 		}
 	}
-
+#endif /* WITH_WSREP */
 	DBUG_RETURN(0);
 }
 


### PR DESCRIPTION
Issue:
Using an innodb_page_size=4096 causes an assert, requires a start-stop-start
cycle.

Solution:
Galera takes a part of the page, if the size is too small then this will
start to overlap with some of the innodb structures.  For now, require
that we only use the 16K page size.
