### PR TITLE
- PXC#768: Allow CTAS with temporary table in PXC strict mode

### DIFF
--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -1185,6 +1185,12 @@ i
 2
 create table tinnodb2 (i int, primary key pk(i)) as (select * from tinnodb);
 ERROR HY000: Percona-XtraDB-Cluster prohibits use of CREATE TABLE AS SELECT with pxc_strict_mode = ENFORCING or MASTER
+create temporary table tmp (i int, primary key pk(i)) as (select * from tinnodb);
+select * from tmp;
+i
+1
+2
+drop table tmp;
 #node-2
 select * from tinnodb2;
 ERROR 42S02: Table 'test.tinnodb2' doesn't exist

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -1255,6 +1255,9 @@ insert into tinnodb values (1), (2);
 select * from tinnodb;
 --error ER_UNKNOWN_ERROR
 create table tinnodb2 (i int, primary key pk(i)) as (select * from tinnodb);
+create temporary table tmp (i int, primary key pk(i)) as (select * from tinnodb);
+select * from tmp;
+drop table tmp;
 #
 --connection node_2
 --echo #node-2

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3737,41 +3737,47 @@ case SQLCOM_PREPARE:
     {
 
 #ifdef WITH_WSREP
-      bool block= false;
+      bool is_temporary_table=
+        (lex->create_info.options & HA_LEX_CREATE_TMP_TABLE);
 
-      switch(pxc_strict_mode)
+      if (!is_temporary_table)
       {
-      case PXC_STRICT_MODE_DISABLED:
-        break;
-      case PXC_STRICT_MODE_PERMISSIVE:
-        WSREP_WARN("Percona-XtraDB-Cluster doesn't recommend use of"
-                   " CREATE TABLE AS SELECT"
-                   " with pxc_strict_mode = PERMISSIVE");
-        push_warning_printf(thd, Sql_condition::SL_WARNING,
-                            ER_UNKNOWN_ERROR,
-                            "Percona-XtraDB-Cluster doesn't recommend use of"
-                            " CREATE TABLE AS SELECT"
-                            " with pxc_strict_mode = PERMISSIVE");
-        break;
-      case PXC_STRICT_MODE_ENFORCING:
-      case PXC_STRICT_MODE_MASTER:
-        block= true;
-        WSREP_ERROR("Percona-XtraDB-Cluster prohibits use of"
-                    " CREATE TABLE AS SELECT"
-                    " with pxc_strict_mode = ENFORCING or MASTER");
-        char message[1024];
-        sprintf(message,
-                "Percona-XtraDB-Cluster prohibits use of"
-                " CREATE TABLE AS SELECT"
-                " with pxc_strict_mode = ENFORCING or MASTER");
-        my_message(ER_UNKNOWN_ERROR, message, MYF(0));
-        break;
-      }
+        bool block= false;
 
-      if (block)
-      {
-        res= 1;
-        goto end_with_restore_list;
+        switch(pxc_strict_mode)
+        {
+        case PXC_STRICT_MODE_DISABLED:
+          break;
+        case PXC_STRICT_MODE_PERMISSIVE:
+          WSREP_WARN("Percona-XtraDB-Cluster doesn't recommend use of"
+                     " CREATE TABLE AS SELECT"
+                     " with pxc_strict_mode = PERMISSIVE");
+          push_warning_printf(thd, Sql_condition::SL_WARNING,
+                              ER_UNKNOWN_ERROR,
+                              "Percona-XtraDB-Cluster doesn't recommend use of"
+                              " CREATE TABLE AS SELECT"
+                              " with pxc_strict_mode = PERMISSIVE");
+          break;
+        case PXC_STRICT_MODE_ENFORCING:
+        case PXC_STRICT_MODE_MASTER:
+          block= true;
+          WSREP_ERROR("Percona-XtraDB-Cluster prohibits use of"
+                      " CREATE TABLE AS SELECT"
+                      " with pxc_strict_mode = ENFORCING or MASTER");
+          char message[1024];
+          sprintf(message,
+                  "Percona-XtraDB-Cluster prohibits use of"
+                  " CREATE TABLE AS SELECT"
+                  " with pxc_strict_mode = ENFORCING or MASTER");
+          my_message(ER_UNKNOWN_ERROR, message, MYF(0));
+          break;
+        }
+
+        if (block)
+        {
+          res= 1;
+          goto end_with_restore_list;
+        }
       }
 #endif /* WITH_WSREP */
 


### PR DESCRIPTION
  CTAS is blocked in pxc_strict_mode = ENFORCING as it involves
  DDL + DML which and can lead to GTID consistency issue.
  This is now applicable if table is temporary as it is local
  to the node and statement is not replicated.
  Allow CTAS on temporary table.