### PR TITLE
- #PXC-393: Optimized and accurate way to get mmap file gcache size using mincore syscall

### DIFF
--- a/mysql-test/suite/galera/r/galera_show_memory_usage.result
+++ b/mysql-test/suite/galera/r/galera_show_memory_usage.result
@@ -7,6 +7,9 @@ wsrep_cert_bucket_count	*
 SHOW GLOBAL STATUS LIKE 'wsrep_gcache_pool_size';
 Variable_name	Value
 wsrep_gcache_pool_size	*
+SELECT * FROM INFORMATION_SCHEMA.WSREP_STATS WHERE VARIABLE_NAME = 'wsrep_gcache_actual_pool_size';
+VARIABLE_NAME	VARIABLE_VALUE
+wsrep_gcache_actual_pool_size	*
 CREATE TABLE ten (f1 INTEGER);
 INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 SET GLOBAL wsrep_provider_options="gcache.keep_pages_count=16;gcache.keep_pages_size=128M;gcache.page_size=4096;gcache.mem_size=4096";
@@ -21,6 +24,9 @@ wsrep_cert_bucket_count	*
 SHOW GLOBAL STATUS LIKE 'wsrep_gcache_pool_size';
 Variable_name	Value
 wsrep_gcache_pool_size	*
+SELECT * FROM INFORMATION_SCHEMA.WSREP_STATS WHERE VARIABLE_NAME = 'wsrep_gcache_actual_pool_size';
+VARIABLE_NAME	VARIABLE_VALUE
+wsrep_gcache_actual_pool_size	*
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 1000
@@ -37,6 +43,9 @@ wsrep_cert_bucket_count	*
 SHOW GLOBAL STATUS LIKE 'wsrep_gcache_pool_size';
 Variable_name	Value
 wsrep_gcache_pool_size	*
+SELECT * FROM INFORMATION_SCHEMA.WSREP_STATS WHERE VARIABLE_NAME = 'wsrep_gcache_actual_pool_size';
+VARIABLE_NAME	VARIABLE_VALUE
+wsrep_gcache_actual_pool_size	*
 SELECT COUNT(*) FROM t2;
 COUNT(*)
 1000

--- a/mysql-test/suite/galera/t/galera_show_memory_usage.test
+++ b/mysql-test/suite/galera/t/galera_show_memory_usage.test
@@ -16,6 +16,8 @@ SHOW GLOBAL STATUS LIKE 'wsrep_cert_index_size';
 SHOW GLOBAL STATUS LIKE 'wsrep_cert_bucket_count';
 --replace_column 2 *
 SHOW GLOBAL STATUS LIKE 'wsrep_gcache_pool_size';
+--replace_column 2 *
+SELECT * FROM INFORMATION_SCHEMA.WSREP_STATS WHERE VARIABLE_NAME = 'wsrep_gcache_actual_pool_size';
 
 CREATE TABLE ten (f1 INTEGER);
 INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
@@ -31,6 +33,8 @@ SHOW GLOBAL STATUS LIKE 'wsrep_cert_index_size';
 SHOW GLOBAL STATUS LIKE 'wsrep_cert_bucket_count';
 --replace_column 2 *
 SHOW GLOBAL STATUS LIKE 'wsrep_gcache_pool_size';
+--replace_column 2 *
+SELECT * FROM INFORMATION_SCHEMA.WSREP_STATS WHERE VARIABLE_NAME = 'wsrep_gcache_actual_pool_size';
 
 SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
@@ -46,6 +50,8 @@ SHOW GLOBAL STATUS LIKE 'wsrep_cert_index_size';
 SHOW GLOBAL STATUS LIKE 'wsrep_cert_bucket_count';
 --replace_column 2 *
 SHOW GLOBAL STATUS LIKE 'wsrep_gcache_pool_size';
+--replace_column 2 *
+SELECT * FROM INFORMATION_SCHEMA.WSREP_STATS WHERE VARIABLE_NAME = 'wsrep_gcache_actual_pool_size';
 
 SELECT COUNT(*) FROM t2;
 DROP TABLE t2;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -726,7 +726,8 @@ enum enum_schema_tables
   SCH_USER_PRIVILEGES,
   SCH_USER_STATS,
   SCH_VARIABLES,
-  SCH_VIEWS
+  SCH_VIEWS,
+  SCH_WSREP_STATS
 };
 
 struct TABLE_SHARE;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1325,6 +1325,7 @@ THD::THD(bool enable_plugins)
   wsrep_retry_command     = COM_CONNECT;
   wsrep_consistency_check = NO_CONSISTENCY_CHECK;
   wsrep_status_vars       = 0;
+  wsrep_ext_status_vars   = 0;
   wsrep_mysql_replicated  = 0;
   wsrep_sync_wait_gtid    = WSREP_GTID_UNDEFINED;
   wsrep_affected_rows     = 0;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3517,6 +3517,7 @@ public:
   enum wsrep_consistency_check_mode 
                             wsrep_consistency_check;
   wsrep_stats_var*          wsrep_status_vars;
+  wsrep_stats_var*          wsrep_ext_status_vars;
   int                       wsrep_mysql_replicated;
 
   /* query to apply before actual TOI query. Needed in case of

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -135,6 +135,7 @@ extern const char* wsrep_provider_version;
 extern const char* wsrep_provider_vendor;
 
 int  wsrep_show_status(THD *thd, SHOW_VAR *var, char *buff);
+int  wsrep_show_status_ext(THD *thd, SHOW_VAR *var, char *buff);
 void wsrep_free_status(THD *thd);
 
 /* Filters out --wsrep-new-cluster oprtion from argv[]

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -702,9 +702,13 @@ wsrep_assign_to_mysql (SHOW_VAR* mysql, wsrep_stats_var* wsrep)
 // somehow this mysql status thing works only with statically allocated arrays.
 static SHOW_VAR*          mysql_status_vars = NULL;
 static int                mysql_status_len  = -1;
+static SHOW_VAR*          mysql_ext_status_vars = NULL;
+static int                mysql_ext_status_len  = -1;
 #else
 static SHOW_VAR           mysql_status_vars[512 + 1];
 static const int          mysql_status_len  = 512;
+static SHOW_VAR           mysql_ext_status_vars[512 + 1];
+static const int          mysql_ext_status_len  = 512;
 #endif
 
 static void export_wsrep_status_to_mysql(THD* thd)
@@ -715,7 +719,11 @@ static void export_wsrep_status_to_mysql(THD* thd)
   instead free them on next invocation as the reference to status
   is feeded in MySQL show status array. Freeing them on completion
   will make these references invalid. */
-  wsrep_free_status(thd);
+  if (thd->wsrep_status_vars)
+  {
+    wsrep->stats_free (wsrep, thd->wsrep_status_vars);
+    thd->wsrep_status_vars = 0;
+  }
 
   thd->wsrep_status_vars = wsrep->stats_get(wsrep);
 
@@ -764,11 +772,81 @@ int wsrep_show_status (THD *thd, SHOW_VAR *var, char *buff)
   return 0;
 }
 
+static void export_wsrep_ext_status_to_mysql(THD* thd)
+{
+  int wsrep_ext_status_len, i;
+
+  /* Avoid freeing the stats immediately on completion of the call
+  instead free them on next invocation as the reference to status
+  is feeded in MySQL show status array. Freeing them on completion
+  will make these references invalid. */
+  if (thd->wsrep_ext_status_vars)
+  {
+    wsrep->stats_free (wsrep, thd->wsrep_ext_status_vars);
+    thd->wsrep_ext_status_vars = 0;
+  }
+
+  thd->wsrep_ext_status_vars= wsrep->stats_ext_get(wsrep);
+
+  if (!thd->wsrep_ext_status_vars) {
+      return;
+  }
+
+  for (wsrep_ext_status_len= 0;
+       thd->wsrep_ext_status_vars[wsrep_ext_status_len].name != NULL;
+       wsrep_ext_status_len++) {
+      /* */
+  }
+
+#if DYNAMIC
+  if (wsrep_ext_status_len != mysql_ext_status_len)
+  {
+      void* tmp = realloc (mysql_ext_status_vars,
+                           (wsrep_ext_status_len + 1) * sizeof(SHOW_VAR));
+      if (!tmp)
+      {
+          sql_print_error ("Out of memory for wsrep extended status variables."
+                           "Number of variables: %d", wsrep_status_len);
+          return;
+      }
+      mysql_ext_status_len  = wsrep_ext_status_len;
+      mysql_ext_status_vars = (SHOW_VAR*)tmp;
+  }
+  /* @TODO: fix this: */
+#else
+  if (mysql_ext_status_len < wsrep_ext_status_len)
+      wsrep_ext_status_len= mysql_ext_status_len;
+#endif
+
+  for (i = 0; i < wsrep_ext_status_len; i++)
+  {
+      wsrep_assign_to_mysql (mysql_ext_status_vars + i,
+                             thd->wsrep_ext_status_vars + i);
+  }
+
+  mysql_ext_status_vars[wsrep_ext_status_len].name  = NullS;
+  mysql_ext_status_vars[wsrep_ext_status_len].value = NullS;
+  mysql_ext_status_vars[wsrep_ext_status_len].type  = SHOW_LONG;
+}
+
+int wsrep_show_status_ext (THD *thd, SHOW_VAR *var, char *buff)
+{
+  export_wsrep_ext_status_to_mysql(thd);
+  var->type= SHOW_ARRAY;
+  var->value= (char *) &mysql_ext_status_vars;
+  return 0;
+}
+
 void wsrep_free_status (THD* thd)
 {
   if (thd->wsrep_status_vars)
   {
     wsrep->stats_free (wsrep, thd->wsrep_status_vars);
     thd->wsrep_status_vars = 0;
+  }
+  if (thd->wsrep_ext_status_vars)
+  {
+    wsrep->stats_free (wsrep, thd->wsrep_ext_status_vars);
+    thd->wsrep_ext_status_vars = 0;
   }
 }

--- a/wsrep/wsrep_api.h
+++ b/wsrep/wsrep_api.h
@@ -999,6 +999,15 @@ struct wsrep {
     struct wsrep_stats_var* (*stats_get) (wsrep_t* wsrep);
 
   /*!
+   * @brief Returns an array of extended status variables.
+   *        Array is terminated by Null variable name.
+   *
+   * @param wsrep provider handle
+   * @return array of struct wsrep_status_var.
+   */
+    struct wsrep_stats_var* (*stats_ext_get) (wsrep_t* wsrep);
+
+  /*!
    * @brief Release resources that might be associated with the array.
    *
    * @param wsrep     provider handle.

--- a/wsrep/wsrep_dummy.c
+++ b/wsrep/wsrep_dummy.c
@@ -284,6 +284,16 @@ static struct wsrep_stats_var* dummy_stats_get (wsrep_t* w)
     return dummy_stats;
 }
 
+static struct wsrep_stats_var dummy_stats_ext[] = {
+    { NULL, WSREP_VAR_STRING, { 0 } }
+};
+
+static struct wsrep_stats_var* dummy_stats_ext_get (wsrep_t* w)
+{
+    WSREP_DBUG_ENTER(w);
+    return dummy_stats_ext;
+}
+
 static void dummy_stats_free (
     wsrep_t* w,
     struct wsrep_stats_var* stats __attribute__((unused)))
@@ -373,6 +383,7 @@ static wsrep_t dummy_iface = {
     &dummy_sst_received,
     &dummy_snapshot,
     &dummy_stats_get,
+    &dummy_stats_ext_get,
     &dummy_stats_free,
     &dummy_stats_reset,
     &dummy_pause,

--- a/wsrep/wsrep_loader.c
+++ b/wsrep/wsrep_loader.c
@@ -91,6 +91,7 @@ static int verify(const wsrep_t *wh, const char *iface_ver)
     VERIFY(wh->sst_sent);
     VERIFY(wh->sst_received);
     VERIFY(wh->stats_get);
+    VERIFY(wh->stats_ext_get);
     VERIFY(wh->stats_free);
     VERIFY(wh->stats_reset);
     VERIFY(wh->pause);


### PR DESCRIPTION
This patch implements a new information schema table ("WSREP_STATS"),
which contains the "wsrep_gcache_actual_pool_size" variable that reflects
the exact amount of memory, which is used by the "gcache" memory pool.

Using a separate information schema table for this variable avoids
deceleration of regular queries, such as SHOW STATUS.

To determine the actual amount of memory occupied by the gcache,
the mincore() syscall is used.

At the same time, I limited the size of additional vector, which used
by mincore() syscall, by dividing of large memory ranges into relatively
small 512MB chunks, which are passed to mincore() syscall. This introduces
slight performance loss due to additional syscalls, however, these costs
is less than 1%, while only the 128 kilobytes of additional memory is
allocated for mincore()-related vector.

I made sure that the state of gcache pages measured only up to the
currently achieved "watermark", but not around the entire allocated
pool - to accelerate scenarios such as
https://bugs.launchpad.net/percona-xtradb-cluster/+bug/1462674

In addition, measurement of the actual amount of memory occupied
by the gcache avoids long-term locking of the other gcache operations,
except when mutex is aquired by the allocation or deallocation of
overflow pages (in the "Pages" storage). In this case mid-term
locking is possible – until the code that uses memcore() syscall
will stop working. However, while we do not create/free the overflow
pages, a global lock does not happen.

The related Galera patch is located here: https://github.com/percona/galera/pull/100