### PR TITLE
- PXC#252/PXC#426: Race condition in IST

### DIFF
--- a/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
+++ b/mysql-test/suite/galera/r/galera_seqno_gone_forward.result
@@ -1,0 +1,18 @@
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+Shutting down server ...
+CREATE TABLE t2 (f1 INTEGER);
+INSERT INTO t2 VALUES (3);
+INSERT INTO t2 VALUES (2);
+INSERT INTO t2 VALUES (1);
+SET GLOBAL wsrep_provider_options = 'dbug=d,simulate_seqno_shift';
+Starting server ...
+# restart
+SELECT COUNT(*) = 10 FROM t1;
+COUNT(*) = 10
+1
+SELECT COUNT(*) = 384 FROM t2;
+COUNT(*) = 384
+1
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
+++ b/mysql-test/suite/galera/t/galera_seqno_gone_forward.test
@@ -1,0 +1,120 @@
+#
+# This test is artificially creating a situation where
+# the state of the donor node goes too far and diverged from
+# the state of another node, which joining the cluster, and
+# therefore the joining node unable to initiate the IST state
+# transfer.
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+--connection node_1
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer because the donor seqno had gone forward during IST'
+# error messages in the log file before and after testing. To do this
+# we need to save original log file before testing:
+#
+--let TEST_LOG=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   if (-e $test_log_copy) {
+      unlink $test_log_copy;
+   }
+EOF
+--copy_file $TEST_LOG $TEST_LOG.copy
+
+CREATE TABLE t1 (f1 INTEGER);
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+--connection node_2
+
+# Initiate normal shutdown on the node 2:
+
+--echo Shutting down server ...
+--source include/shutdown_mysqld.inc
+
+# Waiting until shutdown on node 2 has been completed:
+
+--connection node_1
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Do some changes on node 1:
+
+CREATE TABLE t2 (f1 INTEGER);
+
+# We need to do a minimum of 128 * <the number of nodes> changes,
+# to perform a good check of the safety_gap heuristic:
+
+--disable_query_log
+--let $count = 384
+while ($count)
+{
+   # Print the last three oparatola to a log file:
+   if ($count == 3) {
+      --enable_query_log
+   }
+   --eval INSERT INTO t2 VALUES ($count)
+   --dec $count
+}
+
+# Simulate shift of the donor seqno:
+
+--let $galera_sync_point = simulate_seqno_shift
+--source include/galera_set_sync_point.inc
+
+# Restarting the second node:
+
+--connection node_2
+
+--echo Starting server ...
+--source include/start_mysqld.inc
+
+--connection node_1
+
+# Waiting until start of node 2:
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Sanity check (node 2 is running now and can perform SQL operators):
+
+--connection node_2
+
+SELECT COUNT(*) = 10 FROM t1;
+SELECT COUNT(*) = 384 FROM t2;
+
+--connection node_1
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+#
+# We should count the number of 'Failed to prepare for incremental
+# state transfer because the donor seqno had gone forward during IST'
+# error messages in the log file during test phase - to print the
+# error message if quantity of such warnings in log file increased
+# at the end of the test:
+#
+--perl
+   use strict;
+   my $test_log=$ENV{'TEST_LOG'} or die "TEST_LOG not set";
+   my $test_log_copy=$test_log . '.copy';
+   open(FILE, $test_log_copy) or die("Unable to open $test_log_copy: $!\n");
+   my $initial=grep(/Failed to prepare for incremental state transfer because the donor seqno had gone forward during IST/gi,<FILE>);
+   close(FILE);
+   open(FILE, $test_log) or die("Unable to open $test_log: $!\n");
+   my $count_warnings=grep(/Failed to prepare for incremental state transfer because the donor seqno had gone forward during IST/gi,<FILE>);
+   close(FILE);
+   if ($count_warnings != $initial) {
+      my $diff=$count_warnings-$initial;
+      print "Failed to prepare for incremental state transfer $diff times.\n";
+   }
+EOF
+--remove_file $TEST_LOG.copy

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1511,7 +1511,7 @@ extern "C" void unireg_abort(int exit_code)
   if (wsrep)
   {
     /* Cancel the SST script if it is running: */
-    wsrep_sst_cancel();
+    wsrep_sst_cancel(true);
     /* This is an abort situation, we cannot expect to gracefully close all
      * wsrep threads here, we can only disconnect from service */
     wsrep_close_client_connections(false, true);

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -22,6 +22,10 @@
 #include "mysqld_thd_manager.h"          // Global_THD_manager
 #include "sql_class.h"
 
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif
+
 #ifdef _WIN32
 #include <crtdbg.h>
 #define SIGNAL_FMT "exception 0x%x"
@@ -62,6 +66,14 @@ extern "C" void handle_fatal_signal(int sig)
   }
 
   segfaulted = 1;
+
+/*
+  The wsrep subsystem has their its own actions
+  which need be performed before exiting:
+*/
+#ifdef WITH_WSREP
+  wsrep_handle_fatal_signal(sig);
+#endif
 
 #ifdef _WIN32
   SYSTEMTIME utc_time;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1110,6 +1110,7 @@ int wsrep_init()
   wsrep_args.unordered_cb    = wsrep_unordered_cb;
   wsrep_args.sst_donate_cb   = wsrep_sst_donate_cb;
   wsrep_args.synced_cb       = wsrep_synced_cb;
+  wsrep_args.abort_cb        = wsrep_abort_cb;
   wsrep_args.pfs_instr_cb    = NULL;
 #ifdef HAVE_PSI_INTERFACE
   wsrep_args.pfs_instr_cb    = wsrep_pfs_instr_cb;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -190,6 +190,7 @@ extern "C" void wsrep_thd_set_wsrep_last_query_id(THD *thd, query_id_t id);
 extern "C" void wsrep_thd_awake(THD *thd, my_bool signal);
 extern "C" int wsrep_thd_retry_counter(THD *thd);
 
+extern "C" void wsrep_handle_fatal_signal(int sig);
 
 extern void wsrep_close_client_connections(bool wait_to_end, bool server_shutdown);
 extern int  wsrep_wait_committing_connections_close(int wait_time);

--- a/sql/wsrep_priv.h
+++ b/sql/wsrep_priv.h
@@ -35,6 +35,7 @@ wsrep_cb_status wsrep_sst_donate_cb (void* app_ctx,
                                      const wsrep_gtid_t* state_id,
                                      const char* state, size_t state_len,
                                      bool bypass);
+void wsrep_abort_cb (void);
 
 extern wsrep_uuid_t  local_uuid;
 extern wsrep_seqno_t local_seqno;

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -438,18 +438,29 @@ static wsp::process * sst_process= static_cast<wsp::process*>(NULL);
 
 static bool sst_cancelled= false;
 
-void wsrep_sst_cancel ()
+void wsrep_sst_cancel (bool call_wsrep_cb)
 {
   if (mysql_mutex_lock (&LOCK_wsrep_sst)) abort();
   if (!sst_cancelled)
   {
     sst_cancelled=true;
+    /*
+      When we launched the SST process, then we need
+      to terminate it before exit from the parent (server)
+      process:
+    */
     if (sst_process)
     {
       sst_process->terminate();
       sst_process = NULL;
     }
-    if (sst_awaiting_callback)
+    /*
+      If this is a normal shutdown, then we need to notify
+      the wsrep provider about completion of the SST, to
+      prevent infinite waitng in the wsrep provider after
+      the SST process was canceled:
+    */
+    if (call_wsrep_cb && sst_awaiting_callback)
     {
       WSREP_INFO("Signalling cancellation of the SST request.");
       wsrep_gtid_t const state_id = {
@@ -461,6 +472,23 @@ void wsrep_sst_cancel ()
     }
   }
   mysql_mutex_unlock (&LOCK_wsrep_sst);
+}
+
+/*
+  Handling of fatal signals: SIGABRT, SIGTERM, etc.
+*/
+extern "C" void wsrep_handle_fatal_signal (int sig)
+{
+  wsrep_sst_cancel(false);
+}
+
+/*
+  This callback is invoked in the case of abnormal
+  termination of the wsrep provider:
+*/
+void wsrep_abort_cb (void)
+{
+  wsrep_sst_cancel(false);
 }
 
 static void* sst_joiner_thread (void* a)

--- a/sql/wsrep_sst.h
+++ b/sql/wsrep_sst.h
@@ -40,7 +40,7 @@ extern bool wsrep_sst_wait();
 /*! Signals wsrep that initialization is complete, writesets can be applied */
 extern void wsrep_sst_continue();
 /*! Cancel the SST script if it is running */
-extern void wsrep_sst_cancel();
+extern void wsrep_sst_cancel(bool call_wsrep_cb);
 
 extern void wsrep_SE_init_grab();   /*! grab init critical section */
 extern void wsrep_SE_init_wait();   /*! wait for SE init to complete */

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -779,7 +779,15 @@ void process::terminate ()
 {
   if (pid_)
   {
+    /*
+      If we have an appropriated system call, then we try
+      to terminate entire process group:
+    */
+#if _XOPEN_SOURCE >= 500 || _DEFAULT_SOURCE || _BSD_SOURCE
+    if (killpg(pid_, SIGTERM))
+#else
     if (kill(pid_, SIGTERM))
+#endif
     {
       WSREP_WARN("Unable to terminate process: %s: %d (%s)",
                  str_, errno, strerror(errno));

--- a/wsrep/wsrep_api.h
+++ b/wsrep/wsrep_api.h
@@ -574,6 +574,18 @@ typedef void (*wsrep_pfs_instr_cb_t) (
 typedef wsrep_pfs_instr_cb_t gu_pfs_instr_cb_t;
 
 /*!
+ * @brief a callback to signal application that wsrep provider was
+ * terminated abnormally. In this case, the application can perform
+ * the critical steps to clean its state, for example, it can terminate
+ * the child processes associated with the SST.
+ *
+ * This callback is called after wsrep library was terminated
+ * abnormally using abort() call.
+ */
+typedef void (*wsrep_abort_cb_t) (void);
+
+
+/*!
  * Initialization parameters for wsrep provider.
  */
 struct wsrep_init_args
@@ -605,6 +617,10 @@ struct wsrep_init_args
     /* State Snapshot Transfer callbacks */
     wsrep_sst_donate_cb_t sst_donate_cb;   //!< starting to donate
     wsrep_synced_cb_t     synced_cb;       //!< synced with group
+
+    /* Abnormal termination callback: */
+    wsrep_abort_cb_t      abort_cb;        //!< wsrep provider terminated
+                                           //!< abnormally
 
    /* Instrument mutex/condition variables through MySQL Performance
    Schema infrastructure. Callback help in creating these mutexes in MySQL


### PR DESCRIPTION
  (patch from Julius)

  PART I: PXC#426: Race condition during IST

---

  The node lost connectivity with other nodes in the cluster for some time due
  to network problems. After this, it need to run IST to synchronize the state
  with the cluster. However, the IST request still fails.

  (Probable cause: donor has made progress and no more holds a needed
   seqno needed for IST to complete successfully)

  Galera has concept of safety_gap to handle this problem (though not 100%
  fool-proof) and if the check fails then it suggest switching to SST.
  If server is configured to use rsync or XB method online SST during
  node operation is not possible.

  It is important that if server is forced to switch to SST
  and SST is not possible then node indicate so and shutdown properly.
  (State of node should be restored too).

  PART II: PXC#252: SST operation failure should ensure cleanup

---

  If the SST fails for the reason mentioned above the node should successully
  clean the resources before shutdown.

  PART III: Changes in the wsrep API (continuation of the #PXC-252):

---

  In addition, I found that the failure during the SST, which is diagnosed on
  the Galera level, leads to the completion of the server using abort() call,
  but in this case the child processes that have been launched for the SST
  continues to run after completion of the server.

  This makes it impossible to re-start the server before all timeouts expired
  (in these SST-related processes). Otherwise we failed due to the busy sockets
  or it leads to other fatal errors due to interference between new and old
  instances of the SST scripts.

  In this patch, I added new checks to safely shutdown the server, for correct
  processing of a failed attempts to make a new connection and the SST, and for
  the destruction of all child processes when the server terminated abnormally
  by initiative of the Galera.

  To do this, I needed to add a new callback to wsrep API, because the Galera
  intercepts the SIGABRT signal. Therefore we cannot intercept abnormal
  termination of the server process (after it calls abort() function from the
  Galera side) without expanding the Galera API by adding to it new callback.

Conflicts:
    sql/signal_handler.cc
    sql/wsrep_mysqld.cc
    wsrep/wsrep_api.h
