### PR TITLE
Fix PXC-624 : galera_bf_abort fails with "table t1 doesn't exist" occ…

### DIFF
--- a/mysql-test/suite/galera/t/galera_auto_inc_off.test
+++ b/mysql-test/suite/galera/t/galera_auto_inc_off.test
@@ -9,17 +9,18 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
+--connection node_2
 SET GLOBAL auto_increment_increment=10;
 SET GLOBAL auto_increment_offset=7;
 SET GLOBAL wsrep_auto_increment_control='OFF';
 
 SHOW GLOBAL VARIABLES LIKE '%auto_increment%';
 
---let $galera_connection_name = node_1a
---let $galera_server_number = 1
+--let $galera_connection_name = node_2a
+--let $galera_server_number = 2
 --source include/galera_connect.inc
 
---connection node_1a
+--connection node_2a
 
 SHOW VARIABLES LIKE '%auto_increment%';
 
@@ -29,13 +30,13 @@ SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHE
 SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
 SELECT @@wsrep_auto_increment_control = 1;
 
---connection node_1
+--connection node_2
 
---let $galera_connection_name = node_1b
---let $galera_server_number = 1
+--let $galera_connection_name = node_2b
+--let $galera_server_number = 2
 --source include/galera_connect.inc
 
---connection node_1b
+--connection node_2b
 
 SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
 SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
@@ -45,12 +46,15 @@ SET GLOBAL wsrep_auto_increment_control='OFF';
 
 SHOW VARIABLES LIKE '%auto_increment%';
 
---connection node_1
+--connection node_2
 
 SET GLOBAL wsrep_auto_increment_control='ON';
 
 --let $restart_parameters = "restart:--auto-increment-increment=7 --auto-increment-offset=5"
 --source include/restart_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
 
 SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
 SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;


### PR DESCRIPTION
…asionally

Issue:
This test case started to fail more often (in a recent run it failed on every
node).

Solution:
Need to ensure that the nodes form a cluster (not two independent nodes).
(1) Work with node 2 so that it forms up with node 1
(2) Check to ensure that we have a cluster of size 2 is formed
