### PR TITLE
- PXC#658: INSERT .. SELECT * from table fails with pxc-strict-mode

### DIFF
--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -373,15 +373,27 @@ drop table tmem;
 #node-1
 create table tinnodb (i int, primary key pk(i)) engine=innodb;
 insert into tinnodb values (1), (2);
+set global pxc_strict_mode='DISABLED';
+create table temp (i int) engine=myisam;
+insert into temp values (10), (20), (30);
+set global pxc_strict_mode='ENFORCING';
+insert into tinnodb select * from temp;
 select * from tinnodb;
 i
 1
 2
+10
+20
+30
+drop table temp;
 #node-2
 select * from tinnodb;
 i
 1
 2
+10
+20
+30
 #node-1
 truncate table tinnodb;
 select * from tinnodb;

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -386,7 +386,13 @@ drop table tmem;
 --echo #node-1
 create table tinnodb (i int, primary key pk(i)) engine=innodb;
 insert into tinnodb values (1), (2);
+set global pxc_strict_mode='DISABLED';
+create table temp (i int) engine=myisam;
+insert into temp values (10), (20), (30);
+set global pxc_strict_mode='ENFORCING';
+insert into tinnodb select * from temp;
 select * from tinnodb;
+drop table temp;
 #
 --connection node_2
 --echo #node-2

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5984,7 +5984,9 @@ restart:
 
   legacy_db_type db_type= (tbl ? tbl->file->ht->db_type : DB_TYPE_UNKNOWN);
 
-  if (db_type != DB_TYPE_INNODB             &&
+
+  if (tables == *start                      &&
+      db_type != DB_TYPE_INNODB             &&
       db_type != DB_TYPE_UNKNOWN            &&
       db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
       is_dml_stmt                           &&
@@ -6041,7 +6043,8 @@ restart:
     }
   }
 
-  if (is_dml_stmt                           &&
+  if (tables == *start                      &&
+      is_dml_stmt                           &&
       db_type != DB_TYPE_PERFORMANCE_SCHEMA &&
       tbl && tbl->s->primary_key == MAX_KEY &&
       !is_system_db                         &&


### PR DESCRIPTION
  INSERT .... SELECT \* from table involves 2 different tables.
  source table (copy data from) and destination table (copy data to)

  We just need to check that destination table is not a non-transactional
  table. Source table could be non-transactional table and still it should
  work. pxc-strict-mode check wrongly enforced it on all tables causing
  insert .... select \* to fail.
