### PR TITLE
- PXC#588: Avoid changing wsrep_provider when node is paused and/or d…

### DIFF
--- a/mysql-test/suite/galera/r/galera_flush.result
+++ b/mysql-test/suite/galera/r/galera_flush.result
@@ -66,3 +66,15 @@ SELECT * FROM t1;
 f1
 100
 DROP TABLE t1;
+#node-1
+call mtr.add_suppression("WSREP: Cannot modify wsrep_provider while node is paused or desynced");
+CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
+FLUSH TABLE t1 WITH READ LOCK;
+SET GLOBAL wsrep_provider=none;
+ERROR 42000: Variable 'wsrep_provider' can't be set to the value of 'none'
+UNLOCK TABLES;
+FLUSH TABLE WITH READ LOCK;
+SET GLOBAL wsrep_provider=none;
+ERROR 42000: Variable 'wsrep_provider' can't be set to the value of 'none'
+UNLOCK TABLES;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -316,3 +316,26 @@ UNLOCK TABLES;
 --sleep 4
 SELECT * FROM t1;
 DROP TABLE t1;
+
+
+#-------------------------------------------------------------------------------
+#
+# Trying to set a provider when node is paused
+#
+--connection node_1
+--echo #node-1
+call mtr.add_suppression("WSREP: Cannot modify wsrep_provider while node is paused or desynced");
+#
+CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
+# pause node
+FLUSH TABLE t1 WITH READ LOCK;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_provider=none;
+UNLOCK TABLES;
+# pause and desync node
+FLUSH TABLE WITH READ LOCK;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL wsrep_provider=none;
+UNLOCK TABLES;
+#
+DROP TABLE t1;

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -260,6 +260,24 @@ static int wsrep_provider_verify (const char* provider_str)
 @return false if no error encountered with check else return true. */
 bool wsrep_provider_check (sys_var *self, THD* thd, set_var* var)
 {
+  mysql_mutex_lock(&LOCK_wsrep_pause_count);
+  bool node_paused = (wsrep_pause_count == 0) ? false : true;
+  bool desycned = !wsrep_node_is_synced();
+  mysql_mutex_unlock(&LOCK_wsrep_pause_count);
+
+  if (node_paused || desycned)
+  {
+     /* If node is paused or desycned this means node is up-to-data.
+    Pause node hasn't applied all the write-set and desycned node
+     may have sent flow control. Avoid changing wsrep_provider
+     in such critical conditions. */
+     WSREP_WARN("Cannot modify wsrep_provider while node is paused"
+                " or desynced.");
+    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), var->var->name.str,
+             var->save_result.string_value.str);
+    return true;
+  }
+
   char wsrep_provider_buf[FN_REFLEN];
 
   if ((! var->save_result.string_value.str) ||


### PR DESCRIPTION
…esycned.
- If node is paused then even though node may have recieved all the write-set
  it hasn't applied them. Switching off wsrep_provider during this time
  is not advisable to maintain data consistent state.
  Desync is another such operation which may have paused cluster.
  So it is not advisable to change wsrep_provider during this time too.
