### PR TITLE
Fix PXC-654 : Better support in the wsrep_sst_* scripts for the defau…

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -224,7 +224,18 @@ parse_cnf()
     # normalize the variable names specified in cnf file (user can use _ or - for example log-bin or log_bin)
     # then grep for needed variable
     # finally get the variable value (if variables has been specified multiple time use the last value only)
-    reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
+
+    # look in group+suffix
+    if [[ -n $WSREP_SST_OPT_CONF_SUFFIX ]]; then
+        reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF "${group}${WSREP_SST_OPT_CONF_SUFFIX}" | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
+    fi
+
+    # look in group
+    if [[ -z $reval ]]; then
+        reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
+    fi
+
+    # use default if we haven't found a value
     if [[ -z $reval ]]; then
         [[ -n $3 ]] && reval=$3
     fi

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -32,12 +32,7 @@ export PATH="/usr/sbin:/sbin:$PATH"
 
 wsrep_check_programs rsync
 
-if [[ -n $WSREP_SST_OPT_CONF_SUFFIX ]]; then
-    keyring=$(parse_cnf mysqld${WSREP_SST_OPT_CONF_SUFFIX} keyring-file-data "")
-fi
-if [[ -z $keyring ]]; then
-    keyring=$(parse_cnf mysqld keyring-file-data "")
-fi
+keyring=$(parse_cnf mysqld keyring-file-data "")
 if [[ -z $keyring ]]; then
     keyring=$(parse_cnf sst keyring-file-data "")
 fi
@@ -104,10 +99,13 @@ rm -rf "$KEYRING_FILE"
 WSREP_LOG_DIR=${WSREP_LOG_DIR:-""}
 # if WSREP_LOG_DIR env. variable is not set, try to get it from my.cnf
 if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$($MY_PRINT_DEFAULTS --defaults-file \
-                   "$WSREP_SST_OPT_CONF" mysqld server mysqld-5.6 \
-                    | grep -- '--innodb[-_]log[-_]group[-_]home[-_]dir=' \
-                    | cut -b 29- )
+    WSREP_LOG_DIR=$(parse_cnf mysqld-5.6 innodb_log_group_home_dir "")
+fi
+if [ -z "$WSREP_LOG_DIR" ]; then
+    WSREP_LOG_DIR=$(parse_cnf mysqld innodb_log_group_home_dir "")
+fi
+if [ -z "$WSREP_LOG_DIR" ]; then
+    WSREP_LOG_DIR=$(parse_cnf server innodb_log_group_home_dir "")
 fi
 
 if [ -n "$WSREP_LOG_DIR" ]; then

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -294,12 +294,7 @@ read_cnf()
     scomp=$(parse_cnf sst compressor "")
     sdecomp=$(parse_cnf sst decompressor "")
 
-    if [[ -n $WSREP_SST_OPT_CONF_SUFFIX ]]; then
-        keyring=$(parse_cnf mysqld${WSREP_SST_OPT_CONF_SUFFIX} keyring-file-data "")
-    fi
-    if [[ -z $keyring ]]; then
-        keyring=$(parse_cnf mysqld keyring-file-data "")
-    fi
+    keyring=$(parse_cnf mysqld keyring-file-data "")
     if [[ -z $keyring ]]; then
         keyring=$(parse_cnf sst keyring-file-data "")
     fi
@@ -308,12 +303,7 @@ read_cnf()
         KEYRING_DIR=$(dirname "${keyring}")
     fi
 
-    if [[ -n $WSREP_SST_OPT_CONF_SUFFIX ]]; then
-        keyringsid=$(parse_cnf mysqld${WSREP_SST_OPT_CONF_SUFFIX} server-id "")
-    fi
-    if [[ -z $keyringsid ]]; then
-        keyringsid=$(parse_cnf mysqld server-id "")
-    fi
+    keyringsid=$(parse_cnf mysqld server-id "")
     if [[ -z $keyringsid ]]; then
         keyringsid=$(parse_cnf sst server-id "")
     fi


### PR DESCRIPTION
…lts-group-suffix option

Issue:
When looking up the value of options in the config files, the group suffix is often
ignored.  This makes it difficult to use a single config file for a test, which
would make it easier to describe a particular test configuration.

Solution:
Have the parse_cnf() function also check and use the group suffix when
looking for a particular configuration value.
