### PR TITLE
- PXC#561: InnoDB: Failing assertion: lock_get_wait(other_lock) in fi…

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2010,9 +2010,8 @@ RecLock::add_to_waitq(const lock_t* wait_for, const lock_prdt_t* prdt)
 		return(DB_SUCCESS);
 	}
 
-#endif /* WITH_WSREP */
-
 	ut_ad(lock_get_wait(lock));
+#endif /* WITH_WSREP */
 
 	dberr_t	err = deadlock_check(lock);
 


### PR DESCRIPTION
…le lock0lock.cc line 5944

  Original issue was due to use of table without explict primary key but we
  re-observed this issue post 5.7 merge due to accidentally missed merge
  that tried to mix semantics of galera + mysql group replication.
