### PR TITLE
Fix mysql start, updated my.cnf, add garbd to dependences

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -282,7 +282,7 @@ Description: Percona XtraDB Cluster with Galera
 Package: percona-xtradb-cluster-full-57
 Section: database
 Architecture: any
-Depends: percona-xtradb-cluster-server-5.7 (>= ${binary:Version}), percona-xtradb-cluster-client-5.7 (>= ${binary:Version}), percona-xtradb-cluster-test-5.7 (>= ${binary:Version}), percona-xtradb-cluster-5.7-dbg (>= ${binary:Version}),  percona-xtradb-cluster-server-debug-5.7, ${misc:Depends}
+Depends: percona-xtradb-cluster-server-5.7 (>= ${binary:Version}), percona-xtradb-cluster-client-5.7 (>= ${binary:Version}), percona-xtradb-cluster-test-5.7 (>= ${binary:Version}), percona-xtradb-cluster-5.7-dbg (>= ${binary:Version}),  percona-xtradb-cluster-server-debug-5.7, percona-xtradb-cluster-garbd-5.7, ${misc:Depends}
 Description: Percona XtraDB Cluster with Galera
  This is a meta-package providing PXC57 server, client, test and debug packages.
 

--- a/build-ps/debian/extra/my.cnf
+++ b/build-ps/debian/extra/my.cnf
@@ -1,39 +1,35 @@
-#
-# Percona Server configuration file.
-#
-# For explanations see
-# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
-
-[client]
-port            = 3306
-socket          = /var/run/mysqld/mysqld.sock
-
-[mysqld_safe]
-pid-file        = /var/run/mysqld/mysqld.pid
-socket          = /var/run/mysqld/mysqld.sock
-nice            = 0
-
+# Template my.cnf for PXC
+# Edit to your requirements.
 [mysqld]
-user            = mysql
-pid-file        = /var/run/mysqld/mysqld.pid
-socket          = /var/run/mysqld/mysqld.sock
-port            = 3306
-basedir         = /usr
-datadir         = /var/lib/mysql
-tmpdir          = /tmp
-lc-messages-dir = /usr/share/mysql
-explicit_defaults_for_timestamp
-
-# Instead of skip-networking the default is now to listen only on
-# localhost which is more compatible and is not less secure.
-bind-address    = 127.0.0.1
-
-log-error       = /var/log/mysql/error.log
-
+server-id=1
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
+log-bin
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
-
-# * IMPORTANT: Additional settings that can override those from this file!
-#   The files must end with '.cnf', otherwise they'll be ignored.
-#
-!includedir /etc/mysql/conf.d/
+# Path to Galera library
+wsrep_provider=/usr/lib64/galera3/libgalera_smm.so
+# Cluster connection URL contains IPs of nodes
+# No IP suggest start this node in cluster bootstrap mode a new cluster
+# will be created.
+wsrep_cluster_address=gcomm://
+# In order for Galera to work correctly binlog format should be ROW
+binlog_format=ROW
+# MyISAM storage engine has only experimental support
+default_storage_engine=InnoDB
+# Slave thread to use
+wsrep_slave_threads= 8
+# This changes how InnoDB autoincrement locks are managed and is a requirement for Galera
+innodb_autoinc_lock_mode=2
+innodb_locks_unsafe_for_binlog=1
+# Node IP address
+#wsrep_node_address=192.168.70.63
+# Cluster name
+wsrep_cluster_name=pxc-cluster
+wsrep_node_name=pxc-cluster-node-1
+# SST method
+wsrep_sst_method=xtrabackup-v2
+#Authentication for SST method
+#wsrep_sst_auth="sstuser:s3cretPass"

--- a/build-ps/debian/extra/mysql-systemd-start
+++ b/build-ps/debian/extra/mysql-systemd-start
@@ -54,7 +54,7 @@ sanity () {
 
 	if [ ! "$(ls -A ${MYSQLDATA}/mysql)" ];
 	then
-		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on 2>&1 > /dev/null"
+		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --no-defaults --initialize-insecure=on 2>&1 > /dev/null"
 		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --log_error_verbosity=2 2>&1 > /dev/null &"
 		pinger
 		mysql -e "INSTALL PLUGIN auth_socket SONAME 'auth_socket.so'"

--- a/build-ps/debian/percona-xtradb-cluster-server-5.7.postinst
+++ b/build-ps/debian/percona-xtradb-cluster-server-5.7.postinst
@@ -37,10 +37,10 @@ USE mysql;
 UPDATE user SET authentication_string=PASSWORD('${PASSWD}') WHERE user='root';
 EOF
 				PASSWD=""
-				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on --init-file=${SQL} 2>&1 > /dev/null"
+				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --no-defaults --initialize-insecure=on --init-file=${SQL} 2>&1 > /dev/null"
 				rm -f ${SQL}
 			else
-				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on 2>&1 > /dev/null"
+				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --no-defaults --initialize-insecure=on 2>&1 > /dev/null"
 				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --log_error_verbosity=2 2>&1 > /dev/null &"
 				while [ ! -e $(my_print_defaults mysqld | grep pid-file | cut -d= -f2) ]; do sleep 1; done
 				mysql -e "INSTALL PLUGIN auth_socket SONAME 'auth_socket.so'"

--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -377,9 +377,9 @@ This is a meta-package which installs server, client and galera-3.
 Summary:        Percona XtraDB Cluster - full package
 Group:          Applications/Databases
 %if "%rhel" == "5"
-Requires:       %{distro_requires} Percona-XtraDB-Cluster-server%{product_suffix} Percona-XtraDB-Cluster-client%{product_suffix} Percona-XtraDB-Cluster-test%{product_suffix} Percona-XtraDB-Cluster%{product_suffix}-debuginfo
+Requires:       %{distro_requires} Percona-XtraDB-Cluster-server%{product_suffix} Percona-XtraDB-Cluster-client%{product_suffix} Percona-XtraDB-Cluster-test%{product_suffix} Percona-XtraDB-Cluster%{product_suffix}-debuginfo Percona-XtraDB-Cluster-garbd%{product_suffix}
 %else
-Requires:       %{distro_requires} Percona-XtraDB-Cluster-server%{product_suffix} Percona-XtraDB-Cluster-client%{product_suffix} Percona-XtraDB-Cluster-devel%{product_suffix} Percona-XtraDB-Cluster-test%{product_suffix} Percona-XtraDB-Cluster%{product_suffix}-debuginfo
+Requires:       %{distro_requires} Percona-XtraDB-Cluster-server%{product_suffix} Percona-XtraDB-Cluster-client%{product_suffix} Percona-XtraDB-Cluster-devel%{product_suffix} Percona-XtraDB-Cluster-test%{product_suffix} Percona-XtraDB-Cluster%{product_suffix}-debuginfo Percona-XtraDB-Cluster-garbd%{product_suffix}
 %endif
 
 %description -n Percona-XtraDB-Cluster-full%{product_suffix}

--- a/build-ps/rpm/my.cnf
+++ b/build-ps/rpm/my.cnf
@@ -1,48 +1,35 @@
 # Template my.cnf for PXC
 # Edit to your requirements.
-
 [mysqld]
-#
-# Remove leading # and set to the amount of RAM for the most important data
-# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
-# innodb_buffer_pool_size = 128M
-#
-# Remove leading # to turn on a very important data integrity option: logging
-# changes to the binary log between backups.
-# log_bin
-#
-# Remove leading # to set options mainly useful for reporting servers.
-# The server defaults are faster for transactions and fast SELECTs.
-# Adjust sizes as needed, experiment to find the optimal values.
-# join_buffer_size = 128M
-# sort_buffer_size = 2M
-# read_rnd_buffer_size = 2M
+server-id=1
 datadir=/var/lib/mysql
 socket=/var/lib/mysql/mysql.sock
-# Disabling symbolic-links is recommended to prevent assorted security risks
-symbolic-links=0
-server-id=1
-
 log-error=/var/log/mysqld.log
 pid-file=/var/run/mysqld/mysqld.pid
-
-log_bin
-
-binlog_format                  = ROW
-innodb_buffer_pool_size        = 100M
-innodb_flush_log_at_trx_commit = 0
-innodb_flush_method            = O_DIRECT
-innodb_log_files_in_group      = 2
-innodb_log_file_size           = 20M
-innodb_file_per_table          = 1
-datadir                        = /var/lib/mysql
-
-wsrep_cluster_address          = gcomm://
-wsrep_provider                 = /usr/lib64/galera3/libgalera_smm.so
-
-wsrep_slave_threads            = 8
-wsrep_cluster_name             = Cluster
-wsrep_node_name                = Node1
-
-innodb_locks_unsafe_for_binlog = 1
-innodb_autoinc_lock_mode       = 2
+log-bin
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+# Path to Galera library
+wsrep_provider=/usr/lib64/galera3/libgalera_smm.so
+# Cluster connection URL contains IPs of nodes
+# No IP suggest start this node in cluster bootstrap mode a new cluster
+# will be created.
+wsrep_cluster_address=gcomm://
+# In order for Galera to work correctly binlog format should be ROW
+binlog_format=ROW
+# MyISAM storage engine has only experimental support
+default_storage_engine=InnoDB
+# Slave thread to use
+wsrep_slave_threads= 8
+# This changes how InnoDB autoincrement locks are managed and is a requirement for Galera
+innodb_autoinc_lock_mode=2
+innodb_locks_unsafe_for_binlog=1
+# Node IP address
+#wsrep_node_address=192.168.70.63
+# Cluster name
+wsrep_cluster_name=pxc-cluster
+wsrep_node_name=pxc-cluster-node-1
+# SST method
+wsrep_sst_method=xtrabackup-v2
+#Authentication for SST method
+#wsrep_sst_auth="sstuser:s3cretPass"

--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -58,7 +58,7 @@ install_db () {
     fi
 
     # Create initial db
-    /usr/sbin/mysqld --initialize --datadir="$datadir" --user=mysql
+    /usr/sbin/mysqld --no-defaults --initialize --datadir="$datadir" --user=mysql
     exit 0
 }
 

--- a/build-ps/rpm/mysql.init
+++ b/build-ps/rpm/mysql.init
@@ -109,7 +109,7 @@ start(){
 		done
 	    fi
 	    # Now create the database
-	    action $"Initializing MySQL database: " /usr/sbin/mysqld --initialize --datadir="$datadir" --user=mysql
+	    action $"Initializing MySQL database: " /usr/sbin/mysqld --no-defaults --initialize --datadir="$datadir" --user=mysql
 	    ret=$?
 	    [ $ret -ne 0 ] && return $ret
 	    chown -R mysql:mysql "$datadir"

--- a/build-ps/ubuntu/control
+++ b/build-ps/ubuntu/control
@@ -282,7 +282,7 @@ Description: Percona XtraDB Cluster with Galera
 Package: percona-xtradb-cluster-full-57
 Section: database
 Architecture: any
-Depends: percona-xtradb-cluster-server-5.7 (>= ${binary:Version}), percona-xtradb-cluster-client-5.7 (>= ${binary:Version}), percona-xtradb-cluster-test-5.7 (>= ${binary:Version}), percona-xtradb-cluster-5.7-dbg (>= ${binary:Version}),  percona-xtradb-cluster-server-debug-5.7, ${misc:Depends}
+Depends: percona-xtradb-cluster-server-5.7 (>= ${binary:Version}), percona-xtradb-cluster-client-5.7 (>= ${binary:Version}), percona-xtradb-cluster-test-5.7 (>= ${binary:Version}), percona-xtradb-cluster-5.7-dbg (>= ${binary:Version}),  percona-xtradb-cluster-server-debug-5.7, percona-xtradb-cluster-garbd-5.7, ${misc:Depends}
 Description: Percona XtraDB Cluster with Galera
  This is a meta-package providing PXC57 server, client, test and debug packages.
 

--- a/build-ps/ubuntu/extra/mysql-systemd-start
+++ b/build-ps/ubuntu/extra/mysql-systemd-start
@@ -54,7 +54,7 @@ sanity () {
 
 	if [ ! "$(ls -A ${MYSQLDATA}/mysql)" ];
 	then
-		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on 2>&1 > /dev/null"
+		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --no-defaults --initialize-insecure=on 2>&1 > /dev/null"
 		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --log_error_verbosity=2 2>&1 > /dev/null &"
 		pinger
 		mysql -e "INSTALL PLUGIN auth_socket SONAME 'auth_socket.so'"

--- a/build-ps/ubuntu/extra/percona-xtradb-cluster.conf.d/mysqld.cnf
+++ b/build-ps/ubuntu/extra/percona-xtradb-cluster.conf.d/mysqld.cnf
@@ -1,32 +1,35 @@
-#
-# The Percona XtraDB CLuster 5.7 configuration file.
-#
-# One can use all long options that the program supports.
-# Run program with --help to get a list of available options and with
-# --print-defaults to see which it would actually understand and use.
-#
-# For explanations see
-# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
-
+# Template my.cnf for PXC
+# Edit to your requirements.
 [mysqld]
-user   = mysql
-pid-file = /var/run/mysqld/mysqld.pid
-socket   = /var/run/mysqld/mysqld.sock
-port   = 3306
-basedir    = /usr
-datadir    = /var/lib/mysql
-tmpdir   = /tmp
-lc-messages-dir  = /usr/share/mysql
-explicit_defaults_for_timestamp
-
-# Instead of skip-networking the default is now to listen only on
-# localhost which is more compatible and is not less secure.
-bind-address = 127.0.0.1
-
-log-error    = /var/log/mysql/error.log
-
-# Recommended in standard MySQL setup
-sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
-
+server-id=1
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
+log-bin
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
+# Path to Galera library
+wsrep_provider=/usr/lib64/galera3/libgalera_smm.so
+# Cluster connection URL contains IPs of nodes
+# No IP suggest start this node in cluster bootstrap mode a new cluster
+# will be created.
+wsrep_cluster_address=gcomm://
+# In order for Galera to work correctly binlog format should be ROW
+binlog_format=ROW
+# MyISAM storage engine has only experimental support
+default_storage_engine=InnoDB
+# Slave thread to use
+wsrep_slave_threads= 8
+# This changes how InnoDB autoincrement locks are managed and is a requirement for Galera
+innodb_autoinc_lock_mode=2
+innodb_locks_unsafe_for_binlog=1
+# Node IP address
+#wsrep_node_address=192.168.70.63
+# Cluster name
+wsrep_cluster_name=pxc-cluster
+wsrep_node_name=pxc-cluster-node-1
+# SST method
+wsrep_sst_method=xtrabackup-v2
+#Authentication for SST method
+#wsrep_sst_auth="sstuser:s3cretPass"

--- a/build-ps/ubuntu/percona-xtradb-cluster-server-5.7.postinst
+++ b/build-ps/ubuntu/percona-xtradb-cluster-server-5.7.postinst
@@ -37,10 +37,10 @@ USE mysql;
 UPDATE user SET authentication_string=PASSWORD('${PASSWD}') WHERE user='root';
 EOF
 				PASSWD=""
-				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on --init-file=${SQL} 2>&1 > /dev/null"
+				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --no-defaults --initialize-insecure=on --init-file=${SQL} 2>&1 > /dev/null"
 				rm -f ${SQL}
 			else
-				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on 2>&1 > /dev/null"
+				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --no-defaults --initialize-insecure=on 2>&1 > /dev/null"
 				su - mysql -s /bin/bash -c "/usr/sbin/mysqld --log_error_verbosity=2 2>&1 > /dev/null &"
 				while [ ! -e $(my_print_defaults mysqld | grep pid-file | cut -d= -f2) ]; do sleep 1; done
 				mysql -e "INSTALL PLUGIN auth_socket SONAME 'auth_socket.so'"


### PR DESCRIPTION
http://jenkins.percona.com/job/percona-xtradb-cluster-5.7-RELEASE/54/

the content of my.cnf was suggested by Krunal

Installed:
  Percona-XtraDB-Cluster-full-57.x86_64 0:5.7.12-25.16.1.el7                                                   

Dependency Installed:
  Percona-XtraDB-Cluster-57-debuginfo.x86_64 0:5.7.12-25.16.1.el7  
  Percona-XtraDB-Cluster-client-57.x86_64 0:5.7.12-25.16.1.el7  
  Percona-XtraDB-Cluster-devel-57.x86_64 0:5.7.12-25.16.1.el7  
  Percona-XtraDB-Cluster-garbd-57.x86_64 0:5.7.12-25.16.1.el7  
  Percona-XtraDB-Cluster-server-57.x86_64 0:5.7.12-25.16.1.el7  
  Percona-XtraDB-Cluster-shared-57.x86_64 0:5.7.12-25.16.1.el7  
  Percona-XtraDB-Cluster-test-57.x86_64 0:5.7.12-25.16.1.el7                                                   

Complete!
[korvin@localhost test]$ sudo service mysql start
Redirecting to /bin/systemctl start  mysql.service
[korvin@localhost test]$ sudo service mysql status
Redirecting to /bin/systemctl status  mysql.service
● mysql.service - Percona XtraDB Cluster
   Loaded: loaded (/usr/lib/systemd/system/mysql.service; disabled; vendor preset: disabled)
   Active: active (running) since Fri 2016-07-01 09:29:25 EDT; 15s ago
  Process: 5262 ExecStartPost=/usr/bin/mysql-systemd start-post $MAINPID (code=exited, status=0/SUCCESS)
  Process: 5191 ExecStartPre=/usr/bin/mysql-systemd start-pre (code=exited, status=0/SUCCESS)
 Main PID: 5261 (mysqld_safe)
   CGroup: /system.slice/mysql.service
           ├─5261 /bin/sh /usr/bin/mysqld_safe --basedir=/usr
           └─5588 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib64/mysql/plu...

Jul 01 09:29:07 localhost.localdomain mysql-systemd[5191]: 2016-07-01T13:29:07.650658Z 0 [Warning] No exi...eb.
Jul 01 09:29:07 localhost.localdomain mysql-systemd[5191]: 2016-07-01T13:29:07.653648Z 0 [Warning] Gtid t...ed.
Jul 01 09:29:08 localhost.localdomain mysql-systemd[5191]: 2016-07-01T13:29:08.003228Z 0 [Warning] CA cer...ed.
Jul 01 09:29:08 localhost.localdomain mysql-systemd[5191]: 2016-07-01T13:29:08.015927Z 1 [Note] A tempora...67m
Jul 01 09:29:24 localhost.localdomain mysqld_safe[5261]: 2016-07-01T13:29:24.315379Z mysqld_safe Logging ...g'.
Jul 01 09:29:24 localhost.localdomain mysqld_safe[5261]: 2016-07-01T13:29:24.341838Z mysqld_safe Starting...sql
Jul 01 09:29:24 localhost.localdomain mysqld_safe[5261]: 2016-07-01T13:29:24.345505Z mysqld_safe Skipping...sql
Jul 01 09:29:24 localhost.localdomain mysqld_safe[5261]: 2016-07-01T13:29:24.347191Z mysqld_safe Assignin...ion
Jul 01 09:29:25 localhost.localdomain mysql-systemd[5262]: SUCCESS!
Jul 01 09:29:25 localhost.localdomain systemd[1]: Started Percona XtraDB Cluster.
Hint: Some lines were ellipsized, use -l to show in full.
[korvin@localhost test]$ 
