### PR TITLE
- PXC#630: Truncate table TOI missed generating key for truncating ta…

### DIFF
--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -481,7 +481,7 @@ bool Sql_cmd_truncate_table::truncate_table(THD *thd, TABLE_LIST *table_ref)
 
 #ifdef WITH_WSREP
     error= true;
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL);
+    WSREP_TO_ISOLATION_BEGIN(table_ref->db, table_ref->table_name, NULL);
 #endif /* WITH_WSREP */
 
     if (lock_table(thd, table_ref, &hton_can_recreate))


### PR DESCRIPTION
…ble.

  While merging PXC-5.6 to PS-5.7 missed passing table to TRUNCATE to
  TOI action that generates the needed isolation key to ensure that
  DML action is applied before any replicated action with higher seqno.

  This eventually caused conflict and rollback DDL action leading to
  said/listed error.
