### PR TITLE
Fix PXC-636 : Doing an SST with encrypt=1 (symmetric encryption) fails

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -889,8 +889,8 @@ then
         if [[ -n $keyring ]]; then
             # Verify that encryption is being used
             # Do NOT send a keyring file without encryption
-            # Need encrypt >= 2
-            if [[ $encrypt -le 1 ]]; then
+            # Need encrypt >= 1
+            if [[ $encrypt -le 0 ]]; then
                 wsrep_log_error "FATAL: An unencrypted channel is being used."
                 wsrep_log_error "Sending/using a keyring requires an encrypted channel."
                 exit 22


### PR DESCRIPTION
Issue:
Previously, this didn't work so the code limited the required encryption
to modes 2 and 3.  Now that this is fixed, encrypt=1 should be allowed also.

Solution:
Allow encrypt mode = 1
