### PR TITLE
Fix PXC-722 : SST falls back to unencrypted mode if socat is not SSL …

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -255,8 +255,11 @@ get_transfer()
         joiner_extra=""
         if [[ $encrypt -eq 2 || $encrypt -eq 3 || $encrypt -eq 4 ]]; then
             if ! socat -V | grep -q WITH_OPENSSL; then
-                wsrep_log_info "NOTE: socat is not openssl enabled, falling back to plain transfer"
-                encrypt=-1
+                wsrep_log_error "******** FATAL ERROR ****************** "
+                wsrep_log_error "* socat is not openssl enabled.         "
+                wsrep_log_error "* Unable to encrypt SST communications. "
+                wsrep_log_error "*************************************** "
+                exit 2
             fi
 
             # Determine the socat version


### PR DESCRIPTION
…enabled, should just fail

Issue:
If socat is not OpenSSL enabled, then the code falls back to using socat as
unencrypted transport.  If the user requests encryption but we cannot provide
it, we should error out rather than use an unencrypted connection.

Solution:
If socat is not OpenSSL enabled, fail with a fatal error during an SST.