### PR TITLE
Fix PXC-655 : when using encrypt=1, performing an SST will display th…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -873,9 +873,9 @@ then
         ttcmd="$tcmd"
         if [[ $encrypt -eq 1 ]]; then
             if [[ -n $scomp ]]; then
-                tcmd=" $ecmd | $scomp | $tcmd "
+                tcmd=" \$ecmd | $scomp | $tcmd "
             else
-                tcmd=" $ecmd | $tcmd "
+                tcmd=" \$ecmd | $tcmd "
             fi
         elif [[ -n $scomp ]]; then
             tcmd=" $scomp | $tcmd "
@@ -930,7 +930,7 @@ then
 
         # Add encryption to the head of the stream (if specified)
         if [[ $encrypt -eq 1 ]]; then
-            tcmd=" $ecmd | $tcmd "
+            tcmd=" \$ecmd | $tcmd "
         fi
 
         set +e
@@ -959,9 +959,9 @@ then
         get_keys
         if [[ $encrypt -eq 1 ]]; then
             if [[ -n $scomp ]]; then
-                tcmd=" $ecmd | $scomp | $tcmd "
+                tcmd=" \$ecmd | $scomp | $tcmd "
             else
-                tcmd=" $ecmd | $tcmd "
+                tcmd=" \$ecmd | $tcmd "
             fi
         elif [[ -n $scomp ]]; then
             tcmd=" $scomp | $tcmd "
@@ -1021,9 +1021,9 @@ then
     get_keys
     if [[ $encrypt -eq 1 && $sencrypted -eq 1 ]]; then
         if [[ -n $sdecomp ]]; then
-            strmcmd=" $sdecomp | $ecmd | $strmcmd"
+            strmcmd=" $sdecomp | \$ecmd | $strmcmd"
         else
-            strmcmd=" $ecmd | $strmcmd"
+            strmcmd=" \$ecmd | $strmcmd"
         fi
     elif [[ -n $sdecomp ]]; then
             strmcmd=" $sdecomp | $strmcmd"


### PR DESCRIPTION
…e encryption key in the logs

Issue:
When using "encryt=1" in the [sst] section, the encryption key will show in
the logs when an SST is done.

Solution:
Have the script late-evaluate the variables, thus they won't show up when
we print out the commands in the script, it'll show up as "$ecmd".
