### PR TITLE
- PXC#681: Avoid generating audit-log event for closing connection

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_cluster_address.result
+++ b/mysql-test/suite/galera/r/galera_var_cluster_address.result
@@ -76,3 +76,14 @@ CALL mtr.add_suppression("gcs connect failed: Connection timed out");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(foo://\\) failed: 7");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(gcomm://192.0.2.1\\) failed: 7");
 CALL mtr.add_suppression("WSREP: Trying to launch slave threads before creating connection at 'gcomm://192.0.2.1'");
+INSTALL PLUGIN audit_log SONAME 'audit_log.so';
+show status like 'wsrep_local_state_comment';
+Variable_name	Value
+wsrep_local_state_comment	Synced
+SET GLOBAL wsrep_cluster_address = 'gcomm://127.0.0.1:13001';;
+UNINSTALL PLUGIN audit_log;
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown
+show status like 'wsrep_cluster_size';
+Variable_name	Value
+wsrep_cluster_size	2

--- a/mysql-test/suite/galera/t/galera_var_cluster_address.test
+++ b/mysql-test/suite/galera/t/galera_var_cluster_address.test
@@ -156,3 +156,25 @@ CALL mtr.add_suppression("gcs connect failed: Connection timed out");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(foo://\\) failed: 7");
 CALL mtr.add_suppression("WSREP: wsrep::connect\\(gcomm://192.0.2.1\\) failed: 7");
 CALL mtr.add_suppression("WSREP: Trying to launch slave threads before creating connection at 'gcomm://192.0.2.1'");
+
+
+#-------------------------------------------------------------------------------
+#
+# Re-load wsrep_cluster_address with audit-plugin enabled and active parallel
+# connection. Closing of connection during stop replication shouldn't
+# generate audit-plugin events.
+#
+--connection node_2
+--let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
+INSTALL PLUGIN audit_log SONAME 'audit_log.so';
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+show status like 'wsrep_local_state_comment';
+
+--eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+#
+UNINSTALL PLUGIN audit_log;
+show status like 'wsrep_cluster_size';
+

--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -519,7 +519,6 @@ char *audit_log_general_record(char *buf, size_t buflen,
                              event->general_query.str,
                              event->general_query.length,
                              event->general_charset, &errors);
-    DBUG_ASSERT(errors == 0);
     query= endptr;
     endptr+= query_length;
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -665,7 +665,7 @@ wsrep_view_handler_cb (void*                    app_ctx,
           WSREP_INFO("closing client connections for "
                      "protocol change %ld -> %d",
                      wsrep_protocol_version, view->proto_ver);
-          wsrep_close_client_connections(true);
+          wsrep_close_client_connections(true, false);
           wsrep_protocol_version= view->proto_ver;
           wsrep_ready_set(wsrep_ready_saved);
       }
@@ -693,7 +693,7 @@ wsrep_view_handler_cb (void*                    app_ctx,
     if (!wsrep_before_SE())
     {
         WSREP_DEBUG("[debug]: closing client connections for PRIM");
-        wsrep_close_client_connections(true);
+        wsrep_close_client_connections(true, false);
     }
 
     ssize_t const req_len= wsrep_sst_prepare (sst_req);
@@ -1199,7 +1199,7 @@ void wsrep_stop_replication(THD *thd)
 
   wsrep_connected= FALSE;
 
-  wsrep_close_client_connections(true);
+  wsrep_close_client_connections(true, false);
 
   /* wait until appliers have stopped */
   wsrep_wait_appliers_close(thd);

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -191,7 +191,7 @@ extern "C" void wsrep_thd_awake(THD *thd, my_bool signal);
 extern "C" int wsrep_thd_retry_counter(THD *thd);
 
 
-extern void wsrep_close_client_connections(bool wait_to_end);
+extern void wsrep_close_client_connections(bool wait_to_end, bool server_shutdown);
 extern int  wsrep_wait_committing_connections_close(int wait_time);
 extern void wsrep_close_applier(THD *thd);
 extern void wsrep_wait_appliers_close(THD *thd);

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -911,7 +911,7 @@ static void sst_reject_queries(my_bool close_conn)
 {
     wsrep_ready_set (FALSE); // this will be resotred when donor becomes synced
     WSREP_INFO("Rejecting client queries for the duration of SST.");
-    if (TRUE == close_conn) wsrep_close_client_connections(false);
+    if (TRUE == close_conn) wsrep_close_client_connections(false, false);
 }
 
 static int sst_donate_mysqldump (const char*         addr,

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -411,7 +411,7 @@ bool wsrep_reject_queries_update(sys_var *self, THD* thd, enum_var_type type)
             WSREP_INFO("Rejecting client queries due to manual setting");
             break;
         case WSREP_REJECT_ALL_KILL:
-            wsrep_close_client_connections(FALSE);
+            wsrep_close_client_connections(false, false);
             WSREP_INFO("Rejecting client queries and killing connections due to manual setting");
             break;
         default:


### PR DESCRIPTION
  While closing connection audit-log event should not be generated.
  Fix for this was implemented in upstream but there are different
  classes for closing wsrep connection that failed to inherit this
  fix. Corrected it now.
