### PR TITLE
Fix in mysql-systemd for service-startup-timeout variable (#1623819)

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -191,7 +191,7 @@ export PATH
 
 pid_path=$(parse_cnf pid-file "" server mysqld mysqld_safe)
 datadir=$(parse_cnf datadir "" server mysqld mysqld_safe)
-service_startup_timeout=$(parse_cnf service-startup-timeout $service_startup_timeout server mysqld)
+service_startup_timeout=$(parse_cnf service-startup-timeout $service_startup_timeout mysqld_safe)
 
 if [[ -z ${datadir:-} ]];then
     datadir="/var/lib/mysql"


### PR DESCRIPTION
Bug: https://bugs.launchpad.net/percona-xtradb-cluster/+bug/1623819

Since the server doesn't know about `service-startup-timeout` variable it's best to search for it in [mysqld_safe] section where if user wants can change default value for the startup timeout.
This is only used on centos7.

If specified under [mysqld] section the server won't start:
`2016-09-15 03:27:13 11868 [ERROR] /usr/sbin/mysqld: unknown variable 'service-startup-timeout=100'`
And if used under [mysqld_safe] section it seems to work ok.
