### PR TITLE
- PXC#671: Node transitioning to non-primary with active ALTER TABLE …

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1410,8 +1410,11 @@ int wsrep_to_isolation_begin(THD *thd, char *db_, char *table_,
   such such action should be blocked at TOI level. */
   if (!wsrep_ready)
   {
-    WSREP_DEBUG("WSREP has not yet prepared node for application use");
-    return 0;
+    WSREP_DEBUG("WSREP replication failed."
+                " Check your wsrep connection state and retry the query.");
+    my_error(ER_LOCK_DEADLOCK, MYF(0), "WSREP replication failed. Check "
+	     "your wsrep connection state and retry the query.");
+    return -1;
   }
 
   int ret= 0;


### PR DESCRIPTION
…result in crash.

  If ALTER (or any DDL command that needs TOI) is active before it execute
  TOI action if node is transitioned to non-primary state then ALTER command
  should fail. This failure is handled and generated by check in
  wsrep_to_isolation_begin. As part of PXC#570 fix this check got suppressed
  and instead of returning error it started to return success.
  Corrected it now to return error.
