### PR TITLE
Fix PXC-654 : Better support in the wsrep_sst_* scripts for the defau…

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -87,10 +87,13 @@ fi
 WSREP_LOG_DIR=${WSREP_LOG_DIR:-""}
 # if WSREP_LOG_DIR env. variable is not set, try to get it from my.cnf
 if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$($MY_PRINT_DEFAULTS --defaults-file \
-                   "$WSREP_SST_OPT_CONF" mysqld server mysqld-5.6 \
-                    | grep -- '--innodb[-_]log[-_]group[-_]home[-_]dir=' \
-                    | cut -b 29- )
+    WSREP_LOG_DIR=$(parse_cnf mysqld-5.6 innodb_log_group_home_dir "")
+fi
+if [ -z "$WSREP_LOG_DIR" ]; then
+    WSREP_LOG_DIR=$(parse_cnf mysqld innodb_log_group_home_dir "")
+fi
+if [ -z "$WSREP_LOG_DIR" ]; then
+    WSREP_LOG_DIR=$(parse_cnf server innodb_log_group_home_dir "")
 fi
 
 if [ -n "$WSREP_LOG_DIR" ]; then

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -239,21 +239,6 @@ get_transfer()
 
 }
 
-parse_cnf()
-{
-    local group=$1
-    local var=$2
-    # print the default settings for given group using my_print_default.
-    # normalize the variable names specified in cnf file (user can use _ or - for example log-bin or log_bin)
-    # then grep for needed variable
-    # finally get the variable value (if variables has been specified multiple time use the last value only)
-    reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
-    if [[ -z $reval ]];then 
-        [[ -n $3 ]] && reval=$3
-    fi
-    echo $reval
-}
-
 get_footprint()
 {
     pushd $WSREP_SST_OPT_DATA 1>/dev/null


### PR DESCRIPTION
…lts-group-suffix option

Issue:
When looking up the value of options in the config files, the group suffix is often
ignored.  This makes it difficult to use a single config file for a test, which
would make it easier to describe a particular test configuration.

Solution:
Have the parse_cnf() function also check and use the group suffix when
looking for a particular configuration value.
