### PR TITLE
Ported fixes for DOC-226 and DOC-280 (5.7)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -95,14 +95,6 @@ rst_prolog = '''
 
 .. |PXC|  replace:: Percona XtraDB Cluster
 
-.. _`MariaDB`: https://www.mariadb.com
-
-.. _`MySQL`: https://www.mysql.com
-
-.. _`Percona Server`: https://www.percona.com/software/mysql-database/percona-server
-
-.. _`XtraDB`: https://www.percona.com/software/mysql-database/percona-server/xtradb
-
 .. _`Percona XtraBackup`: https://www.percona.com/software/mysql-database/percona-xtrabackup
 
 .. |check|  replace:: ``|[[---CHECK---]]|``

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -24,7 +24,7 @@ In a single-node workload, locking is handled in the same way as |InnoDB|.
 In case of write load on several nodes, |PXC| uses `optimistic locking <http://en.wikipedia.org/wiki/Optimistic_concurrency_control>`_
 and the application may receive lock error in response to ``COMMIT`` query.
 
-What if a node crashes and InnoDB recovery rolls back some transactions? 
+What if a node crashes and InnoDB recovery rolls back some transactions?
 ========================================================================
 
 When a node crashes, after restarting,
@@ -34,7 +34,7 @@ it will copy the whole dataset from another node
 How can I check the Galera node health?
 =======================================
 
-To check the health of a Galera node, use the following query: 
+To check the health of a Galera node, use the following query:
 
 .. code-block:: mysql
 
@@ -58,13 +58,13 @@ First set up the ``clustercheck`` user:
 
 .. **
 
-You can then check a node's health by running the ``clustercheck`` script: 
+You can then check a node's health by running the ``clustercheck`` script:
 
 .. code-block:: bash
 
    /usr/bin/clustercheck clustercheck password 0
 
-If the node is running, you should get the following status: :: 
+If the node is running, you should get the following status: ::
 
   HTTP/1.1 200 OK
   Content-Type: text/plain
@@ -73,14 +73,14 @@ If the node is running, you should get the following status: ::
 
   Percona XtraDB Cluster Node is synced.
 
-In case node isn't synced or if it is offline, status will look like: :: 
+In case node isn't synced or if it is offline, status will look like: ::
 
   HTTP/1.1 503 Service Unavailable
   Content-Type: text/plain
   Connection: close
   Content-Length: 44
 
-  Percona XtraDB Cluster Node is not synced. 
+  Percona XtraDB Cluster Node is not synced.
 
 .. note::
 
@@ -101,7 +101,7 @@ There are wsrep variables for maximum row count
 and maximum size of write set
 to make sure that the server does not run out of memory.
 
-Is it possible to have different table structures on the nodes? 
+Is it possible to have different table structures on the nodes?
 ===============================================================
 
 For example, if there are four nodes, with four tables:
@@ -124,9 +124,10 @@ in a new component strictly exceeds half that
 of the preceding Primary Component,
 minus the nodes which left gracefully.
 
-The mechanism is described in detail in `Galera documentation <http://galeracluster.com/documentation-webpages/weightedquorum.html>`_.
+The mechanism is described in detail in `Galera documentation
+<http://galeracluster.com/documentation-webpages/weightedquorum.html>`_.
 
-How would the quorum mechanism handle split brain? 
+How would the quorum mechanism handle split brain?
 ==================================================
 
 The quorum mechanism cannot handle split brain.
@@ -135,14 +136,15 @@ If there is no way to decide on the primary component,
 The minimal recommendation is to have 3 nodes.
 However, it is possibile to allow a node to handle traffic
 with the following option: ::
-  
+
   wsrep_provider_options="pc.ignore_sb = yes"
 
 Why a node stops accepting commands if the other one fails in a 2-node setup?
 =============================================================================
 
 This is expected behavior to prevent |split brain|.
-For more information, see previous question or `Galera documentation <http://galeracluster.com/documentation-webpages/weightedquorum.html>`_.
+For more information, see previous question or `Galera documentation
+<http://galeracluster.com/documentation-webpages/weightedquorum.html>`_.
 
 Is it possible to set up a cluster without state transfer?
 ==========================================================
@@ -180,7 +182,7 @@ You may need to open up to four ports if you are using a firewall:
 
      wsrep_provider_options = "ist.recv_addr=10.11.12.206:7777; "
 
-Is there "async" mode or only "sync" commits are supported? 
+Is there "async" mode or only "sync" commits are supported?
 ===========================================================
 
 |PXC| does not support "async" mode, all commits are synchronous on all nodes.
@@ -199,8 +201,10 @@ you should enable ``log-bin`` and ``log-slave-update`` options.
 Why the init script (/etc/init.d/mysql) does not start?
 =======================================================
 
-Try to disable SELinux with the following command: ::
-  
+Try to disable SELinux with the following command:
+
+.. code-block:: bash
+
   echo 0 > /selinux/enforce
 
 What does "nc: invalid option -- 'd'" in the sst.err log file mean?

--- a/doc/source/features/pxc-strict-mode.rst
+++ b/doc/source/features/pxc-strict-mode.rst
@@ -79,7 +79,7 @@ and do not rely on operations not supported by |PXC|.
 .. warning:: If an unsupported operation is performed on a node
    with ``pxc_strict_mode`` set to ``DISABLED`` or ``PERMISSIVE``,
    it will not be validated on nodes where it is replicated to,
-   even if the destination node has ``pxc_strict_mode`` set to ``ENFORCING``. 
+   even if the destination node has ``pxc_strict_mode`` set to ``ENFORCING``.
 
 This section describes the purpose and consequences of each validation.
 

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -5,34 +5,111 @@
 .. glossary::
 
    LSN
-     Each InnoDB page (usually 16kb in size) contains a log sequence number, or LSN. The LSN is the system version number for the entire database. Each page's LSN shows how recently it was changed.
+     Each InnoDB page (usually 16kb in size) contains a log sequence number, or
+     LSN. The LSN is the system version number for the entire database. Each
+     page's LSN shows how recently it was changed.
 
    InnoDB
-      Storage engine which provides ACID-compliant transactions and foreign key support, among others improvements over :term:`MyISAM`. It is the default engine for |MySQL| as of the 5.5 series.
+      Storage engine which provides ACID-compliant transactions and foreign key
+      support, among others improvements over :term:`MyISAM`. It is the default
+      engine for |MySQL| as of the 5.5 series.
 
    MyISAM
-     Previous default storage engine for |MySQL| for versions prior to 5.5. It doesn't fully support transactions but in some scenarios may be faster than :term:`InnoDB`. Each table is stored on disk in 3 files: :term:`.frm`, :term:`.MYD`, :term:`.MYI`.
+     Previous default storage engine for |MySQL| for versions prior to 5.5. It
+     doesn't fully support transactions but in some scenarios may be faster
+     than :term:`InnoDB`. Each table is stored on disk in 3 files: :term:`.frm`,i
+     :file:`.MYD`, :file:`.MYI`.
 
    GTID
-     Global Transaction ID, in *Percona XtraDB Cluster* it consists of :term:`UUID` and an ordinal sequence number which denotes the position of the change in the sequence.
-   
+     Global Transaction ID, in *Percona XtraDB Cluster* it consists of
+     :term:`UUID` and an ordinal sequence number which denotes the position of
+     the change in the sequence.
+
    HAProxy
-     `HAProxy <http://haproxy.1wt.eu/>`_ is a free, very fast and reliable solution offering high availability, load balancing, and proxying for TCP and HTTP-based applications. It is particularly suited for web sites crawling under very high loads while needing persistence or Layer7 processing. Supporting tens of thousands of connections is clearly realistic with todays hardware. Its mode of operation makes its integration into existing architectures very easy and riskless, while still offering the possibility not to expose fragile web servers to the net.
-	
+     `HAProxy <http://haproxy.1wt.eu/>`_ is a free, very fast and reliable
+     solution offering high availability, load balancing, and proxying for TCP
+     and HTTP-based applications. It is particularly suited for web sites
+     crawling under very high loads while needing persistence or Layer7
+     processing. Supporting tens of thousands of connections is clearly
+     realistic with todays hardware. Its mode of operation makes its
+     integration into existing architectures very easy and riskless, while
+     still offering the possibility not to expose fragile web servers to the
+     net.
+
    IST
-     Incremental State Transfer. Functionality which instead of whole state snapshot can catch up with te group by receiving the missing writesets, but only if the writeset is still in the donor's writeset cache.
+     Incremental State Transfer. Functionality which instead of whole state
+     snapshot can catch up with te group by receiving the missing writesets,
+     but only if the writeset is still in the donor's writeset cache.
 
    SST
-     State Snapshot Transfer is the full copy of data from one node to another. It's used when a new node joins the cluster, it has to transfer data from existing node. There are three methods of SST available in Percona XtraDB Cluster: :program:`mysqldump`, :program:`rsync` and :program:`xtrabackup`. The downside of `mysqldump` and `rsync` is that the node becomes *READ-ONLY* while data is being copied from one node to another (SST applies :command:`FLUSH TABLES WITH READ LOCK` command). Xtrabackup SST does not require :command:`READ LOCK` for the entire syncing process, only for syncing the |MySQL| system tables and writing the information about the binlog, galera and slave information (same as the regular XtraBackup backup). State snapshot transfer method can be configured with the :variable:`wsrep_sst_method` variable.
+     State Snapshot Transfer is the full copy of data from one node to another.
+     It's used when a new node joins the cluster, it has to transfer data from
+     existing node. There are three methods of SST available in |Percona XtraDB
+     Cluster|: :program:`mysqldump`, :program:`rsync` and
+     :program:`xtrabackup`. The downside of `mysqldump` and `rsync` is that the
+     node becomes *READ-ONLY* while data is being copied from one node to
+     another (SST applies :command:`FLUSH TABLES WITH READ LOCK` command).
+     Xtrabackup SST does not require :command:`READ LOCK` for the entire
+     syncing process, only for syncing the |MySQL| system tables and writing
+     the information about the binlog, galera and slave information (same as
+     the regular |Percona XtraBackup| backup). State snapshot transfer method
+     can be configured with the :variable:`wsrep_sst_method` variable.
 
-   UUID 
-      Universally Unique IDentifier which uniquely identifies the state and the sequence of changes node undergoes.
+   UUID
+     Universally Unique IDentifier which uniquely identifies the state and the
+     sequence of changes node undergoes. 128-bit UUID is a classic DCE UUID
+     Version 1 (based on current time and MAC address). Although in theory this
+     UUID could be generated based on the real MAC-address, in the Galera it is
+     always (without exception) based on the generated pseudo-random addresses
+     ("locally administered" bit in the node address (in the UUID structure) is
+     always equal to unity).
+
+     Complete structure of the 128-bit UUID field and explanation for its
+     generation are as follows:
+
+     ===== ====  ======= =====================================================
+     From  To    Length  Content
+     ===== ====  ======= =====================================================
+      0     31    32     Bits 0-31 of Coordinated Universal Time (UTC) as a
+                         count of 100-nanosecond intervals since 00:00:00.00,
+                         15 October 1582, encoded as big-endian 32-bit number.
+     32     47    16     Bits 32-47 of UTC as a count of 100-nanosecond
+                         intervals since 00:00:00.00, 15 October 1582, encoded
+                         as big-endian 16-bit number.
+     48     59    12     Bits 48-59 of UTC as a count of 100-nanosecond
+                         intervals since 00:00:00.00, 15 October 1582, encoded
+                         as big-endian 16-bit number.
+     60     63     4     UUID version number: always equal to 1 (DCE UUID).
+     64     69     6     most-significants bits of random number, which
+                         generated from the server process PID and Coordinated
+                         Universal Time (UTC) as a count of 100-nanosecond
+                         intervals since 00:00:00.00, 15 October 1582.
+     70     71     2     UID variant: always equal to binary 10 (DCE variant).
+     72     79     8     8 least-significant bits of  random number, which
+                         generated from the server process PID and Coordinated
+                         Universal Time (UTC) as a count of 100-nanosecond
+                         intervals since 00:00:00.00, 15 October 1582.
+     80     80     1     Random bit ("unique node identifier").
+     81     81     1     Always equal to the one ("locally administered MAC
+                         address").
+     82    127    46     Random bits ("unique node identifier"): readed from
+                         the :file:`/dev/urandom` or (if :file:`/dev/urandom`
+                         is unavailable) generated based on the server process
+                         PID, current time and bits of the default "zero node
+                         identifier" (entropy data).
+     ===== ====  ======= =====================================================
 
    XtraBackup
-     *Percona XtraBackup* is an open-source hot backup utility for |MySQL| - based servers that doesn’t lock your database during the backup.
+     *Percona XtraBackup* is an open-source hot backup utility for |MySQL| -
+     based servers that doesn't lock your database during the backup.
 
    XtraDB
-     *Percona XtraDB* is an enhanced version of the InnoDB storage engine, designed to better scale on modern hardware, and including a variety of other features useful in high performance environments. It is fully backwards compatible, and so can be used as a drop-in replacement for standard InnoDB. More information `here <http://www.percona.com/doc/percona-server/5.5/percona_xtradb.html>`_ .
+     *Percona XtraDB* is an enhanced version of the InnoDB storage engine,
+     designed to better scale on modern hardware, and including a variety of
+     other features useful in high performance environments. It is fully
+     backwards compatible, and so can be used as a drop-in replacement for
+     standard InnoDB. More information `here
+     <http://www.percona.com/doc/percona-server/5.7/percona_xtradb.html>`_ .
 
    XtraDB Cluster
      *Percona XtraDB Cluster* is a high availability solution for MySQL.
@@ -41,71 +118,51 @@
      *Percona XtraDB Cluster* (PXC) is a high availability solution for MySQL.
 
    my.cnf
-     This file refers to the database server's main configuration file. Most Linux distributions place it as :file:`/etc/mysql/my.cnf`, but the location and name depends on the particular installation. Note that this is not the only way of configuring the server, some systems does not have one even and rely on the command options to start the server and its defaults values.
+     This file refers to the database server's main configuration file. Most
+     Linux distributions place it as :file:`/etc/mysql/my.cnf` or
+     :file:`/etc/my.cnf`, but the location and name depends on the particular
+     installation. Note that this is not the only way of configuring the
+     server, some systems does not have one even and rely on the command
+     options to start the server and its defaults values.
 
    cluster replication
-     Normal replication path for cluster members. Can be encrypted (not by default) and unicast or multicast (unicast by default). Runs on tcp port 4567 by default.
+     Normal replication path for cluster members. Can be encrypted (not by
+     default) and unicast or multicast (unicast by default). Runs on tcp port
+     4567 by default.
 
    datadir
-    The directory in which the database server stores its databases. Most Linux distribution use :file:`/var/lib/mysql` by default.
+    The directory in which the database server stores its databases. Most Linux
+    distribution use :file:`/var/lib/mysql` by default.
 
    donor node
     The node elected to provide a state transfer (SST or IST).
 
    ibdata
-     Default prefix for tablespace files, e.g. :file:`ibdata1` is a 10MB  autoextendable file that |MySQL| creates for the shared tablespace by default. 
-
-   innodb_file_per_table
-     InnoDB option to use separate .ibd files for each table.
+     Default prefix for tablespace files, e.g. :file:`ibdata1` is a 10MB
+     autoextendable file that |MySQL| creates for the shared tablespace by
+     default.
 
    joiner node
      The node joining the cluster, usually a state transfer target.
-    
+
    node
      A cluster node -- a single mysql instance that is in the cluster.
-     
-   primary cluster
-     A cluster with :term:`quorum`. A non-primary cluster will not allow any operations and will give ``Unknown command`` errors on any clients attempting to read or write from the database.
 
-   quorum 
-     A majority (> 50%) of nodes. In the event of a network partition, only the cluster partition that retains a quorum (if any) will remain Primary by default.
+   primary cluster
+     A cluster with :term:`quorum`. A non-primary cluster will not allow any
+     operations and will give ``Unknown command`` errors on any clients
+     attempting to read or write from the database.
+
+   quorum
+     A majority (> 50%) of nodes. In the event of a network partition, only the
+     cluster partition that retains a quorum (if any) will remain Primary by
+     default.
 
    split brain
-     Split brain occurs when two parts of a computer cluster are disconnected, each part believing that the other is no longer running. This problem can lead to data inconsistency.
+     Split brain occurs when two parts of a computer cluster are disconnected,
+     each part believing that the other is no longer running. This problem can
+     lead to data inconsistency.
 
    .frm
-     For each table, the server will create a file with the ``.frm`` extension containing the table definition (for all storage engines).
-
-   .ibd
-     On a multiple tablespace setup (:term:`innodb_file_per_table` enabled), |MySQL| will store each newly created table on a file with a ``.ibd`` extension.
-
-   .MYD
-     Each |MyISAM| table has ``.MYD`` (MYData) file which contains the data on it.
-
-   .MYI
-     Each |MyISAM| table has ``.MYI`` (MYIndex) file which contains the table's indexes.
-
-   .MRG
-     Each table using the :program:`MERGE` storage engine, besides of a :term:`.frm` file, will have :term:`.MRG` file containing the names of the |MyISAM| tables associated with it.
-
-   .TRG
-     File containing the triggers associated to a table, e.g. :file:`mytable.TRG`. With the :term:`.TRN` file, they represent all the trigger definitions.
-
-   .TRN
-     File containing the triggers' Names associated to a table, e.g. :file:`mytable.TRN`. With the :term:`.TRG` file, they represent all the trigger definitions.
-
-   .ARM
-     Each table with the :program:`Archive Storage Engine` has ``.ARM`` file which contains the metadata of it.
-
-   .ARZ
-     Each table with the :program:`Archive Storage Engine` has ``.ARZ`` file which contains the data of it.
-
-   .CSM
-     Each table with the :program:`CSV Storage Engine` has ``.CSM`` file which contains the metadata of it.
-
-   .CSV
-     Each table with the :program:`CSV Storage` engine has ``.CSV`` file which contains the data of it (which is a standard Comma Separated Value file).
-
-   .opt
-     |MySQL| stores options of a database (like charset) in a file with a :option:`.opt` extension in the database directory.
-
+     For each table, the server will create a file with the :file:`.frm`
+     extension containing the table definition (for all storage engines).

--- a/doc/source/howtos/3nodesec2.rst
+++ b/doc/source/howtos/3nodesec2.rst
@@ -24,7 +24,7 @@ To set up |PXC|:
       mkdir -p /mnt/data
       mysql_install_db --datadir=/mnt/data --user=mysql
 
-#. Stop the firewall service: 
+#. Stop the firewall service:
 
    .. code-block:: bash
 

--- a/doc/source/howtos/centos_howto.rst
+++ b/doc/source/howtos/centos_howto.rst
@@ -8,7 +8,7 @@ This tutorial describes how to install and configure three |PXC| nodes
 on CentOS 6.3 servers, using the packages from Percona repositories.
 
 * Node 1
-  
+
   * Host name: ``percona1``
   * IP address: ``192.168.70.71``
 
@@ -86,7 +86,7 @@ For more information about bootstrapping the cluster, see :ref:`bootstrap`.
       the bootstrap service should be used instead: ::
 
          [root@percona1 ~]#  systemctl start mysql@bootstrap.service
- 
+
    The previous command will start the cluster
    with initial :variable:`wsrep_cluster_address` variable
    set to ``gcomm://``.
@@ -96,7 +96,7 @@ For more information about bootstrapping the cluster, see :ref:`bootstrap`.
 #. After the first node has been started,
    cluster status can be checked with the following command:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql> show status like 'wsrep%';
       +----------------------------+--------------------------------------+
@@ -115,18 +115,18 @@ For more information about bootstrapping the cluster, see :ref:`bootstrap`.
       +----------------------------+--------------------------------------+
       40 rows in set (0.01 sec)
 
-   This output shows that the cluster has been successfully bootstrapped. 
+   This output shows that the cluster has been successfully bootstrapped.
 
 .. note:: It is not recommended to leave an empty password
    for the root account. Password can be changed as follows:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql@percona1> UPDATE mysql.user SET password=PASSWORD("Passw0rd") where user='root';
       mysql@percona1> FLUSH PRIVILEGES;
 
 To perform :ref:`state_snapshot_transfer` using |XtraBackup|,
-set up a new user with proper `privileges <http://www.percona.com/doc/percona-xtrabackup/innobackupex/privileges.html#permissions-and-privileges-needed>`_: 
+set up a new user with proper `privileges <http://www.percona.com/doc/percona-xtrabackup/innobackupex/privileges.html#permissions-and-privileges-needed>`_:
 
 .. code-block:: mysql
 
@@ -174,8 +174,10 @@ Step 3. Configuring the second node
 
       #Authentication for SST method
       wsrep_sst_auth="sstuser:s3cret"
- 
-#. Start the second node with the following command::
+
+#. Start the second node with the following command:
+
+.. code-block:: bash
 
       [root@percona2 ~]# /etc/init.d/mysql start
 
@@ -185,9 +187,9 @@ Step 3. Configuring the second node
    In order to connect to the cluster and check the status,
    the root password from the first node should be used.
    Cluster status can be checked on both nodes.
-   The following is an example of status from the second node (``percona2``): 
+   The following is an example of status from the second node (``percona2``):
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql> show status like 'wsrep%';
       +----------------------------+--------------------------------------+
@@ -206,7 +208,7 @@ Step 3. Configuring the second node
       +----------------------------+--------------------------------------+
       40 rows in set (0.01 sec)
 
-   This output shows that the new node has been successfully added to the cluster. 
+   This output shows that the new node has been successfully added to the cluster.
 
 Step 4. Configuring the third node
 ==================================
@@ -246,16 +248,18 @@ Step 4. Configuring the third node
       #Authentication for SST method
       wsrep_sst_auth="sstuser:s3cret"
 
-#. Start the third node with the following command:: 
+#. Start the third node with the following command:
+
+.. code-block:: bash
 
       [root@percona3 ~]# /etc/init.d/mysql start
 
 #. After the server has been started,
    it should receive SST automatically.
    Cluster status can be checked on all three nodes.
-   The following is an example of status from the third node (``percona3``): 
+   The following is an example of status from the third node (``percona3``):
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql> show status like 'wsrep%';
       +----------------------------+--------------------------------------+
@@ -283,16 +287,16 @@ To test replication, lets create a new database on second node,
 create a table for that database on the third node,
 and add some records to the table on the first node.
 
-1. Create a new database on the second node: 
+1. Create a new database on the second node:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql@percona2> CREATE DATABASE percona;
       Query OK, 1 row affected (0.01 sec)
 
-#. Create a table on the third node: 
-  
-   .. code-block:: mysql 
+#. Create a table on the third node:
+
+   .. code-block:: mysql
 
       mysql@percona3> USE percona;
       Database changed
@@ -300,16 +304,16 @@ and add some records to the table on the first node.
       mysql@percona3> CREATE TABLE example (node_id INT PRIMARY KEY, node_name VARCHAR(30));
       Query OK, 0 rows affected (0.05 sec)
 
-#. Insert records on the first node: 
+#. Insert records on the first node:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql@percona1> INSERT INTO percona.example VALUES (1, 'percona1');
       Query OK, 1 row affected (0.02 sec)
 
-#. Retrieve all the rows from that table on the second node: 
+#. Retrieve all the rows from that table on the second node:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql@percona2> SELECT * FROM percona.example;
       +---------+-----------+
@@ -321,4 +325,3 @@ and add some records to the table on the first node.
 
 This simple procedure should ensure that all nodes in the cluster
 are synchronized and working as intended.
-

--- a/doc/source/howtos/encrypt-traffic.rst
+++ b/doc/source/howtos/encrypt-traffic.rst
@@ -22,21 +22,23 @@ you need to generate and use SSL keys and certificates.
 The following example shows :file:`my.cnf` configuration
 for server nodes and client instances to use SSL:
 
-.. code-block:: none
+.. code-block:: text
 
    [mysqld]
    ssl-ca=ca.pem
    ssl-cert=server-cert.pem
    ssl-key=server-key.pem
-   
+
    [client]
    ssl-ca=ca.pem
    ssl-cert=client-cert.pem
    ssl-key=client-key.pem
 
 For more information, see the relevant sections about SSL certificates
-in `Galera Cluster Documentation <http://galeracluster.com/documentation-webpages/sslcert.html>`_.
-and `MySQL Server Documentation <http://dev.mysql.com/doc/refman/5.7/en/creating-ssl-files-using-openssl.html>`_.
+in `Galera Cluster Documentation
+<http://galeracluster.com/documentation-webpages/sslcert.html>`_.
+and `MySQL Server Documentation
+<http://dev.mysql.com/doc/refman/5.7/en/creating-ssl-files-using-openssl.html>`_.
 
 SST Traffic
 ===========
@@ -51,7 +53,7 @@ When copying encrypted data via SST,
 the keyring must be sent over with the files for decryption.
 Make sure that the following options are set in :file:`my.cnf` on all nodes:
 
-.. code-block:: none
+.. code-block:: text
 
    early-plugin-load=keyring_file.so
    keyring-file-data=/path/to/keyring/file
@@ -118,7 +120,7 @@ Depending on the mode you select, other options will be required.
 
 * To enable built-in XtraBackup encryption, use the following configuration:
 
-  .. code-block:: none
+  .. code-block:: text
 
      [sst]
      encrypt=1
@@ -133,7 +135,7 @@ Depending on the mode you select, other options will be required.
 * To enable SST encryption based on OpenSSL
   with the certificate authority (``tca``) and certificate (``tcert``) files:
 
-  .. code-block:: none
+  .. code-block:: text
 
      [sst]
      encrypt=2
@@ -146,7 +148,7 @@ Depending on the mode you select, other options will be required.
 * To enable SST encryption based on OpenSSL
   with the key (``tkey``) and certificate (``tcert``) files:
 
-  .. code-block:: none
+  .. code-block:: text
 
      [sst]
      encrypt=2
@@ -164,8 +166,8 @@ whenever a transaction is performed on one node,
 it is replicated to all other nodes.
 Service messages ensure that all nodes are synchronized.
 
-All of this traffic is transferred via the same underlying communication channel
-used by Galera (``gcomm``).
+All of this traffic is transferred via the same underlying communication
+channel used by Galera (``gcomm``).
 Securing this channel will ensure that IST traffic, write-set replication,
 and service messages are encypted.
 
@@ -188,7 +190,7 @@ using the following parameters.
 
 To set these parameters, use the :variable:`wsrep_provider_options` variable.
 
-.. code-block:: none
+.. code-block:: text
 
    wsrep_provider_options="socket.ssl=yes;socket.ssl_key=/path/to/server-key.pem;socket.ssl_cert=/path/to/server-cert.pem;socket.ssl_ca=/path/to/cacert.pem"
 
@@ -216,21 +218,21 @@ assumig there are two nodes in the cluster:
 
    Set the :variable:`wsrep_provider_options` variable similar to the following:
 
-   .. code-block:: none
+   .. code-block:: text
 
       wsrep_provider_options=socket.ssl=yes;socket.ssl_ca=/path/to/upgrade-ca.pem;socket.ssl_cert=path/to/old-cert.pem;socket.ssl_key=/path/to/old-key.pem
 
 #. Restart Node 2 with the new ``socket.ssl_ca``, ``socket.ssl_cert``,
    and ``socket.ssl_key``.
 
-   .. code-block:: none
+   .. code-block:: text
 
       wsrep_provider_options=socket.ssl=yes;socket.ssl_ca=/path/to/upgrade-ca.pem;socket.ssl_cert=/path/to/new-cert.pem;socket.ssl_key=/path/to/new-key.pem
 
 #. Restart Node 1 with the new ``socket.ssl_ca``, ``socket.ssl_cert``,
    and ``socket.ssl_key``.
 
-   .. code-block:: none
+   .. code-block:: text
 
       wsrep_provider_options=socket.ssl=yes;socket.ssl_ca=/path/to/upgrade-ca.pem;socket.ssl_cert=/path/to/new-cert.pem;socket.ssl_key=/path/to/new-key.pem
 

--- a/doc/source/howtos/haproxy.rst
+++ b/doc/source/howtos/haproxy.rst
@@ -10,7 +10,7 @@ The following is an example of the configuration file for HAProxy::
 
         # this config requires haproxy-1.4.20
 
-        global 
+        global
                 log 127.0.0.1   local0
                 log 127.0.0.1   local1 notice
                 maxconn 4096
@@ -45,15 +45,16 @@ With this configuration, HAProxy will balance the load between three nodes.
 In this case, it only checks if ``mysqld`` listens on port 3306,
 but it doesn't take into an account the state of the node.
 So it could be sending queries to the node that has ``mysqld`` running
-even if it's in ``JOINING`` or ``DISCONNECTED`` state.  
+even if it's in ``JOINING`` or ``DISCONNECTED`` state.
 
 To check the current status of a node we need a more complex check.
-This idea was taken from `codership-team google groups <https://groups.google.com/group/codership-team/browse_thread/thread/44ee59c8b9c458aa/98b47d41125cfae6>`_.
+This idea was taken from `codership-team google groups
+<https://groups.google.com/group/codership-team/browse_thread/thread/44ee59c8b9c458aa/98b47d41125cfae6>`_.
 
-To implement this setup, you will need two scripts: 
+To implement this setup, you will need two scripts:
 
   *  **clustercheck** (located in :file:`/usr/local/bin`)
-     and a config for ``xinetd`` 
+     and a config for ``xinetd``
   *  **mysqlchk** (located in :file:`/etc/xinetd.d`) on each node
 
 Both scripts are available in binaries and source distributions of |PXC|.
@@ -94,7 +95,7 @@ The following is an example of the HAProxy configuration file in this case::
             balance roundrobin
             option  httpchk
 
-            server db01 10.4.29.100:3306 check port 9200 inter 12000 rise 3 fall 3 
-            server db02 10.4.29.99:3306 check port 9200 inter 12000 rise 3 fall 3 
-            server db03 10.4.29.98:3306 check port 9200 inter 12000 rise 3 fall 3 
+            server db01 10.4.29.100:3306 check port 9200 inter 12000 rise 3 fall 3
+            server db02 10.4.29.99:3306 check port 9200 inter 12000 rise 3 fall 3
+            server db03 10.4.29.98:3306 check port 9200 inter 12000 rise 3 fall 3
 

--- a/doc/source/howtos/proxysql.rst
+++ b/doc/source/howtos/proxysql.rst
@@ -20,7 +20,7 @@ and traffic-related settings can all be changed at runtime.
 ProxySQL also support |Percona XtraDB Cluster| node status check using
 scheduler.
 
-.. note:: 
+.. note::
 
   More details on how ProxySQL works can be found in official ProxySQL
   `documentation <https://github.com/sysown/proxysql/tree/master/doc>`_.
@@ -197,7 +197,8 @@ Configuring the backends in ProxySQL is as easy as inserting records into
 ``mysql_servers`` table representing those backends, and specifying the correct
 ``hostgroup_id`` based on their roles:
 
-This example adds three |PXC| nodes to write hostgroups, this means that all three servers will be receiving both write and read traffic:
+This example adds three |PXC| nodes to write hostgroups, this means that all
+three servers will be receiving both write and read traffic:
 
 .. code-block:: mysql
 
@@ -435,7 +436,7 @@ add the same user on one of the nodes:
 Testing the cluster with sysbench
 ---------------------------------
 
-You can install sysbench from Percona repositories by running: 
+You can install sysbench from Percona repositories by running:
 
 .. code-block:: bash
 
@@ -455,7 +456,7 @@ Create the database that will be used for testing:
 
   mysql@pxc1> CREATE DATABASE sbtest;
 
-Populate the table with data for the benchmark: 
+Populate the table with data for the benchmark:
 
 .. code-block:: bash
 

--- a/doc/source/howtos/singlebox.rst
+++ b/doc/source/howtos/singlebox.rst
@@ -19,7 +19,7 @@ To set up the cluster:
 
    * :file:`/etc/my.4000.cnf`
 
-     .. code-block:: none
+     .. code-block:: text
 
         [mysqld]
         port = 4000
@@ -32,7 +32,7 @@ To set up the cluster:
         wsrep_cluster_address='gcomm://192.168.2.21:5030,192.168.2.21:6030'
         wsrep_provider=/usr/local/Percona-XtraDB-Cluster-5.7.11-rel4beta-25.14.2.beta.Linux.x86_64/lib/libgalera_smm.so
         wsrep_sst_receive_address=192.168.2.21:4020
-        wsrep_node_incoming_address=192.168.2.21 
+        wsrep_node_incoming_address=192.168.2.21
         wsrep_slave_threads=2
         wsrep_cluster_name=trimethylxanthine
         wsrep_provider_options = "gmcast.listen_addr=tcp://192.168.2.21:4030;"
@@ -42,7 +42,7 @@ To set up the cluster:
 
    * :file:`/etc/my.5000.cnf`
 
-     .. code-block:: none
+     .. code-block:: text
 
         [mysqld]
         port = 5000
@@ -55,7 +55,7 @@ To set up the cluster:
         wsrep_cluster_address='gcomm://192.168.2.21:4030,192.168.2.21:6030'
         wsrep_provider=/usr/local/Percona-XtraDB-Cluster-5.7.11-rel4beta-25.14.2.beta.Linux.x86_64/lib/libgalera_smm.so
         wsrep_sst_receive_address=192.168.2.21:5020
-        wsrep_node_incoming_address=192.168.2.21 
+        wsrep_node_incoming_address=192.168.2.21
         wsrep_slave_threads=2
         wsrep_cluster_name=trimethylxanthine
         wsrep_provider_options = "gmcast.listen_addr=tcp://192.168.2.21:5030;"
@@ -65,7 +65,7 @@ To set up the cluster:
 
    * :file:`/etc/my.6000.cnf`
 
-     .. code-block:: none
+     .. code-block:: text
 
         [mysqld]
         port = 6000
@@ -78,7 +78,7 @@ To set up the cluster:
         wsrep_cluster_address='gcomm://192.168.2.21:4030,192.168.2.21:5030'
         wsrep_provider=/usr/local/Percona-XtraDB-Cluster-5.7.11-rel4beta-25.14.2.beta.Linux.x86_64/lib/libgalera_smm.so
         wsrep_sst_receive_address=192.168.2.21:6020
-        wsrep_node_incoming_address=192.168.2.21 
+        wsrep_node_incoming_address=192.168.2.21
         wsrep_slave_threads=2
         wsrep_cluster_name=trimethylxanthine
         wsrep_provider_options = "gmcast.listen_addr=tcp://192.168.2.21:6030;"
@@ -104,12 +104,13 @@ To set up the cluster:
     111215 19:01:49 [Note] WSREP: Shifting JOINED -> SYNCED (TO: 0)
     111215 19:01:49 [Note] WSREP: New cluster view: global state: 4c286ccc-2792-11e1-0800-94bd91e32efa:0, view# 1: Primary, number of nodes: 1, my index: 0, protocol version 1
 
-   To check the ports, run the following command::
-        
-        $ netstat -anp | grep mysqld
-        tcp        0      0 192.168.2.21:4030           0.0.0.0:*                   LISTEN      21895/mysqld        
-        tcp        0      0 0.0.0.0:4000                0.0.0.0:*                   LISTEN      21895/mysqld 
+   To check the ports, run the following command:
 
+   .. code-block:: bash
+
+        $ netstat -anp | grep mysqld
+        tcp        0      0 192.168.2.21:4030           0.0.0.0:*                   LISTEN      21895/mysqld
+        tcp        0      0 0.0.0.0:4000                0.0.0.0:*                   LISTEN      21895/mysqld
 
 #. Start the second and third nodes::
 
@@ -123,7 +124,9 @@ To set up the cluster:
     111215 19:22:26 [Note] WSREP: Shifting JOINED -> SYNCED (TO: 2)
     111215 19:22:26 [Note] WSREP: Synchronized with group, ready for connections
 
-   To check the cluster size, run the following command:: 
+   To check the cluster size, run the following command:
+
+   .. code-block:: mysql
 
     mysql -h127.0.0.1 -P6000 -e "show global status like 'wsrep_cluster_size';"
     +--------------------+-------+
@@ -135,7 +138,9 @@ To set up the cluster:
 After that you can connect to any node and perform queries,
 which will be automatically synchronized with other nodes.
 For example, to create a database on the second node,
-you can run the following command::
-        
+you can run the following command:
+
+  .. code-block: mysql
+
     mysql -h127.0.0.1 -P5000 -e "CREATE DATABASE hello_peter"
 

--- a/doc/source/howtos/ubuntu_howto.rst
+++ b/doc/source/howtos/ubuntu_howto.rst
@@ -87,14 +87,14 @@ For more information about bootstrapping the cluster, see :ref:`bootstrap`.
 #. Start the first node with the following command: ::
 
     [root@pxc1 ~]# /etc/init.d/mysql bootstrap-pxc
- 
+
    This command will start the first node and bootstrap the cluster.
 
 #. After the first node has been started,
    cluster status can be checked with the following command:
 
-   .. code-block:: mysql 
-   
+   .. code-block:: mysql
+
      mysql> show status like 'wsrep%';
      +----------------------------+--------------------------------------+
      | Variable_name              | Value                                |
@@ -112,10 +112,11 @@ For more information about bootstrapping the cluster, see :ref:`bootstrap`.
      +----------------------------+--------------------------------------+
      40 rows in set (0.01 sec)
 
-  This output shows that the cluster has been successfully bootstrapped. 
+  This output shows that the cluster has been successfully bootstrapped.
 
 To perform :ref:`state_snapshot_transfer` using |XtraBackup|,
-set up a new user with proper `privileges <http://www.percona.com/doc/percona-xtrabackup/innobackupex/privileges.html#permissions-and-privileges-needed>`_: 
+set up a new user with proper `privileges
+<http://www.percona.com/doc/percona-xtrabackup/innobackupex/privileges.html#permissions-and-privileges-needed>`_:
 
 .. code-block:: mysql
 
@@ -163,7 +164,7 @@ Step 3. Configuring the second node
 
     #Authentication for SST method
     wsrep_sst_auth="sstuser:s3cretPass"
- 
+
 #. Start the second node with the following command: ::
 
     [root@pxc2 ~]# /etc/init.d/mysql start
@@ -171,10 +172,10 @@ Step 3. Configuring the second node
 #. After the server has been started,
    it should receive |SST| automatically.
    Cluster status can now be checked on both nodes.
-   The following is an example of status from the second node (``pxc2``): 
+   The following is an example of status from the second node (``pxc2``):
 
-   .. code-block:: mysql 
-   
+   .. code-block:: mysql
+
      mysql> show status like 'wsrep%';
      +----------------------------+--------------------------------------+
      | Variable_name              | Value                                |
@@ -192,7 +193,7 @@ Step 3. Configuring the second node
      +----------------------------+--------------------------------------+
      40 rows in set (0.01 sec)
 
-   This output shows that the new node has been successfully added to the cluster. 
+   This output shows that the new node has been successfully added to the cluster.
 
 Step 4. Configuring the third node
 ==================================
@@ -232,17 +233,17 @@ Step 4. Configuring the third node
     #Authentication for SST method
     wsrep_sst_auth="sstuser:s3cretPass"
 
-#. Start the third node with the following command: :: 
+#. Start the third node with the following command: ::
 
     [root@pxc3 ~]# /etc/init.d/mysql start
 
 #. After the server has been started,
    it should receive SST automatically.
    Cluster status can be checked on all nodes.
-   The following is an example of status from the third node (``pxc3``): 
+   The following is an example of status from the third node (``pxc3``):
 
-   .. code-block:: mysql 
-   
+   .. code-block:: mysql
+
      mysql> show status like 'wsrep%';
      +----------------------------+--------------------------------------+
      | Variable_name              | Value                                |
@@ -269,16 +270,16 @@ To test replication, lets create a new database on the second node,
 create a table for that database on the third node,
 and add some records to the table on the first node.
 
-1. Create a new database on the second node: 
+1. Create a new database on the second node:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql@pxc2> CREATE DATABASE percona;
       Query OK, 1 row affected (0.01 sec)
 
-#. Create a table on the third node: 
-  
-   .. code-block:: mysql 
+#. Create a table on the third node:
+
+   .. code-block:: mysql
 
       mysql@pxc3> USE percona;
       Database changed
@@ -286,16 +287,16 @@ and add some records to the table on the first node.
       mysql@pxc3> CREATE TABLE example (node_id INT PRIMARY KEY, node_name VARCHAR(30));
       Query OK, 0 rows affected (0.05 sec)
 
-#. Insert records on the first node: 
+#. Insert records on the first node:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql@pxc1> INSERT INTO percona.example VALUES (1, 'percona1');
       Query OK, 1 row affected (0.02 sec)
 
-#. Retrieve all the rows from that table on the second node: 
+#. Retrieve all the rows from that table on the second node:
 
-   .. code-block:: mysql 
+   .. code-block:: mysql
 
       mysql@pxc2> SELECT * FROM percona.example;
       +---------+-----------+

--- a/doc/source/howtos/virt_sandbox.rst
+++ b/doc/source/howtos/virt_sandbox.rst
@@ -79,7 +79,7 @@ with application servers.
    |SST| is performed by taking a backup using XtraBackup,
    then copying it to the new node with ``netcat``.
    After a successful |SST|, you should see the following in the error log::
-   
+
       120619 13:20:17 [Note] WSREP: State transfer required:
            Group state: 77c9da88-b965-11e1-0800-ea53b7b12451:97
            Local state: 00000000-0000-0000-0000-000000000000:-1
@@ -125,14 +125,14 @@ with application servers.
       120619 13:21:19 [Note] WSREP: Member 0 (ip-10-244-33-92) synced with group.
       120619 13:21:19 [Note] WSREP: Shifting JOINED -> SYNCED (TO: 105)
       120619 13:21:20 [Note] WSREP: Synchronized with group, ready for connections
-   
+
    For debugging information about the |SST|,
    you can check the :file:`sst.err` file and the error log.
-   
+
    After |SST| finishes, you can check the cluster size as follows:
-   
+
    .. code-block:: mysql
-   
+
       mysql> show global status like 'wsrep_cluster_size';
       +--------------------+-------+
       | Variable_name      | Value |
@@ -148,7 +148,7 @@ with application servers.
    You can configure HAProxy to connect and write to all cluster nodes
    or to one node at a time.
    The former method can lead to rollbacks due to conflicting writes
-   when optimistic locking at commit time is triggered, 
+   when optimistic locking at commit time is triggered,
    while the latter method avoids rollbacks.
 
    However, most good applications should be able to handle rollbacks,
@@ -245,7 +245,7 @@ with application servers.
       it will send a response with HTTP code ``200 OK``.
       Otherwise, it sends ``503``.
 
-      To create the ``clustercheck`` user, run the following: 
+      To create the ``clustercheck`` user, run the following:
 
       .. code-block:: mysql
 
@@ -266,11 +266,11 @@ with application servers.
          Content-Type: Content-Type: text/plain
 
       You can use ``xinetd`` to daemonize the script.
-      If `xinetd` is not installed, you can install it with ``yum``:: 
+      If `xinetd` is not installed, you can install it with ``yum``::
 
          # yum -y install xinetd
 
-      The service is configured in :file:`/etc/xinetd.d/mysqlchk`:: 
+      The service is configured in :file:`/etc/xinetd.d/mysqlchk`::
 
          # default: on
          # description: mysqlchk
@@ -359,4 +359,11 @@ This example shows how to do it with ``sysbench`` from the EPEL repository.
    All 8 threads are connected to the ``c1`` server.
    ``c2`` and ``c3`` are acting as backup nodes.
 
-If you are using |HAProxy| for |MySQL| you can break the privilege system’s host part, because |MySQL| will think that the connections are always coming from the load balancer. You can work this around using T-Proxy patches and some `iptables` magic for the backwards connections. However in the setup described in this how-to this is not an issue, since each application server has it's own |HAProxy| instance, each application server connects to 127.0.0.1, so MySQL will see that connections are coming from the application servers. Just like in the normal case.
+If you are using |HAProxy| for |MySQL| you can break the privilege system’s
+host part, because |MySQL| will think that the connections are always coming
+from the load balancer. You can work this around using T-Proxy patches and some
+`iptables` magic for the backwards connections. However in the setup described
+in this how-to this is not an issue, since each application server has it's own
+|HAProxy| instance, each application server connects to 127.0.0.1, so MySQL
+will see that connections are coming from the application servers. Just like in
+the normal case.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,13 +4,13 @@
 Percona XtraDB Cluster |version| Documentation
 ==============================================
 
-|PXC| is a high-availability solution for MySQL.
+|Percona XtraDB Cluster| is a high-availability solution for MySQL.
 It ensures the highest possible uptime,
 prevents data loss,
 and provides linear scalability for a growing environment.
 
-Features of |PXC| include:
- 
+Features of |Percona XtraDB Cluster| include:
+
 * **Synchronous replication**:
   Data is written to all nodes simultaneously,
   or not written at all if it fails even on a single node.
@@ -27,8 +27,10 @@ Features of |PXC| include:
 * **Data consistency**:
   No more unsynchronized nodes.
 
-|PXC| is fully compatible with `MySQL Server Community Edition <MySQL>`_,
-`Percona Server`_, and `MariaDB`_ in the following sense:
+|PXC| is fully compatible with `MySQL Server Community Edition
+<https://www.mysql.com>`_, `Percona Server
+<https://www.percona.com/software/mysql-database/percona-server>`_, and
+`MariaDB <https://www.mariadb.com>`_ in the following sense:
 
 * **Data compatibility**:
   You can use data created by any MySQL variant.

--- a/doc/source/install/apt.rst
+++ b/doc/source/install/apt.rst
@@ -103,7 +103,7 @@ Pinning the Packages
 
 If you want to pin your packages to avoid upgrades,
 create a new file :file:`/etc/apt/preferences.d/00percona.pref`
-and add the following lines to it: :: 
+and add the following lines to it: ::
 
   Package: *
   Pin: release o=Percona Development Team

--- a/doc/source/install/compile.rst
+++ b/doc/source/install/compile.rst
@@ -12,7 +12,7 @@ Before you begin, make sure that the following packages are installed:
    :header-rows: 1
    :stub-columns: 1
 
-   * - 
+   * -
      - apt
      - yum
    * - Git
@@ -58,7 +58,9 @@ Before you begin, make sure that the following packages are installed:
      - ``libpam-dev``
      - ``pam-devel``
 
-You will likely have all or most of the packages already installed. If you are not sure, run one of the following commands to install any missing dependencies:
+You will likely have all or most of the packages already installed. If you are
+not sure, run one of the following commands to install any missing
+dependencies:
 
 .. code-block:: bash
 

--- a/doc/source/install/index.rst
+++ b/doc/source/install/index.rst
@@ -1,10 +1,10 @@
 .. _install:
 
 =================================
-Installing Percona XtraDB Cluster 
+Installing Percona XtraDB Cluster
 =================================
 
-|PXC| supports most 64-bit Linux distributions.
+|Percona XtraDB Cluster| supports most 64-bit Linux distributions.
 Percona provides packages for popular DEB-based and RPM-based distributions:
 
 * Debian 7 ("wheezy")
@@ -36,7 +36,7 @@ the default storage engine is InnoDB (MyISAM has only experimental support),
 and set the mode of InnoDB autoincrement locks to ``2``.
 The following is an example of the :file:`my.cnf` file:
 
-.. code-block:: none
+.. code-block:: text
 
    [mysqld]
 

--- a/doc/source/install/upgrade_guide.rst
+++ b/doc/source/install/upgrade_guide.rst
@@ -43,14 +43,14 @@ To upgrade the cluster, follow these steps for each node:
 
    * On CentOS or RHEL:
 
-     .. code-block:: none
+     .. code-block:: bash
 
         sudo yum remove 'Percona*'
         sudo yum install Percona-XtraDB-Cluster-57
 
    * On Debian or Ubuntu:
 
-     .. code-block:: none
+     .. code-block:: bash
 
         sudo apt-get remove percona-*
         sudo apt-get install percona-xtradb-cluster-57

--- a/doc/source/install/yum.rst
+++ b/doc/source/install/yum.rst
@@ -37,7 +37,7 @@ Installing from Percona Repository
 ==================================
 
 1. Install the Percona repository package:
-   
+
    .. code-block:: bash
 
       sudo yum install http://www.percona.com/downloads/percona-release/redhat/0.1-3/percona-release-0.1-3.noarch.rpm
@@ -45,7 +45,7 @@ Installing from Percona Repository
    Confirm installation and you should see the following if successful: ::
 
       Installed:
-        percona-release.noarch 0:0.1-3                                      
+        percona-release.noarch 0:0.1-3
 
       Complete!
 
@@ -62,14 +62,14 @@ Installing from Percona Repository
    For more information, see :ref:`yum-testing-repo`.
 
 #. Check that the packages are available:
-   
+
    .. code-block:: bash
 
       yum list | grep Percona-XtraDB-Cluster
 
    You should see output similar to the following:
 
-   .. code-block:: none
+   .. code-block:: bash
 
       Percona-XtraDB-Cluster-57.x86_64           1:5.7.11-25.14.2.el7        percona-release-x86_64
       Percona-XtraDB-Cluster-57-debuginfo.x86_64 1:5.7.11-25.14.2.el7        percona-release-x86_64

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -50,7 +50,10 @@ Drawbacks:
 Components
 ==========
 
-|PXC| is based on `Percona Server`_ running with the `XtraDB`_ storage engine.
+|PXC| is based on `Percona Server
+<https://www.percona.com/doc/percona-server/5.7/index.html>`_ running with the
+`XtraDB <https://www.percona.com/doc/percona-server/5.7/percona_xtradb.html>`_
+storage engine.
 It uses the `Galera library <https://github.com/percona/galera>`_,
 which is an implementation of the write set replication (wsrep) API
 developed by `Codership Oy <http://www.galeracluster.com/>`_.

--- a/doc/source/limitation.rst
+++ b/doc/source/limitation.rst
@@ -59,7 +59,7 @@ The following limitations apply to |PXC|:
 
 * InnoDB fake changes feature is not supported.
 
-* ``enforce_storage_engine=InnoDB`` is not compatible with 
+* ``enforce_storage_engine=InnoDB`` is not compatible with
   ``wsrep_replicate_myisam=OFF`` (default).
 
 * The :variable:`binlog_rows_query_log_events` variable is not supported.

--- a/doc/source/manual/bootstrap.rst
+++ b/doc/source/manual/bootstrap.rst
@@ -11,15 +11,15 @@ you need to define which node contains the most relevant data.
 Other nodes will synchronize to this initial node using |SST|.
 
 The |MySQL| configuration file (:file:`my.cnf`) should contain
-at least the following necessary configuration options: :: 
+at least the following necessary configuration options: ::
 
   [mysqld]
   # Path to Galera library
   wsrep_provider=/usr/lib64/libgalera_smm.so
-  
+
   # Cluster connection URL
   wsrep_cluster_address=gcomm://
-  
+
   # Binlog format (Galera requires it to be ROW)
   binlog_format=ROW
 
@@ -40,10 +40,10 @@ Bootstrapping the cluster involes the following steps:
 
 2. After starting a single-node cluster,
    change the :variable:`wsrep_cluster_address` variable
-   to list all the other nodes in the cluster. For example: :: 
+   to list all the other nodes in the cluster. For example: ::
 
     wsrep_cluster_address=gcomm://192.168.70.2,192.168.70.3,192.168.70.4
- 
+
    Cluster membership is not defined by this setting.
    It is defined by the nodes that join the cluster
    with the proper cluster name configured
@@ -58,26 +58,31 @@ Bootstrapping the cluster involes the following steps:
 3. Once the first node is configured, start other nodes, one at a time.
 
    When bootstrapping, other nodes will most likely be using |SST|,
-   so you should avoid joining multiple nodes at once. 
+   so you should avoid joining multiple nodes at once.
 
 If the cluster has been bootstrapped before,
-to avoid editing the :file:`my.cnf` twice to change the :variable:`wsrep_cluster_address` to ``gcomm://`` and then to other node addresses,
-the initial node can be started with: ::
- 
+to avoid editing the :file:`my.cnf` twice to change the
+:variable:`wsrep_cluster_address` to ``gcomm://`` and then to other node
+addresses, the initial node can be started with:
+
+.. code-block:: bash
+
   /etc/init.d/mysql bootstrap-pxc
 
-.. note:: 
+.. note::
 
-   On CentOS/RHEL 7, the following bootstrap command should be used: :: 
+   On CentOS/RHEL 7, the following bootstrap command should be used:
 
-    systemctl start mysql@bootstrap.service
+   .. code-block:: bash
+
+     systemctl start mysql@bootstrap.service
 
 The above commands will ensure that values in :file:`my.cnf` remain unchanged.
 The next time the node is restarted,
 it won't require updating the configuration file.
 This can be useful when the cluster has been previously set up
 and for some reason all nodes went down
-and the cluster needs to be restored. 
+and the cluster needs to be restored.
 
 Other Reading
 =============

--- a/doc/source/manual/certification.rst
+++ b/doc/source/manual/certification.rst
@@ -98,9 +98,7 @@ Common Situation
 
 The following example shows what happens in a common situation.
 ``act_id`` is incremented and assigned only for totally ordered actions,
-and only in primary state (skip messages while in state exchange).
-
-.. code-block:: none
+and only in primary state (skip messages while in state exchange). ::
 
    rcvd->id = ++group->act_id_;
 
@@ -191,9 +189,7 @@ The applier transaction will always win
 and the local conflicting transaction will be rolled back.
 
 The following example shows what happens
-if one of the nodes has local changes that are not synced with the group:
-
-.. code-block:: none
+if one of the nodes has local changes that are not synced with the group: ::
 
   create (id primary key) -> insert (1), (2), (3), (4);
   node-1: wsrep_on=0; insert (5); wsrep_on=1

--- a/doc/source/manual/failover.rst
+++ b/doc/source/manual/failover.rst
@@ -47,14 +47,14 @@ It applies at various levels of your infrastructure,
 depending on how far the cluster is spread out
 to avoid single points of failure. For example:
 
- * A cluster on a single switch should have 3 nodes 
+ * A cluster on a single switch should have 3 nodes
  * A cluster spanning switches should be spread evenly
    across at least 3 switches
  * A cluster spanning networks should span at least 3 networks
  * A cluster spanning data centers should span at least 3 data centers
 
 These rules will prevent split brain situations
-and ensure automatic failover works correctly. 
+and ensure automatic failover works correctly.
 
 Using an arbitrator
 ===================
@@ -79,7 +79,9 @@ In the event of a 2-node cluster
 the failure of one node will cause the other to become non-primary
 and refuse operations.
 However, you can recover the node from non-primary state
-using the following command: :: 
+using the following command:
+
+.. code-block:: mysql
 
   SET GLOBAL wsrep_provider_options='pc.bootstrap=true';
 
@@ -104,7 +106,7 @@ the following high availability features will be available:
   (because of the arbitrator)
 
 * Failure of the primary data center would leave the secondary
-  in a non-primary state. 
+  in a non-primary state.
 
 * If a disaster-recovery failover has been executed,
   you can tell the secondary data center to bootstrap itself

--- a/doc/source/manual/monitoring.rst
+++ b/doc/source/manual/monitoring.rst
@@ -61,7 +61,7 @@ at least for the following:
  * Queue sizes:
    :variable:`wsrep_local_recv_queue` and :variable:`wsrep_local_send_queue`
 
- * Flow control: 
+ * Flow control:
    :variable:`wsrep_flow_control_sent` and :variable:`wsrep_flow_control_recv`
 
  * Number of transactions for a node:

--- a/doc/source/manual/state_snapshot_transfer.rst
+++ b/doc/source/manual/state_snapshot_transfer.rst
@@ -69,10 +69,12 @@ To test if the credentials will work,
 run |innobackupex| on the donor node with the username and password
 specified in the :variable:`wsrep_sst_auth` variable.
 For example, if the value of :variable:`wsrep_sst_auth` is ``root:Passw0rd``,
-the |innobackupex| command should look like this: :: 
+the |innobackupex| command should look like this:
+
+.. code-block:: bash
 
   innobackupex --user=root --password=Passw0rd /tmp/
- 
+
 Detailed information on this method
 is provided in :ref:`xtrabackup_sst` documentation.
 

--- a/doc/source/manual/threading_model.rst
+++ b/doc/source/manual/threading_model.rst
@@ -44,7 +44,8 @@ There is only one rollback thread to perform rollbacks in case of conflicts.
 Transactions executed in parallel can conflict and may need to roll back.
 Applier transactions always take priority over local transactions.
 This is natural, as applier transactions have been accepted by the cluster,
-and some of the nodes may have already applied them. Local conflicting transactions still have a window to rollback.
+and some of the nodes may have already applied them. Local conflicting
+transactions still have a window to rollback.
 
 All the transactions that need to be rolled back
 are added to the rollback queue, and the rollback thread is notified.

--- a/doc/source/manual/xtrabackup_sst.rst
+++ b/doc/source/manual/xtrabackup_sst.rst
@@ -19,9 +19,6 @@ Percona XtraBackup SST works in two stages:
 
 .. note:: As of |PXC| 5.7, ``xtrabackup-v2`` is the only XtraBackup SST method.
 
-.. note:: It is recommended to use |Percona Xtrabackup| 2.1.x
-   versions for XtraBackup SST.
-
 SST Options
 -----------
 
@@ -41,7 +38,7 @@ under ``[sst]``.
 
 .. option:: streamfmt
 
-     :Values: xbstream, tar  
+     :Values: xbstream, tar
      :Default: xbstream
      :Match: Yes
 
@@ -51,13 +48,13 @@ Certain features are not available with ``tar``, for instance:
 encryption, compression, parallel streaming, streaming incremental backups.
 For more information about the ``xbstream`` format, see `The xbstream Binary
 <https://www.percona.com/doc/percona-xtrabackup/2.4/xbstream/xbstream.html>`_.
-             
+
 .. option:: transferfmt
 
      :Values: socat, nc
      :Default: socat
      :Match: Yes
-     
+
 Used to specify the data transfer format.
 The recommended value is ``transferfmt=socat``,
 because it allows for socket options, such as transfer buffer sizes.
@@ -70,14 +67,14 @@ For more information, see `socat(1)
 
 Used to specify the full path to the certificate authority (CA) file
 for ``socat`` encryption based on OpenSSL.
-                          
+
 .. option:: tcert
 
      :Example: tcert=~/etc/ssl/certs/mycert.pem
 
 Used to specify the full path to the certificate file in PEM format
 for ``socat`` encryption based on OpenSSL.
-    
+
 .. note:: For more information about ``tca`` and ``tcert``,
    see http://www.dest-unreach.org/socat/doc/socat-openssltunnel.html.
    The ``tca`` is essentially the self-signed certificate in that example,
@@ -162,12 +159,12 @@ If this is a FIFO, it needs to exist and be open on reader end before itself,
 otherwise ``wsrep_sst_xtrabackup`` will block indefinitely.
 
 .. note:: Value of 0 is not valid.
-           
+
 .. option:: rebuild
 
-    :Values: 0, 1 
+    :Values: 0, 1
     :Default: 0
-    
+
 Used to enable rebuilding of index on joiner node.
 This is independent of compaction, though compaction enables it.
 Rebuild of indexes may be used as an optimization.
@@ -176,11 +173,11 @@ Rebuild of indexes may be used as an optimization.
 
 .. option:: time
 
-    :Values: 0, 1 
-    :Default: 0   
+    :Values: 0, 1
+    :Default: 0
 
 Enabling this option instruments key stages of backup and restore in SST.
-               
+
 .. option:: rlimit
 
     :Example: rlimit=128k
@@ -217,7 +214,7 @@ in :file:`my.cnf` before you enable this option.
 Used to define the files that need to be deleted in the :term:`datadir`
 before running SST,
 so that the state of the other node can be restored cleanly.
-For example: :: 
+For example: ::
 
   [sst]
   cpat='.*galera\.cache$\|.*sst_in_progress$\|.*grastate\.dat$\|.*\.err$\|.*\.log$\|.*RPM_UPGRADE_MARKER$\|.*RPM_UPGRADE_HISTORY$\|.*\.xyz$'
@@ -225,21 +222,8 @@ For example: ::
 .. note:: This option can only be used when :variable:`wsrep_sst_method`
    is set to ``xtrabackup-v2`` (which is the default value).
 
-.. option:: sst_special_dirs
-   
-     :Values: 0, 1
-     :Default: 1
-
-This option was introduced in |PXC| :rn:`5.6.15-25.2`
-to enable XtraBackup SST to support :variable:`innodb_data_home_dir`
-and :variable:`innodb_log_home_dir` variables in the configuration file.
-|Percona Xtrabackup| 2.1.6 or later is required for this option to work.
- 
-.. note:: This option can only be used when :variable:`wsrep_sst_method`
-   is set to ``xtrabackup-v2`` (which is the default).
- 
 .. option:: compressor
- 
+
     :Default: not set (disabled)
     :Example: compressor='gzip'
 
@@ -281,7 +265,7 @@ for backup, apply, and move stages.
    because they are for passing innobackupex options.
 
 .. option:: sst-initial-timeout
-   
+
    :Default: 100
    :Unit: seconds
 

--- a/doc/source/release-notes/Percona-XtraDB-Cluster-5.7.11-4beta-25.14.2.rst
+++ b/doc/source/release-notes/Percona-XtraDB-Cluster-5.7.11-4beta-25.14.2.rst
@@ -1,7 +1,7 @@
 .. rn:: 5.7.11-4beta-25.14.2
 
 =============================================
-|Percona XtraDB Cluster| 5.7.11-4beta-25.14.2 
+|Percona XtraDB Cluster| 5.7.11-4beta-25.14.2
 =============================================
 
 Percona is glad to announce the release of
@@ -30,4 +30,3 @@ and the following changes:
   It has been replace by ``wsrep_sst_xtrabackup_v2``.
 
 *  The ``wsrep_mysql_replication_bundle`` variable has been removed.
-

--- a/doc/source/release-notes/Percona-XtraDB-Cluster-5.7.12-5beta-25.16.rst
+++ b/doc/source/release-notes/Percona-XtraDB-Cluster-5.7.12-5beta-25.16.rst
@@ -1,7 +1,7 @@
 .. rn:: 5.7.12-26.15
 
 =====================================
-|Percona XtraDB Cluster| 5.7.12-25.16 
+|Percona XtraDB Cluster| 5.7.12-25.16
 =====================================
 
 Percona is glad to announce the release of

--- a/doc/source/release-notes/Percona-XtraDB-Cluster-5.7.12-5rc1-26.16.rst
+++ b/doc/source/release-notes/Percona-XtraDB-Cluster-5.7.12-5rc1-26.16.rst
@@ -1,7 +1,7 @@
 .. rn:: 5.7.12-5rc1-26.16
 
 ==========================================
-|Percona XtraDB Cluster| 5.7.12-5rc1-26.16 
+|Percona XtraDB Cluster| 5.7.12-5rc1-26.16
 ==========================================
 
 Percona is glad to announce the release of

--- a/doc/source/wsrep-provider-index.rst
+++ b/doc/source/wsrep-provider-index.rst
@@ -4,20 +4,27 @@
 Index of :variable:`wsrep_provider` options
 ===========================================
 
-The following variables can be set and checked in the :variable:`wsrep_provider_options` variable. The value of the variable can be changed in the |MySQL| configuration file, :file:`my.cnf`, or by setting the variable value in the |MySQL| client.
+The following variables can be set and checked in the
+:variable:`wsrep_provider_options` variable. The value of the variable can be
+changed in the |MySQL| configuration file, :file:`my.cnf`, or by setting the
+variable value in the |MySQL| client.
 
-To change the value in :file:`my.cnf`, the following syntax should be used: :: 
+To change the value in :file:`my.cnf`, the following syntax should be used: ::
 
   wsrep_provider_options="variable1=value1;[variable2=value2]"
 
-For example to set the size of the Galera buffer storage to 512 MB, specify the following in :file:`my.cnf`: ::
+For example to set the size of the Galera buffer storage to 512 MB, specify the
+following in :file:`my.cnf`: ::
 
   wsrep_provider_options="gcache.size=512M"
 
-Dynamic variables can be changed from the |MySQL| client using the ``SET GLOBAL`` command. For example, to change the value of the :variable:`pc.ignore_sb`, use the following command: :: 
+Dynamic variables can be changed from the |MySQL| client using the ``SET
+GLOBAL`` command. For example, to change the value of the
+:variable:`pc.ignore_sb`, use the following command:
+
+.. code-block:: mysql
 
   mysql> SET GLOBAL wsrep_provider_options="pc.ignore_sb=true";
-
 
 Index
 =====
@@ -40,7 +47,9 @@ This variable specifies the data directory.
    :dyn: No
    :default: value of :variable:`wsrep_node_address`
 
-This variable sets the value of the node's base IP. This is an IP address on which Galera listens for connections from other nodes. Setting this value incorrectly would stop the node from communicating with other nodes.
+This variable sets the value of the node's base IP. This is an IP address on
+which Galera listens for connections from other nodes. Setting this value
+incorrectly would stop the node from communicating with other nodes.
 
 .. variable:: base_port
 
@@ -50,7 +59,9 @@ This variable sets the value of the node's base IP. This is an IP address on whi
    :dyn: No
    :default: 4567
 
-This variable sets the port on which Galera listens for connections from other nodes. Setting this value incorrectly would stop the node from communicating with other nodes.
+This variable sets the port on which Galera listens for connections from other
+nodes. Setting this value incorrectly would stop the node from communicating
+with other nodes.
 
 .. variable:: cert.log_conflicts
 
@@ -60,10 +71,11 @@ This variable sets the port on which Galera listens for connections from other n
    :dyn: No
    :default: no
 
-This variable is used to specify if the details of the certification failures should be logged.
+This variable is used to specify if the details of the certification failures
+should be logged.
 
 .. variable:: debug
-   
+
    :cli: Yes
    :conf: Yes
    :scope: Global
@@ -73,15 +85,17 @@ This variable is used to specify if the details of the certification failures sh
 When this variable is set to ``yes``, it will enable debugging.
 
 .. variable:: evs.auto_evict
-  
-   :version: Introduced in :rn:`5.6.21-25.8`
+
    :cli: Yes
    :conf: Yes
    :scope: Global
    :dyn: Yes
    :default: 0
 
-Number of entries allowed on delayed list until auto eviction takes place. Setting value to 0 disables auto eviction protocol on the node, though node response times will still be monitored. EVS protocol version (:variable:`evs.version`) ``1`` is required to enable auto eviction.
+Number of entries allowed on delayed list until auto eviction takes place.
+Setting value to ``0`` disables auto eviction protocol on the node, though node
+response times will still be monitored. EVS protocol version
+(:variable:`evs.version`) ``1`` is required to enable auto eviction.
 
 .. variable:: evs.causal_keepalive_period
 
@@ -91,7 +105,8 @@ Number of entries allowed on delayed list until auto eviction takes place. Setti
    :dyn: No
    :default: value of :variable:`evs.keepalive_period`
 
-This variable is used for development purposes and shouldn't be used by regular users. 
+This variable is used for development purposes and shouldn't be used by regular
+users.
 
 .. variable:: evs.debug_log_mask
 
@@ -101,39 +116,41 @@ This variable is used for development purposes and shouldn't be used by regular 
    :dyn: Yes
    :default: 0x1
 
-This variable is used for EVS (Extended Virtual Synchrony) debugging. It can be used only when :variable:`wsrep_debug` is set to ``ON``.
+This variable is used for EVS (Extended Virtual Synchrony) debugging. It can be
+used only when :variable:`wsrep_debug` is set to ``ON``.
 
 .. variable:: evs.delay_margin
 
-   :version: Introduced in :rn:`5.6.21-25.8`
    :cli: Yes
    :conf: Yes
    :scope: Global
    :dyn: Yes
    :default: PT1S
 
-Time period that a node can delay its response from expected until it is added to delayed list. The value must be higher than the highest RTT between nodes.
+Time period that a node can delay its response from expected until it is added
+to delayed list. The value must be higher than the highest RTT between nodes.
 
 .. variable:: evs.delayed_keep_period
 
-   :version: Introduced in :rn:`5.6.21-25.8`
    :cli: Yes
    :conf: Yes
    :scope: Global
    :dyn: Yes
    :default: PT30S
 
-Time period that node is required to remain responsive until one entry is removed from delayed list.
+Time period that node is required to remain responsive until one entry is
+removed from delayed list.
 
 .. variable:: evs.evict
 
-   :version: Introduced in :rn:`5.6.21-25.8`
    :cli: Yes
    :conf: Yes
    :scope: Global
    :dyn: Yes
 
-Manual eviction can be triggered by setting the :variable:`evs.evict` to a certain node value. Setting the :variable:`evs.evict` to an empty string will clear the evict list on the node where it was set.
+Manual eviction can be triggered by setting the :variable:`evs.evict` to a
+certain node value. Setting the :variable:`evs.evict` to an empty string will
+clear the evict list on the node where it was set.
 
 .. variable:: evs.inactive_check_period
 
@@ -153,7 +170,8 @@ This variable defines how often to check for peer inactivity.
    :dyn: No
    :default: PT15S
 
-This variable defines the inactivity limit, once this limit is reached the node will be considered dead.
+This variable defines the inactivity limit, once this limit is reached the node
+will be considered dead.
 
 .. variable:: evs.info_log_mask
 
@@ -173,7 +191,8 @@ This variable is used for controlling the extra EVS info logging.
    :dyn: Yes
    :default: PT7.5S
 
-This variable defines the timeout on waiting for install message acknowledgments.
+This variable defines the timeout on waiting for install message
+acknowledgments.
 
 .. variable:: evs.join_retrans_period
 
@@ -183,17 +202,19 @@ This variable defines the timeout on waiting for install message acknowledgments
    :dyn: No
    :default: PT1S
 
-This variable defines how often to retransmit EVS join messages when forming cluster membership.
+This variable defines how often to retransmit EVS join messages when forming
+cluster membership.
 
-.. variable:: evs.keepalive_period 
+.. variable:: evs.keepalive_period
 
    :cli: Yes
    :conf: Yes
    :scope: Global
    :dyn: No
-   :default: PT1S 
+   :default: PT1S
 
-This variable defines how often to emit keepalive beacons (in the absence of any other traffic).
+This variable defines how often to emit keepalive beacons (in the absence of
+any other traffic).
 
 .. variable:: evs.max_install_timeouts
 
@@ -203,7 +224,8 @@ This variable defines how often to emit keepalive beacons (in the absence of any
    :dyn: No
    :default: 1
 
-This variable defines how many membership install rounds to try before giving up (total rounds will be :variable:`evs.max_install_timeouts` + 2).
+This variable defines how many membership install rounds to try before giving
+up (total rounds will be :variable:`evs.max_install_timeouts` + 2).
 
 .. variable:: evs.send_window
 
@@ -213,7 +235,10 @@ This variable defines how many membership install rounds to try before giving up
    :dyn: No
    :default: 4
 
-This variable defines the maximum number of data packets in replication at a time. For WAN setups, the variable can be set to a considerably higher value than default (for example,512). The value must not be less than :variable:`evs.user_send_window`.
+This variable defines the maximum number of data packets in replication at a
+time. For WAN setups, the variable can be set to a considerably higher value
+than default (for example,512). The value must not be less than
+:variable:`evs.user_send_window`.
 
 .. variable:: evs.stats_report_period
 
@@ -221,7 +246,7 @@ This variable defines the maximum number of data packets in replication at a tim
    :conf: Yes
    :scope: Global
    :dyn: No
-   :default: PT1M 
+   :default: PT1M
 
 This variable defines the control period of EVS statistics reporting.
 
@@ -233,7 +258,9 @@ This variable defines the control period of EVS statistics reporting.
    :dyn: No
    :default: PT5S
 
-This variable defines the inactivity period after which the node is “suspected” to be dead. If all remaining nodes agree on that, the node will be dropped out of cluster even before :variable:`evs.inactive_timeout` is reached.
+This variable defines the inactivity period after which the node is
+"suspected" to be dead. If all remaining nodes agree on that, the node will be
+dropped out of cluster even before :variable:`evs.inactive_timeout` is reached.
 
 .. variable:: evs.use_aggregate
 
@@ -253,7 +280,9 @@ When this variable is enabled, smaller packets will be aggregated into one.
    :dyn: Yes
    :default: 2
 
-This variable defines the maximum number of data packets in replication at a time. For WAN setups, the variable can be set to a considerably higher value than default (for example, 512).
+This variable defines the maximum number of data packets in replication at a
+time. For WAN setups, the variable can be set to a considerably higher value
+than default (for example, 512).
 
 .. variable:: evs.version
 
@@ -263,7 +292,9 @@ This variable defines the maximum number of data packets in replication at a tim
    :dyn: No
    :default: 0
 
-This variable defines the EVS protocol version. Auto eviction is enabled when this variable is set to ``1``. Default ``0`` is set for backwards compatibility.
+This variable defines the EVS protocol version. Auto eviction is enabled when
+this variable is set to ``1``. Default ``0`` is set for backwards
+compatibility.
 
 .. variable:: evs.view_forget_timeout
 
@@ -273,7 +304,8 @@ This variable defines the EVS protocol version. Auto eviction is enabled when th
    :dyn: No
    :default: P1D
 
-This variable defines the timeout after which past views will be dropped from history.
+This variable defines the timeout after which past views will be dropped from
+history.
 
 .. variable:: gcache.dir
 
@@ -283,18 +315,21 @@ This variable defines the timeout after which past views will be dropped from hi
    :dyn: No
    :default: :term:`datadir`
 
-This variable can be used to define the location of the :file:`galera.cache` file.
+This variable can be used to define the location of the :file:`galera.cache`
+file.
 
 .. variable:: gcache.keep_pages_count
 
-   :version: Implemented in :rn:`5.6.25-25.12`
    :cli: Yes
    :conf: Yes
    :scope: Local, Global
    :dyn: Yes
    :default: 0
 
-This variable is used to limit the number of overflow pages rather than the total memory occupied by all overflow pages. Whenever either this or :variable:`gcache.keep_pages_size` variables are updated at runtime to a non-zero value, cleanup is called on excess overflow pages to delete them.
+This variable is used to limit the number of overflow pages rather than the
+total memory occupied by all overflow pages. Whenever either this or
+:variable:`gcache.keep_pages_size` variables are updated at runtime to a
+non-zero value, cleanup is called on excess overflow pages to delete them.
 
 .. variable:: gcache.keep_pages_size
 
@@ -304,7 +339,8 @@ This variable is used to limit the number of overflow pages rather than the tota
    :dyn: No
    :default: 0
 
-This variable is used to specify total size of the pages in storage to keep for caching purposes. If only page storage is enabled, one page is always present.
+This variable is used to specify total size of the pages in storage to keep for
+caching purposes. If only page storage is enabled, one page is always present.
 
 .. variable:: gcache.mem_size
 
@@ -317,7 +353,8 @@ This variable is used to specify total size of the pages in storage to keep for 
 
 This variable was used to define how much RAM is available for the system.
 
-.. warning:: This variable has been deprecated and shouldn't be used as it could cause a node to crash.
+.. warning:: This variable has been deprecated and shouldn't be used as it
+  could cause a node to crash.
 
 .. variable:: gcache.name
 
@@ -337,7 +374,8 @@ This variable can be used to specify the name of the Galera cache file.
    :dyn: No
    :default: 128M
 
-This variable can be used to specify the size of the page files in the page storage.
+This variable can be used to specify the size of the page files in the page
+storage.
 
 .. variable:: gcache.size
 
@@ -347,7 +385,10 @@ This variable can be used to specify the size of the page files in the page stor
    :dyn: No
    :default: 128M
 
-Size of the transaction cache for Galera replication. This defines the size of the :file:`galera.cache` file which is used as source for |IST|. The bigger the value of this variable, the better are chances that the re-joining node will get IST instead of |SST|.
+Size of the transaction cache for Galera replication. This defines the size of
+the :file:`galera.cache` file which is used as source for |IST|. The bigger the
+value of this variable, the better are chances that the re-joining node will
+get IST instead of |SST|.
 
 .. variable:: gcs.fc_debug
 
@@ -357,7 +398,8 @@ Size of the transaction cache for Galera replication. This defines the size of t
    :dyn: No
    :default: 0
 
-This variable specifies after how many writesets the debug statistics about SST flow control will be posted.
+This variable specifies after how many writesets the debug statistics about SST
+flow control will be posted.
 
 .. variable:: gcs.fc_factor
 
@@ -367,7 +409,9 @@ This variable specifies after how many writesets the debug statistics about SST 
    :dyn: No
    :default: 1
 
-This variable is used for replication flow control. Replication is resumed when the slave queue drops below :variable:`gcs.fc_factor` * :variable:`gcs.fc_limit`.
+This variable is used for replication flow control. Replication is resumed when
+the slave queue drops below :variable:`gcs.fc_factor` *
+:variable:`gcs.fc_limit`.
 
 .. variable:: gcs.fc_limit
 
@@ -377,7 +421,8 @@ This variable is used for replication flow control. Replication is resumed when 
    :dyn: No
    :default: 16
 
-This variable is used for replication flow control. Replication is paused when the slave queue exceeds this limit.
+This variable is used for replication flow control. Replication is paused when
+the slave queue exceeds this limit.
 
 .. variable:: gcs.fc_master_slave
 
@@ -387,7 +432,8 @@ This variable is used for replication flow control. Replication is paused when t
    :dyn: No
    :default: NO
 
-This variable is used to specify if there is only one master node in the cluster.
+This variable is used to specify if there is only one master node in the
+cluster.
 
 .. variable:: gcs.max_packet_size
 
@@ -397,7 +443,8 @@ This variable is used to specify if there is only one master node in the cluster
    :dyn: No
    :default: 64500
 
-This variable is used to specify the writeset size after which they will be fragmented.
+This variable is used to specify the writeset size after which they will be
+fragmented.
 
 .. variable:: gcs.max_throttle
 
@@ -407,8 +454,11 @@ This variable is used to specify the writeset size after which they will be frag
    :dyn: No
    :default: 0.25
 
-This variable specifies how much the replication can be throttled during the state transfer in order to avoid running out of memory. Value can be set to ``0.0`` if stopping replication is acceptable in order to finish state transfer.
- 
+This variable specifies how much the replication can be throttled during the
+state transfer in order to avoid running out of memory. Value can be set to
+``0.0`` if stopping replication is acceptable in order to finish state
+transfer.
+
 .. variable:: gcs.recv_q_hard_limit
 
    :cli: Yes
@@ -417,7 +467,9 @@ This variable specifies how much the replication can be throttled during the sta
    :dyn: No
    :default: 9223372036854775807
 
-This variable specifies the maximum allowed size of the receive queue. This should normally be ``(RAM + swap) / 2``. If this limit is exceeded, Galera will abort the server.
+This variable specifies the maximum allowed size of the receive queue. This
+should normally be ``(RAM + swap) / 2``. If this limit is exceeded, Galera will
+abort the server.
 
 .. variable:: gcs.recv_q_soft_limit
 
@@ -427,7 +479,8 @@ This variable specifies the maximum allowed size of the receive queue. This shou
    :dyn: No
    :default: 0.25
 
-This variable specifies the fraction of the :variable:`gcs.recv_q_hard_limit` after which replication rate will be throttled.
+This variable specifies the fraction of the :variable:`gcs.recv_q_hard_limit`
+after which replication rate will be throttled.
 
 .. variable:: gcs.sync_donor
 
@@ -435,9 +488,11 @@ This variable specifies the fraction of the :variable:`gcs.recv_q_hard_limit` af
    :conf: Yes
    :scope: Global
    :dyn: No
-   :default: NO
+   :default: No
 
-This variable controls if the rest of the cluster should be in sync with the donor node. When this variable is set to ``YES``, the whole cluster will be blocked if the donor node is blocked with SST.
+This variable controls if the rest of the cluster should be in sync with the
+donor node. When this variable is set to ``YES``, the whole cluster will be
+blocked if the donor node is blocked with SST.
 
 .. variable:: gmcast.listen_addr
 
@@ -447,7 +502,8 @@ This variable controls if the rest of the cluster should be in sync with the don
    :dyn: No
    :default: tcp://0.0.0.0:4567
 
-This variable defines the address on which the node listens to connections from other nodes in the cluster.
+This variable defines the address on which the node listens to connections from
+other nodes in the cluster.
 
 .. variable:: gmcast.mcast_addr
 
@@ -487,7 +543,8 @@ This variable specifies the connection timeout to initiate message relaying.
    :dyn: No
    :default: 0
 
-This variable specifies the group segment this member should be a part of. Same segment members are treated as equally physically close.
+This variable specifies the group segment this member should be a part of. Same
+segment members are treated as equally physically close.
 
 .. variable:: gmcast.time_wait
 
@@ -497,7 +554,8 @@ This variable specifies the group segment this member should be a part of. Same 
    :dyn: No
    :default: PT5S
 
-This variable specifies the time to wait until allowing peer declared outside of stable view to reconnect.
+This variable specifies the time to wait until allowing peer declared outside
+of stable view to reconnect.
 
 .. variable:: gmcast.version
 
@@ -507,7 +565,7 @@ This variable specifies the time to wait until allowing peer declared outside of
    :dyn: No
    :default: 0
 
-This variable shows which gmcast protocol version is being used. 
+This variable shows which gmcast protocol version is being used.
 
 .. variable:: ist.recv_addr
 
@@ -517,7 +575,8 @@ This variable shows which gmcast protocol version is being used.
    :dyn: No
    :default: value of :variable:`wsrep_node_address`
 
-This variable specifies the address on which the node listens for Incremental State Transfer (|IST|).
+This variable specifies the address on which the node listens for Incremental
+State Transfer (|IST|).
 
 .. variable:: pc.announce_timeout
 
@@ -527,7 +586,8 @@ This variable specifies the address on which the node listens for Incremental St
    :dyn: No
    :default: PT3S
 
-Cluster joining announcements are sent every 1/2 second for this period of time or less if other nodes are discovered.
+Cluster joining announcements are sent every 1/2 second for this period of time
+or less if other nodes are discovered.
 
 .. variable:: pc.checksum
 
@@ -537,7 +597,8 @@ Cluster joining announcements are sent every 1/2 second for this period of time 
    :dyn: No
    :default: true
 
-This variable controls whether replicated messages should be checksummed or not.
+This variable controls whether replicated messages should be checksummed or
+not.
 
 .. variable::  pc.ignore_quorum
 
@@ -547,7 +608,9 @@ This variable controls whether replicated messages should be checksummed or not.
    :dyn: Yes
    :default: false
 
-When this variable is set to ``TRUE``, the node will completely ignore quorum calculations. This should be used with extreme caution even in master-slave setups, because slaves won't automatically reconnect to master in this case.
+When this variable is set to ``TRUE``, the node will completely ignore quorum
+calculations. This should be used with extreme caution even in master-slave
+setups, because slaves won't automatically reconnect to master in this case.
 
 .. variable::  pc.ignore_sb
 
@@ -557,9 +620,12 @@ When this variable is set to ``TRUE``, the node will completely ignore quorum ca
    :dyn: Yes
    :default: false
 
-When this variable is set to ``TRUE``, the node will process updates even in the case of a split brain. This should be used with extreme caution in multi-master setup, but should simplify things in master-slave cluster (especially if only 2 nodes are used).
+When this variable is set to ``TRUE``, the node will process updates even in
+the case of a split brain. This should be used with extreme caution in
+multi-master setup, but should simplify things in master-slave cluster
+(especially if only 2 nodes are used).
 
-.. variable::  pc.linger 
+.. variable::  pc.linger
 
    :cli: Yes
    :conf: Yes
@@ -567,9 +633,10 @@ When this variable is set to ``TRUE``, the node will process updates even in the
    :dyn: No
    :default: PT20S
 
-This variable specifies the period for which the PC protocol waits for EVS termination.
+This variable specifies the period for which the PC protocol waits for EVS
+termination.
 
-.. variable::  pc.npvo 
+.. variable::  pc.npvo
 
    :cli: Yes
    :conf: Yes
@@ -577,7 +644,8 @@ This variable specifies the period for which the PC protocol waits for EVS termi
    :dyn: No
    :default: false
 
-When this variable is set to ``TRUE``, more recent primary components override older ones in case of conflicting primaries.
+When this variable is set to ``TRUE``, more recent primary components override
+older ones in case of conflicting primaries.
 
 .. variable::  pc.recovery
 
@@ -587,7 +655,13 @@ When this variable is set to ``TRUE``, more recent primary components override o
    :dyn: No
    :default: true
 
-When this variable is set to ``true``, the node stores the Primary Component state to disk. The Primary Component can then recover automatically when all nodes that were part of the last saved state re-establish communication with each other. This feature allows automatic recovery from full cluster crashes, such as in the case of a data center power outage. A subsequent graceful full cluster restart will require explicit bootstrapping for a new Primary Component.
+When this variable is set to ``true``, the node stores the Primary Component
+state to disk. The Primary Component can then recover automatically when all
+nodes that were part of the last saved state re-establish communication with
+each other. This feature allows automatic recovery from full cluster crashes,
+such as in the case of a data center power outage. A subsequent graceful full
+cluster restart will require explicit bootstrapping for a new Primary
+Component.
 
 .. variable::  pc.version
 
@@ -607,7 +681,9 @@ This status variable is used to check which PC protocol version is used.
    :dyn: No
    :default: true
 
-When set to ``TRUE``, the node waits for a primary component for the period of time specified in :variable:`pc.wait_prim_timeout`. This is useful to bring up a non-primary component and make it primary with :variable:`pc.bootstrap`.
+When set to ``TRUE``, the node waits for a primary component for the period of
+time specified in :variable:`pc.wait_prim_timeout`. This is useful to bring up
+a non-primary component and make it primary with :variable:`pc.bootstrap`.
 
 .. variable:: pc.wait_prim_timeout
 
@@ -617,9 +693,10 @@ When set to ``TRUE``, the node waits for a primary component for the period of t
    :dyn: No
    :default: PT30S
 
-This variable is used to specify the period of time to wait for a primary component.
+This variable is used to specify the period of time to wait for a primary
+component.
 
-.. variable::  pc.weight 
+.. variable::  pc.weight
 
    :cli: Yes
    :conf: Yes
@@ -627,7 +704,8 @@ This variable is used to specify the period of time to wait for a primary compon
    :dyn: Yes
    :default: 1
 
-This variable specifies the node weight that's going to be used for Weighted Quorum calculations.
+This variable specifies the node weight that's going to be used for Weighted
+Quorum calculations.
 
 .. variable::  protonet.backend
 
@@ -637,7 +715,8 @@ This variable specifies the node weight that's going to be used for Weighted Quo
    :dyn: No
    :default: asio
 
-This variable is used to define which transport backend should be used. Currently only ``ASIO`` is supported.
+This variable is used to define which transport backend should be used.
+Currently only ``ASIO`` is supported.
 
 .. variable::  protonet.version
 
@@ -647,7 +726,8 @@ This variable is used to define which transport backend should be used. Currentl
    :dyn: No
    :default: 0
 
-This status variable is used to check which transport backend protocol version is used.
+This status variable is used to check which transport backend protocol version
+is used.
 
 .. variable::  repl.causal_read_timeout
 
@@ -667,22 +747,27 @@ This variable specifies the causal read timeout.
    :dyn: No
    :default: 3
 
-This variable is used to specify out-of-order committing (which is used to improve parallel applying performance). The following values are available:
+This variable is used to specify out-of-order committing (which is used to
+improve parallel applying performance). The following values are available:
 
- * ``0`` - BYPASS: all commit order monitoring is turned off (useful for measuring performance penalty)
+ * ``0`` - BYPASS: all commit order monitoring is turned off (useful for
+   measuring performance penalty)
  * ``1`` - OOOC: allow out-of-order committing for all transactions
- * ``2`` - LOCAL_OOOC: allow out-of-order committing only for local transactions
- * ``3`` - NO_OOOC: no out-of-order committing is allowed (strict total order committing)
+ * ``2`` - LOCAL_OOOC: allow out-of-order committing only for local
+   transactions
+ * ``3`` - NO_OOOC: no out-of-order committing is allowed (strict total order
+   committing)
 
-.. variable::  repl.key_format 
- 
+.. variable::  repl.key_format
+
    :cli: Yes
    :conf: Yes
    :scope: Global
    :dyn: Yes
    :default: FLAT8
 
-This variable is used to specify the replication key format. The following values are available:
+This variable is used to specify the replication key format. The following
+values are available:
 
  * ``FLAT8`` - short key with higher probability of key match false positives
  * ``FLAT16`` - longer key with lower probability of false positives
@@ -697,9 +782,10 @@ This variable is used to specify the replication key format. The following value
    :dyn: No
    :default: 2147483647
 
-This variable is used to specify the maximum size of a write-set in bytes. This is limited to 2 gygabytes.
+This variable is used to specify the maximum size of a write-set in bytes. This
+is limited to 2 gygabytes.
 
-.. variable::  repl.proto_max 
+.. variable::  repl.proto_max
 
    :cli: Yes
    :conf: Yes
@@ -707,7 +793,8 @@ This variable is used to specify the maximum size of a write-set in bytes. This 
    :dyn: No
    :default: 7
 
-This variable is used to specify the highest communication protocol version to accept in the cluster. Used only for debugging.
+This variable is used to specify the highest communication protocol version to
+accept in the cluster. Used only for debugging.
 
 .. variable::  socket.checksum
 
@@ -717,7 +804,8 @@ This variable is used to specify the highest communication protocol version to a
    :dyn: No
    :default: 2
 
-This variable is used to choose the checksum algorithm for network packets. The following values are available:
+This variable is used to choose the checksum algorithm for network packets. The
+following values are available:
 
  * ``0`` - disable checksum
  * ``1`` - plain ``CRC32`` (used in Galera 2.x)
@@ -740,7 +828,8 @@ This variable is used to specify if SSL encryption should be used.
    :scope: Global
    :dyn: No
 
-This variable is used to specify the path (absolute or relative to working directory) to an SSL certificate (in PEM format).
+This variable is used to specify the path (absolute or relative to working
+directory) to an SSL certificate (in PEM format).
 
 .. variable:: socket.ssl_key
 
@@ -749,7 +838,8 @@ This variable is used to specify the path (absolute or relative to working direc
    :scope: Global
    :dyn: No
 
-This variable is used to specify the path (absolute or relative to working directory) to an SSL private key for the certificate (in PEM format).
+This variable is used to specify the path (absolute or relative to working
+directory) to an SSL private key for the certificate (in PEM format).
 
 .. variable:: socket.ssl_compression
 
@@ -761,13 +851,12 @@ This variable is used to specify the path (absolute or relative to working direc
 
 This variable is used to specify if the SSL compression is to be used.
 
-.. variable:: socket.ssl_cipher	
+.. variable:: socket.ssl_cipher
 
    :cli: Yes
    :conf: Yes
    :scope: Global
    :dyn: No
-   :default: AES128-SHA 
+   :default: AES128-SHA
 
 This variable is used to specify what cypher will be used for encryption.
-

--- a/doc/source/wsrep-status-index.rst
+++ b/doc/source/wsrep-status-index.rst
@@ -5,71 +5,85 @@ Index of wsrep status variables
 ===============================
 
 .. variable:: wsrep_apply_oooe
-  
-This variable shows parallelization efficiency, how often writests have been applied out of order. 
+
+This variable shows parallelization efficiency, how often writests have been
+applied out of order.
 
 .. variable:: wsrep_apply_oool
 
-This variable shows how often a writeset with a higher sequence number was applied before one with a lower sequence number.
-  
+This variable shows how often a writeset with a higher sequence number was
+applied before one with a lower sequence number.
+
 .. variable:: wsrep_apply_window
-  
-Average distance between highest and lowest concurrently applied sequence numbers.
+
+Average distance between highest and lowest concurrently applied sequence
+numbers.
 
 .. variable:: wsrep_causal_reads_
 
-Shows the number of writesets processed while the variable :variable:`wsrep_causal_reads` was set to ``ON``.
+Shows the number of writesets processed while the variable
+:variable:`wsrep_causal_reads` was set to ``ON``.
 
 .. variable:: wsrep_cert_bucket_count
 
-This variable, implemented in :rn:`5.6.24-25.11`, shows the number of cells in the certification index hash-table.
+This variable, shows the number of cells in the certification index
+hash-table.
 
 .. variable:: wsrep_cert_deps_distance
- 
-Average distance between highest and lowest sequence number that can be possibly applied in parallel.
+
+Average distance between highest and lowest sequence number that can be
+possibly applied in parallel.
 
 .. variable:: wsrep_cert_index_size
-  
+
 Number of entries in the certification index.
-   
+
 .. variable:: wsrep_cluster_conf_id
 
 Number of cluster membership changes that have taken place.
 
 .. variable:: wsrep_cluster_size
-  
+
 Current number of nodes in the cluster.
 
 .. variable:: wsrep_cluster_state_uuid
-  
-This variable contains :term:`UUID` state of the cluster. When this value is the same as the one in :variable:`wsrep_local_state_uuid`, node is synced with the cluster.
+
+This variable contains :term:`UUID` state of the cluster. When this value is
+the same as the one in :variable:`wsrep_local_state_uuid`, node is synced with
+the cluster.
 
 .. variable:: wsrep_cluster_status
 
 Status of the cluster component. Possible values are:
+
   * ``Primary``
   * ``Non-Primary``
   * ``Disconnected``
 
 .. variable:: wsrep_commit_oooe
-  
+
 This variable shows how often a transaction was committed out of order.
 
 .. variable:: wsrep_commit_oool
-  
+
 This variable currently has no meaning.
 
 .. variable:: wsrep_commit_window
-  
-Average distance between highest and lowest concurrently committed sequence number.
+
+Average distance between highest and lowest concurrently committed sequence
+number.
 
 .. variable:: wsrep_connected
 
-This variable shows if the node is connected to the cluster. If the value is ``OFF``, the node has not yet connected to any of the cluster components. This may be due to misconfiguration. 
- 
+This variable shows if the node is connected to the cluster. If the value is
+``OFF``, the node has not yet connected to any of the cluster components. This
+may be due to misconfiguration.
+
 .. variable:: wsrep_evs_delayed
 
-Comma separated list of nodes that are considered delayed. The node format is ``<uuid>:<address>:<count>``, where ``<count>`` is the number of entries on delayed list for that node.
+Comma separated list of nodes that are considered delayed. The node format is
+``<uuid>:<address>:<count>``, where ``<count>`` is the number of entries on
+delayed list for that node.
 
 .. variable:: wsrep_evs_evict_list
 
@@ -77,7 +91,9 @@ List of UUIDs of the evicted nodes.
 
 .. variable:: wsrep_evs_repl_latency
 
-This status variable provides information regarding group communication replication latency. This latency is measured in seconds from when a message is sent out to when a message is received.
+This status variable provides information regarding group communication
+replication latency. This latency is measured in seconds from when a message is
+sent out to when a message is received.
 
 The format of the output is ``<min>/<avg>/<max>/<std_dev>/<sample_size>``.
 
@@ -86,7 +102,7 @@ The format of the output is ``<min>/<avg>/<max>/<std_dev>/<sample_size>``.
 Internal EVS protocol state.
 
 .. variable:: wsrep_flow_control_paused
-  
+
 Time since the last status query that was paused due to flow control.
 
 .. variable:: wsrep_flow_control_paused_ns
@@ -94,74 +110,88 @@ Time since the last status query that was paused due to flow control.
 Total time spent in a paused state measured in nanoseconds.
 
 .. variable:: wsrep_flow_control_recv
-  
+
 Number of ``FC_PAUSE`` events received since the last status query.
 
 .. variable:: wsrep_flow_control_sent
-  
+
 Number of ``FC_PAUSE`` events sent since the last status query.
 
 .. variable:: wsrep_gcache_pool_size
 
-This variable, implemented in :rn:`5.6.24-25.11`, shows the size of the page pool and dynamic memory allocated for GCache (in bytes).
+This variable shows the size of the page pool and dynamic memory allocated for
+GCache (in bytes).
 
 .. variable:: wsrep_gcomm_uuid
 
-This status variable exposes UUIDs in :file:`gvwstate.dat`, which are Galera view IDs (thus unrelated to cluster state UUIDs). This UUID is unique for each node. You will need to know this value when using manual eviction feature.
+This status variable exposes UUIDs in :file:`gvwstate.dat`, which are Galera
+view IDs (thus unrelated to cluster state UUIDs). This UUID is unique for each
+node. You will need to know this value when using manual eviction feature.
 
 .. variable:: wsrep_incoming_addresses
 
 Shows the comma-separated list of incoming node addresses in the cluster.
 
 .. variable:: wsrep_last_committed
-  
-Sequence number of the last committed transaction. 
- 
+
+Sequence number of the last committed transaction.
+
 .. variable:: wsrep_local_bf_aborts
-  
-Number of local transactions that were aborted by slave transactions while being executed.
+
+Number of local transactions that were aborted by slave transactions while
+being executed.
 
 .. variable:: wsrep_local_cached_downto
 
-The lowest sequence number in GCache. This information can be helpful with determining IST and SST. If the value is ``0``, then it means there are no writesets in GCache (usual for a single node).
+The lowest sequence number in GCache. This information can be helpful with
+determining IST and SST. If the value is ``0``, then it means there are no
+writesets in GCache (usual for a single node).
 
 .. variable:: wsrep_local_cert_failures
-  
+
 Number of writesets that failed the certification test.
 
 .. variable:: wsrep_local_commits
-  
+
 Number of writesets commited on the node.
 
 .. variable:: wsrep_local_index
-  
-Node's index in the cluster. 
+
+Node's index in the cluster.
 
 .. variable:: wsrep_local_recv_queue
-  
-Current length of the receive queue (that is, the number of writesets waiting to be applied).
+
+Current length of the receive queue (that is, the number of writesets waiting
+to be applied).
 
 .. variable:: wsrep_local_recv_queue_avg
-  
-Average length of the receive queue since the last status query. When this number is bigger than ``0`` this means node can't apply writesets as fast as they are received. This could be a sign that the node is overloaded and it may cause replication throttling.
+
+Average length of the receive queue since the last status query. When this
+number is bigger than ``0`` this means node can't apply writesets as fast as
+they are received. This could be a sign that the node is overloaded and it may
+cause replication throttling.
 
 .. variable:: wsrep_local_replays
-  
+
 Number of transaction replays due to *asymmetric lock granularity*.
 
 .. variable:: wsrep_local_send_queue
-  
-Current length of the send queue (that is, the number of writesets waiting to be sent).
+
+Current length of the send queue (that is, the number of writesets waiting to
+be sent).
 
 .. variable:: wsrep_local_send_queue_avg
-  
-Average length of the send queue since the last status query. When cluster experiences network throughput issues or replication throttling, this value will be significantly bigger than ``0``.
+
+Average length of the send queue since the last status query. When cluster
+experiences network throughput issues or replication throttling, this value
+will be significantly bigger than ``0``.
 
 .. variable:: wsrep_local_state
 
 .. variable:: wsrep_local_state_comment
- 
-Internal number and the corresponding human-readable comment of the node's state. Possible values are:
+
+Internal number and the corresponding human-readable comment of the node's
+state. Possible values are:
 
 ===== ================ ======================================================
  Num   Comment          Description
@@ -173,35 +203,37 @@ Internal number and the corresponding human-readable comment of the node's state
 ===== ================ ======================================================
 
 .. variable:: wsrep_local_state_uuid
- 
+
 The :term:`UUID` of the state stored on the node.
 
 .. variable:: wsrep_protocol_version
-  
-Version of the wsrep protocol used. 
+
+Version of the wsrep protocol used.
 
 .. variable:: wsrep_provider_name
-  
+
 Name of the wsrep provider (usually ``Galera``).
 
 .. variable:: wsrep_provider_vendor
-  
+
 Name of the wsrep provider vendor (usually ``Codership Oy``)
 
 .. variable:: wsrep_provider_version
-  
+
 Current version of the wsrep provider.
 
 .. variable:: wsrep_ready
-  
-This variable shows if node is ready to accept queries. If status is ``OFF``, almost all queries will fail with ``ERROR 1047 (08S01) Unknown Command`` error (unless the :variable:`wsrep_on` variable is set to ``0``)
+
+This variable shows if node is ready to accept queries. If status is ``OFF``,
+almost all queries will fail with ``ERROR 1047 (08S01) Unknown Command`` error
+(unless the :variable:`wsrep_on` variable is set to ``0``).
 
 .. variable:: wsrep_received
-  
-Total number of writesets received from other nodes. 
+
+Total number of writesets received from other nodes.
 
 .. variable:: wsrep_received_bytes
-  
+
 Total size (in bytes) of writesets received from other nodes.
 
 .. variable:: wsrep_repl_data_bytes
@@ -221,10 +253,9 @@ Total size (in bytes) of keys replicated.
 Total size of other bits replicated.
 
 .. variable:: wsrep_replicated
-  
+
 Total number of writesets sent to other nodes.
 
 .. variable:: wsrep_replicated_bytes
-  
-Total size (in bytes) of writesets sent to other nodes.
 
+Total size (in bytes) of writesets sent to other nodes.

--- a/doc/source/wsrep-system-index.rst
+++ b/doc/source/wsrep-system-index.rst
@@ -12,19 +12,26 @@ Index of wsrep system variables
    :dyn: Yes
    :default: ON
 
-This variable manages the :variable:`auto_increment_increment` and :variable:`auto_increment_offset` variables automatically depending on the size of the cluster. This helps prevent ``auto_increment`` replication conflicts across the cluster by giving each node it's own range of ``auto_increment`` values.  
-This may not be desirable depending on application's use and assumptions of auto-increments. It can be turned off in Master/Slave clusters.
+This variable manages the :variable:`auto_increment_increment` and
+:variable:`auto_increment_offset` variables automatically depending on the size
+of the cluster. This helps prevent ``auto_increment`` replication conflicts
+across the cluster by giving each node it's own range of ``auto_increment``
+values.  
+This may not be desirable depending on application's use and assumptions of
+auto-increments. It can be turned off in Master/Slave clusters.
 
 .. variable:: wsrep_causal_reads
 
-   :version 5.6.20-25.7: Variable deprecated by :variable:`wsrep_sync_wait`
    :cli: Yes
    :conf: Yes
    :scope: Global, Session
    :dyn: Yes
    :default: OFF
 
-In some cases, master may apply event faster than a slave, which can cause master and slave to become out of sync for a brief moment. When this variable is set to ``ON``, slave will wait until that event is applied before doing any other queries. Enabling this variable will also result in larger latencies.
+In some cases, master may apply event faster than a slave, which can cause
+master and slave to become out of sync for a brief moment. When this variable
+is set to ``ON``, slave will wait until that event is applied before doing any
+other queries. Enabling this variable will also result in larger latencies.
 
 .. variable:: wsrep_certify_nonPK
 
@@ -34,7 +41,9 @@ In some cases, master may apply event faster than a slave, which can cause maste
    :dyn: Yes
    :default: ON
 
-When this variable is enabled, primary keys will be generated automatically for rows that don't have them. Using tables without primary keys is not recommended.
+When this variable is enabled, primary keys will be generated automatically for
+rows that don't have them. Using tables without primary keys is not
+recommended.
 
 .. variable:: wsrep_cluster_address
 
@@ -43,15 +52,22 @@ When this variable is enabled, primary keys will be generated automatically for 
    :scope: Global
    :dyn: Yes
 
-This variable needs to specify at least one other node's address that is alive and a member of the cluster. In practice, it is best (but not necessary) to provide a complete list of all possible cluster nodes. The value should be of the following format: ::
+This variable needs to specify at least one other node's address that is alive
+and a member of the cluster. In practice, it is best (but not necessary) to
+provide a complete list of all possible cluster nodes. The value should be of
+the following format: ::
 
  gcomm://<node1_ip>,<node2_ip>,<node3_ip>
 
-Besides the IP address of the node, you can also specify port and options, for example: ::
+Besides the IP address of the node, you can also specify port and options, for
+example: ::
 
  gcomm://192.168.0.1:4567?gmcast.listen_addr=0.0.0.0:5678
 
-If an empty ``gcomm:/ /`` is provided, the node will bootstrap itself (that is, form a new cluster). This is not recommended for production after the cluster has been bootstrapped initially. If you want to bootstrap a new cluster, you should pass the ``--wsrep-new-cluster`` option when starting.
+If an empty ``gcomm:/ /`` is provided, the node will bootstrap itself (that is,
+form a new cluster). This is not recommended for production after the cluster
+has been bootstrapped initially. If you want to bootstrap a new cluster, you
+should pass the ``--wsrep-new-cluster`` option when starting.
 
 .. variable:: wsrep_cluster_name
 
@@ -61,7 +77,8 @@ If an empty ``gcomm:/ /`` is provided, the node will bootstrap itself (that is, 
    :dyn: Yes
    :default: my_wsrep_cluster
 
-This is the name of the cluster and should be identical on all nodes belonging to the same cluster.
+This is the name of the cluster and should be identical on all nodes belonging
+to the same cluster.
 
 .. note:: It should not exceed 32 characters.
 
@@ -73,7 +90,9 @@ This is the name of the cluster and should be identical on all nodes belonging t
    :dyn: Yes
    :default: OFF
 
-This variable is used to convert ``LOCK/UNLOCK TABLES`` statements to ``BEGIN/COMMIT``. Although this can help some older applications to work with multi-master setup it can also result in having huge writesets.
+This variable is used to convert ``LOCK/UNLOCK TABLES`` statements to
+``BEGIN/COMMIT``. Although this can help some older applications to work with
+multi-master setup it can also result in having huge writesets.
 
 .. variable:: wsrep_data_home_dir
 
@@ -83,7 +102,8 @@ This variable is used to convert ``LOCK/UNLOCK TABLES`` statements to ``BEGIN/CO
    :dyn: No
    :default: mysql :term:`datadir`
 
-This variable can be used to set up the directory where wsrep provider will store its files (like ``grastate.dat``).
+This variable can be used to set up the directory where wsrep provider will
+store its files (like :file:`grastate.dat`).
 
 .. variable:: wsrep_dbug_option
 
@@ -102,29 +122,44 @@ This variable is used to send the ``DBUG`` option to the wsrep provider.
    :dyn: Yes
    :default: OFF
 
-When this variable is set to ``ON``, debug messages will also be logged to the ``error_log``. This can be used when trying to diagnose problems or when submitting a bug.
+When this variable is set to ``ON``, debug messages will also be logged to the
+:file:`error_log`. This can be used when trying to diagnose problems or when
+submitting a bug.
 
 .. variable:: wsrep_desync
- 
+
    :cli: No
    :conf: Yes
    :scope: Global
    :dyn: Yes
    :default: OFF
- 
-This variable controls whether the node participates in Flow Control. Setting the :variable:`wsrep_desync` to ``ON`` does not automatically mean that a node will be out of sync with the cluster. It will continue to replicate in and out the writesets as usual. The only difference is that flow control will no longer take care of the ``desynced`` node. The result is that if :variable:`wsrep_local_recv_queue` gets higher than maximum allowed, all the other nodes will ignore the replication lag on the node being in ``desync`` mode. Toggling this back will require an IST or an SST depending on how long it was desynchronized. This is similar to cluster de-synchronization, which occurs during RSU TOI. Because of this, it's not a good idea to keep desync set for a long period of time, nor should you desync several nodes at once. Also, you'll need to desync a node before it starts causing flow control for it to have any effect. Node can also be desynchronized with  ``/*! WSREP_DESYNC */`` query comment.
+
+This variable controls whether the node participates in Flow Control. Setting
+the :variable:`wsrep_desync` to ``ON`` does not automatically mean that a node
+will be out of sync with the cluster. It will continue to replicate in and out
+the writesets as usual. The only difference is that flow control will no longer
+take care of the ``desynced`` node. The result is that if
+:variable:`wsrep_local_recv_queue` gets higher than maximum allowed, all the
+other nodes will ignore the replication lag on the node being in ``desync``
+mode. Toggling this back will require an IST or an SST depending on how long it
+was desynchronized. This is similar to cluster de-synchronization, which occurs
+during RSU TOI. Because of this, it's not a good idea to keep desync set for a
+long period of time, nor should you desync several nodes at once. Also, you'll
+need to desync a node before it starts causing flow control for it to have any
+effect. Node can also be desynchronized with  ``/*! WSREP_DESYNC */`` query
+comment.
 
 .. variable:: wsrep_dirty_reads
 
-   :version 5.6.24-25.11: Variable introduced
-   :version 5.6.26-25.12: Variable available both on session and global scope
    :cli: Yes
    :conf: Yes
    :scope: Session, Global
    :dyn: Yes
    :default: OFF
 
-This variable is boolean and is ``OFF`` by default. When set to ``ON``, a |Percona XtraDB Cluster| node accepts queries that only read, but not modify data even if the node is in the non-PRIM state 
+This variable is boolean and is ``OFF`` by default. When set to ``ON``, a
+|Percona XtraDB Cluster| node accepts queries that only read, but not modify
+data even if the node is in the non-PRIM state.
 
 .. variable:: wsrep_drupal_282555_workaround
 
@@ -132,9 +167,11 @@ This variable is boolean and is ``OFF`` by default. When set to ``ON``, a |Perco
    :conf: Yes
    :scope: Global
    :dyn: Yes
-   :default: OFF 
+   :default: OFF
 
-This variable was introduced as a workaround for Drupal/MySQL bug `#282555 <http://drupal.org/node/282555>`_. In some cases, duplicate key errors would occur when inserting the ``default`` value into the ``auto_increment`` field. 
+This variable was introduced as a workaround for Drupal/MySQL bug `#282555
+<http://drupal.org/node/282555>`_. In some cases, duplicate key errors would
+occur when inserting the ``default`` value into the ``auto_increment`` field.
 
 .. variable:: wsrep_forced_binlog_format
 
@@ -144,7 +181,9 @@ This variable was introduced as a workaround for Drupal/MySQL bug `#282555 <http
    :dyn: Yes
    :default: NONE
 
-This variable defines a binlog format that will always be effective regardless of session binlog format setting. Possible values for this variable are:
+This variable defines a binlog format that will always be effective regardless
+of session binlog format setting. Possible values for this variable are:
+
   * ``ROW``
   * ``STATEMENT``
   * ``MIXED``
@@ -156,9 +195,10 @@ This variable defines a binlog format that will always be effective regardless o
    :conf: Yes
    :scope: Global
    :dyn: Yes
-   :default: ON 
+   :default: ON
 
-This variable controls whether ``LOAD DATA`` transaction splitting is wanted or not. It doesn't work as expected with ``autocommit=0`` when enabled.
+This variable controls whether ``LOAD DATA`` transaction splitting is wanted or
+not. It doesn't work as expected with ``autocommit=0`` when enabled.
 
 .. variable:: wsrep_log_conflicts
 
@@ -168,7 +208,8 @@ This variable controls whether ``LOAD DATA`` transaction splitting is wanted or 
    :dyn: Yes
    :default: OFF
 
-This variable is used to control whether sole cluster conflicts should be logged. When enabled, details of conflicting |InnoDB| lock will be logged.
+This variable is used to control whether sole cluster conflicts should be
+logged. When enabled, details of conflicting |InnoDB| lock will be logged.
 
 .. variable:: wsrep_max_ws_rows
 
@@ -176,13 +217,13 @@ This variable is used to control whether sole cluster conflicts should be logged
    :conf: Yes
    :scope: Global
    :dyn: Yes
-   :default: 131072 (128K) 
+   :default: 131072 (128K)
 
 **This variable has no effect!**
 
 By design,
-it was supposed to control the maximum number of rows each writeset can contain.
-However, it is hard to predict the number of rows
+it was supposed to control the maximum number of rows each writeset can
+contain. However, it is hard to predict the number of rows
 because of the writeset size limit enforced by :variable:`wsrep_max_ws_size`.
 
 Codership decided to not implement the limit by rows for now.
@@ -197,7 +238,8 @@ There is a discussion open at https://github.com/codership/mysql-wsrep/issues/25
    :dyn: Yes
    :default: 1073741824 (1G)
 
-This variable is used to control maximum writeset size (in bytes). Anything bigger than the specified value will be rejected.
+This variable is used to control maximum writeset size (in bytes). Anything
+bigger than the specified value will be rejected.
 
 .. variable:: wsrep_mysql_replication_bundle
 
@@ -208,7 +250,13 @@ This variable is used to control maximum writeset size (in bytes). Anything bigg
    :default: 0 (no grouping)
    :range: 0-1000
 
-This variable controls how many replication events will be grouped together. Replication events are grouped in SQL slave thread by skipping events which may cause commit. This way the wsrep node acting in |MySQL| slave role and all other wsrep nodes in provider replication group, will see same (huge) transactions. The implementation is still experimental. This may help with the bottleneck of having only one |MySQL| slave facing commit time delay of synchronous provider.
+This variable controls how many replication events will be grouped together.
+Replication events are grouped in SQL slave thread by skipping events which may
+cause commit. This way the wsrep node acting in |MySQL| slave role and all
+other wsrep nodes in provider replication group, will see same (huge)
+transactions. The implementation is still experimental. This may help with the
+bottleneck of having only one |MySQL| slave facing commit time delay of
+synchronous provider.
 
 .. variable:: wsrep_node_address
 
@@ -219,7 +267,12 @@ This variable controls how many replication events will be grouped together. Rep
    :format: <ip address>[:port]
    :default: Usually set up as primary network interface (``eth0``)
 
-This variable is used to specify the network address of the node. In some cases, when there are multiple NICs available, state transfer might not work if the default NIC is on different network. Setting this variable explicitly to the correct value will make SST and IST work correctly out of the box. Even in multi-network setups, IST/SST can be configured to use other interfaces/addresses. 
+This variable is used to specify the network address of the node. In some
+cases, when there are multiple NICs available, state transfer might not work if
+the default NIC is on different network. Setting this variable explicitly to
+the correct value will make SST and IST work correctly out of the box. Even in
+multi-network setups, IST/SST can be configured to use other
+interfaces/addresses.
 
 .. variable:: wsrep_node_incoming_address
 
@@ -229,7 +282,9 @@ This variable is used to specify the network address of the node. In some cases,
    :dyn: No
    :default: <:variable:`wsrep_node_address`>:3306
 
-This is the address at which the node accepts client connections. This information is used for status variable :variable:`wsrep_incoming_addresses` which shows all the active cluster nodes.
+This is the address at which the node accepts client connections. This
+information is used for status variable :variable:`wsrep_incoming_addresses`
+which shows all the active cluster nodes.
 
 .. variable:: wsrep_node_name
 
@@ -248,35 +303,65 @@ Unique name of the node. Defaults to the host name.
    :scope: Global
    :dyn: Yes
 
-This variable is used to set the `notification command <http://galeracluster.com/documentation-webpages/notificationcmd.html>`_ that the server should execute every time cluster membership or local node status changes.
+This variable is used to set the `notification command
+<http://galeracluster.com/documentation-webpages/notificationcmd.html>`_ that
+the server should execute every time cluster membership or local node status
+changes.
 
 .. variable:: wsrep_on
 
-   :version 5.6.27-25.13: Variable available only in session scope
    :cli: No
    :conf: No
    :scope: Session
    :dyn: Yes
    :default: ON
 
-This variable is used to enable/disable wsrep replication. When set to ``OFF``, server will stop replication and behave like standalone |MySQL| server.
+This variable is used to enable/disable wsrep replication. When set to ``OFF``,
+server will stop replication and behave like standalone |MySQL| server.
 
 .. variable:: wsrep_OSU_method
 
-   :version 5.6.24-25.11: Variable available both in global and session scope
    :cli: Yes
    :conf: Yes
    :scope: Global and Session
    :dyn: Yes
    :default: TOI
 
-This variable can be used to select schema upgrade method. Available values are:
+This variable can be used to select schema upgrade method. Available values
+are:
 
-* ``TOI``: When the *Total Order Isolation* method is selected, data definition language (DDL) statements are processed in the same order with regards to other transactions in each cluster node. This guarantees data consistency. In case of DDL statements, cluster will have parts of database locked and it will behave like a single server. In some cases (like big ``ALTER TABLE``) this could have impact on cluster's performance and high availability, but it could be fine for quick changes that happen almost instantly (like fast index changes). When DDL statements are processed under TOI, the DDL statement will be replicated up front to the cluster. That is, cluster will assign global transaction ID for the DDL statement before DDL processing begins. Then every node in the cluster has the responsibility to execute the DDL statement in the given slot in the sequence of incoming transactions, and this DDL execution has to happen with high priority. 
+* ``TOI``: When the *Total Order Isolation* method is selected, data definition
+  language (DDL) statements are processed in the same order with regards to
+  other transactions in each cluster node. This guarantees data consistency. In
+  case of DDL statements, cluster will have parts of database locked and it
+  will behave like a single server. In some cases (like big ``ALTER TABLE``)
+  this could have impact on cluster's performance and high availability, but it
+  could be fine for quick changes that happen almost instantly (like fast index
+  changes). When DDL statements are processed under TOI, the DDL statement will
+  be replicated up front to the cluster. That is, cluster will assign global
+  transaction ID for the DDL statement before DDL processing begins. Then every
+  node in the cluster has the responsibility to execute the DDL statement in
+  the given slot in the sequence of incoming transactions, and this DDL
+  execution has to happen with high priority.
 
-* ``RSU``: When the *Rolling Schema Upgrade* method is selected, DDL statements won't be replicated across the cluster, instead it's up to the user to run them on each node separately. The node applying the changes will desynchronize from the cluster briefly, while normal work happens on all the other nodes. When a DDL statement is processed, node will apply delayed replication events. The schema changes **must** be backwards compatible for this method to work, otherwise the node that receives the change will likely break Galera replication. If replication breaks, SST will be triggered when the node tries to join again but the change will be undone. 
+* ``RSU``: When the *Rolling Schema Upgrade* method is selected, DDL statements
+  won't be replicated across the cluster, instead it's up to the user to run
+  them on each node separately. The node applying the changes will
+  desynchronize from the cluster briefly, while normal work happens on all the
+  other nodes. When a DDL statement is processed, node will apply delayed
+  replication events. The schema changes **must** be backwards compatible for
+  this method to work, otherwise the node that receives the change will likely
+  break Galera replication. If replication breaks, SST will be triggered when
+  the node tries to join again but the change will be undone.
 
-.. note:: Prior to |Percona XtraDB Cluster| :rn:`5.6.24-25.11`, :variable:`wsrep_OSU_method` was only a global variable. Current behavior is now consistent with |MySQL| behavior for variables that have both global and session scope. This means if you want to change the variable in current session, you need to do it with: ``SET wsrep_OSU_method`` (without the ``GLOBAL`` keyword). Setting the variable with ``SET GLOBAL wsrep_OSU_method`` will change the variable globally but it won't have effect on the current session.
+.. note::
+
+  This variable's behavior is consistent with |MySQL| behavior for variables
+  that have both global and session scope. This means if you want to change the
+  variable in current session, you need to do it with: ``SET wsrep_OSU_method``
+  (without the ``GLOBAL`` keyword). Setting the variable with ``SET GLOBAL
+  wsrep_OSU_method`` will change the variable globally but it won't have effect
+  on the current session.
 
 .. variable:: wsrep_preordered
 
@@ -286,9 +371,16 @@ This variable can be used to select schema upgrade method. Available values are:
    :dyn: Yes
    :default: OFF
 
-Use this variable to enable new, transparent handling of preordered replication events (like replication from traditional master). When this variable is enabled, such events will be applied locally first before being replicated to the other nodes of the cluster. This could increase the rate at which they can be processed, which would be otherwise limited by the latency between the nodes in the cluster.
+Use this variable to enable, transparent handling of preordered replication
+events (like replication from traditional master). When this variable is
+enabled, such events will be applied locally first before being replicated to
+the other nodes of the cluster. This could increase the rate at which they can
+be processed, which would be otherwise limited by the latency between the nodes
+in the cluster.
 
-Preordered events should not interfere with events that originate on the local node. Therefore, you should not run local update queries on a table that is also being updated through asynchronous replication.
+Preordered events should not interfere with events that originate on the local
+node. Therefore, you should not run local update queries on a table that is
+also being updated through asynchronous replication.
 
 .. variable:: wsrep_provider
 
@@ -298,7 +390,9 @@ Preordered events should not interfere with events that originate on the local n
    :dyn: Yes
    :default: None
 
-This variable should contain the path to the Galera library (like :file:`/usr/lib64/libgalera_smm.so` on *CentOS*/*RHEL* and :file:`/usr/lib/libgalera_smm.so` on *Debian*/*Ubuntu*).
+This variable should contain the path to the Galera library (like
+:file:`/usr/lib64/libgalera_smm.so` on *CentOS*/*RHEL* and
+:file:`/usr/lib/libgalera_smm.so` on *Debian*/*Ubuntu*).
 
 .. variable:: wsrep_provider_options
 
@@ -344,9 +438,10 @@ The following modes are available:
   This mode can be used with clusters
   in which write operations are isolated to a single node.
 
-By default, ``pxc_strict_mode`` is set to ``ENFORCING``,
+By default, :variable:`pxc_strict_mode` is set to ``ENFORCING``,
 except if the node is acting as a standalone server
-or the node is bootstrapping, then ``pxc_strict_mode`` defaults to ``DISABLED``.
+or the node is bootstrapping, then :variable:`pxc_strict_mode` defaults to
+``DISABLED``.
 
 .. note:: When changing the value of ``pxc_strict_mode``
    from ``DISABLED`` or ``PERMISSIVE`` to ``ENFORCING`` or ``MASTER``,
@@ -368,47 +463,70 @@ For more information, see :ref:`pxc-strict-mode`.
    :default: OFF
    :location: mysqld_safe
 
-When server is started with this variable, it will parse Global Transaction ID (GTID) from log, and if the GTID is found, assign it as initial position for actual server start. This option is used to recover GTID.
+When server is started with this variable, it will parse Global Transaction ID
+(GTID) from log, and if the GTID is found, assign it as initial position for
+actual server start. This option is used to recover GTID.
 
 .. variable:: wsrep_reject_queries
- 
+
    :cli: No
    :conf: Yes
    :scope: Global
    :dyn: Yes
    :default: NONE
- 
-This variable can be used to reject queries for the node. This can be useful during upgrades for keeping node up (with provider enabled) without accepting queries. Using read-only is recommended here unless you want to kill existing queries. This variable accepts the following values:
- 
+
+This variable can be used to reject queries for the node. This can be useful
+during upgrades for keeping node up (with provider enabled) without accepting
+queries. Using read-only is recommended here unless you want to kill existing
+queries. This variable accepts the following values:
+
 * ``NONE``: Nothing is rejected (default)
 * ``ALL``: All queries are rejected with ``Error 1047: Unknown command``
-* ``ALL_KILL``: All queries are rejected and existing client connections are also killed without waiting
- 
-.. note:: This variable doesn't affect Galera replication in any way, only the applications which connect to database are affected. If you want to desync a node, then use :variable:`wsrep_desync`.
+* ``ALL_KILL``: All queries are rejected and existing client connections are
+  also killed without waiting.
+
+.. note:: This variable doesn't affect Galera replication in any way, only the
+  applications which connect to database are affected. If you want to desync a
+  node, then use :variable:`wsrep_desync`.
 
 .. variable:: wsrep_replicate_myisam
 
-   :version 5.6.24-25.11: Variable available both in global and session scope
    :cli: Yes
    :conf: Yes
    :scope: Session, Global
    :dyn: No
    :default: OFF
 
-This variable defines whether MyISAM should be replicated or not. It is disabled by default, because MyISAM replication is still experimental.
+This variable defines whether MyISAM should be replicated or not. It is
+disabled by default, because MyISAM replication is still experimental.
 
-On the global level, :variable:`wsrep_replicate_myisam` can be set only before boot-up. On session level, you can change it during runtime as well.
+On the global level, :variable:`wsrep_replicate_myisam` can be set only before
+boot-up. On session level, you can change it during runtime as well.
 
-For older nodes in the cluster, :variable:`wsrep_replicate_myisam` should work since the TOI decision (for MyISAM DDL) is done on origin node. Mixing of non-MyISAM and MyISAM tables in the same DDL statement is not recommended when :variable:`wsrep_replicate_myisam` is disabled, since if any table in the list is MyISAM, the whole DDL statement is not put under TOI.
+For older nodes in the cluster, :variable:`wsrep_replicate_myisam` should work
+since the TOI decision (for MyISAM DDL) is done on origin node. Mixing of
+non-MyISAM and MyISAM tables in the same DDL statement is not recommended when
+:variable:`wsrep_replicate_myisam` is disabled, since if any table in the list
+is MyISAM, the whole DDL statement is not put under TOI.
 
 .. note:: You should keep in mind the following when using MyISAM replication:
 
-  * DDL (CREATE/DROP/TRUNCATE) statements on MyISAM will be replicated irrespective of :variable:`wsrep_replicate_miysam` value
-  * DML (INSERT/UPDATE/DELETE) statements on MyISAM will be replicated only if :variable:`wsrep_replicate_myisam` is enabled
-  * SST will get full transfer irrespective of :variable:`wsrep_replicate_myisam` value (it will get MyISAM tables from donor)
-  * Difference in configuration of ``pxc-cluster`` node on `enforce_storage_engine <https://www.percona.com/doc/percona-server/5.6/management/enforce_engine.html>`_ front may result in picking up different engine for same table on different nodes
-  * ``CREATE TABLE AS SELECT`` (CTAS) statements use non-TOI replication and are replicated only if there is involvement of InnoDB table that needs transactions (involvement of MyISAM table will cause CTAS statement to skip replication)
-
+  * DDL (CREATE/DROP/TRUNCATE) statements on MyISAM will be replicated
+    irrespective of :variable:`wsrep_replicate_miysam` value
+  * DML (INSERT/UPDATE/DELETE) statements on MyISAM will be replicated only if
+    :variable:`wsrep_replicate_myisam` is enabled
+  * SST will get full transfer irrespective of
+    :variable:`wsrep_replicate_myisam` value (it will get MyISAM tables from
+    donor)
+  * Difference in configuration of ``pxc-cluster`` node on
+    `enforce_storage_engine
+    <https://www.percona.com/doc/percona-server/5.7/management/enforce_engine.html>`_
+    front may result in picking up different engine for same table on different
+    nodes
+  * ``CREATE TABLE AS SELECT`` (CTAS) statements use non-TOI replication and
+    are replicated only if there is involvement of InnoDB table that needs
+    transactions (involvement of MyISAM table will cause CTAS statement to skip
+    replication).
 
 .. variable:: wsrep_restart_slave
 
@@ -418,7 +536,10 @@ For older nodes in the cluster, :variable:`wsrep_replicate_myisam` should work s
    :dyn: Yes
    :default: OFF
 
-This variable controls if |MySQL| slave should be restarted automatically when node joins back to cluster, because asynchronous replication slave thread is stopped when the node tries to apply next replication event while the node is in non-primary state.
+This variable controls if |MySQL| slave should be restarted automatically when
+node joins back to cluster, because asynchronous replication slave thread is
+stopped when the node tries to apply next replication event while the node is
+in non-primary state.
 
 .. variable:: wsrep_retry_autocommit
 
@@ -428,7 +549,14 @@ This variable controls if |MySQL| slave should be restarted automatically when n
    :dyn: No
    :default: 1
 
-This variable sets the number of times autocommitted transactions will be tried in the cluster if it encounters certification errors. In case there is a conflict, it should be safe for the cluster node to simply retry the statement without the client's knowledge hoping that it will pass next time. This can be useful to help an application using autocommit to avoid deadlock errors that can be triggered by replication conflicts. If this variable is set to ``0`` transaction won't be retried and if it is set to ``1``, it will be retried once.
+This variable sets the number of times autocommitted transactions will be tried
+in the cluster if it encounters certification errors. In case there is a
+conflict, it should be safe for the cluster node to simply retry the statement
+without the client's knowledge hoping that it will pass next time. This can be
+useful to help an application using autocommit to avoid deadlock errors that
+can be triggered by replication conflicts. If this variable is set to ``0``
+transaction won't be retried and if it is set to ``1``, it will be retried
+once.
 
 .. variable:: wsrep_slave_FK_checks
 
@@ -438,7 +566,8 @@ This variable sets the number of times autocommitted transactions will be tried 
    :dyn: Yes
    :default: ON
 
-This variable is used to control if Foreign Key checking is done for applier threads.
+This variable is used to control if Foreign Key checking is done for applier
+threads.
 
 .. variable:: wsrep_slave_threads
 
@@ -448,17 +577,29 @@ This variable is used to control if Foreign Key checking is done for applier thr
    :dyn: Yes
    :default: 1
 
-This variable controls the number of threads that can apply replication transactions in parallel. Galera supports true parallel replication, replication that applies transactions in parallel only when it is safe to do so. The variable is dynamic, you can increase/decrease it at any time.
+This variable controls the number of threads that can apply replication
+transactions in parallel. Galera supports true parallel replication,
+replication that applies transactions in parallel only when it is safe to do
+so. The variable is dynamic, you can increase/decrease it at any time.
 
-.. note:: When you decrease it, it won't kill the threads immediately but stop them after they are done applying current transaction (the effect with increase is immediate though). 
+.. note:: When you decrease it, it won't kill the threads immediately but stop
+  them after they are done applying current transaction (the effect with
+  increase is immediate though).
 
-If any replication consistency problems are encountered, it's recommended to set this back to ``1`` to see if that resolves the issue. The default value can be increased for better throughput.
+If any replication consistency problems are encountered, it's recommended to
+set this back to ``1`` to see if that resolves the issue. The default value can
+be increased for better throughput.
 
-You may want to increase it as suggested `in Codership documentation <http://galeracluster.com/documentation-webpages/nodestates.html#flow-control>`_, in ``JOINED`` state for instance to speed up the catchup process to ``SYNCED``.
+You may want to increase it as suggested `in Codership documentation
+<http://galeracluster.com/documentation-webpages/nodestates.html#flow-control>`_,
+in ``JOINED`` state for instance to speed up the catchup process to ``SYNCED``.
 
-You can also estimate the optimal value for this from :variable:`wsrep_cert_deps_distance` as suggested `on this page <http://galeracluster.com/documentation-webpages/monitoringthecluster.html#checking-the-replication-health>`_.
+You can also estimate the optimal value for this from
+:variable:`wsrep_cert_deps_distance` as suggested `on this page
+<http://galeracluster.com/documentation-webpages/monitoringthecluster.html#checking-the-replication-health>`_.
 
-You can also refer to `this <http://galeracluster.com/documentation-webpages/configurationtips.html#setting-parallel-slave-threads>`_ for more configuration tips.
+You can also refer to `this
+<http://galeracluster.com/documentation-webpages/configurationtips.html#setting-parallel-slave-threads>`_ for more configuration tips.
 
 .. variable:: wsrep_slave_UK_checks
 
@@ -468,7 +609,8 @@ You can also refer to `this <http://galeracluster.com/documentation-webpages/con
    :dyn: Yes
    :default: OFF
 
-This variable is used to control if Unique Key checking is done for applier threads.
+This variable is used to control if Unique Key checking is done for applier
+threads.
 
 .. variable:: wsrep_sst_auth
 
@@ -478,7 +620,12 @@ This variable is used to control if Unique Key checking is done for applier thre
    :dyn: Yes
    :format: <username>:<password>
 
-This variable should contain the authentication information needed for State Snapshot Transfer (SST). Required information depends on the method selected in the :variable:`wsrep_sst_method`. More information about required authentication can be found in the :ref:`state_snapshot_transfer` documentation. This variable will appear masked in the logs and in the ``SHOW VARIABLES`` query.
+This variable should contain the authentication information needed for State
+Snapshot Transfer (SST). Required information depends on the method selected in
+the :variable:`wsrep_sst_method`. More information about required
+authentication can be found in the :ref:`state_snapshot_transfer`
+documentation. This variable will appear masked in the logs and in the ``SHOW
+VARIABLES`` query.
 
 .. variable:: wsrep_sst_donor
 
@@ -487,7 +634,15 @@ This variable should contain the authentication information needed for State Sna
    :scope: Global
    :dyn: Yes
 
-This variable contains the name (:variable:`wsrep_node_name`) of the preferred donor for SST. If no node is selected as a preferred donor, it will be chosen from one of the available nodes automatically **if and only if** there is a terminating comma at the end (like 'node1,node2,'). Otherwise, if there is no terminating comma, the list of nodes in :variable:`wsrep_sst_donor` is considered absolute, and thus it won't fall back even if other nodes are available. Please check the note for :option:`sst-initial-timeout` if you are using it without terminating comma or want joiner to wait more than default 100 seconds.
+This variable contains the name (:variable:`wsrep_node_name`) of the preferred
+donor for SST. If no node is selected as a preferred donor, it will be chosen
+from one of the available nodes automatically **if and only if** there is a
+terminating comma at the end (like 'node1,node2,'). Otherwise, if there is no
+terminating comma, the list of nodes in :variable:`wsrep_sst_donor` is
+considered absolute, and thus it won't fall back even if other nodes are
+available. Please check the note for :option:`sst-initial-timeout` if you are
+using it without terminating comma or want joiner to wait more than default 100
+seconds.
 
 .. variable:: wsrep_sst_donor_rejects_queries
 
@@ -497,7 +652,9 @@ This variable contains the name (:variable:`wsrep_node_name`) of the preferred d
    :dyn: Yes
    :default: OFF
 
-When this variable is enabled, SST donor node will not accept incoming queries, instead it will reject queries with ``UNKNOWN COMMAND`` error code. This can be used to signal load-balancer that the node isn't available.
+When this variable is enabled, SST donor node will not accept incoming queries,
+instead it will reject queries with ``UNKNOWN COMMAND`` error code. This can be
+used to signal load-balancer that the node isn't available.
 
 .. variable:: wsrep_sst_method
 
@@ -508,25 +665,47 @@ When this variable is enabled, SST donor node will not accept incoming queries, 
    :default: xtrabackup-v2
    :recommended: xtrabackup-v2
 
-This variable sets up the method for taking the State Snapshot Transfer (SST). Available values are:
+This variable sets up the method for taking the State Snapshot Transfer (SST).
+Available values are:
 
-* ``xtrabackup``: Uses Percona XtraBackup to perform the SST, this method requires :variable:`wsrep_sst_auth` to be set up with <user>:<password> which |XtraBackup| will use on donor. Privileges and permissions needed for running |XtraBackup| can be found `here <http://www.percona.com/doc/percona-xtrabackup/innobackupex/privileges.html#permissions-and-privileges-needed>`_.
+* ``xtrabackup-v2``: Uses |Percona XtraBackup| to perform SST. This method
+  requires :variable:`wsrep_sst_auth` to be set up with ``<user>:<password>``
+  which it will use on donor. Privileges and perimssions needed for running
+  |Percona XtraBackup| can be found `here
+  <https://www.percona.com/doc/percona-xtrabackup/2.4/using_xtrabackup/privileges.html>`_.
 
-* ``xtrabackup-v2``: This is the same as ``xtrabackup``, except that it uses newer protocol, hence is not compatible. This is the **recommended** option for PXC 5.5.34 and above. For more details, please check :ref:`xtrabackup_sst`. This is also the default SST method. For SST with older nodes (< 5.5.34), use ``xtrabackup`` as the SST method.
+  This is the **recommended** and default option for PXC. For more details,
+  please check :ref:`xtrabackup_sst`.
 
-  .. note:: This method is currently recommended if you have ``innodb-log-group_home-dir/innodb-data-home-dir`` in your config. Refer to :option:`sst-special-dirs` for more information.
+  .. note:: This method is currently recommended if you have
+    ``innodb-log-group_home-dir/innodb-data-home-dir`` in your config. Refer to
+    :option:`sst-special-dirs` for more information.
 
-* ``rsync``: Uses ``rsync`` to perform the SST, this method doesn't use the :variable:`wsrep_sst_auth`
+* ``rsync``: Uses ``rsync`` to perform the SST, this method doesn't use the
+  :variable:`wsrep_sst_auth`
 
-* ``mysqldump``: Uses ``mysqldump`` to perform the SST, this method requires :variable:`wsrep_sst_auth` to be set up with <user>:<password>, where user has root privileges on the server.
+* ``mysqldump``: Uses ``mysqldump`` to perform the SST, this method requires
+  :variable:`wsrep_sst_auth` to be set up with <user>:<password>, where user
+  has root privileges on the server.
 
-  .. note::  This mehotd is not recommended unless it is required for specific reasons. Also, it is not compatible with ``bind_address`` set to ``127.0.0.1`` or ``localhost``, and will cause startup to fail if set so.
+  .. note::
+    This mehotd is not recommended unless it is required for specific reasons.
+    Also, it is not compatible with ``bind_address`` set to ``127.0.0.1`` or
+    ``localhost``, and will cause startup to fail if set so.
 
-* ``<custom_script_name>``: Galera supports `Scriptable State Snapshot Transfer <http://galeracluster.com/documentation-webpages/statetransfer.html#scriptable-state-snapshot-transfer>`_. This enables users to create their own custom script for performing an SST. For example, you can create a script :file:`/usr/bin/wsrep_MySST.sh` and specify ``MySST`` for this variable to run your custom SST script.
+* ``<custom_script_name>``: Galera supports `Scriptable State Snapshot Transfer
+  <http://galeracluster.com/documentation-webpages/statetransfer.html#scriptable-state-snapshot-transfer>`_.
+  This enables users to create their own custom script for performing an SST.
+  For example, you can create a script :file:`/usr/bin/wsrep_MySST.sh` and
+  specify ``MySST`` for this variable to run your custom SST script.
 
-* ``skip``: Use this to skip SST, it can be used when initially starting the cluster and manually restoring the same data to all nodes. It shouldn't be used as permanent setting because it could lead to data inconsistency across the nodes.
+* ``skip``: Use this to skip SST, it can be used when initially starting the
+  cluster and manually restoring the same data to all nodes. It shouldn't be
+  used as permanent setting because it could lead to data inconsistency across
+  the nodes.
 
-.. note:: Only ``xtrabackup-v2`` and ``rsync`` provide ``gtid_mode async-slave`` support during SST.
+.. note:: Only ``xtrabackup-v2`` and ``rsync`` provide ``gtid_mode
+  async-slave`` support during SST.
 
 .. variable:: wsrep_sst_receive_address
 
@@ -545,23 +724,29 @@ This variable is used to configure address on which the node expects SST.
    :scope: Global
    :dyn: Yes
 
-This variable contains the ``UUID:seqno`` value. By setting all the nodes to have the same value for this option, cluster can be set up without the state transfer.
+This variable contains the ``UUID:seqno`` value. By setting all the nodes to
+have the same value for this option, cluster can be set up without the state
+transfer.
 
 .. variable:: wsrep_sync_wait
 
-   :version 5.6.20-25.7: Variable introduced
    :cli: Yes
    :conf: Yes
    :scope: Global, Session
    :dyn: Yes
 
-This variable is used to control causality checks on some SQL statements, such as ``SELECT``, ``BEGIN``/``END``, ``SHOW STATUS``, but not on some autocommit SQL statements ``UPDATE`` and ``INSERT``. Causality check is determined by bitmask: 
+This variable is used to control causality checks on some SQL statements, such
+as ``SELECT``, ``BEGIN``/``END``, ``SHOW STATUS``, but not on some autocommit
+SQL statements ``UPDATE`` and ``INSERT``. Causality check is determined by
+bitmask:
 
- * ``1`` Indicates check on ``READ`` statements, including ``SELECT``, ``SHOW``, ``BEGIN``/``START TRANSACTION``.
+ * ``1`` Indicates check on ``READ`` statements, including ``SELECT``,
+   ``SHOW``, ``BEGIN``/``START TRANSACTION``.
 
  * ``2`` Indicates check on ``UPDATE`` and ``DELETE`` statements.
 
  * ``4`` Indicates check on ``INSERT`` and ``REPLACE`` statements
 
-This variable replaced the :variable:`wsrep_causal_reads` variable. Setting :variable:`wsrep_sync_wait` to ``1`` is the equivalent of setting :variable:`wsrep_causal_reads` to ``ON``.
-
+This variable replaced the :variable:`wsrep_causal_reads` variable. Setting
+:variable:`wsrep_sync_wait` to ``1`` is the equivalent of setting
+:variable:`wsrep_causal_reads` to ``ON``.


### PR DESCRIPTION
Removed the xtrabackup from wsrep_sst_method as it isn't supported
anymore
Docs now pass the doc8 test without errors/warning:

percona-xtradb-cluster/doc> doc8 source
Scanning...
# Validating...

Total files scanned = 38
Total files ignored = 0
Total accumulated errors = 0
Detailed error counts:
    - doc8.checks.CheckCarriageReturn = 0
    - doc8.checks.CheckIndentationNoTab = 0
    - doc8.checks.CheckMaxLineLength = 0
    - doc8.checks.CheckNewlineEndOfFile = 0
    - doc8.checks.CheckTrailingWhitespace = 0
    - doc8.checks.CheckValidity = 0
