### PR TITLE
Fix PXC-735: SST with netcat ignores encrypt option

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -298,6 +298,15 @@ get_transfer()
             wsrep_log_error "nc(netcat) not found in path: $PATH"
             exit 2
         fi
+
+        if [[ $encrypt -eq 2 || $encrypt -eq 3 || $encrypt -eq 4 ]]; then
+            wsrep_log_error "******** FATAL ERROR *********************** "
+            wsrep_log_error "* Using SSL encryption (encrypt= 2, 3, or 4) "
+            wsrep_log_error "* is not supported when using nc(netcat).    "
+            wsrep_log_error "******************************************** "
+            exit 22
+        fi
+
         wsrep_log_info "Using netcat as streamer"
         if [[ "$WSREP_SST_OPT_ROLE"  == "joiner" ]]; then
             if nc -h 2>&1 | grep -q ncat; then


### PR DESCRIPTION
Issue:
If nc(netcat) is used as the transfer mechanism (with the 'transferfmt' option)
and SSL encryption is specifed (encrypt=2,3,4), the the encryption options are
ignored.

Solution:
If encryption is requested, then if we can't provide it, we will fail the
SST rather than silently defaulting to unencrypted transport.