### PR TITLE
Fix PXC-755 : Passing use-memory to XB

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -542,6 +542,24 @@ read_cnf()
             ssyslog=1
         fi
     fi
+
+    # Pull out the buffer pool size to be used by PXB
+    # and set it in use-memory (if not specified in inno-apply-opts)
+    #
+    # Is the use-memory option already specified in inno-apply-opts?
+    if ! [[ "$iapts" =~ --use-memory= ]]; then
+        bufferpoolsize=$(parse_cnf xtrabackup use-memory "")
+        if [[ -z "$bufferpoolsize" ]]; then
+            bufferpoolsize=$(parse_cnf mysqld innodb-buffer-pool-size "")
+        fi
+        if [[ -z "$bufferpoolsize" ]]; then
+            bufferpoolsize=$(parse_cnf mysqld innodb_buffer_pool_size "")
+        fi
+        if [[ -n "$bufferpoolsize" ]]; then
+            iapts="$iapts --use-memory=$bufferpoolsize"
+        fi
+    fi
+
 }
 
 #


### PR DESCRIPTION
Issue
The use-memory param to xtrabackup for --apply-log was only being
supplied through setting the inno-apply-opts options.

Solution
Add support for using the options set in [xtrabackup] "use-memory"
and [mysqld] "innodb_buffer_pool_size.