### PR TITLE
PXC-623 : Fix galera_as_slave_autoinc fails occasionally (timing issue)

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
@@ -57,10 +57,11 @@ i	c
 show variables like 'binlog_format';
 Variable_name	Value
 binlog_format	ROW
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
 Variable_name	Value
 auto_increment_increment	2
-auto_increment_offset	1
+show variables like 'wsrep_auto_increment%';
+Variable_name	Value
 wsrep_auto_increment_control	ON
 select * from t1;
 i	c
@@ -77,11 +78,18 @@ i	c
 show variables like 'binlog_format';
 Variable_name	Value
 binlog_format	ROW
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
 Variable_name	Value
 auto_increment_increment	2
-auto_increment_offset	2
+show variables like 'wsrep_auto_increment%';
+Variable_name	Value
 wsrep_auto_increment_control	ON
+total
+3
+result
+1
+result
+1
 DROP TABLE t1;
 STOP SLAVE;
 RESET SLAVE ALL;

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
@@ -61,14 +61,37 @@ show variables like '%auto_increment%';
 select * from t1;
 
 show variables like 'binlog_format';
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
+show variables like 'wsrep_auto_increment%';
+--let $node2_offset = `SELECT @@GLOBAL.auto_increment_offset;`
+
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1;
+--source include/wait_condition.inc
 
 select * from t1;
 
 show variables like 'binlog_format';
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
+show variables like 'wsrep_auto_increment%';
+--let $node3_offset = `SELECT @@GLOBAL.auto_increment_offset;`
+
+
+--disable_query_log
+# The values for auto_increment_offset are 1 and 2 (order doesn't matter)
+# should sum to 3
+--eval SELECT $node2_offset + $node3_offset AS total;
+
+# sanity checks
+# The nodes are all positive values (so summing to 3 is only valid for [1,2])
+eval SELECT $node2_offset > 0 AS result;
+eval SELECT $node3_offset > 0 AS result;
+--enable_query_log
+
 
 --connection node_1
 DROP TABLE t1;


### PR DESCRIPTION
Issue:
The test expects a certain ordering of the auto_increment_offset, but due
to timing isses the order may sometimes be reversed. Which means that the
tests will occasionally fail.

Solution:
To make the tests more robust, verify that the nodes are being assigned
the values of [1,2] in an order-independent way.
