### PR TITLE
- PXC#625: ROLLBACK to savepoint fail to register wsrep_ handler for

### DIFF
--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -706,6 +706,7 @@ bool trans_rollback_to_savepoint(THD *thd, LEX_STRING name)
                 (!((WSREP_EMULATE_BINLOG(thd) ||  mysql_bin_log.is_open()) 
 		   && thd->variables.sql_log_bin) ||
                  ha_rollback_to_savepoint_can_release_mdl(thd));
+  wsrep_register_hton(thd, TRUE);
 #else
   bool mdl_can_safely_rollback_to_savepoint=
                 (!(mysql_bin_log.is_open() && thd->variables.sql_log_bin) ||


### PR DESCRIPTION
  cleanup/rollback

  Before a transaction is rollback in MySQL workflow if there it involves
  wsrep action then wsrep handler needs to be registered as one of the
  plugin to process the needed rollback action.
  This was done for normal rollback workflow but not for rollabck to
  savepoint workflow causing leaving behind the stale and open transaction
  in wsrep/galera sub-system.
