### PR TITLE
- #PXC-330: Possible data corruption on SST with innodb_flush_method=O_DIRECT

### DIFF
--- a/storage/innobase/os/os0proc.cc
+++ b/storage/innobase/os/os0proc.cc
@@ -182,15 +182,22 @@ skip:
 	}
 #endif
 
-#if defined(WITH_WSREP) && defined(UNIV_LINUX)
+#if defined(WITH_WSREP)
 	/* Do not make the pages from this block available to the child after a
 	fork(). This is required to speed up process spawning for Galera SST. */
-
+#if defined(MADV_DONTFORK)
 	if (madvise(ptr, size, MADV_DONTFORK)) {
 		fprintf(stderr, "InnoDB: Warning: madvise(MADV_DONTFORK) is "
 			"not supported by the kernel. Spawning SST processes "
 			"can be slow.\n");
 	}
+#elif defined(__FreeBSD__)
+	if (minherit(ptr, size, INHERIT_NONE)) {
+		fprintf(stderr, "InnoDB: Warning: minherit(INHERIT_NONE) is "
+			"not supported by the kernel. Spawning SST processes "
+			"can be slow.\n");
+	}
+#endif
 #endif
 	return(ptr);
 }


### PR DESCRIPTION
Using O_DIRECT I/Os in conjunction with mmap() can lead to problems,
if the memory buffer is a private mapping. Quoting the Linux man
page for open(2):

```
O_DIRECT I/Os should never be run concurrently with the fork(2) system call,
if the memory buffer is a private mapping (i.e., any mapping created with
the mmap(2) MAP_PRIVATE flag; this includes memory allocated on the heap
and statically allocated buffers). Any such I/Os, whether submitted via
an asynchronous I/O interface or from another thread in the process,
should be completed before fork(2) is called. Failure to do so can result
in data corruption and undefined behavior in parent and child processes.
This restriction does not apply when the memory buffer for the O_DIRECT
I/Os was created using shmat(2) or mmap(2) with the MAP_SHARED flag.
Nor does this restriction apply when the memory buffer has been advised
as MADV_DONTFORK with madvise(2), ensuring that it will not be available
to the child after fork(2).
```

In addition, mmap() can cause problems with a strong deceleration
of the system during the fork() to run processes that perform IST/SST.
Moreover, we may face a sudden error due to lack of memory due to false
alarm, which may be raised by memory overcommitment heuristics in
the Linux kernel.

To avoid all these problems, it is necessary to mark all the large pools
and buffers as MADV_DONTFORK (+ corresponding equivalent from FreeBSD,
as supposed in https://github.com/percona/percona-xtradb-cluster/pull/108),
which is done in this patch.

The related PXC patch is located here: https://github.com/percona/galera/pull/99