### PR TITLE
- PXC#695: Reduce PXC 5.6 dependency from 2.4 to 2.3 due to package u…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -633,7 +633,7 @@ fi
 
 # check the version, we require XB-2.4 to ensure that we can pass the
 # datadir via the command-line option
-XB_REQUIRED_VERSION="2.4.3"
+XB_REQUIRED_VERSION="2.3.5"
 
 XB_VERSION=`$INNOBACKUPEX_BIN --version 2>&1 | grep -oe '[0-9]\.[0-9][\.0-9]*' | head -n1`
 if [[ -z $XB_VERSION ]]; then


### PR DESCRIPTION
…pgrade issue

  PXC-5.6 was made dependent with latest XB-2.4 but creates a problem for inline
  minor upgrade as name of the XB-2.4 and XB-2.3 packages are different.
  Upgrade installer think it is different packages and inline upgrade
  can't be done.

  Resolve it by downgrading PXC-5.6 support to XB-2.3
