### PR TITLE
- PXC#613: Toggling wsrep_provider leave behind stale/unreleased refe…

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_provider_unset_set.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_provider_unset_set.result
@@ -33,3 +33,18 @@ SELECT COUNT(*) = 4 FROM t1;
 COUNT(*) = 4
 1
 DROP TABLE t1;
+#node-2
+call mtr.add_suppression("WSREP: gcs_caused\\(\\) returned -103 \\(Software caused connection abort\\)");
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2
+SET GLOBAL wsrep_provider='none';
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	0
+show status like 'wsrep_cluster_size';
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+SET GLOBAL wsrep_cluster_address = 'gcomm://127.0.0.1:13001';;
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2

--- a/mysql-test/suite/galera/t/galera_wsrep_provider_unset_set.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_provider_unset_set.test
@@ -70,3 +70,34 @@ SELECT COUNT(*) = 5 FROM t1;
 SELECT COUNT(*) = 4 FROM t1;
 
 DROP TABLE t1;
+
+
+#-------------------------------------------------------------------------------
+#
+# Try to run show-status while the galera provider is toggled.
+#
+
+--connection node_2
+--echo #node-2
+--let $wsrep_provider_orig = `SELECT @@wsrep_provider`
+--let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
+call mtr.add_suppression("WSREP: gcs_caused\\(\\) returned -103 \\(Software caused connection abort\\)");
+
+#
+show status like 'wsrep_cluster_size';
+#
+SET GLOBAL wsrep_provider='none';
+show status like 'wsrep_cluster_size';
+#
+--disable_query_log
+--eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
+--enable_query_log
+#
+--error ER_LOCK_WAIT_TIMEOUT
+show status like 'wsrep_cluster_size';
+#
+--eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+#
+show status like 'wsrep_cluster_size';


### PR DESCRIPTION
…rence to

  wsrep_status

  show status result in fetching wsrep-status-variables by making a call
  to galera library function. This galera library function allocates
  a buffer, populate it with needed data and reference to it is passed
  that is then feeded in mysql-array to service the show status command.

  Who deallocates this buffer then ?
- buffer is deallocated only on next call to show status when it try to
  fetch latest values of wsrep-status-variables. (It could have re-used the
  same buffer but that. Not sure why it missed it.)
  
  If provider is unloaded, show status post unload will leave behind stale
  memory reference which turns into memory-leak when show status is fired with
  unloaded provider as unloaded provider can't fire wsrep-status api so it
  return dummy status array.
  
  Next time when provider is reloaded and show status is refired provider
  can call galera library wsrep-api but the caller passes dummy_stats
  reference to library (that is static allocation from stack).
  ## Fix:
- While toggling the wsrep_provider (this including unloading use case too)
  free the stats.
  
  [Note: THD::release_resources is not called on the client connecting
  running the wsrep_provider toggle command.]
