### PR TITLE
Fix 267 : segfault when "SET STATEMENT ... FOR OPTIMIZE TABLE" on tab…

### DIFF
--- a/mysql-test/suite/galera/r/galera_flush_local.result
+++ b/mysql-test/suite/galera/r/galera_flush_local.result
@@ -1,3 +1,9 @@
+SET STATEMENT sort_buffer_size=0,myisam_repair_threads=0 FOR OPTIMIZE TABLE t0;
+Table	Op	Msg_type	Msg_text
+test.t0	optimize	Warning	Truncated incorrect sort_buffer_size value: '0'
+test.t0	optimize	Warning	Truncated incorrect myisam_repair_threads value: '0'
+test.t0	optimize	Error	Table 'test.t0' doesn't exist
+test.t0	optimize	status	Operation failed
 DROP TABLE IF EXISTS t1, t2, x1, x2;
 CREATE TABLE t1 (f1 INTEGER);
 CREATE TABLE t2 (f1 INT PRIMARY KEY AUTO_INCREMENT, f2 INTEGER);

--- a/mysql-test/suite/galera/t/galera_flush_local.test
+++ b/mysql-test/suite/galera/t/galera_flush_local.test
@@ -6,6 +6,12 @@
 --source include/have_innodb.inc
 --source include/have_query_cache.inc
 
+#
+# PXC-267
+#
+SET STATEMENT sort_buffer_size=0,myisam_repair_threads=0 FOR OPTIMIZE TABLE t0;
+
+
 --disable_warnings
 DROP TABLE IF EXISTS t1, t2, x1, x2;
 --enable_warnings

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -804,6 +804,9 @@ static plugin_ref intern_plugin_lock(LEX *lex, plugin_ref rc)
   st_plugin_int *pi= plugin_ref_to_int(rc);
   DBUG_ENTER("intern_plugin_lock");
 
+  if (!rc)
+    DBUG_RETURN(NULL);
+
   mysql_mutex_assert_owner(&LOCK_plugin);
 
   if (pi->state & (PLUGIN_IS_READY | PLUGIN_IS_UNINITIALIZED))


### PR DESCRIPTION
…le that doesn't exist

Issue:
When running this command on a node, this will crash a replicated node.

Solution:
This happens within copy_system_variables() in sql_plugin.cc. The code
tries to do a deep copy and makes a copy of table_plugin and temp_table_plugin
that are set to NULL in WSREP threads. The fix is to check that these values are
non-NULL before copying.
