### PR TITLE
- #PXC-426: Race condition during IST

### DIFF
--- a/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
+++ b/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
@@ -1,0 +1,15 @@
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+Shutting down server ...
+CREATE TABLE t2 (f1 INTEGER);
+INSERT INTO t2 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+SET GLOBAL wsrep_provider_options = 'dbug=d,simulate_seqno_shift';
+Starting server ...
+SELECT COUNT(*) = 10 FROM t1;
+COUNT(*) = 10
+1
+SELECT COUNT(*) = 10 FROM t2;
+COUNT(*) = 10
+1
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
+++ b/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
@@ -1,0 +1,105 @@
+#
+# This test is artificially creating a situation where
+# the state of the donor node goes too far and diverged from
+# the state of another node, which joining the cluster, and
+# therefore the joining node unable to initiate the IST state
+# transfer.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connection node_1
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer because the donor seqno had gone forward during IST'
+# error messages in the log file before and after testing. To do this
+# we need to save original log file before testing:
+#
+--let TEST_LOG=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   if (-e $test_log_copy) {
+      unlink $test_log_copy;
+   }
+EOF
+--copy_file $TEST_LOG $TEST_LOG.copy
+
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+--connection node_2
+
+# Initiate normal shutdown on the node 2:
+
+--echo Shutting down server ...
+--source include/shutdown_mysqld.inc
+
+# Waiting until shutdown on node 2 has been completed:
+
+--connection node_1
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Do some changes on node 1:
+
+CREATE TABLE t2 (f1 INTEGER);
+INSERT INTO t2 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+# Simulate shift of the donor seqno:
+
+--let $galera_sync_point = simulate_seqno_shift
+--source include/galera_set_sync_point.inc
+
+# Restarting the second node:
+
+--connection node_2
+
+--echo Starting server ...
+--source include/start_mysqld.inc
+
+--connection node_1
+
+# Waiting until start of node 2:
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Sanity check (node 2 is running now and can perform SQL operators):
+
+--connection node_2
+
+SELECT COUNT(*) = 10 FROM t1;
+SELECT COUNT(*) = 10 FROM t2;
+
+--connection node_1
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer because the donor seqno had gone forward during IST'
+# error messages in the log file during test phase - to print the
+# error message if quantity of such warnings in log file increased
+# at the end of the test:
+#
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   open(FILE, $test_log_copy) or die("Unable to open $test_log_copy: $!\n");
+   my $initial=grep(/Failed to prepare for incremental state transfer because the donor seqno had gone forward during IST/gi,<FILE>);
+   close(FILE);
+   open(FILE, $test_log) or die("Unable to open $test_log: $!\n");
+   my $count_warnings=grep(/Failed to prepare for incremental state transfer because the donor seqno had gone forward during IST/gi,<FILE>);
+   close(FILE);
+   if ($count_warnings != $initial) {
+      my $diff=$count_warnings-$initial;
+      print "Failed to prepare for incremental state transfer $diff times.\n";
+   }
+EOF
+--remove_file $TEST_LOG.copy

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -20,6 +20,10 @@
 #include "my_stacktrace.h"
 #include "global_threads.h"
 
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
+
 #ifdef __WIN__
 #include <crtdbg.h>
 #define SIGNAL_FMT "exception 0x%x"
@@ -61,6 +65,14 @@ extern "C" sig_handler handle_fatal_signal(int sig)
   }
 
   segfaulted = 1;
+
+/*
+  The wsrep subsystem can have their its own actions
+  which need be performed before exiting:
+*/
+#ifdef WITH_WSREP
+  wsrep_handle_fatal_signal(sig);
+#endif
 
 #ifdef __WIN__
   SYSTEMTIME utc_time;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -180,6 +180,7 @@ extern "C" void wsrep_thd_set_wsrep_last_query_id(THD *thd, query_id_t id);
 extern "C" void wsrep_thd_awake(THD *thd, my_bool signal);
 extern "C" int wsrep_thd_retry_counter(THD *thd);
 
+extern "C" void wsrep_handle_fatal_signal(int sig);
 
 extern void wsrep_close_client_connections(my_bool wait_to_end);
 extern int  wsrep_wait_committing_connections_close(int wait_time);

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -777,7 +777,15 @@ void process::terminate ()
 {
   if (pid_)
   {
+    /*
+      If we have the appropriate system call, then try
+      to terminate the entire process group:
+    */
+    #if _XOPEN_SOURCE >= 500 || _DEFAULT_SOURCE || _BSD_SOURCE
+    if (killpg(pid_, SIGTERM))
+    #else
     if (kill(pid_, SIGTERM))
+    #endif
     {
       WSREP_WARN("Unable to terminate process: %s: %d (%s)",
                  str_, errno, strerror(errno));


### PR DESCRIPTION
The node lost connectivity with other nodes in the cluster for some time due to network problems. After this, it need to run IST to synchronize their state with the cluster. However, the IST request has failed.

If we already have large network delays and packet losses, then during IST we can encounter situation when seqno on the donor node has moved forward so much that IST is not possible and we need to run "full" SST request.

To avoid unsuccessful IST attempts, the Galera introduces the concept of "safety gap" - the window for seqno values in which the heuristic algorithm for selecting the donor prefers to switch to SST.

The immediate cause of the PXC-426 error is the inability of the PXC to start new SST request during node operation (using methods other than mysqldump). PXC and Galera written in such way that normally we need a full restart before launching the new SST.

To resolve this contradiction, we need to change the heuristic algorithm that selecting a donor in such way, that it took into account the impossibility of SST. If a joiner node sends a request without SST part, then after applying this patch the donor node must ignore the safety gap window and still tries to execute IST.

It is much better to have a small probability of failure in the IST, than immediately suffer from failure with 100% guarantee (due to heuristics associated with safety gap window). Moreover, if the request contains the SST-related part (not only IST), then we can leave current logic with the additional heuristics related to safety gap window.

However, the algorithm of the donor selection, which implemented in the GCS, contains the potential flaw, and in rare situation it still may choose as a donor such node, where seqno can gone forward before the IST request will be received.

Therefore, since heuristic that selects the donor node does not give us a 100% guarantee that seqno does not moved forward while the new node joining the cluster, and during node operation we have only a requests for the IST without SST part, then we need a way to informing joiner node, that it should prepare to receive SST. This return path also added to the patch code.

Especially we need this signal to notify the user that server unable to perform the SST instead of IST when xtrabackup or rsynch selected as the state transfer method.

In these cases, we need to show the user an explicit message that indicates that we need to perform SST after node restart. However, current version of the server continues to work, even when the synchronization of the node is no longer possible and it cannot continue normal operation in a cluster. Or vice versa, it falls for one of the assertions in the Galera code. This corrected in the patch.

Theoretically, a similar return path also may be activated if the MySQL server does not prepared structures for the SST in the view callback (in the wsrep_view_handler_cb function) after restart of the node. However, in the current version of PXC this should not happen after node restart, because the wsrep_sst_prepare function (which called from wsrep_view_handler_cb) always returns a non-zero value as length of the SST request (node always prepared for both the SST and IST). However, the assertion in the wsrep_view_handler_cb function only checks for the presence of the SST structure, but not its length. Theoretically, when mysqldump method is used this structure can be created with zero length of the SST part.

Therefore, I changed the Galera code to allow restart SST after failing to perform IST - to be protected against failures in the future, when implementation of the wsrep_sst_prepare function may change.

In addition, if the IST request canceled due to an error at the GCS level or by initiative of the server, and if the node remain in the S_JOINING state, then we must return it to the S_CONNECTED state.
