### PR TITLE
- PXC#588: Avoid changing wsrep_provider when node is paused and/or d…

### DIFF
--- a/mysql-test/suite/galera/r/galera_flush.result
+++ b/mysql-test/suite/galera/r/galera_flush.result
@@ -66,3 +66,15 @@ SELECT * FROM t1;
 f1
 100
 DROP TABLE t1;
+#node-1
+call mtr.add_suppression("WSREP: Cannot modify wsrep_provider while node is paused or desynced");
+CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
+FLUSH TABLE t1 WITH READ LOCK;
+SET GLOBAL wsrep_provider=none;
+ERROR 42000: Variable 'wsrep_provider' can't be set to the value of 'none'
+UNLOCK TABLES;
+FLUSH TABLE WITH READ LOCK;
+SET GLOBAL wsrep_provider=none;
+ERROR 42000: Variable 'wsrep_provider' can't be set to the value of 'none'
+UNLOCK TABLES;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -312,3 +312,26 @@ UNLOCK TABLES;
 --sleep 4
 SELECT * FROM t1;
 DROP TABLE t1;
+
+
+#-------------------------------------------------------------------------------
+#
+# Trying to set a provider when node is paused
+#
+--connection node_1
+--echo #node-1
+call mtr.add_suppression("WSREP: Cannot modify wsrep_provider while node is paused or desynced");
+#
+CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
+# pause node
+FLUSH TABLE t1 WITH READ LOCK;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_provider=none;
+UNLOCK TABLES;
+# pause and desync node
+FLUSH TABLE WITH READ LOCK;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_provider=none;
+UNLOCK TABLES;
+#
+DROP TABLE t1;

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -1057,14 +1057,16 @@ void Global_read_lock::unlock_global_read_lock(THD *thd)
     {
       /* If this is sst_donor then it is resync internally.
       So only resume the cluster. */
-      wsrep_resume();
+      if (provider_paused)
+        wsrep_resume();
     }
     else if (WSREP(thd))
     {
       /* Function will take care of decrementing reference count
       if it is not the last one to get called. Last one will
       perform the resume action. */
-      wsrep_resume();
+      if (provider_paused)
+        wsrep_resume();
 
       int ret = wsrep->resync(wsrep);
       if (ret != WSREP_OK)
@@ -1175,6 +1177,7 @@ bool Global_read_lock::wsrep_pause()
   Just increment the count. */
   if (wsrep_pause_count > 0)
   {
+     provider_paused= true;
      ++wsrep_pause_count;
      mysql_mutex_unlock(&LOCK_wsrep_pause_count);
      return(TRUE);
@@ -1198,6 +1201,7 @@ bool Global_read_lock::wsrep_pause()
     return FALSE;
   }
 
+  provider_paused= true;
   mysql_mutex_unlock(&LOCK_wsrep_pause_count);
   return TRUE;
 }
@@ -1217,6 +1221,7 @@ wsrep_status_t Global_read_lock::wsrep_resume(bool ignore_if_resumed)
 
   if (ignore_if_resumed && wsrep_pause_count == 0)
   {
+    provider_paused= false;
     mysql_mutex_unlock(&LOCK_wsrep_pause_count);
     return ret;
   }
@@ -1231,13 +1236,13 @@ wsrep_status_t Global_read_lock::wsrep_resume(bool ignore_if_resumed)
       WSREP_WARN("Failed to resume provider: %d", ret);
   }
 
+  provider_paused= false;
   mysql_mutex_unlock(&LOCK_wsrep_pause_count);
   return ret;
 }
 
 bool Global_read_lock::wsrep_pause_once()
 {
-    provider_paused= true;
     return wsrep_pause();
 }
 
@@ -1245,7 +1250,6 @@ wsrep_status_t Global_read_lock::wsrep_resume_once(void)
 {
   if (provider_paused)
   {
-    provider_paused= false;
     return wsrep_resume(true);
   }
   return WSREP_OK;

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -256,6 +256,24 @@ static int wsrep_provider_verify (const char* provider_str)
 @return false if no error encountered with check else return true. */
 bool wsrep_provider_check (sys_var *self, THD* thd, set_var* var)
 {
+  mysql_mutex_lock(&LOCK_wsrep_pause_count);
+  bool node_paused = (wsrep_pause_count == 0) ? false : true;
+  bool desycned = !wsrep_node_is_synced();
+  mysql_mutex_unlock(&LOCK_wsrep_pause_count);
+
+  if (node_paused || desycned)
+  {
+     /* If node is paused or desycned this means node is up-to-data.
+    Pause node hasn't applied all the write-set and desycned node
+     may have sent flow control. Avoid changing wsrep_provider
+     in such critical conditions. */
+     WSREP_WARN("Cannot modify wsrep_provider while node is paused"
+                " or desynced.");
+    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), var->var->name.str,
+             var->save_result.string_value.str);
+    return true;
+  }
+
   char wsrep_provider_buf[FN_REFLEN];
 
   if ((! var->save_result.string_value.str) ||


### PR DESCRIPTION
…esycned.
- If node is paused then even though node may have recieved all the write-set
  it hasn't applied them. Switching off wsrep_provider during this time
  is not advisable to maintain data consistent state.
  Desync is another such operation which may have paused cluster.
  So it is not advisable to change wsrep_provider during this time too.
