### PR TITLE
- pxc-strict-mode tried blocking DML/DDL on all Storage Engine including

### DIFF
--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1131,8 +1131,9 @@ static bool pxc_strict_mode_admin_check(THD* thd, TABLE_LIST* table)
                               table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &db_type);
 
-  if (db_type != DB_TYPE_INNODB  &&
-      db_type != DB_TYPE_UNKNOWN &&
+  if (db_type != DB_TYPE_INNODB             &&
+      db_type != DB_TYPE_UNKNOWN            &&
+      db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
       !is_temporary_table(table))
   {
     switch(pxc_strict_mode)

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -359,7 +359,8 @@ bool Sql_cmd_alter_table::execute(THD *thd)
          (create_info.used_fields & HA_CREATE_USED_ENGINE)           &&
          (new_db_type != DB_TYPE_INNODB))
        safe_ops= false;
-     else if (existing_db_type == DB_TYPE_INNODB)
+     else if (existing_db_type == DB_TYPE_INNODB ||
+              existing_db_type == DB_TYPE_PERFORMANCE_SCHEMA)
        safe_ops= true; 
 
     if (!safe_ops)

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5980,9 +5980,10 @@ restart:
 
   legacy_db_type db_type= (tbl ? tbl->file->ht->db_type : DB_TYPE_UNKNOWN);
 
-  if (db_type != DB_TYPE_INNODB   &&
-      db_type != DB_TYPE_UNKNOWN  &&
-      is_dml_stmt                 &&
+  if (db_type != DB_TYPE_INNODB             &&
+      db_type != DB_TYPE_UNKNOWN            &&
+      db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
+      is_dml_stmt                           &&
       !is_temporary_table(tables))
   {
     /* Table is not an InnoDB table and workload is trying to make changes
@@ -6025,6 +6026,7 @@ restart:
   }
 
   if (is_dml_stmt                           &&
+      db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
       tbl && tbl->s->primary_key == MAX_KEY &&
       !is_temporary_table(tables))
   {

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -578,8 +578,9 @@ bool Sql_cmd_truncate_table::execute(THD *thd)
                               first_table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &db_type);
 
-  if (db_type != DB_TYPE_INNODB      &&
-      db_type != DB_TYPE_UNKNOWN     &&
+  if (db_type != DB_TYPE_INNODB             &&
+      db_type != DB_TYPE_UNKNOWN            &&
+      db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
       !is_temporary_table(first_table))
   {
     bool block= false;


### PR DESCRIPTION
  performance-schema. Performance-Schema DML and DDL should be allowed
  as that is part of normal workflow as documented by MySQL documentation.
  Performance_schema is more like special Storage Engine meant to monitor
  server and as expected it doesn't make sense to replicate updates
  to this schema.
