### PR TITLE
Added a my_setwd call for SST remounting the datadir

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5348,6 +5348,13 @@ a file name for --log-bin-index option", opt_binlog_index_name);
       }
     }
   }
+
+  /* 
+   * Forcing a new setwd in case the SST mounted the datadir
+   */
+  if (my_setwd(mysql_real_data_home,MYF(MY_WME)) && !opt_help)
+    unireg_abort(1);        /* purecov: inspected */
+
   if (opt_bin_log)
   {
     /*


### PR DESCRIPTION
This is a fix to allow SST operations that mount the datadir to work correctly.  It adds a my_setwd call right after the SST so that MySQL opens its files in the mounted device instead of in the empty mount point.
