### PR TITLE
Fix PXC-782: PXC xtrabackup-v2 option should use tmpdir option

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_master_and_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_master_and_slave.result
@@ -134,7 +134,7 @@ select locate(':1-7', @@global.gtid_executed);
 locate(':1-7', @@global.gtid_executed)
 VALID_POS
 #node-1 (independent master)
-drop table t;
+DROP TABLE t;
 #node-2 (galera-cluster-node acting as slave to an independent master)
 STOP SLAVE;
 RESET SLAVE ALL;

--- a/mysql-test/suite/galera/r/galera_many_tables_pk.result
+++ b/mysql-test/suite/galera/r/galera_many_tables_pk.result
@@ -1,23 +1,22 @@
 call mtr.add_suppression(" InnoDB: Warning: difficult to find free blocks in.*");
 call mtr.add_suppression(" InnoDB: Warning: difficult to find free blocks in.*");
-SELECT COUNT(*) = 100 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't%';
-COUNT(*) = 100
+SELECT COUNT(*) = 1000 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't%';
+COUNT(*) = 1000
 1
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 COMMIT;
 CREATE TABLE sum_table (f1 INTEGER);
-SELECT SUM(f1) = 100 FROM sum_table;
-SUM(f1) = 100
+SELECT SUM(f1) = 1000 FROM sum_table;
+SUM(f1) = 1000
 1
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
-UPDATE t100 SET f1 = 3;
+UPDATE t1000 SET f1 = 3;
 COMMIT;
 COMMIT;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
-include/diff_servers.inc [servers=1 2]
 DROP SCHEMA test;
 CREATE SCHEMA test;

--- a/mysql-test/suite/galera/t/MW-328A.test
+++ b/mysql-test/suite/galera/t/MW-328A.test
@@ -48,7 +48,7 @@ while ($count)
 
 --disable_query_log
 --eval SELECT $successes > 0 AS have_successes
---eval SELECT $deadlocks > 0 AS have_deadlocks
+--eval SELECT $successes + $deadlocks = 100 AS have_deadlocks
 --enable_query_log
 
 

--- a/mysql-test/suite/galera/t/galera_as_master_and_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_master_and_slave.test
@@ -51,15 +51,36 @@ select * from t;
 # ensure remaining nodes has the needed data.
 --connection node_2
 --echo #node-2 (galera-cluster-node acting as slave to an independent master)
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t;
+--source include/wait_condition.inc
+
 select * from t;
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t;
+--source include/wait_condition.inc
+
 select * from t;
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t;
+--source include/wait_condition.inc
+
 select * from t;
 
 
@@ -76,11 +97,12 @@ update t set c = 'pppppp', i = 50 where i = 5;
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
 select locate(':1-3', @@global.gtid_executed);
-# replication lag
-sleep 1;
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t WHERE i = 50
+--source include/wait_condition.inc
+
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
 select locate(':1-3', @@global.gtid_executed);
@@ -127,11 +149,11 @@ update t set c = 'kkkkk' where i = 1;
 update t set c = 'k2', i = 100 where i = 1;
 select * from t;
 select right(@@global.gtid_executed, 3);
-# replication lag
---sleep 1
 
 --connection node_3
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t WHERE i = 100
+--source include/wait_condition.inc
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
 select locate(':1-7', @@global.gtid_executed);
@@ -141,12 +163,12 @@ select locate(':1-7', @@global.gtid_executed);
 #
 --connection node_1
 --echo #node-1 (independent master)
-drop table t;
-# replication lag
---sleep 1
+DROP TABLE t;
 
 --connection node_2
 --echo #node-2 (galera-cluster-node acting as slave to an independent master)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't'
+--source include/wait_condition.inc
 STOP SLAVE;
 RESET SLAVE ALL;
 
@@ -156,6 +178,8 @@ RESET MASTER;
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't'
+--source include/wait_condition.inc
 STOP SLAVE;
 RESET SLAVE ALL;
 

--- a/mysql-test/suite/galera/t/galera_many_tables_pk.test
+++ b/mysql-test/suite/galera/t/galera_many_tables_pk.test
@@ -9,16 +9,16 @@ call mtr.add_suppression(" InnoDB: Warning: difficult to find free blocks in.*")
 call mtr.add_suppression(" InnoDB: Warning: difficult to find free blocks in.*");
 
 #
-# This test forces 100 tables with a PK to participate in a single transaction
+# This test forces 1K tables with a PK to participate in a single transaction
 #
 
 #
-# First, create 100 tables and make sure the DDLs are all propagated
+# First, create 1K tables and make sure the DDLs are all propagated
 #
 
 --connection node_1
 
---let $count = 100
+--let $count = 1000
 while ($count)
 {
   --disable_query_log
@@ -29,7 +29,7 @@ while ($count)
 }
 
 --connection node_2
-SELECT COUNT(*) = 100 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't%';
+SELECT COUNT(*) = 1000 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME LIKE 't%';
 
 #
 # Second, create a transaction that uses all those tables
@@ -39,11 +39,11 @@ SELECT COUNT(*) = 100 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test'
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 
---let $count = 100
+--let $count = 1000
 while ($count)
 {
   --disable_query_log
-  --let $ddl_var = `SELECT CONCAT("INSERT INTO t", $count, " VALUES (DEFAULT)")`
+  --let $ddl_var = `SELECT CONCAT("INSERT INTO t", $count, " VALUES (1)")`
   --eval $ddl_var
   --enable_query_log
   --dec $count
@@ -58,7 +58,7 @@ COMMIT;
 --connection node_2
 CREATE TABLE sum_table (f1 INTEGER);
 
---let $count = 100
+--let $count = 1000
 while ($count)
 {
   --disable_query_log
@@ -68,7 +68,7 @@ while ($count)
   --dec $count
 }
 
-SELECT SUM(f1) = 100 FROM sum_table;
+SELECT SUM(f1) = 1000 FROM sum_table;
 
 #
 # Fourth, create a deadlock
@@ -78,7 +78,7 @@ SELECT SUM(f1) = 100 FROM sum_table;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 
---let $count = 100
+--let $count = 1000
 while ($count)
 {
   --disable_query_log
@@ -91,17 +91,19 @@ while ($count)
 --connection node_2
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
-UPDATE t100 SET f1 = 3;
+UPDATE t1000 SET f1 = 3;
 
 --connection node_1
 COMMIT;
 
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+--let $wait_condition = SELECT SUM(f1) = 2 FROM t1000
+--source include/wait_condition.inc
+
 --connection node_2
 --error ER_LOCK_DEADLOCK
 COMMIT;
-
---let $diff_servers = 1 2
---source include/diff_servers.inc
 
 DROP SCHEMA test;
 CREATE SCHEMA test;


### PR DESCRIPTION
Issue:
wsrep_sst_xtrabackup-v2.sh does not use the tmpdir option (either [xtrabackup] or [mysqld]).
It creates any needed temporary directories via "mktemp -d").

Solution:
Change the script so that it uses the tmpdir (if in [sst], [xtrabackup] or [mysqld], in
that order).

Additionally:
Fixes to the MW-328A test case.