### PR TITLE
5.7 - Fix in mysql-systemd for service-startup-timeout variable (#1623819)

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -194,7 +194,7 @@ export PATH
 
 pid_path=$(parse_cnf pid-file "" server mysqld mysqld_safe)
 datadir=$(parse_cnf datadir "" server mysqld mysqld_safe)
-service_startup_timeout=$(parse_cnf service-startup-timeout $service_startup_timeout server mysqld)
+service_startup_timeout=$(parse_cnf service-startup-timeout $service_startup_timeout mysqld_safe)
 
 if [[ -z ${datadir:-} ]];then
     datadir="/var/lib/mysql"


### PR DESCRIPTION
Same as: https://github.com/percona/percona-xtradb-cluster/pull/283
just for version 5.7
