### PR TITLE
mysql-common should be installed before pxc-common

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -93,7 +93,7 @@ Description: Percona XtraDB Cluster database development files
 Package: percona-xtradb-cluster-common-5.7
 Section: database
 Architecture: any
-Pre-depends: debconf (>= 0.2.17), ${misc:Pre-Depends}
+Pre-depends: debconf (>= 0.2.17), mysql-common, ${misc:Pre-Depends}
 Multi-Arch: foreign
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Percona XtraDB Cluster database common files (e.g. /etc/mysql/my.cnf)

--- a/build-ps/ubuntu/control
+++ b/build-ps/ubuntu/control
@@ -93,7 +93,7 @@ Description: Percona XtraDB Cluster database development files
 Package: percona-xtradb-cluster-common-5.7
 Section: database
 Architecture: any
-Pre-depends: debconf (>= 0.2.17), ${misc:Pre-Depends}
+Pre-depends: debconf (>= 0.2.17), mysql-common, ${misc:Pre-Depends}
 Multi-Arch: foreign
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Percona XtraDB Cluster database common files (e.g. /etc/mysql/my.cnf)


### PR DESCRIPTION
vagrant@jessie:~$ sudo apt-get install percona-xtradb-cluster-5.7
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'percona-xtradb-cluster-5.7-dbg' for regex 'percona-xtradb-cluster-5.7'
The following package was automatically installed and is no longer required:
  libpcap0.8
Use 'apt-get autoremove' to remove it.
The following extra packages will be installed:
  libdbd-mysql-perl libmysqlclient18 mysql-common percona-xtrabackup-24
  percona-xtradb-cluster-client-5.7 percona-xtradb-cluster-common-5.7
  percona-xtradb-cluster-server-5.7
Suggested packages:
  tinyca netcat-openbsd pv qpress
The following NEW packages will be installed:
  libdbd-mysql-perl libmysqlclient18 mysql-common percona-xtrabackup-24
  percona-xtradb-cluster-5.7-dbg percona-xtradb-cluster-client-5.7
  percona-xtradb-cluster-common-5.7 percona-xtradb-cluster-server-5.7
0 upgraded, 8 newly installed, 0 to remove and 78 not upgraded.
Need to get 186 MB/192 MB of archives.
After this operation, 370 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://repo.percona.com/apt/ jessie/experimental percona-xtradb-cluster-common-5.7 amd64 5.7.17-27.20-1.jessie [6940 B]
Get:2 http://repo.percona.com/apt/ jessie/experimental percona-xtradb-cluster-client-5.7 amd64 5.7.17-27.20-1.jessie [1360 kB]
Get:3 http://repo.percona.com/apt/ jessie/experimental percona-xtradb-cluster-server-5.7 amd64 5.7.17-27.20-1.jessie [10.6 MB]
Get:4 http://repo.percona.com/apt/ jessie/experimental percona-xtradb-cluster-5.7-dbg amd64 5.7.17-27.20-1.jessie [174 MB]
Fetched 186 MB in 6min 26s (481 kB/s)                                                             
Can't set locale; make sure $LC_* and $LANG are correct!
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LC_TIME = "ba_RU.UTF-8",
        LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to a fallback locale ("en_US.UTF-8").
locale: Cannot set LC_ALL to default locale: No such file or directory
Preconfiguring packages ...
/usr/bin/locale: Cannot set LC_ALL to default locale: No such file or directory
Selecting previously unselected package mysql-common.
(Reading database ... 37291 files and directories currently installed.)
Preparing to unpack .../mysql-common_5.5.54-0+deb8u1_all.deb ...
Unpacking mysql-common (5.5.54-0+deb8u1) ...
Selecting previously unselected package libmysqlclient18:amd64.
Preparing to unpack .../libmysqlclient18_5.5.54-0+deb8u1_amd64.deb ...
Unpacking libmysqlclient18:amd64 (5.5.54-0+deb8u1) ...
Setting up mysql-common (5.5.54-0+deb8u1) ...
Selecting previously unselected package percona-xtradb-cluster-common-5.7.
(Reading database ... 37309 files and directories currently installed.)
Preparing to unpack .../percona-xtradb-cluster-common-5.7_5.7.17-27.20-1.jessie_amd64.deb ...
Unpacking percona-xtradb-cluster-common-5.7 (5.7.17-27.20-1.jessie) ...
Selecting previously unselected package percona-xtradb-cluster-client-5.7.
Preparing to unpack .../percona-xtradb-cluster-client-5.7_5.7.17-27.20-1.jessie_amd64.deb ...
Unpacking percona-xtradb-cluster-client-5.7 (5.7.17-27.20-1.jessie) ...
Selecting previously unselected package libdbd-mysql-perl.
Preparing to unpack .../libdbd-mysql-perl_4.028-2+deb8u2_amd64.deb ...
Unpacking libdbd-mysql-perl (4.028-2+deb8u2) ...
Selecting previously unselected package percona-xtrabackup-24.
Preparing to unpack .../percona-xtrabackup-24_2.4.6-2.jessie_amd64.deb ...
Unpacking percona-xtrabackup-24 (2.4.6-2.jessie) ...
Processing triggers for man-db (2.7.0.2-5) ...
Setting up percona-xtradb-cluster-common-5.7 (5.7.17-27.20-1.jessie) ...
 -------------
   *  The suggested mysql options and settings are in /etc/mysql/percona-xtradb-cluster.conf.d/mysqld.cnf
   *  If you want to use mysqld.cnf as default configuration file please make backup of /etc/my.cnf
   *  Once it is done please execute the following commands:
 rm -rf /etc/my.cnf
 update-alternatives --install /etc/mysql/my.cnf my.cnf "/etc/mysql/percona-xtradb-cluster.cnf" 200
 -------------
Selecting previously unselected package percona-xtradb-cluster-server-5.7.
(Reading database ... 37382 files and directories currently installed.)
Preparing to unpack .../percona-xtradb-cluster-server-5.7_5.7.17-27.20-1.jessie_amd64.deb ...
Unpacking percona-xtradb-cluster-server-5.7 (5.7.17-27.20-1.jessie) ...
Selecting previously unselected package percona-xtradb-cluster-5.7-dbg.
Preparing to unpack .../percona-xtradb-cluster-5.7-dbg_5.7.17-27.20-1.jessie_amd64.deb ...
Unpacking percona-xtradb-cluster-5.7-dbg (5.7.17-27.20-1.jessie) ...
Processing triggers for systemd (215-17+deb8u5) ...
Processing triggers for man-db (2.7.0.2-5) ...
Setting up libmysqlclient18:amd64 (5.5.54-0+deb8u1) ...
Setting up percona-xtradb-cluster-client-5.7 (5.7.17-27.20-1.jessie) ...
Setting up libdbd-mysql-perl (4.028-2+deb8u2) ...
Setting up percona-xtrabackup-24 (2.4.6-2.jessie) ...
Setting up percona-xtradb-cluster-server-5.7 (5.7.17-27.20-1.jessie) ...
locale: Cannot set LC_ALL to default locale: No such file or directory


 * Percona XtraDB Cluster is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
 * Run the following commands to create these functions:

        mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
        mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
        mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"

 * See http://www.percona.com/doc/percona-server/5.7/management/udf_percona_toolkit.html for more details


Setting up percona-xtradb-cluster-5.7-dbg (5.7.17-27.20-1.jessie) ...
Processing triggers for libc-bin (2.19-18+deb8u6) ...
Processing triggers for systemd (215-17+deb8u5) ...