### PR TITLE
- PXC#647: PXC-5.7 to PXC-5.7 upgrade fails.

### DIFF
--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1131,7 +1131,9 @@ static bool pxc_strict_mode_admin_check(THD* thd, TABLE_LIST* table)
                               table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &db_type);
 
-  bool is_system_db= (table && (strcmp(table->db, "mysql") == 0));
+  bool is_system_db= (table &&
+                      ((strcmp(table->db, "mysql") == 0) ||
+                       (strcmp(table->db, "information_schema") == 0)));
 
   if (db_type != DB_TYPE_INNODB             &&
       db_type != DB_TYPE_UNKNOWN            &&

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -332,7 +332,9 @@ bool Sql_cmd_alter_table::execute(THD *thd)
                               first_table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &existing_db_type);
 
-  bool is_system_db= (first_table && (strcmp(first_table->db, "mysql") == 0));
+  bool is_system_db= (first_table &&
+                      ((strcmp(first_table->db, "mysql") == 0) ||
+                       (strcmp(first_table->db, "information_schema") == 0)));
 
   if (!is_temporary_table(first_table) && !is_system_db)
   {

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5978,7 +5978,9 @@ restart:
      thd->lex->sql_command== SQLCOM_LOAD           ||
      thd->lex->sql_command== SQLCOM_DELETE);
 
-  bool is_system_db= (tbl && (strcmp(tbl->s->db.str, "mysql") == 0));
+  bool is_system_db= (tbl &&
+                      ((strcmp(tbl->s->db.str, "mysql") == 0) ||
+                       (strcmp(tbl->s->db.str, "information_schema") == 0)));
 
   legacy_db_type db_type= (tbl ? tbl->file->ht->db_type : DB_TYPE_UNKNOWN);
 

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -578,7 +578,9 @@ bool Sql_cmd_truncate_table::execute(THD *thd)
                               first_table->table_name, reg_ext, 0);
   dd_frm_type(thd, path, &db_type);
 
-  bool is_system_db= (first_table && (strcmp(first_table->db, "mysql") == 0));
+  bool is_system_db= (first_table &&
+                      ((strcmp(first_table->db, "mysql") == 0) ||
+                       (strcmp(first_table->db, "information_schema") == 0)));
 
   if (db_type != DB_TYPE_INNODB             &&
       db_type != DB_TYPE_UNKNOWN            &&


### PR DESCRIPTION
  PXC-5.7 upgrade needs to update INFORMATION_SCHEMA. Tables in
  INFORMATION_SCHEMA are maintained in-memory using MEMORY engine.
  Even though these are temporary table, MySQL is_temporary_table fail
  to classify them as they are system-temporary tables. Fixed it by
  treating information_schema as system db.
