### PR TITLE
- #PXC-252: [pz@percona.com: Testing Auto Recover]

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1914,7 +1914,7 @@ extern "C" void unireg_abort(int exit_code)
   if (wsrep)
   {
     /* Cancel the SST script if it is running: */
-    wsrep_sst_cancel();
+    wsrep_sst_cancel(true);
     /* This is an abort situation, we cannot expect to gracefully close all
      * wsrep threads here, we can only diconnect from service */
     wsrep_close_client_connections(FALSE);

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -20,6 +20,10 @@
 #include "my_stacktrace.h"
 #include "global_threads.h"
 
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
+
 #ifdef __WIN__
 #include <crtdbg.h>
 #define SIGNAL_FMT "exception 0x%x"
@@ -61,6 +65,14 @@ extern "C" sig_handler handle_fatal_signal(int sig)
   }
 
   segfaulted = 1;
+
+/*
+  The wsrep subsystem has their its own actions
+  which need be performed before exiting:
+*/
+#ifdef WITH_WSREP
+  wsrep_handle_fatal_signal(sig);
+#endif
 
 #ifdef __WIN__
   SYSTEMTIME utc_time;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -639,6 +639,7 @@ int wsrep_init()
   wsrep_args.unordered_cb    = wsrep_unordered_cb;
   wsrep_args.sst_donate_cb   = wsrep_sst_donate_cb;
   wsrep_args.synced_cb       = wsrep_synced_cb;
+  wsrep_args.abort_cb        = wsrep_abort_cb;
 
   rcode = wsrep->init(wsrep, &wsrep_args);
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -180,6 +180,7 @@ extern "C" void wsrep_thd_set_wsrep_last_query_id(THD *thd, query_id_t id);
 extern "C" void wsrep_thd_awake(THD *thd, my_bool signal);
 extern "C" int wsrep_thd_retry_counter(THD *thd);
 
+extern "C" void wsrep_handle_fatal_signal(int sig);
 
 extern void wsrep_close_client_connections(my_bool wait_to_end);
 extern int  wsrep_wait_committing_connections_close(int wait_time);

--- a/sql/wsrep_priv.h
+++ b/sql/wsrep_priv.h
@@ -35,6 +35,7 @@ wsrep_cb_status wsrep_sst_donate_cb (void* app_ctx,
                                      const wsrep_gtid_t* state_id,
                                      const char* state, size_t state_len,
                                      bool bypass);
+void wsrep_abort_cb (void);
 
 extern wsrep_uuid_t  local_uuid;
 extern wsrep_seqno_t local_seqno;

--- a/sql/wsrep_sst.h
+++ b/sql/wsrep_sst.h
@@ -32,7 +32,7 @@ extern bool wsrep_sst_wait();
 /*! Signals wsrep that initialization is complete, writesets can be applied */
 extern void wsrep_sst_continue();
 /*! Cancel the SST script if it is running */
-extern void wsrep_sst_cancel();
+extern void wsrep_sst_cancel(bool call_wsrep_cb);
 
 extern void wsrep_SE_init_grab();   /*! grab init critical section */
 extern void wsrep_SE_init_wait();   /*! wait for SE init to complete */

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -777,7 +777,15 @@ void process::terminate ()
 {
   if (pid_)
   {
+    /*
+      If we have an appropriated system call, then we try
+      to terminate entire process group:
+    */
+#if _XOPEN_SOURCE >= 500 || _DEFAULT_SOURCE || _BSD_SOURCE
+    if (killpg(pid_, SIGTERM))
+#else
     if (kill(pid_, SIGTERM))
+#endif
     {
       WSREP_WARN("Unable to terminate process: %s: %d (%s)",
                  str_, errno, strerror(errno));

--- a/wsrep/wsrep_api.h
+++ b/wsrep/wsrep_api.h
@@ -454,6 +454,18 @@ typedef void (*wsrep_synced_cb_t) (void* app_ctx);
 
 
 /*!
+ * @brief a callback to signal application that wsrep provider was
+ * terminated abnormally. In this case, the application can perform
+ * the critical steps to clean its state, for example, it can terminate
+ * the child processes associated with the SST.
+ *
+ * This callback is called after wsrep library was terminated
+ * abnormally using abort() call.
+ */
+typedef void (*wsrep_abort_cb_t) (void);
+
+
+/*!
  * Initialization parameters for wsrep provider.
  */
 struct wsrep_init_args
@@ -485,6 +497,10 @@ struct wsrep_init_args
     /* State Snapshot Transfer callbacks */
     wsrep_sst_donate_cb_t sst_donate_cb;   //!< starting to donate
     wsrep_synced_cb_t     synced_cb;       //!< synced with group
+
+    /* Abnormal termination callback: */
+    wsrep_abort_cb_t      abort_cb;        //!< wsrep provider terminated
+                                           //!< abnormally
 };
 
 
@@ -824,8 +840,8 @@ struct wsrep {
    *
    * Whenever a new connection ID is passed to wsrep provider through
    * any of the API calls, a connection context is allocated for this
-   * connection. This call is to explicitly notify provider fo connection
-   * closing.
+   * connection. This call is to explicitly notify provider to close the
+   * connection.
    *
    * @param wsrep       provider handle
    * @param conn_id     connection ID
@@ -974,7 +990,7 @@ struct wsrep {
                                const char* donor_spec);
 
   /*!
-   * @brief Returns an array fo status variables.
+   * @brief Returns an array of status variables.
    *        Array is terminated by Null variable name.
    *
    * @param wsrep provider handle


### PR DESCRIPTION
We cannot restart the SST automatically whenever SST fails because the server usually does not have enough information to understand why this was happened. For example, the analysis of the log indicates that the connection has been restored and the 22 error was not fatal:

```
>2014-12-05 17:16:08 2596 [Warning] WSREP: Could not find peer:
>2014-12-05 17:16:08 2596 [Warning] WSREP: 1.0 (nuc3): State transfer to
>-1.-1 (left the group) failed: -22 (Invalid argument)
...
>2014-12-05 17:16:08 2596 [Note] WSREP: Member 1.0 (nuc3) synced with group
```

At the same time log analysis shows that in fact the SST process was completed with another error = 1 ("Operation not permitted"). Perhaps it was a mistake due to insufficient access rights or incorrect password, but not a network error.

If this diagnosis is correct, then restart of the SST did not help us to resolve this problem. If it is wrong, it turns out that at this point we do not have enough information to make the right decision. A simple patch cannot eliminate this (in this case, I think here we need to talk about architecture refining as a separate development task, not just a patch on the product support level).

However, we definitely has a serious problem that we should eliminate. Namely - after detecting a failure due to permissions, the server process is completed improperly, leaving the unfinished thread:

```
Error in my_thread_global_end(): 1 threads didn't exit
>141205 17:16:28 mysqld_safe mysqld from pid file /var/lib/mysql/mysqld.pid
>ended
```

We have already eliminated this error in most scenarios by a previous patches, but I found new possible branches, which similar error arise (for example, it is possible when we repeat the connection attempts after the failure of the SST - although I was not able to reproduce this situation manually or by automatic script since it is rare race condition).

In addition, I found that the failure during the SST, which is diagnosed on the Galera level, leads to the completion of the server using abort() call, but in this case the child processes that have been launched for the SST continues to run after completion of the server.

This makes it impossible to re-start the server before all timeouts expired (in these SST-related processes). Otherwise we failed due to the busy sockets or it leads to other fatal errors due to interference between new and old instances of the SST scripts.

In this patch, I added new checks to safely shutdown the server, for correct processing of a failed attempts to make a new connection and the SST, and for the destruction of all child processes when the server terminated abnormally by initiative of the Galera.

To do this, I needed to add a new callback to wsrep API, because the Galera intercepts the SIGABRT signal. Therefore we cannot intercept abnormal termination of the server process (after it calls abort() function from the Galera side) without expanding the Galera API by adding to it new callback.

Galera part of this patch is located here: https://github.com/percona/galera/pull/77
