### PR TITLE
Remove files from datadir in case of presence of sst_in_progress

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -53,6 +53,9 @@ install_db () {
 
     # If special mysql dir is in place, skip db install 
     [ -d "$datadir/mysql" ] && exit 0
+    if [ -f "$datadir/sst_in_progress" ]; then
+        rm -rf $datadir/*
+    fi
 
     # Create initial db
     /usr/sbin/mysqld --initialize --datadir="$datadir" --user=mysql

--- a/build-ps/rpm/mysql.init
+++ b/build-ps/rpm/mysql.init
@@ -94,6 +94,9 @@ start(){
 	    then
 		mkdir -p "$datadir" || exit 1
 	    fi
+	    if [ -f "$datadir/sst_in_progress" ]; then
+		rm -rf $datadir/*
+	    fi
 	    chown mysql:mysql "$datadir"
 	    chmod 0751 "$datadir"
 	    if [ -x /sbin/restorecon ] ; then

--- a/support-files/mysql.server.sh
+++ b/support-files/mysql.server.sh
@@ -359,6 +359,9 @@ case "$mode" in
         then
           mkdir -p "$datadir" || exit 1
         fi
+        if [ -f "$datadir/sst_in_progress" ]; then
+            rm -rf $datadir/*
+        fi
         chown mysql:mysql "$datadir"
         chmod 0751 "$datadir"
         if [ -x /sbin/restorecon ] ; then


### PR DESCRIPTION
[korvin@localhost ~]$ sudo rm -rf /var/lib/mysql/mysql
[korvin@localhost ~]$ sudo -s
[root@localhost korvin]# cd /var/lib/mysql
[root@localhost mysql]# ls
auto.cnf    client-cert.pem  grastate.dat    ib_logfile0           localhost-bin.000002  private_key.pem  server-key.pem
ca-key.pem  client-key.pem   ib_buffer_pool  ib_logfile1           localhost-bin.index   public_key.pem   sys
ca.pem      galera.cache     ibdata1         localhost-bin.000001  performance_schema    server-cert.pem
[root@localhost mysql]# touch sst_in_progress
[root@localhost mysql]# systemctl start mysql
[root@localhost mysql]# systemctl status mysql
● mysql.service - LSB: start and stop MySQL (Percona XtraDB Cluster)
   Loaded: loaded (/etc/rc.d/init.d/mysql)
   Active: active (running) since ср 2016-06-08 07:11:12 EDT; 6s ago
     Docs: man:systemd-sysv-generator(8)
  Process: 2875 ExecStop=/etc/rc.d/init.d/mysql stop (code=exited, status=0/SUCCESS)
  Process: 2932 ExecStart=/etc/rc.d/init.d/mysql start (code=exited, status=0/SUCCESS)
   CGroup: /system.slice/mysql.service
           ├─2982 /bin/sh /usr/bin/mysqld_safe --datadir=/var/lib/mysql --pid-file=/var/run/mysqld/mysqld.pid
           └─3352 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib64/mysql/plugin --user...

чер 08 07:11:04 localhost.localdomain systemd[1]: Starting LSB: start and stop MySQL (Percona XtraDB Cluster)...
чер 08 07:11:11 localhost.localdomain mysql[2932]: Initializing MySQL database:  [  OK  ]
чер 08 07:11:12 localhost.localdomain mysql[2932]: Starting MySQL (Percona XtraDB Cluster). SUCCESS!
чер 08 07:11:12 localhost.localdomain systemd[1]: Started LSB: start and stop MySQL (Percona XtraDB Cluster).

So with these changes everything works correctly.
The changes are needed only for Centos as on debian it informs that directory should be backuped  and cleaned.
