### PR TITLE
- PXC#570: Asynchronous TOI action on non-primary node can cause node…

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1486,6 +1486,18 @@ int wsrep_to_isolation_begin(THD *thd, char *db_, char *table_,
    */
   if (thd->wsrep_exec_mode == REPL_RECV) return 0;
 
+  /* Generally if node enters non-primary state then execution of DDL+DML
+  is blocked on such node but there are some asynchronous pre-register
+  action that can cause invocation of TOI. For example: DROP of event
+  on completion of EVENT tenure is one such asynchronous action which
+  doesn't need to be fired by user and so if node is asynchronous
+  such such action should be blocked at TOI level. */
+  if (!wsrep_ready)
+  {
+    WSREP_DEBUG("WSREP has not yet prepared node for application use");
+    return 0;
+  }
+
   int ret= 0;
   mysql_mutex_lock(&thd->LOCK_wsrep_thd);
 


### PR DESCRIPTION
… to crash

  Issue:

---

  CREATE event will be auto-removed on completion of tenure (tenure is defined
  by event end-time). This auto-removal is DDL action of DROP event that is
  replication in galera as expected.

  If event is active and node becomes non-primary then such auto-removal action
  are still triggered which eventually causes TOI error.

  Solution:

---
- Ensure that TOI check for node readiness to process DDL+DML before
  kickstarting the execution. Generally this is done by parent level
  for user-triggered command but for such auto-triggered command a
  local hook at TOI level is needed.
