### PR TITLE
PXC-623 : [JIRA] (PXC-623) Fix galera_as_slave_autoinc fails occasion…

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_autoinc.result
@@ -57,11 +57,15 @@ i	c
 show variables like 'binlog_format';
 Variable_name	Value
 binlog_format	ROW
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
 Variable_name	Value
 auto_increment_increment	2
-auto_increment_offset	1
+show variables like 'wsrep_auto_increment%';
+Variable_name	Value
 wsrep_auto_increment_control	ON
+select @@global.auto_increment_offset in (1,2);
+@@global.auto_increment_offset in (1,2)
+1
 select * from t1;
 i	c
 1	dummy_text
@@ -77,11 +81,15 @@ i	c
 show variables like 'binlog_format';
 Variable_name	Value
 binlog_format	ROW
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
 Variable_name	Value
 auto_increment_increment	2
-auto_increment_offset	2
+show variables like 'wsrep_auto_increment%';
+Variable_name	Value
 wsrep_auto_increment_control	ON
+select @@global.auto_increment_offset in (1,2);
+@@global.auto_increment_offset in (1,2)
+1
 DROP TABLE t1;
 STOP SLAVE;
 RESET SLAVE ALL;

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
@@ -61,14 +61,25 @@ show variables like '%auto_increment%';
 select * from t1;
 
 show variables like 'binlog_format';
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
+show variables like 'wsrep_auto_increment%';
+select @@global.auto_increment_offset in (1,2);
+
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1;
+--source include/wait_condition.inc
 
 select * from t1;
 
 show variables like 'binlog_format';
-show variables like '%auto_increment%';
+show variables like 'auto_increment_increment';
+show variables like 'wsrep_auto_increment%';
+select @@global.auto_increment_offset in (1,2);
+
 
 --connection node_1
 DROP TABLE t1;


### PR DESCRIPTION
…ally (timing issue)

Issue:
The test assumes that the two nodes will receive the auto_increment_offset in a certain
order [1,2], however depending on the timing the values may appear as [2,1].

Solution:
Change the test assuming that each node can take on both values.
