### PR TITLE
- PXC#568: EXPLAIN/SHOW commands interruption by TOI results in crash.

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -3175,13 +3175,6 @@ bool sql_exchange::escaped_given(void)
 bool Query_result_send::send_result_set_metadata(List<Item> &list, uint flags)
 {
   bool res;
-#ifdef WITH_WSREP
-  if (WSREP(thd) && thd->wsrep_retry_query)
-  {
-    WSREP_DEBUG("skipping select metadata");
-    return FALSE;
-  }
-#endif /* WITH_WSREP */
   if (!(res= thd->send_result_metadata(&list, flags)))
     is_result_set_started= 1;
   return res;


### PR DESCRIPTION
  Let's say node is executing EXPLAIN/SHOW KEYS/FIELDS command and
  a high priority transaction (say ALTER that changes table structure
  and can affect result of local transaction) is replicated from node-2.

  local: explain select \* from t2 where i = 2;
  replicated: alter table t2 drop primary key;

  Both of these transactions will conflicts.
  Replication transaction is allow to proceed and local transaction
  is aborted and re-tried.

  Till 5.6, MySQL use to send metadata to client before fetching the result
  set and then use to feed result set. This means if retrying a transaction
  should avoid resending of metadata.
  Starting 5.7, sending metadata action is delayed till complete set is
  available. This means on retry metadata is not sent on wire and should
  be send on retry. WSREP added a check to skip sending metadata on retry
  that is no more needed.
  (With this WSREP-check, metadata fields were never initialized
   causing assert in result-set population.)
