### PR TITLE
Fix PXC-690: Display Flow control interval as a status variable

### DIFF
--- a/mysql-test/suite/galera/r/galera_defaults.result
+++ b/mysql-test/suite/galera/r/galera_defaults.result
@@ -45,12 +45,12 @@ WSREP_SST_DONOR
 WSREP_SST_DONOR_REJECTS_QUERIES	OFF
 WSREP_SST_METHOD	xtrabackup-v2
 WSREP_SYNC_WAIT	7
-<BASE_DIR>; <BASE_HOST>; <BASE_PORT>; cert.log_conflicts = no; debug = no; evs.auto_evict = 0; evs.causal_keepalive_period = PT1S; evs.debug_log_mask = 0x1; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.info_log_mask = 0; evs.install_timeout = PT7.5S; evs.join_retrans_period = PT1S; evs.keepalive_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT10S; evs.use_aggregate = true; evs.user_send_window = 2; evs.version = 0; evs.view_forget_timeout = P1D; <GCACHE_DIR>; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; <GCACHE_NAME>; gcache.page_size = 128M; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; <RECV_Q_HARD_LIMIT>;gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; <GMCAST_LISTEN_ADDR>; gmcast.mcast_addr = ; gmcast.mcast_ttl = 1; gmcast.peer_timeout = PT3S; gmcast.segment = 0; gmcast.time_wait = PT5S; gmcast.version = 0; <IST_RECV_ADDR>; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.linger = PT20S; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = P30S; pc.weight = 1; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT90S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 7; socket.checksum = 2; socket.recv_buf_size = 212992; 
+<BASE_DIR>; <BASE_HOST>; <BASE_PORT>; cert.log_conflicts = no; debug = no; evs.auto_evict = 0; evs.causal_keepalive_period = PT1S; evs.debug_log_mask = 0x1; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.info_log_mask = 0; evs.install_timeout = PT7.5S; evs.join_retrans_period = PT1S; evs.keepalive_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT10S; evs.use_aggregate = true; evs.user_send_window = 2; evs.version = 0; evs.view_forget_timeout = P1D; <GCACHE_DIR>; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; <GCACHE_NAME>; gcache.page_size = 128M; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; <RECV_Q_HARD_LIMIT>;gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; <GMCAST_LISTEN_ADDR>; gmcast.mcast_addr = ; gmcast.mcast_ttl = 1; gmcast.peer_timeout = PT3S; gmcast.segment = 0; gmcast.time_wait = PT5S; gmcast.version = 0; <IST_RECV_ADDR>; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.linger = PT20S; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = P30S; pc.weight = 1; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT90S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 7; socket.checksum = 2; socket.recv_buf_size = 212992; 
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_STATUS
 WHERE VARIABLE_NAME LIKE 'wsrep_%'
 AND VARIABLE_NAME != 'wsrep_debug_sync_waiters';
 COUNT(*)
-59
+60
 SELECT VARIABLE_NAME FROM INFORMATION_SCHEMA.GLOBAL_STATUS
 WHERE VARIABLE_NAME LIKE 'wsrep_%'
 AND VARIABLE_NAME != 'wsrep_debug_sync_waiters'
@@ -77,6 +77,7 @@ WSREP_EVS_DELAYED
 WSREP_EVS_EVICT_LIST
 WSREP_EVS_REPL_LATENCY
 WSREP_EVS_STATE
+WSREP_FLOW_CONTROL_INTERVAL
 WSREP_FLOW_CONTROL_PAUSED
 WSREP_FLOW_CONTROL_PAUSED_NS
 WSREP_FLOW_CONTROL_RECV

--- a/mysql-test/suite/galera/r/galera_gcs_fc_limit.result
+++ b/mysql-test/suite/galera/r/galera_gcs_fc_limit.result
@@ -3,6 +3,17 @@ INSERT INTO t1 VALUES (1);
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+Variable_name	Value
+wsrep_flow_control_interval	[ 23, 23 ]
+SET GLOBAL wsrep_provider_options = 'gcs.fc_limit=100';
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+Variable_name	Value
+wsrep_flow_control_interval	[ 141, 141 ]
+SET GLOBAL wsrep_provider_options = 'gcs.fc_factor=0.5';
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+Variable_name	Value
+wsrep_flow_control_interval	[ 71, 141 ]
 SET GLOBAL wsrep_provider_options = 'gcs.fc_limit=1';
 LOCK TABLE t1 WRITE;
 SET GLOBAL DEBUG = "d,thd_proc_info.wsrep_run_wsrep_commit";

--- a/mysql-test/suite/galera/t/galera_gcs_fc_limit.test
+++ b/mysql-test/suite/galera/t/galera_gcs_fc_limit.test
@@ -1,5 +1,6 @@
 #
 # Test that under gcs.fc_limit=1 on the slave, transactions on the master can not commit.
+# Also tests wsrep_flow_control_interval is set properly
 #
 
 --source include/galera_cluster.inc
@@ -14,6 +15,26 @@ SELECT COUNT(*) = 1 FROM t1;
 --sleep 1
 
 --let $wsrep_provider_options_orig = `SELECT @@wsrep_provider_options`
+
+#
+# Test that the wsrep_flow_control interval is set properly
+#
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+
+SET GLOBAL wsrep_provider_options = 'gcs.fc_limit=100';
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+
+SET GLOBAL wsrep_provider_options = 'gcs.fc_factor=0.5';
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+
+--disable_query_log
+--eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_orig';
+--enable_query_log
+
+
+#
+# Test that under gcs.fc_limit=1 on the slave, transactions on the master can not commit.
+#
 SET GLOBAL wsrep_provider_options = 'gcs.fc_limit=1';
 
 # Block the slave applier thread


### PR DESCRIPTION
Issue:
The values for the flow control interval can only be seen in the
logs when the values are changed.

Solution:
Add a status variable ('wsrep_flow_control_interval') to expose
the lower and upper limits of the flow control mechanism.
This is a read-only variable.