### PR TITLE
- PXC#641: CREATE TRIGGER TOI missed generating key.

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5805,7 +5805,7 @@ end_with_restore_list:
   case SQLCOM_CREATE_TRIGGER:
   {
 #ifdef WITH_WSREP
-      WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, all_tables)
 #endif /* WITH_WSREP */
     /* Conditionally writes to binlog. */
     res= mysql_create_or_drop_trigger(thd, all_tables, 1);
@@ -5815,7 +5815,7 @@ end_with_restore_list:
   case SQLCOM_DROP_TRIGGER:
   {
 #ifdef WITH_WSREP
-      WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
 #endif /* WITH_WSREP */
     /* Conditionally writes to binlog. */
     res= mysql_create_or_drop_trigger(thd, all_tables, 0);


### PR DESCRIPTION
  For TOI isolation to avoid conflict of it with normal operation
  isolation key is generated based on the table/object being modified.
  CREATE TRIGGER is done on a said table specified by user but TOI
  key was not being generated for it.

Conflicts:
    sql/sql_parse.cc
