### PR TITLE
- PXC#639: Exclude system tables (tables in mysql db) from pxc-strict…

### DIFF
--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1131,9 +1131,12 @@ static bool pxc_strict_mode_admin_check(THD* thd, TABLE_LIST* table)
                               table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &db_type);
 
+  bool is_system_db= (table && (strcmp(table->db, "mysql") == 0));
+
   if (db_type != DB_TYPE_INNODB             &&
       db_type != DB_TYPE_UNKNOWN            &&
       db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
+      !is_system_db                         &&
       !is_temporary_table(table))
   {
     switch(pxc_strict_mode)

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -332,7 +332,9 @@ bool Sql_cmd_alter_table::execute(THD *thd)
                               first_table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &existing_db_type);
 
-  if (!is_temporary_table(first_table))
+  bool is_system_db= (first_table && (strcmp(first_table->db, "mysql") == 0));
+
+  if (!is_temporary_table(first_table) && !is_system_db)
   {
     bool safe_ops= false;
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5978,12 +5978,15 @@ restart:
      thd->lex->sql_command== SQLCOM_LOAD           ||
      thd->lex->sql_command== SQLCOM_DELETE);
 
+  bool is_system_db= (tbl && (strcmp(tbl->s->db.str, "mysql") == 0));
+
   legacy_db_type db_type= (tbl ? tbl->file->ht->db_type : DB_TYPE_UNKNOWN);
 
   if (db_type != DB_TYPE_INNODB             &&
       db_type != DB_TYPE_UNKNOWN            &&
       db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
       is_dml_stmt                           &&
+      !is_system_db                         &&
       !is_temporary_table(tables))
   {
     /* Table is not an InnoDB table and workload is trying to make changes
@@ -6039,6 +6042,7 @@ restart:
   if (is_dml_stmt                           &&
       db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
       tbl && tbl->s->primary_key == MAX_KEY &&
+      !is_system_db                         &&
       !is_temporary_table(tables))
   {
     /* Table doesn't have explicit primary-key defined. */

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -578,9 +578,12 @@ bool Sql_cmd_truncate_table::execute(THD *thd)
                               first_table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &db_type);
 
+  bool is_system_db= (first_table && (strcmp(first_table->db, "mysql") == 0));
+
   if (db_type != DB_TYPE_INNODB             &&
       db_type != DB_TYPE_UNKNOWN            &&
       db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
+      !is_system_db                         &&
       !is_temporary_table(first_table))
   {
     bool block= false;


### PR DESCRIPTION
…-mode checks.

  pxc-strict-mode blocks insert to non-transactional tables which includes
  system table created with MyISAM.

  This causes inconvenience to end-user as there is no easy corrective action
  except changing the pxc-strict-mode to DISABLED or PERMISSIVE.

  With that thought-line in place we have decided to exclude system-tables
  (located in mysql database) from pxc-strict-mode gamut.
