### PR TITLE
Fix PXC-636 : Doing an SST with encrypt=1 (symmetric encryption) fails

### DIFF
--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -5,7 +5,5 @@ galera_toi_ddl_fk_insert : qa#39 galera_toi_ddl_fk_insert fails sporadically
 galera_toi_ddl_online : fails randomly with "deadlock error" as sequence of action is causing an issue.
 galera.galera_fk_multitable : check upstream bug http://bugs.mysql.com/bug.php?id=80478.
 galera_split_brain : fails quite often. bug logged to investigate the failure.
-galera_sst_xtrabackup-v2-options : SST Encryption does not work with xtrabackup 2.4.2
 galera_log_output_csv : Upstream bug#80467. MySQL-5.7.11 fails to log queries to slow table even though queries are using table scan.
 galera_sst_xtrabackup-v2_keyring : Requires xtrabackup 2.4.4
-

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -881,14 +881,6 @@ then
         fi
 
         get_keys
-        if [[ $encrypt -eq 1 ]]; then
-            if [[ -n $ekey ]]; then
-                INNOEXTRA+=" --encrypt=$ealgo --encrypt-key=$ekey "
-            else
-                INNOEXTRA+=" --encrypt=$ealgo --encrypt-key-file=$ekeyfile "
-            fi
-        fi
-
         check_extra
 
         ttcmd="$tcmd"
@@ -929,6 +921,7 @@ then
 
         fi
 
+        # Restore the transport commmand to its original state
         tcmd="$ttcmd"
         if [[ -n $progress ]]; then
             get_footprint
@@ -943,8 +936,14 @@ then
 
         wsrep_log_info "Streaming the backup to joiner at ${REMOTEIP} ${SST_PORT:-4444}"
 
+        # Add compression to the head of the stream (if specified)
         if [[ -n $scomp ]]; then
             tcmd="$scomp | $tcmd"
+        fi
+
+        # Add encryption to the head of the stream (if specified)
+        if [[ $encrypt -eq 1 ]]; then
+            tcmd=" $ecmd | $tcmd "
         fi
 
         set +e


### PR DESCRIPTION
Issue:
When using symmetric encryption, the data stream was changed, starting
from PXB 2.3.  This broke wsrep_sst_xtrabackup-v2.sh.

Solution:
Change the code in wsrep_sst_xtrabackup-v2.sh to match PXB 2.3+.  Also,
add a requirement that at least PXB 2.4.3 is required.

Conflicts:
    mysql-test/suite/galera/t/disabled.def
    scripts/wsrep_sst_xtrabackup-v2.sh
