### PR TITLE
- Some test-cases failed due to underlying infrastructure differences.

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -281,7 +281,7 @@ INSERT INTO global_suppressions VALUES
  ("WSREP: Failed to prepare for incremental state transfer: Local state seqno is undefined:"),
  ("WSREP: gcs_caused\\(\\) returned -107 \\(Transport endpoint is not connected\\)"),
  ("WSREP: gcs_caused\\(\\) returned -1 \\(Operation not permitted\\)"),
- ("WSREP: Action message in non-primary configuration from member 0"),
+ ("WSREP: Action message in non-primary configuration from member"),
  ("InnoDB: Resizing redo log from"),
  ("InnoDB: Starting to delete and rewrite log files"),
  ("InnoDB: New log files created, LSN="),

--- a/mysql-test/suite/galera/r/galera_as_master_and_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_master_and_slave.result
@@ -55,8 +55,8 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate('1-3', @@global.gtid_executed);
-locate('1-3', @@global.gtid_executed)
+select locate(':1-3', @@global.gtid_executed);
+locate(':1-3', @@global.gtid_executed)
 VALID_POS
 #node-4 (independent slave replicating from galera-node-2)
 select * from t;
@@ -65,8 +65,8 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate('1-3', @@global.gtid_executed);
-locate('1-3', @@global.gtid_executed)
+select locate(':1-3', @@global.gtid_executed);
+locate(':1-3', @@global.gtid_executed)
 VALID_POS
 #node-1 (independent master)
 delete from t where i = 2;
@@ -88,8 +88,8 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate('1-5', @@global.gtid_executed);
-locate('1-5', @@global.gtid_executed)
+select locate(':1-5', @@global.gtid_executed);
+locate(':1-5', @@global.gtid_executed)
 VALID_POS
 #node-3 (galera-cluster-node-2 that act as master to independent slave)
 select * from t;
@@ -98,8 +98,8 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate('1-5', @@global.gtid_executed);
-locate('1-5', @@global.gtid_executed)
+select locate(':1-5', @@global.gtid_executed);
+locate(':1-5', @@global.gtid_executed)
 VALID_POS
 #node-4 (independent slave replicating from galera-node-2)
 select * from t;
@@ -108,8 +108,8 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate('1-5', @@global.gtid_executed);
-locate('1-5', @@global.gtid_executed)
+select locate(':1-5', @@global.gtid_executed);
+locate(':1-5', @@global.gtid_executed)
 VALID_POS
 #node-1 (independent master)
 update t set c = 'kkkkk' where i = 1;
@@ -130,8 +130,8 @@ i	c
 4	zzzzzz
 50	pppppp
 100	k2
-select locate('1-7', @@global.gtid_executed);
-locate('1-7', @@global.gtid_executed)
+select locate(':1-7', @@global.gtid_executed);
+locate(':1-7', @@global.gtid_executed)
 VALID_POS
 #node-1 (independent master)
 drop table t;

--- a/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
@@ -6,22 +6,13 @@ c char(32) DEFAULT 'dummy_text',
 PRIMARY KEY (i)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 insert into t1(i) values(null);
-select * from t1;
-i	c
-1	dummy_text
 insert into t1(i) values(null), (null), (null);
-select * from t1;
-i	c
-1	dummy_text
-3	dummy_text
-5	dummy_text
-7	dummy_text
-select * from t1;
-i	c
-1	dummy_text
-3	dummy_text
-5	dummy_text
-7	dummy_text
+select sum(i) = SUM from t1;;
+sum(i) = SUM
+1
+select sum(i) = SUM from t1;;
+sum(i) = SUM
+1
 SET GLOBAL wsrep_forced_binlog_format='none';
 SET GLOBAL wsrep_forced_binlog_format='none';
 drop table t1;
@@ -59,11 +50,12 @@ SET SESSION binlog_format='ROW';
 show variables like 'binlog_format';
 Variable_name	Value
 binlog_format	ROW
-show variables like '%auto_increment%';
-Variable_name	Value
-auto_increment_increment	2
-auto_increment_offset	1
-wsrep_auto_increment_control	ON
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+@@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size')
+1
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+@@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1
+1
 SET GLOBAL wsrep_auto_increment_control='OFF';
 show variables like '%auto_increment%';
 Variable_name	Value

--- a/mysql-test/suite/galera/r/lp1435482.result
+++ b/mysql-test/suite/galera/r/lp1435482.result
@@ -9,40 +9,40 @@ SELECT @@session.wsrep_replicate_myisam;
 @@session.wsrep_replicate_myisam
 0
 # Create MyISAM table which should be replicated due to enforce_storage_engine.
-CREATE TABLE t1 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=MyISAM;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=MyISAM;
 Warnings:
 Note	1266	Using storage engine InnoDB for table 't1'
 # The next step should crash it without the fix
-INSERT INTO t1 values (NULL);
+INSERT INTO t1 values (1);
 # The table should exist and be InnoDB.
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f1` int(11) NOT NULL AUTO_INCREMENT,
+  `f1` int(11) NOT NULL,
   PRIMARY KEY (`f1`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 # Values should be replicated
 SELECT * from t1;
 f1
 1
 # Make sure enforce_storage_engine works without any engine and InnoDB.
-CREATE TABLE t2 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB;
-CREATE TABLE t3 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY);
-INSERT INTO t2 values (NULL);
-INSERT INTO t3 values (NULL);
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t2 values (1);
+INSERT INTO t3 values (1);
 # The tables should exist.
 SHOW CREATE TABLE t2;
 Table	Create Table
 t2	CREATE TABLE `t2` (
-  `f1` int(11) NOT NULL AUTO_INCREMENT,
+  `f1` int(11) NOT NULL,
   PRIMARY KEY (`f1`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 SHOW CREATE TABLE t3;
 Table	Create Table
 t3	CREATE TABLE `t3` (
-  `f1` int(11) NOT NULL AUTO_INCREMENT,
+  `f1` int(11) NOT NULL,
   PRIMARY KEY (`f1`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 # Values should be replicated
 SELECT * from t2;
 f1
@@ -52,33 +52,33 @@ f1
 1
 # Make sure wsrep_replicate_myisam doesn't interfere
 SET @@session.wsrep_replicate_myisam = ON;
-CREATE TABLE t4 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=MyISAM;
+CREATE TABLE t4 (f1 INTEGER PRIMARY KEY) ENGINE=MyISAM;
 Warnings:
 Note	1266	Using storage engine InnoDB for table 't4'
-CREATE TABLE t5 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB;
-CREATE TABLE t6 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY);
-INSERT INTO t4 values (NULL);
-INSERT INTO t5 values (NULL);
-INSERT INTO t6 values (NULL);
+CREATE TABLE t5 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t6 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t4 values (1);
+INSERT INTO t5 values (1);
+INSERT INTO t6 values (1);
 # The table should exist and be InnoDB.
 SHOW CREATE TABLE t4;
 Table	Create Table
 t4	CREATE TABLE `t4` (
-  `f1` int(11) NOT NULL AUTO_INCREMENT,
+  `f1` int(11) NOT NULL,
   PRIMARY KEY (`f1`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 SHOW CREATE TABLE t5;
 Table	Create Table
 t5	CREATE TABLE `t5` (
-  `f1` int(11) NOT NULL AUTO_INCREMENT,
+  `f1` int(11) NOT NULL,
   PRIMARY KEY (`f1`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 SHOW CREATE TABLE t6;
 Table	Create Table
 t6	CREATE TABLE `t6` (
-  `f1` int(11) NOT NULL AUTO_INCREMENT,
+  `f1` int(11) NOT NULL,
   PRIMARY KEY (`f1`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
 # Values should be replicated
 SELECT * from t4;
 f1

--- a/mysql-test/suite/galera/t/galera_as_master_and_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_master_and_slave.test
@@ -75,7 +75,7 @@ update t set c = 'zzzzzz' where i = 4;
 update t set c = 'pppppp', i = 50 where i = 5;
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate('1-3', @@global.gtid_executed);
+select locate(':1-3', @@global.gtid_executed);
 # replication lag
 sleep 1;
 
@@ -83,7 +83,7 @@ sleep 1;
 --echo #node-4 (independent slave replicating from galera-node-2)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate('1-3', @@global.gtid_executed);
+select locate(':1-3', @@global.gtid_executed);
 
 # repeat same workload on independent master now.
 # replication will cause the re-execution of action on slave but slave
@@ -104,19 +104,19 @@ sleep 1;
 --echo #node-2 (galera-cluster-node acting as slave to an independent master)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate('1-5', @@global.gtid_executed);
+select locate(':1-5', @@global.gtid_executed);
 
 --connection node_3
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate('1-5', @@global.gtid_executed);
+select locate(':1-5', @@global.gtid_executed);
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate('1-5', @@global.gtid_executed);
+select locate(':1-5', @@global.gtid_executed);
 
 #
 # do some more transaction to rule-out existence of GTID gaps.
@@ -134,7 +134,7 @@ select right(@@global.gtid_executed, 3);
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate('1-7', @@global.gtid_executed);
+select locate(':1-7', @@global.gtid_executed);
 
 #
 # Step-n: Remove seed table and break all replication links as part of cleanup.

--- a/mysql-test/suite/galera/t/galera_as_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_slave.test
@@ -41,6 +41,7 @@ SELECT COUNT(*) = 3 FROM t1;
 DROP TABLE t1;
 
 --connection node_2
+--sleep 1
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
@@ -76,6 +76,7 @@ SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.
 DROP TABLE t1;
 
 --connection node_2
+--sleep 1
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/galera/t/galera_as_slave_crash_safe.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_crash_safe.test
@@ -69,6 +69,7 @@ INSERT INTO t1 VALUES (3);
 DROP TABLE t1;
 
 --connection node_3
+--sleep 1
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_binlog_stmt_autoinc.test
@@ -25,15 +25,18 @@ CREATE TABLE t1 (
 
 insert into t1(i) values(null);
 
-select * from t1;
-
 insert into t1(i) values(null), (null), (null);
 
-select * from t1;
+# based on which node start first value of auto-increment will differ so we base
+# the logic to check the values using wsrep_local_index.
+--let $delta = `SELECT 16 + VARIABLE_VALUE*4 as delta FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index'`
+--replace_regex /[1-9][0-9]+/SUM/
+--eval select sum(i) = $delta from t1;
 
 --connection node_2
 
-select * from t1;
+--replace_regex /[1-9][0-9]+/SUM/
+--eval select sum(i) = $delta from t1;
 
 SET GLOBAL wsrep_forced_binlog_format='none';
 
@@ -94,7 +97,11 @@ SET GLOBAL wsrep_auto_increment_control='ON';
 SET SESSION binlog_format='ROW';
 
 show variables like 'binlog_format';
-show variables like '%auto_increment%';
+--disable_warnings
+SELECT @@auto_increment_increment = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size');
+SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_index') + 1;
+--enable_warnings
+
 
 ##
 ## Verify the recovery of original user-defined values after

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -207,6 +207,8 @@ FLUSH CHANGED_PAGE_BITMAPS;
 CREATE TABLE t1 (f1 INTEGER);
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
 --connection node_1

--- a/mysql-test/suite/galera/t/galera_rsu_drop_pk.test
+++ b/mysql-test/suite/galera/t/galera_rsu_drop_pk.test
@@ -21,6 +21,10 @@ INSERT INTO t1 (f1) SELECT 000000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3
 --connection node_2
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 DROP PRIMARY KEY;
+# alter rsu is asynchronous action (this is upstream behavior) and so to be consistent
+# we ensure that post-alter action to get the node back to SYNC state are completed before
+# firing followup events.
+--sleep 5
 SET SESSION wsrep_OSU_method = "TOI";
 
 # Insert even more data after the ALTER has completed

--- a/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
@@ -19,6 +19,7 @@ INSERT INTO t1 (f1) SELECT 000000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3
 --connection node_2
 SET GLOBAL wsrep_desync = TRUE;
 SET SESSION wsrep_on = FALSE;
+--SLEEP 5
 
 ALTER TABLE t1 ADD PRIMARY KEY (f1);
 

--- a/mysql-test/suite/galera/t/lp1435482.test
+++ b/mysql-test/suite/galera/t/lp1435482.test
@@ -13,10 +13,10 @@ SELECT @@global.wsrep_replicate_myisam;
 SELECT @@session.wsrep_replicate_myisam;
 
 --echo # Create MyISAM table which should be replicated due to enforce_storage_engine.
-CREATE TABLE t1 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=MyISAM;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=MyISAM;
 
 --echo # The next step should crash it without the fix
-INSERT INTO t1 values (NULL);
+INSERT INTO t1 values (1);
 
 --connection node_2
 
@@ -28,10 +28,10 @@ SELECT * from t1;
 
 --echo # Make sure enforce_storage_engine works without any engine and InnoDB.
 --connection node_1
-CREATE TABLE t2 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB;
-CREATE TABLE t3 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY);
-INSERT INTO t2 values (NULL);
-INSERT INTO t3 values (NULL);
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t2 values (1);
+INSERT INTO t3 values (1);
 
 --connection node_2
 
@@ -47,12 +47,12 @@ SELECT * from t3;
 --connection node_1
 SET @@session.wsrep_replicate_myisam = ON;
 
-CREATE TABLE t4 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=MyISAM;
-CREATE TABLE t5 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB;
-CREATE TABLE t6 (f1 INTEGER AUTO_INCREMENT PRIMARY KEY);
-INSERT INTO t4 values (NULL);
-INSERT INTO t5 values (NULL);
-INSERT INTO t6 values (NULL);
+CREATE TABLE t4 (f1 INTEGER PRIMARY KEY) ENGINE=MyISAM;
+CREATE TABLE t5 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t6 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t4 values (1);
+INSERT INTO t5 values (1);
+INSERT INTO t6 values (1);
 
 --connection node_2
 


### PR DESCRIPTION
  For example: Depending on which node boot first based on machine load
  value of auto-increment column differs.
  This patch aims at making these test-cases infrastructure independent.
