### PR TITLE
Fix for centos7 systemd

### DIFF
--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -594,7 +594,7 @@ mkdir debug
            -DWITH_EMBEDDED_SERVER=OFF \
            -DWITH_INNODB_MEMCACHED=ON \
 %if 0%{?systemd}
-           -DWITH_SYSTEMD=ON \
+           -DWITH_SYSTEMD=OFF \
 %endif
            -DENABLE_DTRACE=OFF \
            -DWITH_SSL=system \
@@ -630,7 +630,7 @@ mkdir release
            -DWITH_EMBEDDED_SERVER=OFF \
            -DWITH_INNODB_MEMCACHED=ON \
 %if 0%{?systemd}
-           -DWITH_SYSTEMD=ON \
+           -DWITH_SYSTEMD=OFF \
 %endif
            -DENABLE_DTRACE=OFF \
            -DWITH_SSL=system \
@@ -1289,10 +1289,8 @@ fi
 %attr(755, root, root) %{_bindir}/mysql_tzinfo_to_sql
 %attr(755, root, root) %{_bindir}/mysql_upgrade
 %attr(755, root, root) %{_bindir}/mysql_plugin
-%if 0%{?systemd} == 0
-%attr(755, root, root) %{_bindir}/mysqld_multi
 %attr(755, root, root) %{_bindir}/mysqld_safe
-%endif
+%attr(755, root, root) %{_bindir}/mysqld_multi
 %attr(755, root, root) %{_bindir}/mysqldumpslow
 %attr(755, root, root) %{_bindir}/mysqltest
 %attr(755, root, root) %{_bindir}/perror
@@ -1337,13 +1335,10 @@ fi
 %dir %attr(750, mysql, mysql) /var/lib/mysql-keyring
 %dir %attr(755, mysql, mysql) /var/run/mysqld
 %if 0%{?systemd}
-%attr(644, root, root) %{_unitdir}/mysqld.service
 %attr(644, root, root) %{_unitdir}/mysql.service
 %attr(644, root, root) %{_unitdir}/mysql@.service
 %attr(644, root, root) %config(noreplace,missingok) %{_sysconfdir}/sysconfig/mysql.bootstrap
-%attr(644, root, root) %{_tmpfilesdir}/mysql.conf
 %attr(755, root, root) %{_bindir}/mysql-systemd
-%attr(755, root, root) %{_bindir}/mysqld_pre_systemd
 %else
 %attr(755, root, root) %{_sysconfdir}/init.d/mysql
 %endif

--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -151,6 +151,28 @@ wait_for_pid () {
   fi
 }
 
+pinger () {
+    # Wait for ping to answer to signal startup completed,
+    # might take a while in case of e.g. crash recovery
+    # MySQL systemd service will timeout script if no answer
+    datadir=$(parse_cnf datadir server mysqld)
+    if [[ -z ${datadir:-} ]]; then
+        datadir="/var/lib/mysql"
+    fi
+    socket=$(parse_cnf socket server mysqld)
+    case $socket in
+        /*) adminsocket="$socket" ;;
+        "") adminsocket="$datadir/mysql.sock" ;;
+        *) adminsocket="$datadir/$socket" ;;
+    esac
+
+    while /bin/true ; do
+        sleep 1
+        mysqladmin --no-defaults --socket="$adminsocket" --user=UNKNOWN_MYSQL_USER ping >/dev/null 2>&1 && break
+    done
+    exit 0
+}
+
 
 action=$1
 manager=${2:-0}

--- a/build-ps/rpm/mysql.service
+++ b/build-ps/rpm/mysql.service
@@ -15,39 +15,34 @@ WantedBy=multi-user.target
 Alias=mysql.service
 
 [Service]
-User=mysql
-Group=mysql
-
-Type=forking
-
-PIDFile=/var/run/mysqld/mysqld.pid
-
-# Disable service start and stop timeout logic of systemd for mysqld service.
-TimeoutSec=0
-
-# Execute pre and post scripts as root
-PermissionsStartOnly=true
-
-# Needed to create system tables
+# Needed to create system tables etc.
 ExecStartPre=/usr/bin/mysql-systemd start-pre
 
+EnvironmentFile=-/etc/sysconfig/mysql
 # Start main service
-ExecStart=/usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid $MYSQLD_OPTS
+ExecStart=/usr/bin/mysqld_safe --basedir=/usr
+
+# Don't signal startup success before a ping works
+ExecStartPost=/usr/bin/mysql-systemd start-post $MAINPID
+
 ExecStop=/usr/bin/mysql-systemd stop
 
 ExecStopPost=/usr/bin/mysql-systemd stop-post
 
 ExecReload=/usr/bin/mysql-systemd reload
 
-# Use this to switch malloc implementation
-EnvironmentFile=-/etc/sysconfig/mysql
+# Timeout is handled elsewhere
+# service-startup-timeout in my.cnf 
+# Default is 900 seconds
+TimeoutStartSec=0
 
-# Sets open_files_limit
-LimitNOFILE = 5000
+# Maximum time to stop
+TimeoutStopSec=900
 
-Restart=on-failure
-
-RestartPreventExitStatus=1
+# Unsafe for PXC
+# mysqld_safe handles this too.
+Restart=no
 
 PrivateTmp=false
+
 


### PR DESCRIPTION
Running with only mysqld in systemd service was faulty if we used IP addresses to initialize new cluster.
So I have returned the mysqld_safe here and we will use it for now until better solution.
This is a change only for centos7.

I have tested and successfully created a two node cluster with xtrabackup sst:

```
| wsrep_evs_state                               | OPERATIONAL
| wsrep_cluster_size                            | 2
| wsrep_cluster_state_uuid                      | de8f79d8-28b8-11e6-a3e0-6f5158deb7b9
| wsrep_cluster_status                          | Primary
| wsrep_connected                               | ON
| wsrep_local_bf_aborts                         | 0
| wsrep_local_index                             | 0
| wsrep_provider_name                           | Galera
| wsrep_provider_vendor                         | Codership Oy <info@codership.com>
| wsrep_provider_version                        | 3.14.2(r53b88eb)
| wsrep_ready                                   | ON
```
