### PR TITLE
Fix PXC-769: galera_gcache_recover fails intermittently

### DIFF
--- a/mysql-test/suite/galera/t/galera_gcache_recover.test
+++ b/mysql-test/suite/galera/t/galera_gcache_recover.test
@@ -22,6 +22,8 @@ SET SESSION wsrep_sync_wait = 0;
 
 INSERT INTO t1 VALUES (2);
 
+--sleep 5
+
 --source include/kill_galera.inc
 
 --sleep 1


### PR DESCRIPTION
Issue
This test case fails intermittently.

Solution
It appears that we kill PXC too quickly, we don't give InnoDB
enough time to commit (especially under load). This causes InnoDB
to rollback the transction during the --wsrep-recover stage (this
output goes to a different log file so we don't see this output).
Thus the IST becomes an SST since a transaction is missing.

So the solution is to give the operation a little more time before
killing the node.