### PR TITLE
- PXC#662: PXC-5.7 mtr valgrind run

### DIFF
--- a/mysql-test/suite/galera/r/galera_toi_drop_database.result
+++ b/mysql-test/suite/galera/r/galera_toi_drop_database.result
@@ -4,6 +4,7 @@ CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO ten VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
+set session wsrep_sync_wait=0;
 INSERT INTO t1 (f1) SELECT 1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;;
 USE database1;
 INSERT INTO t2 (f1) SELECT 1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;;

--- a/mysql-test/suite/galera/t/galera_toi_drop_database.test
+++ b/mysql-test/suite/galera/t/galera_toi_drop_database.test
@@ -21,6 +21,7 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
 
 # Insert 1M rows
+set session wsrep_sync_wait=0;
 --send INSERT INTO t1 (f1) SELECT 1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6;
 
 --connection node_1a

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6259,8 +6259,12 @@ void* start_wsrep_THD(void *arg)
   {
     close_connection(thd, ER_OUT_OF_RESOURCES);
     thd->release_resources();
-    // TODO: do we need to check for initialized plugin.
-    delete thd;
+    // Note: We can't call THD destructor without crashing
+    // if plugins have not been initialized. However, in most of the
+    // cases this means that pre SE initialization SST failed and
+    // we are going to exit anyway.
+    if (plugins_are_initialized)
+      delete thd;
     return(NULL);
   }
 

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -855,7 +855,10 @@ public:
   void cleanup_after_session()
   {
     if (deferred_events)
+    {
       delete deferred_events;
+      deferred_events= NULL;
+    }
   };
    
   /**

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2279,7 +2279,15 @@ void THD::release_resources()
   mysql_mutex_destroy(&LOCK_wsrep_thd);
   mysql_cond_destroy(&COND_wsrep_thd);
 
-  if (wsrep_rli) delete wsrep_rli;
+  if (wsrep_rli)
+  {
+    if (wsrep_rli->current_mts_submode != NULL)
+      delete wsrep_rli->current_mts_submode;
+    delete wsrep_rli;
+    wsrep_rli= NULL;
+    /* rli_slave MySQL counter part which is initialized to wsrep_rli. */
+    rli_slave= NULL;
+  }
   wsrep_free_status(this);
 #endif
 }

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1282,6 +1282,7 @@ static int sst_donate_other (const char*   method,
   mysql_cond_wait (&arg.COND_wsrep_sst_thread, &arg.LOCK_wsrep_sst_thread);
 
   WSREP_INFO("sst_donor_thread signaled with %d", arg.err);
+  pthread_detach(tmp);
   return arg.err;
 }
 

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -168,10 +168,7 @@ static void wsrep_prepare_bf_thd(THD *thd, struct wsrep_thd_shadow* shadow)
   thd->wsrep_rli->info_thd = thd;
   thd->init_for_queries(thd->wsrep_rli);
 
-  if (thd->wsrep_rli->channel_mts_submode != MTS_PARALLEL_TYPE_DB_NAME)
-    thd->wsrep_rli->current_mts_submode= new Mts_submode_logical_clock();
-  else
-    thd->wsrep_rli->current_mts_submode= new Mts_submode_database();
+  thd->wsrep_rli->current_mts_submode= new Mts_submode_database();
 
   thd->wsrep_exec_mode= REPL_RECV;
   thd->get_protocol_classic()->set_vio(NULL);

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -140,7 +140,11 @@ static const ulint	OS_AIO_MERGE_N_CONSECUTIVE = 64;
 extern bool buf_page_cleaner_is_active;
 
 #ifdef WITH_INNODB_DISALLOW_WRITES
-#define WAIT_ALLOW_WRITES() os_event_wait(srv_allow_writes_event)
+#define WAIT_ALLOW_WRITES() 						\
+	do {								\
+		if (srv_allow_writes_event)				\
+			os_event_wait(srv_allow_writes_event); 		\
+	} while (0)
 #else
 #define WAIT_ALLOW_WRITES() do { } while (0)
 #endif /* WITH_INNODB_DISALLOW_WRITES */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1149,6 +1149,10 @@ srv_free(void)
 
 	os_event_destroy(srv_buf_resize_event);
 
+#ifdef WITH_INNODB_DISALLOW_WRITES
+	os_event_destroy(srv_allow_writes_event);
+#endif /* WITH_INNODB_DISALLOW_WRITES */
+
 #ifdef UNIV_DEBUG
 	os_event_destroy(srv_master_thread_disabled_event);
 	srv_master_thread_disabled_event = NULL;


### PR DESCRIPTION
- Correct valgrind error highlighted by PXC-5.7 mtr run.
- This mainly included:
  - de-attaching sst_donote thread.
  - correcting double-free of relay_log info structure used by wsrep-applier.
  - destory a wsrep specific event srv_allow_writes_event.
