### PR TITLE
- PXC#717: ALTER USER is not replicated

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5982,6 +5982,10 @@ end_with_restore_list:
       goto error;
     }
 
+#ifdef WITH_WSREP
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+#endif /* WITH_WSREP */
+
     /* Conditionally writes to binlog */
     if (!(res = mysql_alter_user(thd, lex->users_list, lex->drop_if_exists)))
       my_ok(thd);


### PR DESCRIPTION
  CREATE/DROP USER are replicated but as listed here
  https://bugs.launchpad.net/codership-mysql/+bug/1376269 ALTER USER
  is not replicated.

Conflicts:
    sql/sql_parse.cc
