### PR TITLE
- PXC#717: ALTER USER is not replicated

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6180,6 +6180,9 @@ create_sp_error:
     if (check_access(thd, UPDATE_ACL, "mysql", NULL, NULL, 1, 1) &&
         check_global_access(thd, CREATE_USER_ACL))
       break;
+#ifdef WITH_WSREP
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+#endif /* WITH_WSREP */
     /* Conditionally writes to binlog */
     if (!(res= mysql_user_password_expire(thd, lex->users_list)))
       my_ok(thd);


### PR DESCRIPTION
  CREATE/DROP USER are replicated but as listed here
  https://bugs.launchpad.net/codership-mysql/+bug/1376269 ALTER USER
  is not replicated.
