### PR TITLE
Fix PXC-636 : Doing an SST with encrypt=1 (symmetric encryption) fails

### DIFF
--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -4,4 +4,3 @@ galera_bf_abort_for_update : mysql-wsrep#26 SELECT FOR UPDATE sometimes allowed 
 galera_toi_ddl_fk_insert : qa#39 galera_toi_ddl_fk_insert fails sporadically
 galera_toi_ddl_online : fails randomly with "deadlock error" as sequence of action is causing an issue.
 galera_split_brain : fails quite often. bug logged to investigate the failure.
-galera_sst_xtrabackup-v2-options : SST Encryption does not work with xtrabackup 2.4.2


### PR DESCRIPTION
Issue:
When using symmetric encryption, the data stream was changed, starting
from PXB 2.3.  This broke wsrep_sst_xtrabackup-v2.sh.

Solution:
Change the code in wsrep_sst_xtrabackup-v2.sh to match PXB 2.3+.  Also,
add a requirement that at least PXB 2.4.3 is required.
