### PR TITLE
Fix PXC-655 : when using encrypt=1, performing an SST will display th…

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -169,6 +169,11 @@ wsrep_log_error()
     wsrep_log "[ERROR] $*"
 }
 
+wsrep_log_warning()
+{    
+    wsrep_log "[WARNING] $*"
+}
+
 wsrep_log_info()
 {
     wsrep_log "[INFO] $*"

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -149,6 +149,10 @@ get_keys()
     if [[ -z $ekey ]];then
         ecmd="xbcrypt --encrypt-algo=$ealgo --encrypt-key-file=$ekeyfile"
     else
+        wsrep_log_warning "Using the 'encrypt-key' option causes the encryption key"
+        wsrep_log_warning "to be set via the command-line and is considered insecure."
+        wsrep_log_warning "It is recommended to use the 'encrypt-key-file' option instead."
+
         ecmd="xbcrypt --encrypt-algo=$ealgo --encrypt-key=$ekey"
     fi
 
@@ -759,9 +763,9 @@ then
 
         if [[ $encrypt -eq 1 ]];then
             if [[ -n $scomp ]];then 
-                tcmd=" $ecmd | $scomp | $tcmd "
+                tcmd=" \$ecmd | $scomp | $tcmd "
             else 
-                tcmd=" $ecmd | $tcmd "
+                tcmd=" \$ecmd | $tcmd "
             fi
         elif [[ -n $scomp ]];then 
             tcmd=" $scomp | $tcmd "
@@ -791,7 +795,7 @@ then
 
         # Add encryption to the head of the stream (if specified)
         if [[ $encrypt -eq 1 ]]; then
-            tcmd=" $ecmd | $tcmd "
+            tcmd=" \$ecmd | $tcmd "
         fi
 
         set +e
@@ -820,9 +824,9 @@ then
         get_keys
         if [[ $encrypt -eq 1 ]];then
             if [[ -n $scomp ]];then 
-                tcmd=" $ecmd | $scomp | $tcmd "
+                tcmd=" \$ecmd | $scomp | $tcmd "
             else
-                tcmd=" $ecmd | $tcmd "
+                tcmd=" \$ecmd | $tcmd "
             fi
         elif [[ -n $scomp ]];then 
             tcmd=" $scomp | $tcmd "
@@ -877,9 +881,9 @@ then
     get_keys
     if [[ $encrypt -eq 1 && $sencrypted -eq 1 ]];then
         if [[ -n $sdecomp ]];then 
-            strmcmd=" $sdecomp | $ecmd | $strmcmd"
+            strmcmd=" $sdecomp | \$ecmd | $strmcmd"
         else 
-            strmcmd=" $ecmd | $strmcmd"
+            strmcmd=" \$ecmd | $strmcmd"
         fi
     elif [[ -n $sdecomp ]];then 
             strmcmd=" $sdecomp | $strmcmd"


### PR DESCRIPTION
…e encryption key in the logs

Issue:
When using "encryt=1" in the [sst] section, the encryption key will show in
the logs when an SST is done.

Solution:
Have the script late-evaluate the variables, thus they won't show up when
we print out the commands in the script, it'll show up as "$ecmd".
