### PR TITLE
Added a my_setwd for snapshot based SST

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5362,6 +5362,13 @@ a file name for --log-bin-index option", opt_binlog_index_name);
       }
     }
   }
+
+  /* 
+   * Forcing a new setwd in case the SST mounted the datadir
+   */
+  if (my_setwd(mysql_real_data_home,MYF(MY_WME)) && !opt_help)
+    unireg_abort(1);        /* purecov: inspected */
+
   if (opt_bin_log)
   {
     /*


### PR DESCRIPTION
Added a my_setwd after the call to allow sst by snapshots to work properly, forcing mysql to cd to the new mounted device after the sst and not stay on the underlying mount point
