### PR TITLE
- PXC#641: CREATE TRIGGER TOI missed generating key.

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6016,7 +6016,7 @@ create_sp_error:
   case SQLCOM_CREATE_TRIGGER:
   {
     /* Conditionally writes to binlog. */
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, all_tables)
     res= mysql_create_or_drop_trigger(thd, all_tables, 1);
 
     break;


### PR DESCRIPTION
  For TOI isolation to avoid conflict of it with normal operation
  isolation key is generated based on the table/object being modified.
  CREATE TRIGGER is done on a said table specified by user but TOI
  key was not being generated for it.
