### PR TITLE
- #PXC-604: Setting wsrep_auto_increment_control to OFF doesn't restore the original user set value

### DIFF
--- a/mysql-test/suite/galera/r/galera_auto_inc_off.result
+++ b/mysql-test/suite/galera/r/galera_auto_inc_off.result
@@ -1,0 +1,64 @@
+SET GLOBAL auto_increment_increment=10;
+SET GLOBAL auto_increment_offset=7;
+SET GLOBAL wsrep_auto_increment_control='OFF';
+SHOW GLOBAL VARIABLES LIKE '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	10
+auto_increment_offset	7
+wsrep_auto_increment_control	OFF
+SHOW VARIABLES LIKE '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	10
+auto_increment_offset	7
+wsrep_auto_increment_control	OFF
+SET GLOBAL wsrep_auto_increment_control='ON';
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+@@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size')
+1
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+@@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1
+1
+SELECT @@wsrep_auto_increment_control = 1;
+@@wsrep_auto_increment_control = 1
+1
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+@@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size')
+1
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+@@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1
+1
+SELECT @@wsrep_auto_increment_control = 1;
+@@wsrep_auto_increment_control = 1
+1
+SET GLOBAL wsrep_auto_increment_control='OFF';
+SHOW VARIABLES LIKE '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	10
+auto_increment_offset	7
+wsrep_auto_increment_control	OFF
+SET GLOBAL wsrep_auto_increment_control='ON';
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+@@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size')
+1
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+@@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1
+1
+SELECT @@wsrep_auto_increment_control = 1;
+@@wsrep_auto_increment_control = 1
+1
+SET GLOBAL wsrep_auto_increment_control='OFF';
+SHOW VARIABLES LIKE '%auto_increment%';
+Variable_name	Value
+auto_increment_increment	7
+auto_increment_offset	5
+wsrep_auto_increment_control	OFF
+SET GLOBAL wsrep_auto_increment_control='ON';
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+@@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size')
+1
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+@@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1
+1
+SELECT @@wsrep_auto_increment_control = 1;
+@@wsrep_auto_increment_control = 1
+1

--- a/mysql-test/suite/galera/t/galera_auto_inc_off.test
+++ b/mysql-test/suite/galera/t/galera_auto_inc_off.test
@@ -1,0 +1,67 @@
+#
+# 1) Check that the values of auto-increment step and offset,
+#    which are set by the user, are saved and restored when user
+#    turning off the automatic control for these options.
+# 2) Check that these options are successfuly passed to new session.
+# 3) Check that the same logic works for the auto-increment parameters
+#    passed via command line.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+SET GLOBAL auto_increment_increment=10;
+SET GLOBAL auto_increment_offset=7;
+SET GLOBAL wsrep_auto_increment_control='OFF';
+
+SHOW GLOBAL VARIABLES LIKE '%auto_increment%';
+
+--let $galera_connection_name = node_1a
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+
+--connection node_1a
+
+SHOW VARIABLES LIKE '%auto_increment%';
+
+SET GLOBAL wsrep_auto_increment_control='ON';
+
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+SELECT @@wsrep_auto_increment_control = 1;
+
+--connection node_1
+
+--let $galera_connection_name = node_1b
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+
+--connection node_1b
+
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+SELECT @@wsrep_auto_increment_control = 1;
+
+SET GLOBAL wsrep_auto_increment_control='OFF';
+
+SHOW VARIABLES LIKE '%auto_increment%';
+
+--connection node_1
+
+SET GLOBAL wsrep_auto_increment_control='ON';
+
+--let $restart_parameters = "restart:--auto-increment-increment=7 --auto-increment-offset=5"
+--source include/restart_mysqld.inc
+
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+SELECT @@wsrep_auto_increment_control = 1;
+
+SET GLOBAL wsrep_auto_increment_control='OFF';
+
+SHOW VARIABLES LIKE '%auto_increment%';
+
+SET GLOBAL wsrep_auto_increment_control='ON';
+
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+SELECT @@wsrep_auto_increment_control = 1;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4191,20 +4191,6 @@ int init_common_variables()
   */
   global_system_variables.time_zone= my_tz_SYSTEM;
 
-#ifdef WITH_WSREP
-  /*
-    We need to initialize auxiliary variables, that will be
-    further keep the original values of auto-increment options
-    as they set by the user. These variables used to restore
-    user-defined values of the auto-increment options after
-    setting of the wsrep_auto_increment_control to 'OFF'.
-  */
-  global_system_variables.saved_auto_increment_increment=
-    global_system_variables.auto_increment_increment;
-  global_system_variables.saved_auto_increment_offset=
-    global_system_variables.auto_increment_offset;
-#endif
-
 #ifdef HAVE_PSI_INTERFACE
   /*
     Complete the mysql_bin_log initialization.
@@ -4326,6 +4312,21 @@ int init_common_variables()
 #endif /* WITH_WSREP */
   if (get_options(&remaining_argc, &remaining_argv))
     return 1;
+
+#ifdef WITH_WSREP
+  /*
+    We need to initialize auxiliary variables, that will be
+    further keep the original values of auto-increment options
+    as they set by the user. These variables used to restore
+    user-defined values of the auto-increment options after
+    setting of the wsrep_auto_increment_control to 'OFF'.
+  */
+  global_system_variables.saved_auto_increment_increment=
+    global_system_variables.auto_increment_increment;
+  global_system_variables.saved_auto_increment_offset=
+    global_system_variables.auto_increment_offset;
+#endif
+
   set_server_version();
 
   sql_print_information("%s (mysqld %s) starting as process %lu ...",


### PR DESCRIPTION
If the user set values of auto_increment_increment and offset to x and y respectively, then setting wsrep_auto_increment_control to OFF should restore the original values.

Unfortunately, this works fine when SET operator used for setting the auto-increment options, but is not working, when auto-increment parameters passed via command line.

Even after setting auto-increment control to OFF, default values of 1 are being used. This is because of misplaced code snippet that caches these values to restore when wsrep_auto_increment_offset is set to OFF.

This fragment just need to be moved slightly lower - so that it executed after call to the get_options function (in the mysqld.cc file).

Jenkins build here: http://jenkins.percona.com/job/pxc56.build/606/
