### PR TITLE
- PXC#710: ProxySQL assisted PXC maintenance mode.

### DIFF
--- a/mysql-test/include/default_mysqld.cnf
+++ b/mysql-test/include/default_mysqld.cnf
@@ -32,6 +32,7 @@ log-bin=mysqld-bin
 # It is maintainance challange to keep on modifying n different
 # galera.cnf file for this setting
 pxc_strict_mode=DISABLED
+pxc_maint_transition_period=0
 
 # MAINTAINER:
 # the loose- syntax is to make sure the cnf file is also

--- a/mysql-test/suite/galera/r/pxc_maint_mode.result
+++ b/mysql-test/suite/galera/r/pxc_maint_mode.result
@@ -1,0 +1,48 @@
+#node-1
+select @@pxc_maint_mode;
+@@pxc_maint_mode
+DISABLED
+set global pxc_maint_mode = 'DISABLED';
+set session pxc_maint_mode = 'DISALBED';
+ERROR HY000: Variable 'pxc_maint_mode' is a GLOBAL variable and should be set with SET GLOBAL
+set global pxc_maint_mode = 'MAINTENANCE';
+select @@pxc_maint_mode;
+@@pxc_maint_mode
+MAINTENANCE
+set global pxc_maint_mode = 'DISABLED';
+select @@pxc_maint_mode;
+@@pxc_maint_mode
+DISABLED
+set global pxc_maint_mode = 'SHUTDOWN';
+ERROR HY000: Can't change pxc_maint_mode from DISABLED to SHUTDOWN
+select @@pxc_maint_transition_period;
+@@pxc_maint_transition_period
+0
+set global pxc_maint_transition_period=180;
+select @@pxc_maint_transition_period;
+@@pxc_maint_transition_period
+180
+set global pxc_maint_transition_period=3600;
+select @@pxc_maint_transition_period;
+@@pxc_maint_transition_period
+3600
+set global pxc_maint_transition_period=9999;
+Warnings:
+Warning	1292	Truncated incorrect pxc_maint_transition_period value: '9999'
+select @@pxc_maint_transition_period;
+@@pxc_maint_transition_period
+3600
+set global pxc_maint_transition_period=-1;
+Warnings:
+Warning	1292	Truncated incorrect pxc_maint_transition_period value: '-1'
+select @@pxc_maint_transition_period;
+@@pxc_maint_transition_period
+0
+set global pxc_maint_transition_period=default;
+select @@pxc_maint_transition_period;
+@@pxc_maint_transition_period
+30
+set global pxc_maint_transition_period=0;
+select @@pxc_maint_transition_period;
+@@pxc_maint_transition_period
+0

--- a/mysql-test/suite/galera/t/pxc_maint_mode.test
+++ b/mysql-test/suite/galera/t/pxc_maint_mode.test
@@ -1,0 +1,44 @@
+
+#
+# Test different options with different variation of pxc-strict-mode.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+
+#-------------------------------------------------------------------------------
+#
+--connection node_1
+--echo #node-1
+select @@pxc_maint_mode;
+set global pxc_maint_mode = 'DISABLED';
+--error ER_GLOBAL_VARIABLE
+set session pxc_maint_mode = 'DISALBED';
+#
+# setting to and from maintenance is allowed.
+set global pxc_maint_mode = 'MAINTENANCE';
+select @@pxc_maint_mode;
+set global pxc_maint_mode = 'DISABLED';
+select @@pxc_maint_mode;
+#
+# setting to shutdown is blocked
+--error ER_UNKNOWN_ERROR
+set global pxc_maint_mode = 'SHUTDOWN';
+
+
+#
+#
+select @@pxc_maint_transition_period;
+set global pxc_maint_transition_period=180;
+select @@pxc_maint_transition_period;
+set global pxc_maint_transition_period=3600;
+select @@pxc_maint_transition_period;
+set global pxc_maint_transition_period=9999;
+select @@pxc_maint_transition_period;
+set global pxc_maint_transition_period=-1;
+select @@pxc_maint_transition_period;
+set global pxc_maint_transition_period=default;
+select @@pxc_maint_transition_period;
+set global pxc_maint_transition_period=0;
+select @@pxc_maint_transition_period;

--- a/mysql-test/suite/sys_vars/r/all_vars.result
+++ b/mysql-test/suite/sys_vars/r/all_vars.result
@@ -1,8 +1,12 @@
 create table t1 (test_name text);
 create table t2 (variable_name text);
 load data infile "MYSQLTEST_VARDIR/tmp/sys_vars.all_vars.txt" into table t1;
-insert into t2 select variable_name from information_schema.global_variables where variable_name not like 'innodb_disallow_writes';
-insert into t2 select variable_name from information_schema.session_variables where variable_name not like 'innodb_disallow_writes';
+insert into t2 select variable_name from information_schema.global_variables
+where variable_name not like 'innodb_disallow_writes'
+  and   variable_name not like '%pxc_%';
+insert into t2 select variable_name from information_schema.session_variables
+where variable_name not like 'innodb_disallow_writes'
+  and   variable_name not like '%pxc_%';
 update t2 set variable_name= replace(variable_name, "PERFORMANCE_SCHEMA_", "PFS_");
 update t2 set variable_name= replace(variable_name, "_HISTORY_LONG_", "_HL_");
 update t2 set variable_name= replace(variable_name, "_HISTORY_", "_H_");

--- a/mysql-test/suite/sys_vars/t/all_vars.test
+++ b/mysql-test/suite/sys_vars/t/all_vars.test
@@ -50,8 +50,12 @@ create table t2 (variable_name text);
 eval load data infile "$MYSQLTEST_VARDIR/tmp/sys_vars.all_vars.txt" into table t1;
 
 --disable_warnings
-insert into t2 select variable_name from information_schema.global_variables where variable_name not like 'innodb_disallow_writes';
-insert into t2 select variable_name from information_schema.session_variables where variable_name not like 'innodb_disallow_writes';
+insert into t2 select variable_name from information_schema.global_variables
+  where variable_name not like 'innodb_disallow_writes'
+  and   variable_name not like '%pxc_%';
+insert into t2 select variable_name from information_schema.session_variables
+  where variable_name not like 'innodb_disallow_writes'
+  and   variable_name not like '%pxc_%';
 --enable_warnings
 
 # Performance schema variables are too long for files named

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2712,6 +2712,18 @@ extern "C" void *signal_hand(void *arg MY_ATTRIBUTE((unused)))
     switch (sig) {
     case SIGTERM:
     case SIGQUIT:
+
+#ifdef WITH_WSREP
+      if (WSREP_ON)
+      {
+        pxc_maint_mode= PXC_MAINT_MODE_SHUTDOWN;
+        sql_print_information("Recieved shutdown signal. Will sleep for %lu secs"
+                              " before initiating shutdown. pxc_maint_mode switched"
+                              " to SHUTDOWN", pxc_maint_transition_period);
+        sleep(pxc_maint_transition_period);
+      }
+#endif /* WITH_WSREP */
+
       // Switch to the file log message processing.
       query_logger.set_handlers((log_output_options != LOG_NONE) ?
                                 LOG_FILE : LOG_NONE);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6218,6 +6218,19 @@ static Sys_var_enum Sys_pxc_strict_mode (
        NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(pxc_strict_mode_check),
        ON_UPDATE(0));
 
+static const char *pxc_maint_modes[]= { "DISABLED", "SHUTDOWN", "MAINTENANCE", NullS };
+static Sys_var_enum Sys_pxc_maint_mode (
+       "pxc_maint_mode", "ProxySQL assisted PXC maintenance mode",
+       GLOBAL_VAR(pxc_maint_mode), CMD_LINE(OPT_ARG),
+       pxc_maint_modes, DEFAULT(PXC_MAINT_MODE_DISABLED),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(pxc_maint_mode_check),
+       ON_UPDATE(0));
+
+static Sys_var_ulong Sys_pxc_maint_transition_period (
+       "pxc_maint_transition_period", "Period before the shutdown signal is delivered",
+       GLOBAL_VAR(pxc_maint_transition_period), CMD_LINE(REQUIRED_ARG),
+       VALID_RANGE(0, 3600), DEFAULT(30), BLOCK_SIZE(1));
+
 #endif /* WITH_WSREP */
 
 static bool fix_host_cache_size(sys_var *, THD *, enum_var_type)

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -84,6 +84,12 @@ my_bool wsrep_slave_FK_checks          = 0; // slave thread does FK checks
 /* pxc-strict-mode help control behavior of experimental features like
 myisam table replication, etc... */
 ulong   pxc_strict_mode                = PXC_STRICT_MODE_ENFORCING;
+
+/* pxc-maint-mode help put node in maintenance mode so that proxysql
+can stop diverting queries to this node. */
+ulong   pxc_maint_mode                = PXC_MAINT_MODE_DISABLED;
+/* sleep for this period before delivering shutdown signal. */
+ulong   pxc_maint_transition_period   = 30;
 /*
  * End configuration options
  */

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -131,6 +131,15 @@ enum enum_pxc_strict_modes {
 };
 extern ulong       pxc_strict_mode;
 
+enum enum_pxc_maint_modes {
+    PXC_MAINT_MODE_DISABLED = 0,
+    PXC_MAINT_MODE_SHUTDOWN,
+    PXC_MAINT_MODE_MAINTENANCE,
+};
+extern ulong       pxc_maint_mode;
+extern ulong       pxc_maint_transition_period;
+
+
 // MySQL status variables
 extern my_bool     wsrep_connected;
 extern my_bool     wsrep_ready;

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -94,4 +94,6 @@ extern bool wsrep_replicate_myisam_check     CHECK_ARGS;
 
 extern bool pxc_strict_mode_check            CHECK_ARGS;
 
+extern bool pxc_maint_mode_check            CHECK_ARGS;
+
 #endif /* WSREP_VAR_H */


### PR DESCRIPTION
  Often PXC nodes needs to be taken down for maintenance
  and this generally involve co-ordination with load balance
  and the real node.

  To simply this flow we now introduce a proxysql assisted
  pxc maintenance mode. User will shutdown or set the maintenance
  mode on real node as usual without caring if load balancer
  has active traffic diverted to this node.
  Load Balance (currently only ProxySQL) will be tuned to
  understand this change and divert the traffic to other nodes.

  This of-course means node action will be delayed so that
  active transaction are given time to complete.
  (long running transaction will be killed as before
   but user can still increase this transition time by setting
   pxc_maint_transition_period)