### PR TITLE
- #PXC-608: Assertion `node->desync_count > 0' failed in void gcs_node_update_status(gcs_node_t*, const gcs_state_quorum_t*)

### DIFF
--- a/mysql-test/suite/galera/r/galera_desync_non_prim.result
+++ b/mysql-test/suite/galera/r/galera_desync_non_prim.result
@@ -1,0 +1,15 @@
+SET SESSION wsrep_sync_wait=0;
+SET @@global.wsrep_desync = 'ON';
+SET @@global.wsrep_cluster_address = '';
+SHOW STATUS LIKE 'wsrep_ready';
+Variable_name	Value
+wsrep_ready	OFF
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	non-Primary
+SHOW STATUS LIKE 'wsrep_ready';
+Variable_name	Value
+wsrep_ready	ON
+SHOW STATUS LIKE 'wsrep_cluster_status';
+Variable_name	Value
+wsrep_cluster_status	Primary

--- a/mysql-test/suite/galera/t/galera_desync_non_prim.test
+++ b/mysql-test/suite/galera/t/galera_desync_non_prim.test
@@ -1,0 +1,29 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connection node_2
+
+# Set wsrep_sync_wait to avoid ER_LOCK_WAIT_TIMEOUT.
+SET SESSION wsrep_sync_wait=0;
+
+SET @@global.wsrep_desync = 'ON';
+
+--let $wsrep_cluster_address_saved = `SELECT @@global.wsrep_cluster_address`
+SET @@global.wsrep_cluster_address = '';
+
+# Must return 'OFF':
+SHOW STATUS LIKE 'wsrep_ready';
+
+# Must return 'Non-primary':
+SHOW STATUS LIKE 'wsrep_cluster_status';
+
+--disable_query_log
+--eval SET @@global.wsrep_cluster_address = '$wsrep_cluster_address_saved'
+--enable_query_log
+--source include/wait_until_connected_again.inc
+
+# Must return 'ON':
+SHOW STATUS LIKE 'wsrep_ready';
+
+# Must return 'Primary':
+SHOW STATUS LIKE 'wsrep_cluster_status';

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1204,6 +1204,16 @@ void wsrep_stop_replication(THD *thd)
   /* wait until appliers have stopped */
   wsrep_wait_appliers_close(thd);
 
+  /* After disconnecting the node from the cluster and closing all */
+  /* client connections we need to reset the desynchronization counter: */
+
+  wsrep_desync = 0;
+
+  /* We do not have a distinct status for this situation, */
+  /* but WSREP_MEMBER_JOINER is most suitable for this: */
+
+  local_status.set(WSREP_MEMBER_JOINER);
+
   return;
 }
 


### PR DESCRIPTION
This error occurs because although disconnection node from the cluster involves stop of replication, closing of all client connections and consequently the cancellation of all transactions (which are tied to client connections), but the desynchronization counter associated with the current node, as well as the last state of the node, which is stored in the prim_state field of the gcs_group_t structure, are not cleared even after disconnecting the node from the cluster.

Galera part of this patch is located here: https://github.com/percona/galera/pull/81
