### PR TITLE
- PXC#674: Skip PFS transaction registration for WSREP engine.

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1440,7 +1440,13 @@ void trans_register_ha(THD *thd, bool all, handlerton *ht_arg,
 */
 #ifdef HAVE_PSI_TRANSACTION_INTERFACE
   if (thd->m_transaction_psi == NULL &&
-      ht_arg->db_type != DB_TYPE_BINLOG)
+      ht_arg->db_type != DB_TYPE_BINLOG
+#ifdef WITH_WSREP
+      /* Do not register transactions for WSREP engine registration should be
+      done by the base transactional storage engine (InnoDB). */
+      && ht_arg->db_type != DB_TYPE_WSREP
+#endif /* WITH_WSREP */
+     )
   {
     const XID *xid= trn_ctx->xid_state()->get_xid();
     my_bool autocommit= !thd->in_multi_stmt_transaction_mode();


### PR DESCRIPTION
  WSREP has dependent action as in WSREP is not a standalone storage
  engine. It replicate the action performed by the mainline storage
  engine (for example: InnoDB) and so the performance schema registration
  of transaction should be done mainline storage engine and not by
  WSREP storage engine. (Same as binlog storage engine).
