### PR TITLE
- PXC#268: binlog_rows_query_log_events causes replicated node to crash.

### DIFF
--- a/mysql-test/suite/galera/r/galera_binlog_rows_query_log_events.result
+++ b/mysql-test/suite/galera/r/galera_binlog_rows_query_log_events.result
@@ -1,4 +1,7 @@
-SET GLOBAL binlog_rows_query_log_events=TRUE;
+SET SESSION binlog_rows_query_log_events=TRUE;
+SELECT @@SESSION.binlog_rows_query_log_events;
+@@SESSION.binlog_rows_query_log_events
+1
 CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SELECT COUNT(*) = 1 FROM t1;

--- a/mysql-test/suite/galera/t/galera_binlog_rows_query_log_events.test
+++ b/mysql-test/suite/galera/t/galera_binlog_rows_query_log_events.test
@@ -7,7 +7,8 @@
 
 --let $binlog_rows_query_log_events_orig = `SELECT @@binlog_rows_query_log_events`
 
-SET GLOBAL binlog_rows_query_log_events=TRUE;
+SET SESSION binlog_rows_query_log_events=TRUE;
+SELECT @@SESSION.binlog_rows_query_log_events;
 
 CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
 

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -184,7 +184,11 @@ static wsrep_cb_status_t wsrep_apply_events(THD*        thd,
       DBUG_RETURN(WSREP_CB_FAILURE);
     }
 
-    delete ev;
+    /* row-query-log-event is generated to log extra information when following
+    configuration is set "binlog_rows_query_log_events". The event is cleared
+    after processing of ROWS_LOG_EVENT. Avoid removing it here. */
+    if (ev->get_type_code() != binary_log::ROWS_QUERY_LOG_EVENT)
+      delete ev;
   }
 
  error:


### PR DESCRIPTION
  Setting binlog_rows_query_log_events to ON will generate ROW_QUERY_LOG_EVENT.
  This event logs an extra information while logging row information and so
  event should be kept infact till ROW_LOG_EVENT is processed and should be
  freed once ROW_LOG_EVENT is done.

  PXC/Galera logic freed this event immediately on handling it (like any other
  replicated event) this created 2 issues:
- ROW_LOG_EVENT is access a stale information.
- ROW_LOG_EVENT trying to clean this event as part of its clean up code
  result in double-free.
