### PR TITLE
- PXC#616: PXC is not starting with `--innodb_autoinc_lock_mode=1

### DIFF
--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -997,9 +997,6 @@ i
 2
 drop table tinnodb;
 set session transaction isolation level repeatable read;
-# restart with innodb_autoinc_lock_mode=2
-"grep --count "WSREP: Percona-XtraDB-Cluster requires innodb_autoinc_lock_mode"
-1
 #node-1
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
@@ -1099,6 +1096,13 @@ ERROR 08S01: WSREP doesn't support XA transaction
 xa commit 'testxa2' one phase;
 ERROR 08S01: WSREP doesn't support XA transaction
 drop table t;
+#node-2
+"Shutdown node-2"
+"Try restarting node-2 with --innodb_autoinc_lock_mode=1"
+"grep --count "WSREP: Percona-XtraDB-Cluster requires innodb_autoinc_lock_mode"
+1
+"Try restarting node-2 with default options"
+# restart
 #node-1
 set global pxc_strict_mode = DISABLED;;
 #node-2

--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -7,4 +7,3 @@ galera.galera_fk_multitable : check upstream bug http://bugs.mysql.com/bug.php?i
 galera_split_brain : fails quite often. bug logged to investigate the failure.
 galera_sst_xtrabackup-v2-options : SST Encryption does not work with xtrabackup 2.4.2
 galera_log_output_csv : Upstream bug#80467. MySQL-5.7.11 fails to log queries to slow table even though queries are using table scan.
-

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -1065,18 +1065,7 @@ set session transaction isolation level repeatable read;
 
 #-------------------------------------------------------------------------------
 #
-# Scenario-7: innodb_autoinc_lock_mode=Interleaved/2
-#
---echo # restart with innodb_autoinc_lock_mode=2
---error 1
---exec $MYSQLD --no-defaults --wsrep_provider="libgalera_smm.so" --innodb_autoinc_lock_mode=1 > $restartdir/restart.log 2>&1
---echo "grep --count \"WSREP: Percona-XtraDB-Cluster requires innodb_autoinc_lock_mode"
---exec grep --count "WSREP: Percona-XtraDB-Cluster requires innodb_autoinc_lock_mode" $restartdir/restart.log
---remove_file $restartdir/restart.log
-
-#-------------------------------------------------------------------------------
-#
-# Scenario-8: Test effect of pxc-strict-mode on CTAS
+# Scenario-7: Test effect of pxc-strict-mode on CTAS
 #
 
 #----------------------------
@@ -1179,6 +1168,30 @@ xa end 'testxa2';
 --error ER_UNKNOWN_COM_ERROR
 xa commit 'testxa2' one phase;
 drop table t;
+
+#-------------------------------------------------------------------------------
+#
+# Scenario-8: innodb_autoinc_lock_mode=Interleaved/2
+#
+--connection node_2
+--echo #node-2
+--echo "Shutdown node-2"
+--source include/shutdown_mysqld.inc
+#
+--let $start_mysqld_params="--innodb_autoinc_lock_mode=1 --pxc_strict_mode=ENFORCING --log-error=$restartdir/restart.log"
+--echo "Try restarting node-2 with --innodb_autoinc_lock_mode=1"
+--exec echo "try:$start_mysqld_params" > $_expect_file_name
+--sleep 30
+#
+--echo "grep --count \"WSREP: Percona-XtraDB-Cluster requires innodb_autoinc_lock_mode"
+--exec grep --count "WSREP: Percona-XtraDB-Cluster requires innodb_autoinc_lock_mode" $restartdir/restart.log
+--remove_file $restartdir/restart.log
+#
+--echo "Try restarting node-2 with default options"
+--let $start_mysqld_params=""
+--source include/start_mysqld.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
 
 #-------------------------------------------------------------------------------
 #

--- a/mysys/my_thr_init.c
+++ b/mysys/my_thr_init.c
@@ -237,9 +237,9 @@ void my_thread_global_end()
         my_message_local(ERROR_LEVEL, "Error in my_thread_global_end(): "
                          "%d threads didn't exit", THR_thread_count);
         /* purecov: end */
-#ifdef WITH_WSREP
-        assert(0);
-#endif /* WITH_WSREP */
+//#ifdef WITH_WSREP
+//        assert(0);
+//#endif /* WITH_WSREP */
       }
 #endif
       all_threads_killed= FALSE;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3477,28 +3477,6 @@ int init_common_variables()
         break;
     }
   }
-
-  /* innodb_autoinc_lock_mode (recommended value = Interleaved/2) */
-  if (wsrep_provider_loaded &&
-      !((log_output_options & LOG_NONE) || (log_output_options & LOG_FILE)))
-  {
-    switch(pxc_strict_mode)
-    {
-    case PXC_STRICT_MODE_DISABLED:
-        break;
-    case PXC_STRICT_MODE_PERMISSIVE:
-        WSREP_WARN("Percona-XtraDB-Cluster recommends setting"
-                   " innodb_autoinc_lock_mode = Interleaved/2");
-        break;
-    case PXC_STRICT_MODE_ENFORCING:
-    case PXC_STRICT_MODE_MASTER:
-    default:
-        WSREP_ERROR("Percona-XtraDB-Cluster requires"
-                    " innodb_autoinc_lock_mode = Interleaved/2");
-        return 1;
-        break;
-    }
-  }
 #endif /* WITH_WSREP */
 
 #ifdef WITH_WSREP

--- a/sql/wsrep_check_opts.cc
+++ b/sql/wsrep_check_opts.cc
@@ -279,6 +279,7 @@ check_opts (int const argc, const char* const argv[], struct opt opts[])
        what has been specified on the command line / my.cnf */
     int rcode = 0;
 
+#if 0
     /* PXC/Galera can use Interleaved mode because it enforced ROW based
     replication so make use of better and faster auto-inc locks. */
     if (strcasecmp(opts[WSREP_PROVIDER].value, "none"))
@@ -296,6 +297,7 @@ check_opts (int const argc, const char* const argv[], struct opt opts[])
         rcode = EINVAL;
       }
     }
+#endif
 
     bool locked_in_memory;
     err = get_bool (opts[LOCKED_IN_MEMORY], &locked_in_memory);

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1338,3 +1338,8 @@ void wsrep_SE_initialized()
 {
   SE_initialized = true;
 }
+
+bool wsrep_is_SE_initialized()
+{
+  return SE_initialized;
+}

--- a/sql/wsrep_sst.h
+++ b/sql/wsrep_sst.h
@@ -46,5 +46,6 @@ extern void wsrep_SE_init_grab();   /*! grab init critical section */
 extern void wsrep_SE_init_wait();   /*! wait for SE init to complete */
 extern void wsrep_SE_init_done();   /*! signal that SE init is complte */
 extern void wsrep_SE_initialized(); /*! mark SE initialization complete */
+extern bool wsrep_is_SE_initialized();
 
 #endif /* WSREP_SST_H */


### PR DESCRIPTION
  --pxc_strict_mode=DISABLED` combination.

  Check for innodb_autoinc_lock_mode was wrongly placed.
  innodb_autoinc_lock_mode is InnoDB specific variable and so the check
  should done as part of InnoDB startup validation routine.
