### PR TITLE
- PXC#729: Switching to maintenance mode doesn't for x secs.

### DIFF
--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6224,7 +6224,7 @@ static Sys_var_enum Sys_pxc_maint_mode (
        GLOBAL_VAR(pxc_maint_mode), CMD_LINE(OPT_ARG),
        pxc_maint_modes, DEFAULT(PXC_MAINT_MODE_DISABLED),
        NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(pxc_maint_mode_check),
-       ON_UPDATE(0));
+       ON_UPDATE(pxc_maint_mode_update));
 
 static Sys_var_ulong Sys_pxc_maint_transition_period (
        "pxc_maint_transition_period", "Period before the shutdown signal is delivered",

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -992,3 +992,15 @@ bool pxc_maint_mode_check(sys_var *self, THD* thd, set_var* var)
 
   return false;
 }
+
+bool pxc_maint_mode_update(sys_var *self, THD* thd, enum_var_type type)
+{
+   if (pxc_maint_mode == PXC_MAINT_MODE_MAINTENANCE)
+   {
+     WSREP_INFO ("Sleep for %lu secs while switching to maintenance mode",
+                  pxc_maint_transition_period);
+     sleep(pxc_maint_transition_period);
+   }
+
+   return false;
+}

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -95,5 +95,6 @@ extern bool wsrep_replicate_myisam_check     CHECK_ARGS;
 extern bool pxc_strict_mode_check            CHECK_ARGS;
 
 extern bool pxc_maint_mode_check            CHECK_ARGS;
+extern bool pxc_maint_mode_update           UPDATE_ARGS;
 
 #endif /* WSREP_VAR_H */


### PR DESCRIPTION
  Snippet to introduce wait was missing.
  Added it back.