### PR TITLE
- #PXC-501: galera_split_brain TC failing with following assertion intermittently

### DIFF
--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -3,4 +3,3 @@ pxc-421 : lp1379204 'Unsupported protocol downgrade: incremental data collection
 galera_bf_abort_for_update : mysql-wsrep#26 SELECT FOR UPDATE sometimes allowed to proceed in the face of a concurrent update
 galera_toi_ddl_fk_insert : qa#39 galera_toi_ddl_fk_insert fails sporadically
 galera_toi_ddl_online : fails randomly with "deadlock error" as sequence of action is causing an issue.
-galera_split_brain : fails quite often. bug logged to investigate the failure.


### PR DESCRIPTION
galera_split_brain TC failing with assertion intermittently in the function KeyPart::matches (), which compares the two keys, because one of those keys is empty (the field "version" in this key contains the value "EMPTY").

The key to a locally created transaction may be empty until it is completed, but the current code does not allow this and trying looking for a key in the certification index. However, technically this key would fit to all the elements of the certification index. Therefore, the key comparison function in the KeyPart class has assertion to detect such incorrect comparisons, which leads to the PXC-501 error. However, the fact of the empty key cannot be inserted in the certification index; therefore, we can just skip it immediately.

Related Galera patch here: https://github.com/percona/galera/pull/51
