### PR TITLE
- PXC#252/PXC#426: Race condition in IST

### DIFF
--- a/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
+++ b/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
@@ -1,0 +1,17 @@
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+Shutting down server ...
+CREATE TABLE t2 (f1 INTEGER);
+INSERT INTO t2 VALUES (3);
+INSERT INTO t2 VALUES (2);
+INSERT INTO t2 VALUES (1);
+SET GLOBAL wsrep_provider_options = 'dbug=d,simulate_seqno_shift';
+Starting server ...
+SELECT COUNT(*) = 10 FROM t1;
+COUNT(*) = 10
+1
+SELECT COUNT(*) = 384 FROM t2;
+COUNT(*) = 384
+1
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
+++ b/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
@@ -1,0 +1,120 @@
+#
+# This test is artificially creating a situation where
+# the state of the donor node goes too far and diverged from
+# the state of another node, which joining the cluster, and
+# therefore the joining node unable to initiate the IST state
+# transfer.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+--connection node_1
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer because the donor seqno had gone forward during IST'
+# error messages in the log file before and after testing. To do this
+# we need to save original log file before testing:
+#
+--let TEST_LOG=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   if (-e $test_log_copy) {
+      unlink $test_log_copy;
+   }
+EOF
+--copy_file $TEST_LOG $TEST_LOG.copy
+
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+--connection node_2
+
+# Initiate normal shutdown on the node 2:
+
+--echo Shutting down server ...
+--source include/shutdown_mysqld.inc
+
+# Waiting until shutdown on node 2 has been completed:
+
+--connection node_1
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Do some changes on node 1:
+
+CREATE TABLE t2 (f1 INTEGER);
+
+# We need to do a minimum of 128 * <the number of nodes> changes,
+# to perform a good check of the safety_gap heuristic:
+
+--disable_query_log
+--let $count = 384
+while ($count)
+{
+   # Print the last three oparatola to a log file:
+   if ($count == 3) {
+      --enable_query_log
+   }
+   --eval INSERT INTO t2 VALUES ($count)
+   --dec $count
+}
+
+# Simulate shift of the donor seqno:
+
+--let $galera_sync_point = simulate_seqno_shift
+--source include/galera_set_sync_point.inc
+
+# Restarting the second node:
+
+--connection node_2
+
+--echo Starting server ...
+--source include/start_mysqld.inc
+
+--connection node_1
+
+# Waiting until start of node 2:
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Sanity check (node 2 is running now and can perform SQL operators):
+
+--connection node_2
+
+SELECT COUNT(*) = 10 FROM t1;
+SELECT COUNT(*) = 384 FROM t2;
+
+--connection node_1
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer because the donor seqno had gone forward during IST'
+# error messages in the log file during test phase - to print the
+# error message if quantity of such warnings in log file increased
+# at the end of the test:
+#
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   open(FILE, $test_log_copy) or die("Unable to open $test_log_copy: $!\n");
+   my $initial=grep(/Failed to prepare for incremental state transfer because the donor seqno had gone forward during IST/gi,<FILE>);
+   close(FILE);
+   open(FILE, $test_log) or die("Unable to open $test_log: $!\n");
+   my $count_warnings=grep(/Failed to prepare for incremental state transfer because the donor seqno had gone forward during IST/gi,<FILE>);
+   close(FILE);
+   if ($count_warnings != $initial) {
+      my $diff=$count_warnings-$initial;
+      print "Failed to prepare for incremental state transfer $diff times.\n";
+   }
+EOF
+--remove_file $TEST_LOG.copy

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1915,7 +1915,7 @@ extern "C" void unireg_abort(int exit_code)
   if (wsrep)
   {
     /* Cancel the SST script if it is running: */
-    wsrep_sst_cancel();
+    wsrep_sst_cancel(true);
     /* This is an abort situation, we cannot expect to gracefully close all
      * wsrep threads here, we can only diconnect from service */
     wsrep_close_client_connections(FALSE);

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -20,6 +20,10 @@
 #include "my_stacktrace.h"
 #include "global_threads.h"
 
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
+
 #ifdef __WIN__
 #include <crtdbg.h>
 #define SIGNAL_FMT "exception 0x%x"
@@ -61,6 +65,14 @@ extern "C" sig_handler handle_fatal_signal(int sig)
   }
 
   segfaulted = 1;
+
+/*
+  The wsrep subsystem has their its own actions
+  which need be performed before exiting:
+*/
+#ifdef WITH_WSREP
+  wsrep_handle_fatal_signal(sig);
+#endif
 
 #ifdef __WIN__
   SYSTEMTIME utc_time;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -638,6 +638,7 @@ int wsrep_init()
   wsrep_args.unordered_cb    = wsrep_unordered_cb;
   wsrep_args.sst_donate_cb   = wsrep_sst_donate_cb;
   wsrep_args.synced_cb       = wsrep_synced_cb;
+  wsrep_args.abort_cb        = wsrep_abort_cb;
 
   rcode = wsrep->init(wsrep, &wsrep_args);
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -180,6 +180,7 @@ extern "C" void wsrep_thd_set_wsrep_last_query_id(THD *thd, query_id_t id);
 extern "C" void wsrep_thd_awake(THD *thd, my_bool signal);
 extern "C" int wsrep_thd_retry_counter(THD *thd);
 
+extern "C" void wsrep_handle_fatal_signal(int sig);
 
 extern void wsrep_close_client_connections(my_bool wait_to_end);
 extern int  wsrep_wait_committing_connections_close(int wait_time);

--- a/sql/wsrep_priv.h
+++ b/sql/wsrep_priv.h
@@ -35,6 +35,7 @@ wsrep_cb_status wsrep_sst_donate_cb (void* app_ctx,
                                      const wsrep_gtid_t* state_id,
                                      const char* state, size_t state_len,
                                      bool bypass);
+void wsrep_abort_cb (void);
 
 extern wsrep_uuid_t  local_uuid;
 extern wsrep_seqno_t local_seqno;

--- a/sql/wsrep_sst.h
+++ b/sql/wsrep_sst.h
@@ -32,7 +32,7 @@ extern bool wsrep_sst_wait();
 /*! Signals wsrep that initialization is complete, writesets can be applied */
 extern void wsrep_sst_continue();
 /*! Cancel the SST script if it is running */
-extern void wsrep_sst_cancel();
+extern void wsrep_sst_cancel(bool call_wsrep_cb);
 
 extern void wsrep_SE_init_grab();   /*! grab init critical section */
 extern void wsrep_SE_init_wait();   /*! wait for SE init to complete */

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -777,7 +777,15 @@ void process::terminate ()
 {
   if (pid_)
   {
+    /*
+      If we have an appropriated system call, then we try
+      to terminate entire process group:
+    */
+#if _XOPEN_SOURCE >= 500 || _DEFAULT_SOURCE || _BSD_SOURCE
+    if (killpg(pid_, SIGTERM))
+#else
     if (kill(pid_, SIGTERM))
+#endif
     {
       WSREP_WARN("Unable to terminate process: %s: %d (%s)",
                  str_, errno, strerror(errno));

--- a/wsrep/wsrep_api.h
+++ b/wsrep/wsrep_api.h
@@ -63,7 +63,7 @@ extern "C" {
  *                                                                        *
  **************************************************************************/
 
-#define WSREP_INTERFACE_VERSION "26"
+#define WSREP_INTERFACE_VERSION "25"
 
 /*! Empty backend spec */
 #define WSREP_NONE "none"
@@ -452,126 +452,6 @@ typedef enum wsrep_cb_status (*wsrep_sst_donate_cb_t) (
  */
 typedef void (*wsrep_synced_cb_t) (void* app_ctx);
 
-/*!
- * @brief different instruments that we want to monitor through PFS.
- */
-typedef enum wsrep_pfs_instr_type
-{
-    WSREP_PFS_INSTR_TYPE_UNKNOWN,
-    WSREP_PFS_INSTR_TYPE_MUTEX,
-    WSREP_PFS_INSTR_TYPE_CONDVAR,
-    WSREP_PFS_INSTR_TYPE_THREAD,
-    WSREP_PFS_INSTR_TYPE_FILE
-} wsrep_pfs_instr_type_t;
-
-/*!
- * @brief type of operation on instruments to monitor.
- */
-typedef enum wsrep_pfs_instr_ops
-{
-    WSREP_PFS_INSTR_OPS_UNKNOWN,
-    WSREP_PFS_INSTR_OPS_INIT,
-    WSREP_PFS_INSTR_OPS_DESTROY,
-    WSREP_PFS_INSTR_OPS_LOCK,
-    WSREP_PFS_INSTR_OPS_UNLOCK,
-    WSREP_PFS_INSTR_OPS_WAIT,
-    WSREP_PFS_INSTR_OPS_TIMEDWAIT,
-    WSREP_PFS_INSTR_OPS_SIGNAL,
-    WSREP_PFS_INSTR_OPS_BROADCAST,
-    WSREP_PFS_INSTR_OPS_CREATE,
-    WSREP_PFS_INSTR_OPS_OPEN,
-    WSREP_PFS_INSTR_OPS_CLOSE,
-    WSREP_PFS_INSTR_OPS_DELETE
-} wsrep_pfs_instr_ops_t;
-
-/*!
- * @brief name/tag of different instruments.
- */
-typedef enum wsrep_pfs_instr_tag
-{
-    /* Mutex tag */
-    WSREP_PFS_INSTR_TAG_CERT_MUTEX = 0,
-    WSREP_PFS_INSTR_TAG_STATS_MUTEX,
-    WSREP_PFS_INSTR_TAG_DUMMY_GCS_MUTEX,
-    WSREP_PFS_INSTR_TAG_SERVICE_THD_MUTEX,
-    WSREP_PFS_INSTR_TAG_IST_RECEIVER_MUTEX,
-    WSREP_PFS_INSTR_TAG_LOCAL_MONITOR_MUTEX,
-    WSREP_PFS_INSTR_TAG_APPLY_MONITOR_MUTEX,
-    WSREP_PFS_INSTR_TAG_COMMIT_MONITOR_MUTEX,
-    WSREP_PFS_INSTR_TAG_ASYNC_SENDER_MONITOR_MUTEX,
-    WSREP_PFS_INSTR_TAG_IST_RECEIVER_MONITOR_MUTEX,
-    WSREP_PFS_INSTR_TAG_SST_MUTEX,
-    WSREP_PFS_INSTR_TAG_INCOMING_MUTEX,
-    WSREP_PFS_INSTR_TAG_SAVED_STATE_MUTEX,
-    WSREP_PFS_INSTR_TAG_TRX_HANDLE_MUTEX,
-    WSREP_PFS_INSTR_TAG_WSDB_TRX_MUTEX,
-    WSREP_PFS_INSTR_TAG_WSDB_CONN_MUTEX,
-    WSREP_PFS_INSTR_TAG_PROFILE_MUTEX,
-    WSREP_PFS_INSTR_TAG_GCACHE_MUTEX,
-    WSREP_PFS_INSTR_TAG_PROTSTACK_MUTEX,
-    WSREP_PFS_INSTR_TAG_PRODCONS_MUTEX,
-    WSREP_PFS_INSTR_TAG_GCOMMCONN_MUTEX,
-    WSREP_PFS_INSTR_TAG_RECVBUF_MUTEX,
-    WSREP_PFS_INSTR_TAG_MEMPOOL_MUTEX,
-
-    /* CondVar tag */
-    WSREP_PFS_INSTR_TAG_DUMMY_GCS_CONDVAR,
-    WSREP_PFS_INSTR_TAG_SERVICE_THD_CONDVAR,
-    WSREP_PFS_INSTR_TAG_SERVICE_THD_FLUSH_CONDVAR,
-    WSREP_PFS_INSTR_TAG_IST_RECEIVER_CONDVAR,
-    WSREP_PFS_INSTR_TAG_IST_CONSUMER_CONDVAR,
-    WSREP_PFS_INSTR_TAG_LOCAL_MONITOR_CONDVAR,
-    WSREP_PFS_INSTR_TAG_APPLY_MONITOR_CONDVAR,
-    WSREP_PFS_INSTR_TAG_COMMIT_MONITOR_CONDVAR,
-    WSREP_PFS_INSTR_TAG_ASYNC_SENDER_MONITOR_CONDVAR,
-    WSREP_PFS_INSTR_TAG_IST_RECEIVER_MONITOR_CONDVAR,
-    WSREP_PFS_INSTR_TAG_SST_CONDVAR,
-    WSREP_PFS_INSTR_TAG_PRODCONS_CONDVAR,
-    WSREP_PFS_INSTR_TAG_GCACHE_CONDVAR,
-    WSREP_PFS_INSTR_TAG_RECVBUF_CONDVAR,
-
-    /* Thread tag */
-    WSREP_PFS_INSTR_TAG_SERVICE_THD_THREAD,
-    WSREP_PFS_INSTR_TAG_IST_RECEIVER_THREAD,
-    WSREP_PFS_INSTR_TAG_IST_ASYNC_SENDER_THREAD,
-    WSREP_PFS_INSTR_TAG_WRITESET_CHECKSUM_THREAD,
-    WSREP_PFS_INSTR_TAG_GCACHE_REMOVEFILE_THREAD,
-    WSREP_PFS_INSTR_TAG_RECEIVER_THREAD,
-    WSREP_PFS_INSTR_TAG_GCOMMCONN_THREAD,
-
-    /* File tag */
-    WSREP_PFS_INSTR_TAG_RECORDSET_FILE,
-    WSREP_PFS_INSTR_TAG_RINGBUFFER_FILE,
-    WSREP_PFS_INSTR_TAG_GCACHE_PAGE_FILE,
-    WSREP_PFS_INSTR_TAG_GRASTATE_FILE,
-    WSREP_PFS_INSTR_TAG_GVWSTATE_FILE
-
-} wsrep_pfs_instr_tag_t;
-
-/*!
- * @brief a callback to create PFS instrumented mutex/condition variables
- * threads/file-instances
- *
- *
- * @param type          mutex/condition variable/thread/file-instance
- * @param ops           add/init or remove/destory mutex/condition variable
- * @param tag           tag/name of instrument to monitor
- * @param value         created mutex/condition variable/file-descriptor.
- * @param alliedvalue   allied value for supporting operation.
-                        for example: while waiting for cond-var corresponding
-                        mutex is passes through this variable.
- * @param ts            if cond-var then time to wait
-                        if file then name of the file.
- */
-typedef void (*wsrep_pfs_instr_cb_t) (
-    wsrep_pfs_instr_type_t        type,
-    wsrep_pfs_instr_ops_t         ops,
-    wsrep_pfs_instr_tag_t         tag,
-    void**                        value,
-    void**                        alliedvalue,
-    const void*                   ts);
-
-typedef wsrep_pfs_instr_cb_t gu_pfs_instr_cb_t;
 
 /*!
  * @brief a callback to signal application that wsrep provider was
@@ -621,11 +501,6 @@ struct wsrep_init_args
     /* Abnormal termination callback: */
     wsrep_abort_cb_t      abort_cb;        //!< wsrep provider terminated
                                            //!< abnormally
-
-   /* Instrument mutex/condition variables through MySQL Performance
-   Schema infrastructure. Callback help in creating these mutexes in MySQL
-   space with needed infrastructure to register them. */
-   wsrep_pfs_instr_cb_t   pfs_instr_cb;    //!< register for pfs instrumentation
 };
 
 


### PR DESCRIPTION
  (patch from Julius)

  PART I: PXC#426: Race condition during IST

---

  The node lost connectivity with other nodes in the cluster for some time due
  to network problems. After this, it need to run IST to synchronize the state
  with the cluster. However, the IST request still fails.

  (Probable cause: donor has made progress and no more holds a needed
   seqno needed for IST to complete successfully)

  Galera has concept of safety_gap to handle this problem (though not 100%
  fool-proof) and if the check fails then it suggest switching to SST.
  If server is configured to use rsync or XB method online SST during
  node operation is not possible.

  It is important that if server is forced to switch to SST
  and SST is not possible then node indicate so and shutdown properly.
  (State of node should be restored too).

  PART II: PXC#252: SST operation failure should ensure cleanup

---

  If the SST fails for the reason mentioned above the node should successully
  clean the resources before shutdown.

  PART III: Changes in the wsrep API (continuation of the #PXC-252):

---

  In addition, I found that the failure during the SST, which is diagnosed on
  the Galera level, leads to the completion of the server using abort() call,
  but in this case the child processes that have been launched for the SST
  continues to run after completion of the server.

  This makes it impossible to re-start the server before all timeouts expired
  (in these SST-related processes). Otherwise we failed due to the busy sockets
  or it leads to other fatal errors due to interference between new and old
  instances of the SST scripts.

  In this patch, I added new checks to safely shutdown the server, for correct
  processing of a failed attempts to make a new connection and the SST, and for
  the destruction of all child processes when the server terminated abnormally
  by initiative of the Galera.

  To do this, I needed to add a new callback to wsrep API, because the Galera
  intercepts the SIGABRT signal. Therefore we cannot intercept abnormal
  termination of the server process (after it calls abort() function from the
  Galera side) without expanding the Galera API by adding to it new callback.
