### PR TITLE
- PXC#659: Disable switching slave_preserve_commit_order to ON

### DIFF
--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3736,6 +3736,22 @@ static bool check_not_null_not_empty(sys_var *self, THD *thd, set_var *var)
   if (res && res->is_empty())
     return true;
 
+#ifdef WITH_WSREP
+   if (WSREP(thd) && var->save_result.ulonglong_value == 1)
+   {
+     WSREP_ERROR("Percona-XtraDB-Cluster prohibits enabling"
+                 " slave_preserve_commit_order as it conflicts with galera"
+                 " multi-master commit order semantics");
+     char message[1024];
+     sprintf(message,
+             "Percona-XtraDB-Cluster prohibits enabling"
+             " slave_preserve_commit_order as it conflicts with galera"
+             " multi-master commit order semantics");
+     my_message(ER_UNKNOWN_ERROR, message, MYF(0));
+     return true;
+   }
+#endif /* WITH_WSREP */
+
   return false;
 }
 


### PR DESCRIPTION
  When slave is configured to use multi-threads for applying master
  replicated action, slave_preserve_commit_order can help enforce
  application of these action in same sequence like master.

  In short, this is nothing but a commit monitor.

  If slave is pxc-node (galera-node) then galera already has commit
  monitor (being multi-master setup) but with different semantics
  to cater to multi-master setup. These 2 semantics conflicts
  and PXC need to opt for one of the semantics and naturally PXC
  opts for galera semantics.
