### PR TITLE
- PXC#707: FLUSH TABLE on master can cause pxc-node (acting as slave)…

### DIFF
--- a/sql/sql_reload.cc
+++ b/sql/sql_reload.cc
@@ -331,11 +331,11 @@ bool reload_acl_and_cache(THD *thd, unsigned long options,
         }
       }
 
-      if (thd && thd->wsrep_applier)
+      if (thd && (thd->wsrep_applier || thd->slave_thread))
       {
         /*
-          In case of applier thread, do not wait for table share(s) to be
-          removed from table definition cache.
+          In case of wsrep-applier/mysql-slave thread, do not wait for table
+          share(s) to be removed from table definition cache.
 
           This is important otherwise it can lead to a deadlock in following
           scenario:


### PR DESCRIPTION
… to stall DML workload

  Use-case has master that replicates (using mysql asynchronous replication) to
  a slave node that is also a pxc-node from cluster.
- pxc-node is running DML workload which keeps on opening and closing the table.
- master executes FLUSH TABLE which is then replicated on slave/pxc-node.
- FLUSH TABLE is further replicating by wsrep-replication logic of pxc-node
  within the cluster. This replication is done using TOI replication protocol.
  TOI needs CommitMonitor so FLUSH TABLE holds CommitMonitor before it starts
  execution.
- FLUSH TABLE execution waits to removal old-table-share from the table-cache.
  But this table-share can be removed only when active DML are done.
- DML can't proceed as they too need CommitMonitor to complete which is currently
  held by FLUSH TABLE thread
  
  Fix is to skip removal of the table share by passing REFRESH_FAST option
  while closing the table.
  (Fix for this was added in bug#1520491 that considered use-case of
   replication from one-pxc-node to other pxc-node but this use-case
   is trying to exercise replication from master to pxc-node).
