### PR TITLE
- PXC#672: ALTERing non-existing table emitted wrong message from

### DIFF
--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -367,7 +367,9 @@ bool Sql_cmd_alter_table::execute(THD *thd)
              existing_db_type == DB_TYPE_PERFORMANCE_SCHEMA)
       safe_ops= true;
 
-    if (!safe_ops && existing_db_type != DB_TYPE_INNODB)
+    if (!safe_ops &&
+        existing_db_type != DB_TYPE_INNODB &&
+        existing_db_type != DB_TYPE_UNKNOWN)
     {
       bool block= false;
 


### PR DESCRIPTION
  pxc-strict-mode module.

  If an non-existing table is altered then pxc-strict-mode claimed it to be
  a table with non-transaction storage engine. Corrected the table existence
  check.
