### PR TITLE
- #PXC-601: show status while updating group state can cause an assert (likely race)

### DIFF
--- a/mysql-test/suite/galera/r/galera_desync_count_non_prim.result
+++ b/mysql-test/suite/galera/r/galera_desync_count_non_prim.result
@@ -1,0 +1,20 @@
+SET SESSION wsrep_sync_wait=0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,gcs_get_status,self_leave_non_prim,gcs_close_before_exit';
+SET SESSION wsrep_sync_wait=0;
+SHOW STATUS LIKE 'wsrep_desync_count';;
+SET @@global.wsrep_cluster_address = '';;
+SET SESSION wsrep_on = 0;
+SET GLOBAL wsrep_provider_options = 'signal=gcs_close_before_exit';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SHOW STATUS LIKE 'wsrep_ready';
+Variable_name	Value
+wsrep_ready	OFF
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	non-Primary
+SHOW STATUS LIKE 'wsrep_ready';
+Variable_name	Value
+wsrep_ready	ON
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	Primary

--- a/mysql-test/suite/galera/t/galera_desync_count_non_prim.test
+++ b/mysql-test/suite/galera/t/galera_desync_count_non_prim.test
@@ -1,0 +1,77 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+--connection node_2
+
+--let $wsrep_cluster_address_saved = `SELECT @@global.wsrep_cluster_address`
+
+--let $galera_connection_name = node_2a
+--let $galera_server_number = 2
+--source include/galera_connect.inc
+
+--let $galera_connection_name = node_2b
+--let $galera_server_number = 2
+--source include/galera_connect.inc
+
+--connection node_2
+
+SET SESSION wsrep_sync_wait=0;
+
+--let $galera_sync_point = gcs_get_status,self_leave_non_prim,gcs_close_before_exit
+--source include/galera_set_sync_point.inc
+
+--connection node_2a
+
+SET SESSION wsrep_sync_wait=0;
+
+--disable_result_log
+--send SHOW STATUS LIKE 'wsrep_desync_count';
+
+--connection node_2
+
+--sleep 5
+
+--connection node_2b
+
+--send SET @@global.wsrep_cluster_address = '';
+
+--connection node_2a
+
+--error 0,ER_QUERY_INTERRUPTED
+--reap
+--enable_result_log
+
+--connection node_2
+
+SET SESSION wsrep_on = 0;
+
+--let $galera_sync_point = gcs_close_before_exit
+--let $wait_condition = SELECT 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_debug_sync_waiters' AND VARIABLE_VALUE = '$galera_sync_point'
+--source include/wait_condition.inc
+--source include/galera_signal_sync_point.inc
+
+--connection node_2b
+
+--reap
+
+--connection node_2
+
+--source include/galera_clear_sync_point.inc
+
+# Must return 'OFF':
+SHOW STATUS LIKE 'wsrep_ready';
+
+# Must return 'Non-primary':
+SHOW STATUS LIKE 'wsrep_cluster_status';
+
+--disable_query_log
+--eval SET @@global.wsrep_cluster_address = '$wsrep_cluster_address_saved'
+--enable_query_log
+--source include/wait_until_connected_again.inc
+
+# Must return 'ON':
+SHOW STATUS LIKE 'wsrep_ready';
+
+# Must return 'Primary':
+SHOW STATUS LIKE 'wsrep_cluster_status';


### PR DESCRIPTION
The gcs_group_get_status function does not check that the group->my_idx can be equal to -1 (for example, when node receives self-leave message during non-primary state or technically due to implementation details of the gcs_group_handle_comp_msg function). Therefore, gcs_group_get_status function refers to memory beyond the array, which leads to SIGFAULT during execution of the to_string function.

To fix this error we should not read desync counter until the gcs_group_handle_comp_msg function returns the group->my_idx to definite state.

In addition, we should handle the situation where node is in the non-primary state and we got self-leave message. In this case node is desynchronized from the cluster, therefore I propose to return desync counter = 1.

Galera part of this patch is available here: https://github.com/percona/galera/pull/67

Jenkins job: http://jenkins.percona.com/job/pxc56.build/615/
