### PR TITLE
- PXC#628: Applier trx failure failed to rollback statement

### DIFF
--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -335,6 +335,9 @@ static wsrep_cb_status_t wsrep_rollback(THD* const thd)
 #endif /* WSREP_PROC_INFO */
 #endif /* WITH_WSREP */
 
+  /* Check for comments in Relay_log_info::cleanup_context */
+  trans_rollback_stmt(thd);
+
   wsrep_cb_status_t const rcode(trans_rollback(thd) ?
                                 WSREP_CB_FAILURE : WSREP_CB_SUCCESS);
 


### PR DESCRIPTION
  Ideally apply trx should never fail given that nodes are consistent.
  If for some un-foreseen reason it fails (generally due to human
  introduce incompatibilities) transaction is rollback.
  This rollback should ensure that statement open by apply_trx
  are also rollback before the real transaction is rollback.
  Check Relay_log_info::cleanup_context for detail comments.
