### PR TITLE
- #PXC-665: SST donor node has status "JOINED" after successful resync

### DIFF
--- a/mysql-test/suite/galera/r/galera_rsu_during_sst.result
+++ b/mysql-test/suite/galera/r/galera_rsu_during_sst.result
@@ -1,0 +1,21 @@
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+INSERT INTO t1 VALUES (1, 'a'), (2, 'a'), (3, 'a');
+SELECT * FROM t1;
+f1	f2
+1	a
+2	a
+3	a
+Shutting down server ...
+SET GLOBAL wsrep_provider_options = 'dbug=d,sst_sent';
+Starting server ...
+SET SESSION wsrep_OSU_method = "RSU";
+CREATE TABLE t2 (f1 INTEGER);
+SET GLOBAL wsrep_provider_options = 'signal=sst_sent';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SELECT * FROM t1;
+f1	f2
+1	a
+2	a
+3	a
+DROP TABLE t2;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_rsu_during_sst.test
+++ b/mysql-test/suite/galera/t/galera_rsu_during_sst.test
@@ -1,0 +1,82 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+INSERT INTO t1 VALUES (1, 'a'), (2, 'a'), (3, 'a');
+
+SELECT * FROM t1;
+
+# Initiate normal shutdown on the node 2:
+
+--connection node_2
+
+--echo Shutting down server ...
+--source include/shutdown_mysqld.inc
+
+# Wait until shutdown has been completed:
+
+--connection node_1
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Remove the "grastate.dat" file to initiate new SST after restart:
+
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# Set debug synch point:
+
+--let $galera_sync_point = sst_sent
+--source include/galera_set_sync_point.inc
+
+# Create new connection:
+
+--let $galera_connection_name = node_1a
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+
+# Restart node 2:
+
+--connection node_2
+
+--echo Starting server ...
+--let $start_mysqld_params=
+--source include/start_mysqld.inc
+
+# Waiting for the SST sync point:
+
+--connection node_1a
+
+--disable_query_log
+--source include/galera_wait_sync_point.inc
+--enable_query_log
+
+# Initiate RSU operation during SST:
+
+SET SESSION wsrep_OSU_method = "RSU";
+CREATE TABLE t2 (f1 INTEGER);
+
+# Signalling sync point (to complete SST):
+
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Wait until node 2 is ready:
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Sanity check (node 2 is running now and can perform SQL operators):
+
+--connection node_2
+
+SELECT * FROM t1;
+
+--connection node_1a
+
+DROP TABLE t2;
+
+--connection node_1
+
+DROP TABLE t1;


### PR DESCRIPTION
Operations that use the global lock (such as FLUSH TABLES FOR READ LOCK) and DDL operations that are protected via the RSU can be performed during SST. In this case, they come into interference with the SST process, which leads to a variety of bugs, including hang or crash of the donor node after SST donation. Alternatively, the SST donor node stays in the "JOINED" status, even after the completion of the SST.

This patch solves the problem with the incorrect classification of the "JOIN" message (which is generated as response to the wsrep->resync() call) at the GCS layer. Improper handling of the JOIN message leads to ignoring of the subsequent SYNC message and generates the above-described problems.

Pausing of the RSU operations during the SST will be solved as a separate issue in another patch.

Galera part of this patch is located here: https://github.com/percona/galera/pull/80
