### PR TITLE
- PXC#426: Race condition during IST

### DIFF
--- a/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
+++ b/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
@@ -1,0 +1,15 @@
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+Shutting down server ...
+CREATE TABLE t2 (f1 INTEGER);
+INSERT INTO t2 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+SET GLOBAL wsrep_provider_options = 'dbug=d,process_state_req_ist';
+Starting server ...
+SELECT COUNT(*) = 10 FROM t1;
+COUNT(*) = 10
+1
+SELECT COUNT(*) = 10 FROM t2;
+COUNT(*) = 10
+1
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
+++ b/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
@@ -1,0 +1,57 @@
+#
+# This test is artificially creating a situation where
+# the state of the donor node goes too far and diverged from
+# the state of another node, which joining the cluster, and
+# therefore the joining node unable to initiate the IST state
+# transfer.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connection node_1
+
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+--connection node_2
+
+# Initiate normal shutdown on the node 2:
+
+--echo Shutting down server ...
+--source include/shutdown_mysqld.inc
+
+# Waiting until shutdown on node 2 has been completed:
+
+--connection node_1
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Do some changes on node 1:
+
+CREATE TABLE t2 (f1 INTEGER);
+INSERT INTO t2 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+# Simulate shift of the donor seqno:
+
+--let $galera_sync_point = process_state_req_ist
+--source include/galera_set_sync_point.inc
+
+# Restarting the second node:
+
+--connection node_2
+
+--let $start_mysqld_params=
+
+--echo Starting server ...
+--source include/start_mysqld.inc
+
+# Sanity check (node 2 is running now and can perform SQL operators):
+
+SELECT COUNT(*) = 10 FROM t1;
+SELECT COUNT(*) = 10 FROM t2;
+
+--connection node_1
+
+DROP TABLE t1;
+DROP TABLE t2;


### PR DESCRIPTION
  (On behalf of Julius)

  The node lost connectivity with other nodes in the cluster (for some time)
  due to network problems. Therefore, it needs to run IST to synchronize their
  state with cluster, but the IST request was failed.

  During node operation IST starts only when local_seqno < group_seqno while
  configuration change is detected in the cluster (this detected at the GCS
  layer, then the GCS_ACT_CONF message is sent to the action source handler and
  processed in the Replicator).

  This occurs after the cluster becomes non-primary state, and then returns to
  the state with primary component. Alternatively, IST started when node lost
  connectivity with the cluster (but this is recoverable condition) and then it
  re-joined the cluster.

  However, if we already have large network delays and packet losses, then
  during IST we can encounter situation when seqno on the donor node has moved
  forward so much that IST is not possible and we need to run "full" SST request.

  The immediate cause of the PXC-426 error is the inability of the PXC to run
  SST (using methods that different from mysqldump) on the working node. PXC and
  Galera written in such way that we need a full restart before launching new SST.

  Therefore, we need to show the user a message that indicates that we need to
  perform SST after restart and to stop working. However, currently the server
  continues to work, even when the synchronization of the node is no longer
  possible and it cannot continue normal operation in a cluster.

  However, why we encountered situation when seqno had goes forward during IST?

  The fact, that the heuristic algorithm of the donor selection, which
  implemented in the GCS, contains the flaw, and may choose as a donor such
  node, where seqno can go forward before the IST request will be received.

  Therefore, we need to improve the heuristics in the donor node selection
  algorithm (in the group_find_ist_donor function) to make this flaw less likely.

  And since the heuristic that selects the donor node does not give us a 100%
  guarantee that seqno does not move forward while the new node joining the
  cluster, if we have only a request for the IST (but we do not have a request
  for SST), then we need to informing new node, that it should prepare to
  receive SST.

  Especially because we need this signal to notify the user of the impossibility
  to perform the SST instead of IST in the current version of the server
  (when xtrabackup or rsynch was selected as the state transfer method).

  It is difficult to assess the situation from which we have only the server
  logs - but it is possible that the correction of the heuristic would not help
  us to eliminate all cases when situation like the PXC-426 can arise.

  In this case, as I have said above, we need to tell the user that the IST is
  impossible and server restart is required (because we cannot change PXC
  architecture quickly, without rewriting large fragments of its code).

  Theoretically, a similar diagnostic and error also possible if the MySQL
  server does not prepared structures for the SST in the view callback (in the
  wsrep_view_handler_cb function) after restart of the node - when it returns
  only the structures for IST. For example, when new node joining the cluster,
  it may trying to avoid unnecessary SST request when its seqno matches the
  group seqno.

  But in the current version of PXC this should not happen after node restart,
  because after restrart the wsrep_sst_prepare function (which called from
  wsrep_view_handler_cb) always returns a non-zero value as length of the SST
  request and node always prepared both for the SST and IST.

  However, the assertion in the wsrep_view_handler_cb function only checks for
  the presence of the SST structure, but not its length. Theoretically, when
  mysqldump method is used this structure can be created only in order to point
  to the IST (with zero length of the SST part).

  Therefore, in the Galera code we should be ready to restart SST after failing
  to perform IST - to be protected against failures in the future, when
  implementation of the wsrep_sst_prepare function may change. And, especially,
  when mysqldump is used as state transfer method.

  In addition, if the IST request was canceled due to an error at the GCS level
  or by initiative of the server, and if the node remain in the S_JOINING state,
  then we must return it to the S_CONNECTED state.
