### PR TITLE
- PXC#731: make wsrep_cluster_name read-only

### DIFF
--- a/mysql-test/suite/sys_vars/r/wsrep_cluster_name_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_cluster_name_basic.result
@@ -12,48 +12,8 @@ my_wsrep_cluster
 SELECT @@session.wsrep_cluster_name;
 ERROR HY000: Variable 'wsrep_cluster_name' is a GLOBAL variable
 SET @@global.wsrep_cluster_name='my_galera_cluster';
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-my_galera_cluster
-
-# valid values
-SET @@global.wsrep_cluster_name='my_quoted_galera_cluster';
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-my_quoted_galera_cluster
-SET @@global.wsrep_cluster_name=my_unquoted_cluster;
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-my_unquoted_cluster
-SET @@global.wsrep_cluster_name=OFF;
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-OFF
-SET @@global.wsrep_cluster_name=default;
+ERROR HY000: Variable 'wsrep_cluster_name' is a read only variable
 SELECT @@global.wsrep_cluster_name;
 @@global.wsrep_cluster_name
 my_wsrep_cluster
-
-# invalid values
-SET @@global.wsrep_cluster_name=NULL;
-ERROR 42000: Variable 'wsrep_cluster_name' can't be set to the value of 'NULL'
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-my_wsrep_cluster
-set @@global.wsrep_cluster_name="1234567890123456789012345678901234567890";
-ERROR 42000: Variable 'wsrep_cluster_name' can't be set to the value of '1234567890123456789012345678901234567890'
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-my_wsrep_cluster
-set @@global.wsrep_cluster_name="12345678901234567890123456789012";
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-12345678901234567890123456789012
-SET @@global.wsrep_cluster_name=default;
-SELECT @@global.wsrep_cluster_name;
-@@global.wsrep_cluster_name
-my_wsrep_cluster
-
-# restore the initial value
-SET @@global.wsrep_cluster_name = @wsrep_cluster_name_global_saved;
 # End of test

--- a/mysql-test/suite/sys_vars/t/wsrep_cluster_name_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_cluster_name_basic.test
@@ -1,3 +1,4 @@
+#
 --source include/have_wsrep.inc
 
 --echo #
@@ -14,36 +15,8 @@ SELECT @@global.wsrep_cluster_name;
 --echo # scope
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SELECT @@session.wsrep_cluster_name;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SET @@global.wsrep_cluster_name='my_galera_cluster';
 SELECT @@global.wsrep_cluster_name;
-
---echo
---echo # valid values
-SET @@global.wsrep_cluster_name='my_quoted_galera_cluster';
-SELECT @@global.wsrep_cluster_name;
-SET @@global.wsrep_cluster_name=my_unquoted_cluster;
-SELECT @@global.wsrep_cluster_name;
-SET @@global.wsrep_cluster_name=OFF;
-SELECT @@global.wsrep_cluster_name;
-SET @@global.wsrep_cluster_name=default;
-SELECT @@global.wsrep_cluster_name;
-
---echo
---echo # invalid values
---error ER_WRONG_VALUE_FOR_VAR
-SET @@global.wsrep_cluster_name=NULL;
-# trying to set the cluster-name of size > 32 bytes.
-SELECT @@global.wsrep_cluster_name;
---error ER_WRONG_VALUE_FOR_VAR
-set @@global.wsrep_cluster_name="1234567890123456789012345678901234567890";
-SELECT @@global.wsrep_cluster_name;
-set @@global.wsrep_cluster_name="12345678901234567890123456789012";
-SELECT @@global.wsrep_cluster_name;
-SET @@global.wsrep_cluster_name=default;
-SELECT @@global.wsrep_cluster_name;
-
---echo
---echo # restore the initial value
-SET @@global.wsrep_cluster_name = @wsrep_cluster_name_global_saved;
 
 --echo # End of test

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4866,7 +4866,7 @@ static Sys_var_charptr Sys_wsrep_data_home_dir(
 
 static Sys_var_charptr Sys_wsrep_cluster_name(
        "wsrep_cluster_name", "Name for the cluster",
-       PREALLOCATED GLOBAL_VAR(wsrep_cluster_name), CMD_LINE(REQUIRED_ARG),
+       READ_ONLY GLOBAL_VAR(wsrep_cluster_name), CMD_LINE(REQUIRED_ARG),
        IN_FS_CHARSET, DEFAULT(WSREP_CLUSTER_NAME),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(wsrep_cluster_name_check),


### PR DESCRIPTION
  Changing wsrep_cluster_name at dynamically actually involves
  unload and loading of provider (that re-create node cluster connection).
  This is heavy operation that user never expect to be done for
  a cosemtic variable like wsrep_cluster_name.

  Most of the user never tend to change it and set it during configuration time.
  It just act as a indetifier to uniquely identify nodes of given cluster
  if you have multiple pxc cluster (besides being used for handshake during
  initial node joining sequence).

  With that background in place we have decided to make this variable read-only.