### PR TITLE
- PXC#632: mysqldump sst doesn't work with pxc-strict-mode=ENFORCING.

### DIFF
--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -30,6 +30,7 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits using SERIALIZ
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of CREATE TABLE AS SELECT");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of CREATE TABLE AS SELECT");
 call mtr.add_suppression("WSREP doesn't support XA transaction");
+set global pxc_strict_mode='ENFORCING';
 #node-2
 set global pxc_strict_mode='DISABLED';
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of MyISAM table replication as it is an experimental feature");
@@ -37,7 +38,13 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of TRUNCATE on table created with non-transactional storage engine");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ADMIN command on table created with non-transactional storage engine");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ALTER on table created with non-transactional storage engine");
+set global pxc_strict_mode='ENFORCING';
 #node-1
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
+#node-2
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -148,6 +155,11 @@ alter table tinnodb engine=memory;
 alter table tinnodb engine=innodb;
 drop table tinnodb;
 #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -290,6 +302,11 @@ set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 ENFORCING
+#node-2
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
 #node-1
 create table tmyisam (i int, primary key pk(i)) engine=myisam;
 insert into tmyisam values (1), (2);
@@ -391,6 +408,11 @@ set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 DISABLED
+#node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
 #node-1
 set session wsrep_replicate_myisam = 0;
 select @@wsrep_replicate_myisam;
@@ -426,6 +448,11 @@ i
 2
 drop table tmyisam;
 #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -478,6 +505,11 @@ set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 ENFORCING
+#node-2
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
 #node-1
 set session wsrep_replicate_myisam = 0;
 select @@wsrep_replicate_myisam;
@@ -523,6 +555,11 @@ set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 DISABLED
+#node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
 #node-1
 set session binlog_format = 'STATEMENT';
 select @@binlog_format;
@@ -575,6 +612,11 @@ i
 2
 drop table tinnodb;
 #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -641,6 +683,11 @@ Warning	1231	Percona-XtraDB-Cluster recommends setting binlog_format to ROW
 set global pxc_strict_mode = 'ENFORCING';
 ERROR 42000: Variable 'pxc_strict_mode' can't be set to the value of 'ENFORCING'
 set session binlog_format = 'ROW';
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
+#node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -682,6 +729,11 @@ set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 DISABLED
+#node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
 #node-1
 create table tinnodb (i int) engine=innodb;
 create table tmyisam (i int) engine=innodb;
@@ -704,6 +756,11 @@ i
 2
 drop table tinnodb;
 #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -738,6 +795,11 @@ set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 ENFORCING
+#node-2
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
 #node-1
 create table tinnodb (i int) engine=innodb;
 create table tmyisam (i int) engine=innodb;
@@ -755,6 +817,11 @@ drop table tinnodb;
 set global general_log = 1;
 set global log_output = 'NONE';
 #node-1
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
+#node-2
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -783,6 +850,11 @@ select count(*) from mysql.general_log;
 count(*)
 2
 #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -820,6 +892,11 @@ set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 ENFORCING
+#node-2
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
 #node-1
 set global log_output = 'NONE';
 select 1 from dual;
@@ -849,6 +926,11 @@ count(*)
 1
 #node-1
 #node-1
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
+#node-2
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -920,6 +1002,11 @@ set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 PERMISSIVE
+#node-2
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
 #node-1
 create table tinnodb (i int, primary key pk(i)) engine=innodb;
 insert into tinnodb values (1), (2);
@@ -967,6 +1054,11 @@ set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 ENFORCING
+#node-2
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
 #node-1
 create table tinnodb (i int, primary key pk(i)) engine=innodb;
 insert into tinnodb values (1), (2);
@@ -1002,6 +1094,11 @@ set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
 DISABLED
+#node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
 #node-1
 create table tinnodb (i int, primary key pk(i)) engine=innodb;
 insert into tinnodb values (1), (2);
@@ -1023,6 +1120,11 @@ i
 drop table tinnodb;
 drop table tinnodb2;
 #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 @@pxc_strict_mode
@@ -1050,6 +1152,11 @@ i
 drop table tinnodb;
 drop table tinnodb2;
 #node-1
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
+#node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 @@pxc_strict_mode

--- a/mysql-test/suite/galera/t/galera_as_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_slave.test
@@ -41,6 +41,7 @@ SELECT COUNT(*) = 3 FROM t1;
 DROP TABLE t1;
 
 --connection node_2
+--sleep 5
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/galera/t/galera_var_reject_queries.test
+++ b/mysql-test/suite/galera/t/galera_var_reject_queries.test
@@ -23,7 +23,7 @@ SELECT * FROM t1;
 SET GLOBAL wsrep_reject_queries = ALL_KILL;
 
 --connection node_1a
---sleep 5
+--sleep 10
 --error 2013
 SELECT * FROM t1;
 

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -63,6 +63,8 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of CREATE 
 
 call mtr.add_suppression("WSREP doesn't support XA transaction");
 
+set global pxc_strict_mode='ENFORCING';
+
 --connection node_2
 --echo #node-2
 
@@ -78,6 +80,8 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ADMIN command on table created with non-transactional storage engine");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ALTER on table created with non-transactional storage engine");
 
+set global pxc_strict_mode='ENFORCING';
+
 #-------------------------------------------------------------------------------
 #
 # Scenario-1: Engine-type
@@ -89,6 +93,11 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 # DISABLED
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 
@@ -185,6 +194,11 @@ drop table tinnodb;
 --echo #node-1
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
 
 #
 # base table in myisam format
@@ -276,6 +290,11 @@ drop table tinnodb;
 # ENFORCING
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 
@@ -395,6 +414,11 @@ drop table tinnodb;
 --echo #node-1
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
 
 #
 # wsrep_replicate_myisam = 0
@@ -433,6 +457,11 @@ drop table tmyisam;
 # PERMISSIVE
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 
@@ -476,6 +505,11 @@ drop table tmyisam;
 --error ER_WRONG_VALUE_FOR_VAR
 set global pxc_strict_mode = 'ENFORCING';
 set session wsrep_replicate_myisam = 0;
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 
@@ -538,6 +572,11 @@ drop table tmyisam;
 --echo #node-1
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
 
 #
 # binlog_format=STATEMENT
@@ -593,6 +632,11 @@ drop table tinnodb;
 # PERMISSIVE
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 
@@ -654,6 +698,11 @@ set session binlog_format = 'STATEMENT';
 --error ER_WRONG_VALUE_FOR_VAR
 set global pxc_strict_mode = 'ENFORCING';
 set session binlog_format = 'ROW';
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 
@@ -705,6 +754,11 @@ drop table tinnodb;
 --echo #node-1
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
 
 #
 --connection node_1
@@ -730,6 +784,11 @@ drop table tinnodb;
 --echo #node-1
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
 
 #
 --connection node_1
@@ -753,6 +812,11 @@ drop table tinnodb;
 # ENFORCING
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 
@@ -794,6 +858,11 @@ set global log_output = 'NONE';
 --echo #node-1
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
 
 #
 # log_output=NONE
@@ -826,6 +895,11 @@ select count(*) from mysql.general_log;
 # PERMISSIVE
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
 
@@ -863,6 +937,11 @@ select count(*) from mysql.general_log;
 --error ER_WRONG_VALUE_FOR_VAR
 set global pxc_strict_mode = 'ENFORCING';
 set global log_output = 'FILE';
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 
@@ -922,6 +1001,11 @@ select count(*) from mysql.general_log;
 # DISABLED
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
 
@@ -993,6 +1077,11 @@ drop table tinnodb;
 --echo #node-1
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
 
 #
 # Try to issue different kind of locking statements
@@ -1027,6 +1116,11 @@ drop table tinnodb;
 --error ER_WRONG_VALUE_FOR_VAR
 set global pxc_strict_mode = 'ENFORCING';
 set session transaction isolation level repeatable read;
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 
@@ -1075,6 +1169,11 @@ set session transaction isolation level repeatable read;
 --echo #node-1
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
 
 #
 --connection node_1
@@ -1099,6 +1198,11 @@ drop table tinnodb2;
 --echo #node-1
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
 
 #
 --connection node_1
@@ -1121,6 +1225,11 @@ drop table tinnodb2;
 # ENFORCING
 --connection node_1
 --echo #node-1
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4365,10 +4365,6 @@ end_with_restore_list:
   {
     List<set_var_base> *lex_var_list= &lex->var_list;
 
-#ifdef WITH_WSREP
-    wsrep_replicate_set_stmt= false;
-#endif /* WITH_WSREP */
-
     if ((check_table_access(thd, SELECT_ACL, all_tables, FALSE, UINT_MAX, FALSE)
          || open_and_lock_tables(thd, all_tables, 0)))
       goto error;
@@ -4385,13 +4381,6 @@ end_with_restore_list:
         my_error(ER_WRONG_ARGUMENTS,MYF(0),"SET");
       goto error;
     }
-
-#ifdef WITH_WSREP
-    if (wsrep_replicate_set_stmt)
-      WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
-    wsrep_replicate_set_stmt= false;
-#endif /* WITH_WSREP */
-
     break;
   }
 

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -795,7 +795,7 @@ static const char* pxc_strict_mode_to_string(ulong value)
 bool pxc_strict_mode_check(sys_var *self, THD* thd, set_var* var)
 {
   /* pxc-strict-mode can be changed only if node is cluster-node. */
-  if (!(WSREP(thd)))
+  if (!(WSREP_ON))
   {
     WSREP_ERROR("pxc_strict_mode can be changed only if node is cluster-node");
     my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), var->var->name.str,


### PR DESCRIPTION
- ENFORCING mode prohibits direct update of MyISAM table using
  DML statement. SST method = mysqldump will try to dump and load
  the table as normal DML statement.
  
  With ENFORCING mode mysqldump method usage becomes restrictive.
  In order to address this issue pxc_strict_mode is set to
  DISABLED mode while running the load statements.
  It is fine to do so as mysqldump is used while during node
  bootup stage for recieving SST stream and statement used
  by MySQL are safe and fully supported from PXC perspective.
