### PR TITLE
Fix PXC-716 : netcat help output in error log when running xtrabackup…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -271,7 +271,7 @@ get_transfer()
         fi
         wsrep_log_info "Using netcat as streamer"
         if [[ "$WSREP_SST_OPT_ROLE"  == "joiner" ]]; then
-            if nc -h | grep -q ncat; then
+            if nc -h 2>&1 | grep -q ncat; then
                 tcmd="nc -l ${TSST_PORT}"
             else
                 tcmd="nc -dl ${TSST_PORT}"


### PR DESCRIPTION
… SST

Issue:
Some versions of netcat write the info to stderr rather than just to stdout.

Solution:
Redirect stderr to stdout also (use '2>&1')