### PR TITLE
- PXC#720: wsrep_max_ws_rows check should skip non-replicated write-sets

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_max_ws_rows.result
+++ b/mysql-test/suite/galera/r/galera_var_max_ws_rows.result
@@ -113,3 +113,45 @@ INSERT INTO t1 (f2) VALUES (2);
 ERROR HY000: wsrep_max_ws_rows exceeded
 DROP TABLE t1;
 DROP TABLE ten;
+use test;
+create table t (i int, j int, primary key pk(i)) engine=innodb;
+insert into t values (1, 1);
+insert into t values (2, 1);
+insert into t values (3, 2);
+insert into t values (4, 2);
+insert into t values (5, 3);
+insert into t values (6, 3);
+select * from t;
+i	j
+1	1
+2	1
+3	2
+4	2
+5	3
+6	3
+select j from t group by j;
+j
+1
+2
+3
+set global wsrep_max_ws_rows=2;
+select j from t group by j;
+j
+1
+2
+3
+drop table t;
+use test;
+create temporary table t (i int, primary key pk(i)) engine=innodb;
+select @@wsrep_max_ws_rows;
+@@wsrep_max_ws_rows
+2
+insert into t values (1), (2), (3), (4), (5);
+select * from t;
+i
+1
+2
+3
+4
+5
+drop table t;

--- a/mysql-test/suite/galera/t/galera_var_max_ws_rows.test
+++ b/mysql-test/suite/galera/t/galera_var_max_ws_rows.test
@@ -1,3 +1,5 @@
+#
+#
 --source include/galera_cluster.inc
 
 CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
@@ -152,3 +154,35 @@ INSERT INTO t1 (f2) VALUES (2);
 
 DROP TABLE t1;
 DROP TABLE ten;
+
+
+#
+# Test effect of wsrep_max_ws_rows on temporary table
+# (external or explictly created or internal)
+#
+--let $wsrep_max_ws_rows_orig = `SELECT @@wsrep_max_ws_rows`
+#
+use test;
+create table t (i int, j int, primary key pk(i)) engine=innodb;
+insert into t values (1, 1);
+insert into t values (2, 1);
+insert into t values (3, 2);
+insert into t values (4, 2);
+insert into t values (5, 3);
+insert into t values (6, 3);
+select * from t;
+select j from t group by j;
+set global wsrep_max_ws_rows=2;
+select j from t group by j;
+drop table t;
+#
+use test;
+create temporary table t (i int, primary key pk(i)) engine=innodb;
+select @@wsrep_max_ws_rows;
+insert into t values (1), (2), (3), (4), (5);
+select * from t;
+drop table t;
+
+--disable_query_log
+--eval SET GLOBAL wsrep_max_ws_rows = $wsrep_max_ws_rows_orig
+--enable_query_log

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8338,14 +8338,17 @@ int handler::ha_write_row(uchar *buf)
   if (unlikely((error= binlog_log_row(table, 0, buf, log_func))))
     DBUG_RETURN(error); /* purecov: inspected */
 #ifdef WITH_WSREP
-  current_thd->wsrep_affected_rows++;
-  if (wsrep_max_ws_rows &&
-      current_thd->wsrep_exec_mode != REPL_RECV &&
-      current_thd->wsrep_affected_rows > wsrep_max_ws_rows)
+  if (table->s->tmp_table == NO_TMP_TABLE)
   {
-    trans_rollback_stmt(current_thd) || trans_rollback(current_thd);
-    my_message(ER_ERROR_DURING_COMMIT, "wsrep_max_ws_rows exceeded", MYF(0));
-    DBUG_RETURN(ER_ERROR_DURING_COMMIT);
+    current_thd->wsrep_affected_rows++;
+    if (wsrep_max_ws_rows &&
+        current_thd->wsrep_exec_mode != REPL_RECV &&
+        current_thd->wsrep_affected_rows > wsrep_max_ws_rows)
+    {
+      trans_rollback_stmt(current_thd) || trans_rollback(current_thd);
+      my_message(ER_ERROR_DURING_COMMIT, "wsrep_max_ws_rows exceeded", MYF(0));
+      DBUG_RETURN(ER_ERROR_DURING_COMMIT);
+    }
   }
 #endif /* WITH_WSREP */
 
@@ -8389,14 +8392,17 @@ int handler::ha_update_row(const uchar *old_data, uchar *new_data)
   if (unlikely((error= binlog_log_row(table, old_data, new_data, log_func))))
     DBUG_RETURN(error);
 #ifdef WITH_WSREP
-  current_thd->wsrep_affected_rows++;
-  if (wsrep_max_ws_rows &&
-      current_thd->wsrep_exec_mode != REPL_RECV &&
-      current_thd->wsrep_affected_rows > wsrep_max_ws_rows)
+  if (table->s->tmp_table == NO_TMP_TABLE)
   {
-    trans_rollback_stmt(current_thd) || trans_rollback(current_thd);
-    my_message(ER_ERROR_DURING_COMMIT, "wsrep_max_ws_rows exceeded", MYF(0));
-    DBUG_RETURN(ER_ERROR_DURING_COMMIT);
+    current_thd->wsrep_affected_rows++;
+    if (wsrep_max_ws_rows &&
+        current_thd->wsrep_exec_mode != REPL_RECV &&
+        current_thd->wsrep_affected_rows > wsrep_max_ws_rows)
+    {
+      trans_rollback_stmt(current_thd) || trans_rollback(current_thd);
+      my_message(ER_ERROR_DURING_COMMIT, "wsrep_max_ws_rows exceeded", MYF(0));
+      DBUG_RETURN(ER_ERROR_DURING_COMMIT);
+    }
   }
 #endif /* WITH_WSREP */
   DBUG_RETURN(0);
@@ -8433,14 +8439,17 @@ int handler::ha_delete_row(const uchar *buf)
   if (unlikely((error= binlog_log_row(table, buf, 0, log_func))))
     return error;
 #ifdef WITH_WSREP
-  current_thd->wsrep_affected_rows++;
-  if (wsrep_max_ws_rows &&
-      current_thd->wsrep_exec_mode != REPL_RECV &&
-      current_thd->wsrep_affected_rows > wsrep_max_ws_rows)
+  if (table->s->tmp_table == NO_TMP_TABLE)
   {
-    trans_rollback_stmt(current_thd) || trans_rollback(current_thd);
-    my_message(ER_ERROR_DURING_COMMIT, "wsrep_max_ws_rows exceeded", MYF(0));
-    return ER_ERROR_DURING_COMMIT;
+    current_thd->wsrep_affected_rows++;
+    if (wsrep_max_ws_rows &&
+        current_thd->wsrep_exec_mode != REPL_RECV &&
+        current_thd->wsrep_affected_rows > wsrep_max_ws_rows)
+    {
+      trans_rollback_stmt(current_thd) || trans_rollback(current_thd);
+      my_message(ER_ERROR_DURING_COMMIT, "wsrep_max_ws_rows exceeded", MYF(0));
+      return ER_ERROR_DURING_COMMIT;
+    }
   }
 #endif /* WITH_WSREP */
   return 0;


### PR DESCRIPTION
  * wsrep_max_ws_rows should skip non-replicated write-sets.
    non-replicated write-sets are generated by DML action on temporary
    table (explict or implicit).

Conflicts:
	sql/handler.cc