### PR TITLE
- #PXC-605: Assertion `rcode <= 0' failed in wsrep_status_t galera_sst_sent(wsrep_t*, const wsrep_gtid_t*, int)

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -999,7 +999,7 @@ static int sst_flush_tables(THD* thd)
   if (run_sql_command(thd, "FLUSH TABLES WITH READ LOCK"))
   {
     WSREP_ERROR("Failed to flush and lock tables");
-    err = -1;
+    err = ECANCELED;
   }
   else
   {


### PR DESCRIPTION
Assertion `rcode <= 0' failed in the galera_sst_sent function because the sst_flush_tables function contains the following snippet:

  if (run_sql_command(thd, "FLUSH TABLES WITH READ LOCK"))
  {
    WSREP_ERROR("Failed to flush and lock tables");
    err = -1;
  }

Then sst_donor_thread function applies negation to the value of this variable as follows:

  wsrep->sst_sent (wsrep, &state_id, -err);

We get a positive number that causes assertion in the Galera code.

To avoid this, we must return any non-negative standard error code (for example, ECANCELED) from the sst_flush_tables function.
