### PR TITLE
PXC-333 : Invalid my_error() usage leading to incorrect/misleading er…

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_abort.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort.result
@@ -4,7 +4,7 @@ START TRANSACTION;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (2);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 wsrep_local_aborts_increment
 1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_bf_abort_for_update.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_for_update.result
@@ -4,7 +4,7 @@ START TRANSACTION;
 INSERT INTO t1 VALUES (1);
 INSERT INTO t1 VALUES (1);
 SELECT * FROM t1 FOR UPDATE;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 wsrep_local_aborts_increment
 1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
@@ -6,7 +6,7 @@ SET AUTOCOMMIT=OFF;
 INSERT INTO t1 VALUES (1);
 SELECT GET_LOCK("foo", 1000);;
 INSERT INTO t1 VALUES (1);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 wsrep_local_aborts_increment
 1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_bf_abort_sleep.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_sleep.result
@@ -3,7 +3,7 @@ SET AUTOCOMMIT=OFF;
 INSERT INTO t1 VALUES (1);
 SELECT SLEEP(1000);;
 INSERT INTO t1 VALUES (1);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 wsrep_local_aborts_increment
 1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_enum.result
+++ b/mysql-test/suite/galera/r/galera_enum.result
@@ -28,7 +28,7 @@ START TRANSACTION;
 UPDATE t1 SET f1 = 'four' where f1 = '';
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 'three';
 COUNT(*) = 1
 1

--- a/mysql-test/suite/galera/r/galera_fk_conflict.result
+++ b/mysql-test/suite/galera/r/galera_fk_conflict.result
@@ -18,6 +18,6 @@ START TRANSACTION;
 INSERT INTO child VALUES (2, 2);
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE child;
 DROP TABLE parent;

--- a/mysql-test/suite/galera/r/galera_ftwrl.result
+++ b/mysql-test/suite/galera/r/galera_ftwrl.result
@@ -3,9 +3,9 @@ SET GLOBAL wsrep_provider_options = "repl.causal_read_timeout=PT1S";
 FLUSH TABLES WITH READ LOCK;
 INSERT INTO t1 VALUES (1);
 SHOW TABLES;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ERROR HY000: Synchronous wait failed.
 SELECT * FROM t1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ERROR HY000: Synchronous wait failed.
 UNLOCK TABLES;
 SHOW TABLES;
 Tables_in_test

--- a/mysql-test/suite/galera/r/galera_gcs_fragment.result
+++ b/mysql-test/suite/galera/r/galera_gcs_fragment.result
@@ -11,7 +11,7 @@ SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
 INSERT INTO t1 VALUES (2, "bbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 SET GLOBAL wsrep_provider_options = 'signal=gcs_core_after_frag_send';
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 INSERT INTO t1 VALUES (3, "cccccaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 SELECT * FROM t1;
 f1	f2

--- a/mysql-test/suite/galera/r/galera_insert_multi.result
+++ b/mysql-test/suite/galera/r/galera_insert_multi.result
@@ -37,7 +37,7 @@ START TRANSACTION;
 INSERT INTO t1 VALUES (2), (1);
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 ROLLBACK;
 INSERT INTO t1 VALUES (1), (2);
 ERROR 23000: Duplicate entry '1' for key 'PRIMARY'

--- a/mysql-test/suite/galera/r/galera_many_columns.result
+++ b/mysql-test/suite/galera/r/galera_many_columns.result
@@ -14,7 +14,7 @@ START TRANSACTION;
 UPDATE t1 SET f2 = 'CDE' WHERE f1 = 'XYZ' AND f1017 = 'XYZ';
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 ROLLBACK;
 ROLLBACK;
 START TRANSACTION;

--- a/mysql-test/suite/galera/r/galera_many_indexes.result
+++ b/mysql-test/suite/galera/r/galera_many_indexes.result
@@ -125,5 +125,5 @@ UPDATE t1 SET f1 = REPEAT('e', 767);
 UPDATE t1 SET f1 = REPEAT('f', 767);
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_many_rows.result
+++ b/mysql-test/suite/galera/r/galera_many_rows.result
@@ -27,6 +27,6 @@ START TRANSACTION;
 UPDATE t1 SET f2 = 4;
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE t1;
 DROP TABLE ten;

--- a/mysql-test/suite/galera/r/galera_many_tables_nopk.result
+++ b/mysql-test/suite/galera/r/galera_many_tables_nopk.result
@@ -12,6 +12,6 @@ START TRANSACTION;
 UPDATE t1000 SET f1 = 3;
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP SCHEMA test;
 CREATE SCHEMA test;

--- a/mysql-test/suite/galera/r/galera_many_tables_pk.result
+++ b/mysql-test/suite/galera/r/galera_many_tables_pk.result
@@ -15,6 +15,6 @@ START TRANSACTION;
 UPDATE t1000 SET f1 = 3;
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP SCHEMA test;
 CREATE SCHEMA test;

--- a/mysql-test/suite/galera/r/galera_mdl_race.result
+++ b/mysql-test/suite/galera/r/galera_mdl_race.result
@@ -14,7 +14,7 @@ SET GLOBAL DEBUG = "";
 SET DEBUG_SYNC = "now SIGNAL signal.wsrep_before_mdl_wait";
 SET DEBUG_SYNC = "now SIGNAL signal.wsrep_after_BF_victim_lock";
 UNLOCK TABLES;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'a';
 COUNT(*) = 1
 1

--- a/mysql-test/suite/galera/r/galera_nopk_bit.result
+++ b/mysql-test/suite/galera/r/galera_nopk_bit.result
@@ -22,6 +22,6 @@ START TRANSACTION;
 UPDATE t2 SET f1 = 1 WHERE f1 IS NULL;
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE t1;
 DROP TABLE t2;

--- a/mysql-test/suite/galera/r/galera_nopk_blob.result
+++ b/mysql-test/suite/galera/r/galera_nopk_blob.result
@@ -22,6 +22,6 @@ START TRANSACTION;
 UPDATE t2 SET f1 = 'xyz' WHERE f1 IS NULL;
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE t1;
 DROP TABLE t2;

--- a/mysql-test/suite/galera/r/galera_nopk_large_varchar.result
+++ b/mysql-test/suite/galera/r/galera_nopk_large_varchar.result
@@ -25,6 +25,6 @@ START TRANSACTION;
 UPDATE t2 SET f1 = 'xyz' WHERE f1 = CONCAT(REPEAT('x', 7999), 'a');
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE t1;
 DROP TABLE t2;

--- a/mysql-test/suite/galera/r/galera_nopk_unicode.result
+++ b/mysql-test/suite/galera/r/galera_nopk_unicode.result
@@ -14,7 +14,7 @@ START TRANSACTION;
 UPDATE t1 SET f1 = 'текст3';
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SELECT f1 = 'текст2' FROM t1;
 f1 = 'текст2'
 1

--- a/mysql-test/suite/galera/r/galera_pk_bigint_signed.result
+++ b/mysql-test/suite/galera/r/galera_pk_bigint_signed.result
@@ -21,6 +21,6 @@ UPDATE t1 SET f2 = 'bar' WHERE f1 = -9223372036854775808;
 COMMIT;
 SET AUTOCOMMIT=ON;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SET AUTOCOMMIT=ON;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_pk_bigint_unsigned.result
+++ b/mysql-test/suite/galera/r/galera_pk_bigint_unsigned.result
@@ -18,6 +18,6 @@ UPDATE t1 SET f2 = 'bar' WHERE f1 = 18446744073709551615;
 COMMIT;
 SET AUTOCOMMIT=ON;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SET AUTOCOMMIT=ON;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_query_cache_sync_wait.result
+++ b/mysql-test/suite/galera/r/galera_query_cache_sync_wait.result
@@ -8,7 +8,7 @@ MAX(id)
 1
 INSERT INTO t1 VALUES (2);
 SELECT MAX(id) FROM t1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ERROR HY000: Synchronous wait failed.
 SET GLOBAL DEBUG = "";
 SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 FLUSH QUERY CACHE;
@@ -16,7 +16,7 @@ SET SESSION wsrep_sync_wait = 7;
 SET GLOBAL DEBUG = "d,sync.wsrep_apply_cb";
 INSERT INTO t1 VALUES (3);
 SELECT MAX(id) FROM t1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ERROR HY000: Synchronous wait failed.
 SET GLOBAL DEBUG = "";
 SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 INSERT INTO t1 VALUES (4);

--- a/mysql-test/suite/galera/r/galera_sbr.result
+++ b/mysql-test/suite/galera/r/galera_sbr.result
@@ -5,7 +5,7 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET SESSION binlog_format = 'MIXED';
 INSERT INTO t1 VALUES (2);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1

--- a/mysql-test/suite/galera/r/galera_sbr_binlog.result
+++ b/mysql-test/suite/galera/r/galera_sbr_binlog.result
@@ -5,7 +5,7 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET SESSION binlog_format = 'MIXED';
 INSERT INTO t1 VALUES (2);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1

--- a/mysql-test/suite/galera/r/galera_serializable.result
+++ b/mysql-test/suite/galera/r/galera_serializable.result
@@ -6,7 +6,7 @@ SELECT * FROM t1;
 id	f2
 INSERT INTO t1 VALUES (1,1);
 SELECT * FROM t1;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 ROLLBACK;
 DELETE FROM t1;
 INSERT INTO t1 VALUES (1,1);
@@ -16,12 +16,12 @@ id	f2
 1	1
 UPDATE t1 SET f2 = 2;
 UPDATE t1 SET f2 = 3;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 ROLLBACK;
 DELETE FROM t1;
 START TRANSACTION;
 INSERT INTO t1 VALUES (1,1);
 INSERT INTO t1 VALUES (1,2);
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_split_brain.result
+++ b/mysql-test/suite/galera/r/galera_split_brain.result
@@ -1,6 +1,6 @@
 call mtr.add_suppression("WSREP: TO isolation failed for: ");
 Killing server ...
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SET GLOBAL wsrep_cluster_address = '';
 # restart

--- a/mysql-test/suite/galera/r/galera_toi_ddl_locking.result
+++ b/mysql-test/suite/galera/r/galera_toi_ddl_locking.result
@@ -10,7 +10,7 @@ SELECT COUNT(*) = 0 FROM t2;
 COUNT(*) = 0
 1
 INSERT INTO t1 VALUES (1);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t2 VALUES (1);

--- a/mysql-test/suite/galera/r/galera_toi_lock_exclusive.result
+++ b/mysql-test/suite/galera/r/galera_toi_lock_exclusive.result
@@ -5,7 +5,7 @@ START TRANSACTION;
 INSERT INTO t1 VALUES (2);
 ALTER TABLE t1 ADD COLUMN f2 INTEGER, LOCK=EXCLUSIVE;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 INSERT INTO t1 VALUES (2, 2);
 SELECT COUNT(*) = 2 FROM t1;
 COUNT(*) = 2

--- a/mysql-test/suite/galera/r/galera_unicode_pk.result
+++ b/mysql-test/suite/galera/r/galera_unicode_pk.result
@@ -13,7 +13,7 @@ START TRANSACTION;
 UPDATE t1 SET f1 = 'текст3';
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SELECT f1 = 'текст2' FROM t1;
 f1 = 'текст2'
 1
@@ -26,6 +26,6 @@ START TRANSACTION;
 INSERT INTO t1 VALUES ('текст4');
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 COMMIT;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_var_auto_inc_control_off.result
+++ b/mysql-test/suite/galera/r/galera_var_auto_inc_control_off.result
@@ -51,7 +51,7 @@ f1
 1
 COMMIT;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 SELECT * FROM t1;
 f1	node
 1	node1

--- a/mysql-test/suite/galera/r/galera_var_certify_nonPK_off.result
+++ b/mysql-test/suite/galera/r/galera_var_certify_nonPK_off.result
@@ -3,9 +3,9 @@ SET GLOBAL wsrep_certify_nonPK = OFF;
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB /* Table has no primary key */;
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1), (2);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 CREATE TABLE T3 SELECT 1 c;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 INSERT INTO t2 VALUES (1), (2);
 UPDATE t2 SET f1 = 3 WHERE f1 = 1;
 SELECT COUNT(*) = 0 FROM t1;

--- a/mysql-test/suite/galera/r/galera_var_cluster_address.result
+++ b/mysql-test/suite/galera/r/galera_var_cluster_address.result
@@ -1,6 +1,6 @@
 SET GLOBAL wsrep_cluster_address = 'foo://';
 SHOW STATUS;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ERROR HY000: Synchronous wait failed.
 SET SESSION wsrep_sync_wait=0;
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_STATUS;
 SHOW STATUS LIKE 'wsrep_ready';

--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -548,7 +548,7 @@ select @@binlog_format;
 MIXED
 create table tinnodb (i int, primary key pk(i)) engine=innodb;
 insert into tinnodb values (1), (2);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 select * from tinnodb;
 i
 #node-2
@@ -608,7 +608,7 @@ select @@binlog_format;
 MIXED
 create table tinnodb (i int, primary key pk(i)) engine=innodb;
 insert into tinnodb values (1), (2);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 select * from tinnodb;
 i
 #node-2

--- a/mysql-test/suite/galera_3nodes/r/galera_certification_double_failure.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_certification_double_failure.result
@@ -7,6 +7,6 @@ INSERT INTO t2 VALUES (1);
 INSERT INTO t1 VALUES (1);
 INSERT INTO t2 VALUES (1);
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
 DROP TABLE t1;
 DROP TABLE t2;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1475,7 +1475,7 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
       else
       {
         mysql_reset_thd_for_next_command(thd);
-        my_error(ER_LOCK_DEADLOCK, MYF(0), "wsrep aborted transaction");
+        my_message(ER_LOCK_DEADLOCK, "WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction", MYF(0));
         WSREP_DEBUG("Deadlock error for: %s", WSREP_QUERY(thd));
         mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
         thd->killed               = THD::NOT_KILLED;
@@ -1740,7 +1740,7 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
     }
     if (thd->wsrep_conflict_state== ABORTED) 
     {
-      my_error(ER_LOCK_DEADLOCK, MYF(0), "wsrep aborted transaction");
+      my_message(ER_LOCK_DEADLOCK, "WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction", MYF(0));
       WSREP_DEBUG("Deadlock error for: %s", WSREP_QUERY(thd));
       mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
       thd->killed= THD::NOT_KILLED;
@@ -6534,7 +6534,9 @@ static void wsrep_mysql_parse(THD *thd, const char *rawbuf, uint length,
                       thd->thread_id(), is_autocommit, thd->wsrep_retry_counter,
                       thd->variables.wsrep_retry_autocommit,
                       WSREP_QUERY(thd));
-          my_error(ER_LOCK_DEADLOCK, MYF(0), "wsrep aborted transaction");
+          my_message(ER_LOCK_DEADLOCK, 
+            "WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction",
+            MYF(0));
           thd->killed= THD::NOT_KILLED;
           thd->wsrep_conflict_state= NO_CONFLICT;
           if (thd->wsrep_conflict_state != REPLAYING)

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -854,9 +854,6 @@ bool wsrep_sync_wait (THD* thd, uint mask)
 
     if (unlikely(WSREP_OK != ret))
     {
-      const char* msg;
-      int err;
-
       // Possibly relevant error codes:
       // ER_CHECKREAD, ER_ERROR_ON_READ, ER_INVALID_DEFAULT, ER_EMPTY_QUERY,
       // ER_FUNCTION_NOT_DEFINED, ER_NOT_ALLOWED_COMMAND, ER_NOT_SUPPORTED_YET,
@@ -865,17 +862,13 @@ bool wsrep_sync_wait (THD* thd, uint mask)
       switch (ret)
       {
       case WSREP_NOT_IMPLEMENTED:
-        msg= "synchronous reads by wsrep backend. "
-             "Please unset wsrep_causal_reads variable.";
-        err= ER_NOT_SUPPORTED_YET;
+        my_error(ER_NOT_SUPPORTED_YET, MYF(0), 
+              "Synchronous reads by the WSREP backend. "
+              "Please unset the wsrep_causal_reads variable.");
         break;
       default:
-        msg= "Synchronous wait failed.";
-        err= ER_LOCK_WAIT_TIMEOUT; // NOTE: the above msg won't be displayed
-                                   //       with ER_LOCK_WAIT_TIMEOUT
+        my_message(ER_LOCK_WAIT_TIMEOUT, "Synchronous wait failed.", MYF(0));
       }
-
-      my_error(err, MYF(0), msg);
 
       return true;
     }
@@ -1289,8 +1282,8 @@ static int wsrep_TOI_begin(THD *thd, const char *db_, const char *table_,
     WSREP_WARN("TO isolation failed for: %d, schema: %s, sql: %s. Check wsrep "
                "connection state and retry the query.",
                ret, (thd->db().length ? thd->db().str : "(null)"), WSREP_QUERY(thd));
-    my_error(ER_LOCK_DEADLOCK, MYF(0), "WSREP replication failed. Check "
-	     "your wsrep connection state and retry the query.");
+    my_message(ER_LOCK_DEADLOCK, "WSREP replication failed due to TO isolation failure. Check "
+	     "your wsrep connection state and retry the query.", MYF(0));
     if (buf) my_free(buf);
     wsrep_keys_free(&key_arr);
     return -1;


### PR DESCRIPTION
…ror messages

Issue: Incorrect usage of my_error()/my_message() results in some error
messages not appearing correctly (may not show the desired string or in
the wrong context).

Solution:
Correct the my_error()/my_message() usage to display more WSREP-specific
error messages.
