### PR TITLE
PXC-564 : PXC changes to support the keyring option

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -202,3 +202,26 @@ wsrep_check_programs()
 
     return $ret
 }
+
+#
+# user can specify xtrabackup specific settings that will be used during sst
+# process like encryption, etc.....
+# parse such configuration option. (group for xb settings is [sst] in my.cnf
+#
+# 1st param: group : name of the config file section, e.g. mysqld
+# 2nd param: var : name of the variable in the section, e.g. server-id
+# 3rd param: - : default value for the param
+parse_cnf()
+{
+    local group=$1
+    local var=$2
+    # print the default settings for given group using my_print_default.
+    # normalize the variable names specified in cnf file (user can use _ or - for example log-bin or log_bin)
+    # then grep for needed variable
+    # finally get the variable value (if variables has been specified multiple time use the last value only)
+    reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
+    if [[ -z $reval ]]; then
+        [[ -n $3 ]] && reval=$3
+    fi
+    echo $reval
+}


### PR DESCRIPTION
Issue: wsrep_sst_rsync.sh does not transmit the keyring (so any
use of the keyring option will fail). Also, some modifications
to the wsrep_sst_xtrabackup-v2.sh were needed.

Solution:
Modify wsrep_sst_rsync.sh to send/receive the keyring file.
Modify wsrep_sst_xtrabackup-v2.sh to use the directory the keyring
is in (rather than the datadir). We should not be copying the file
into other directories.  This also removes the need for a temporary
directory.
