### PR TITLE
- PXC#613: Toggling wsrep_provider leave behind stale/unreleased refe…

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_provider_unset_set.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_provider_unset_set.result
@@ -33,3 +33,18 @@ SELECT COUNT(*) = 4 FROM t1;
 COUNT(*) = 4
 1
 DROP TABLE t1;
+#node-2
+call mtr.add_suppression("WSREP: gcs_caused\\(\\) returned -103 \\(Software caused connection abort\\)");
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2
+SET GLOBAL wsrep_provider='none';
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	0
+show status like 'wsrep_cluster_size';
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+SET GLOBAL wsrep_cluster_address = 'gcomm://127.0.0.1:13001';;
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2

--- a/mysql-test/suite/galera/t/galera_wsrep_provider_unset_set.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_provider_unset_set.test
@@ -70,3 +70,34 @@ SELECT COUNT(*) = 5 FROM t1;
 SELECT COUNT(*) = 4 FROM t1;
 
 DROP TABLE t1;
+
+
+#-------------------------------------------------------------------------------
+#
+# Try to run show-status while the galera provider is toggled.
+#
+
+--connection node_2
+--echo #node-2
+--let $wsrep_provider_orig = `SELECT @@wsrep_provider`
+--let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
+call mtr.add_suppression("WSREP: gcs_caused\\(\\) returned -103 \\(Software caused connection abort\\)");
+
+#
+show status like 'wsrep_cluster_size';
+#
+SET GLOBAL wsrep_provider='none';
+show status like 'wsrep_cluster_size';
+#
+--disable_query_log
+--eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
+--enable_query_log
+#
+--error ER_LOCK_WAIT_TIMEOUT
+show status like 'wsrep_cluster_size';
+#
+--eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+#
+show status like 'wsrep_cluster_size';

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -322,6 +322,14 @@ bool wsrep_provider_update (sys_var *self, THD* thd, enum_var_type type)
   bool wsrep_on_saved= thd->variables.wsrep_on;
   thd->variables.wsrep_on= false;
 
+  /* Ensure we free the stats that are allocated by galera-library.
+  wsrep part doesn't know how to free them shouldn't be attempting it
+  as it not allocated by wsrep part.
+  Before unloading cleanup any stale reference and stats is one of it.
+  Given that thd->variables.wsrep.on is turned-off it is safe to assume
+  that no new stats queries will be allowed during this transition time. */
+  wsrep_free_status(thd);
+
   WSREP_DEBUG("wsrep_provider_update: %s", wsrep_provider);
 
   /* stop replication is heavy operation, and includes closing all client 
@@ -333,6 +341,7 @@ bool wsrep_provider_update (sys_var *self, THD* thd, enum_var_type type)
   */
   mysql_mutex_unlock(&LOCK_global_system_variables);
   wsrep_stop_replication(thd);
+
   /*
     Unlock and lock LOCK_wsrep_slave_threads to maintain lock order & avoid
     any potential deadlock.
@@ -680,6 +689,10 @@ static void export_wsrep_status_to_mysql(THD* thd)
 {
   int wsrep_status_len, i;
 
+  /* Avoid freeing the stats immediately on completion of the call
+  instead free them on next invocation as the reference to status
+  is feeded in MySQL show status array. Freeing them on completion
+  will make these references invalid. */
   wsrep_free_status(thd);
 
   thd->wsrep_status_vars = wsrep->stats_get(wsrep);


### PR DESCRIPTION
…rence to

  wsrep_status

  show status result in fetching wsrep-status-variables by making a call
  to galera library function. This galera library function allocates
  a buffer, populate it with needed data and reference to it is passed
  that is then feeded in mysql-array to service the show status command.

  Who deallocates this buffer then ?
- buffer is deallocated only on next call to show status when it try to
  fetch latest values of wsrep-status-variables. (It could have re-used the
  same buffer but that. Not sure why it missed it.)
  
  If provider is unloaded, show status post unload will leave behind stale
  memory reference which turns into memory-leak when show status is fired with
  unloaded provider as unloaded provider can't fire wsrep-status api so it
  return dummy status array.
  
  Next time when provider is reloaded and show status is refired provider
  can call galera library wsrep-api but the caller passes dummy_stats
  reference to library (that is static allocation from stack).
  ## Fix:
- While toggling the wsrep_provider (this including unloading use case too)
  free the stats.
  
  [Note: THD::release_resources is not called on the client connecting
  running the wsrep_provider toggle command.]
