### PR TITLE
Fix PXC-564 : PXC changes to support the keyring option

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
@@ -1,0 +1,18 @@
+SELECT 1;
+1
+1
+Killing server ...
+CREATE TABLE e1 (
+id INT NOT NULL AUTO_INCREMENT,
+text VARCHAR(10) DEFAULT NULL,
+PRIMARY KEY (id)
+) ENCRYPTION='Y';
+INSERT INTO e1(text) VALUES('aaaaa');
+INSERT INTO e1(text) VALUES('bbbbb');
+Restarting node 2 ...
+# restart
+select * from e1;
+id	text
+1	aaaaa
+2	bbbbb
+drop table e1;

--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -7,3 +7,5 @@ galera.galera_fk_multitable : check upstream bug http://bugs.mysql.com/bug.php?i
 galera_split_brain : fails quite often. bug logged to investigate the failure.
 galera_sst_xtrabackup-v2-options : SST Encryption does not work with xtrabackup 2.4.2
 galera_log_output_csv : Upstream bug#80467. MySQL-5.7.11 fails to log queries to slow table even though queries are using table scan.
+galera_sst_xtrabackup-v2_keyring : Requires xtrabackup 2.4.4
+

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.cnf
@@ -1,0 +1,23 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_sst_auth="root:"
+wsrep_debug=ON
+
+[sst]
+encrypt=3
+tkey=@ENV.MYSQL_TEST_DIR/std_data/galera-key.pem
+tcert=@ENV.MYSQL_TEST_DIR/std_data/galera-cert.pem
+
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=1;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TEST_DIR/tmp/keyring.1
+server_id=1
+
+[mysqld.2]
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.size=1;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TEST_DIR/tmp/keyring.2
+server_id=2

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
@@ -1,0 +1,53 @@
+#
+# This test checks that the keyring option is supported by the SST script.
+#
+# The initial SST happens on startup (but may not have an encrypted table).
+# In addition, we also test the case where there is an encrypted table with data.
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+# Force a restart at the end of the test
+--source include/force_restart.inc
+
+SELECT 1;
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+
+# Kill node 2 to force an SST
+# echo Killing node 2 ...
+--connection node_2
+--source include/kill_galera.inc
+
+# Wait until the node is confirmed as being down
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Basic setup, create an encrypted table
+CREATE TABLE e1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  text VARCHAR(10) DEFAULT NULL,
+  PRIMARY KEY (id)
+) ENCRYPTION='Y';
+
+INSERT INTO e1(text) VALUES('aaaaa');
+INSERT INTO e1(text) VALUES('bbbbb');
+
+
+# Restart the server
+--connection node_2
+--echo Restarting node 2 ...
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from e1;
+
+--connection node_1
+drop table e1;


### PR DESCRIPTION
Issue:
Original issue was to support re-encrypt because of the way 5.7.11 uses
keyring encryption, however 5.7.12 changes the way it uses the keyring
so re-encryption is no longer needed.  However, still need to add
support for sending the keyring over.

Solution:
Send the keyring over.  When using the keyring, have to ensure
that it is sent over an encrypted connection.
Also requires PXB 2.4.4
