### PR TITLE
Fix PXC-782: PXC xtrabackup-v2 option should use tmpdir option

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_master_and_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_master_and_slave.result
@@ -134,7 +134,7 @@ select locate(':1-7', @@global.gtid_executed);
 locate(':1-7', @@global.gtid_executed)
 VALID_POS
 #node-1 (independent master)
-drop table t;
+DROP TABLE t;
 #node-2 (galera-cluster-node acting as slave to an independent master)
 STOP SLAVE;
 RESET SLAVE ALL;

--- a/mysql-test/suite/galera/t/MW-328A.test
+++ b/mysql-test/suite/galera/t/MW-328A.test
@@ -48,7 +48,7 @@ while ($count)
 
 --disable_query_log
 --eval SELECT $successes > 0 AS have_successes
---eval SELECT $deadlocks > 0 AS have_deadlocks
+--eval SELECT $successes + $deadlocks = 100 AS have_deadlocks
 --enable_query_log
 
 

--- a/mysql-test/suite/galera/t/galera_as_master_and_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_master_and_slave.test
@@ -51,17 +51,36 @@ select * from t;
 # ensure remaining nodes has the needed data.
 --connection node_2
 --echo #node-2 (galera-cluster-node acting as slave to an independent master)
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t;
+--source include/wait_condition.inc
+
 select * from t;
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t;
+--source include/wait_condition.inc
+
 select * from t;
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
---let $wait_condition = SELECT COUNT(*) = 5 from t
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
 --source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t;
+--source include/wait_condition.inc
+
 select * from t;
 
 
@@ -78,11 +97,12 @@ update t set c = 'pppppp', i = 50 where i = 5;
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
 select locate(':1-3', @@global.gtid_executed);
-# replication lag
-sleep 1;
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t WHERE i = 50
+--source include/wait_condition.inc
+
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
 select locate(':1-3', @@global.gtid_executed);
@@ -129,11 +149,11 @@ update t set c = 'kkkkk' where i = 1;
 update t set c = 'k2', i = 100 where i = 1;
 select * from t;
 select right(@@global.gtid_executed, 3);
-# replication lag
---sleep 1
 
 --connection node_3
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t WHERE i = 100
+--source include/wait_condition.inc
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
 select locate(':1-7', @@global.gtid_executed);
@@ -143,12 +163,12 @@ select locate(':1-7', @@global.gtid_executed);
 #
 --connection node_1
 --echo #node-1 (independent master)
-drop table t;
-# replication lag
---sleep 1
+DROP TABLE t;
 
 --connection node_2
 --echo #node-2 (galera-cluster-node acting as slave to an independent master)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't'
+--source include/wait_condition.inc
 STOP SLAVE;
 RESET SLAVE ALL;
 
@@ -158,6 +178,8 @@ RESET MASTER;
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't'
+--source include/wait_condition.inc
 STOP SLAVE;
 RESET SLAVE ALL;
 

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -42,7 +42,6 @@ nproc=1
 ecode=0
 ssyslog=""
 ssystag=""
-XTRABACKUP_PID=""
 SST_PORT=""
 REMOTEIP=""
 tca=""
@@ -69,7 +68,7 @@ rebuildcmd=""
 payload=0
 pvformat="-F '%N => Rate:%r Avg:%a Elapsed:%t %e Bytes: %b %p' "
 pvopts="-f  -i 10 -N $WSREP_SST_OPT_ROLE "
-STATDIR=""
+
 uextra=0
 disver=""
 
@@ -82,9 +81,15 @@ XB_DONOR_KEYRING_FILE="donor-keyring"
 XB_DONOR_KEYRING_FILE_PATH=""
 KEYRING_DIR=""
 
-tmpopts=""
+# Root directory for temporary files. This directory (and everything in it)
+# will be removed upon exit.
+tmpdirbase=""
+
+# tmpdir used as target-dir for xtrabackup by the donor
 itmpdir=""
-xtmpdir=""
+
+# tmpdir used by the joiner
+STATDIR=""
 
 scomp=""
 sdecomp=""
@@ -703,8 +708,8 @@ cleanup_joiner()
         wsrep_log_debug "Cleaning up fifo file $progress"
         rm $progress
     fi
-    if [[ -n ${STATDIR:-} ]]; then
-       [[ -d $STATDIR ]] && rm -rf $STATDIR
+    if [[ -n "${tmpdirbase}" ]]; then
+        [[ -d "${tmpdirbase}" ]] && rm -rf "${tmpdirbase}" || true
     fi
 
     if [[ -r "${XB_DONOR_KEYRING_FILE_PATH}" ]]; then
@@ -743,14 +748,6 @@ cleanup_donor()
         wsrep_log_error "Cleanup after exit with status:$estatus"
     fi
 
-    if [[ -n ${XTRABACKUP_PID:-} ]]; then
-        if check_pid $XTRABACKUP_PID
-        then
-            wsrep_log_error "xtrabackup process is still running. Killing... "
-            kill_xtrabackup
-        fi
-
-    fi
     rm -f ${DATA}/${IST_FILE} || true
 
     if [[ -n $progress && -p $progress ]]; then
@@ -760,12 +757,8 @@ cleanup_donor()
 
     wsrep_log_debug "Cleaning up temporary directories"
 
-    if [[ -n $xtmpdir ]]; then
-       [[ -d $xtmpdir ]] &&  rm -rf $xtmpdir || true
-    fi
-
-    if [[ -n $itmpdir ]]; then
-       [[ -d $itmpdir ]] &&  rm -rf $itmpdir || true
+    if [[ -n "${tmpdirbase}" ]]; then
+        [[ -d "${tmpdirbase}" ]] && rm -rf "${tmpdirbase}" || true
     fi
 
     # Final cleanup
@@ -786,14 +779,6 @@ cleanup_donor()
     rm -rf "${KEYRING_DIR}/${XB_DONOR_KEYRING_FILE}" || true
 
     exit $estatus
-}
-
-kill_xtrabackup()
-{
-    local PID=$(cat $XTRABACKUP_PID)
-    [ -n "$PID" -a "0" != "$PID" ] && kill $PID && (kill $PID && kill -9 $PID) || :
-    wsrep_log_debug "Removing xtrabackup pid file $XTRABACKUP_PID"
-    rm -f "$XTRABACKUP_PID" || true
 }
 
 setup_ports()
@@ -1000,6 +985,49 @@ check_for_version()
     fi
 }
 
+#
+# Initiailizes the tmpdir
+# Reads the info from the config file and creates the tmpdir as needed.
+#
+# Sets the $tmpdirbase variable to the root of the temporary directory
+# to be used by SST. This directory will be removed upon exiting the script.
+#
+initialize_tmpdir()
+{
+    local tmpdir_path=""
+
+    tmpdir_path=$(parse_cnf sst tmpdir "")
+    if [[ -z "${tmpdir_path}" ]]; then
+        tmpdir_path=$(parse_cnf xtrabackup tmpdir "")
+    fi
+    if [[ -z "${tmpdir_path}" ]]; then
+        tmpdir_path=$(parse_cnf mysqld tmpdir "")
+    fi
+    if [[ -n "${tmpdir_path}" ]]; then
+        if [[ ! -d "${tmpdir_path}" ]]; then
+            wsrep_log_error "Cannot find the directory, ${tmpdir_path}, the tmpdir must exist before startup."
+            exit 2
+        fi
+        if [[ ! -r "${tmpdir_path}" ]]; then
+            wsrep_log_error "The temporary directory, ${tmpdir_path}, is not readable.  Please check the directory permissions."
+            exit 22
+        fi
+        if [[ ! -w "${tmpdir_path}" ]]; then
+            wsrep_log_error "The temporary directory, ${tmpdir_path}, is not writable.  Please check the directory permissions."
+            exit 22
+        fi
+    fi
+
+    if [[ -z "${tmpdir_path}" ]]; then
+        tmpdir_path=$(mktemp -dt pxc_sst_XXXXXXXX)
+    else
+        tmpdir_path=$(mktemp -p "${tmpdir_path}" -dt pxc_sst_XXXXXXXX)
+    fi
+
+    # This directory (and everything in it), will be removed upon exit
+    tmpdirbase=$tmpdir_path
+}
+
 
 #-------------------------------------------------------------------------------
 #
@@ -1144,12 +1172,12 @@ if [[ $ssyslog -eq 1 ]]; then
 
         INNOAPPLY="${INNOBACKUPEX_BIN} $disver $iapts --prepare --binlog-info=ON \$rebuildcmd \$keyringapplyopt --target-dir=\${DATA} 2>&1  | logger -p daemon.err -t ${ssystag}innobackupex-apply "
         INNOMOVE="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF} --datadir=\${TDATA} $disver $impts  --move-back --binlog-info=ON --force-non-empty-directories --target-dir=\${DATA} 2>&1 | logger -p daemon.err -t ${ssystag}innobackupex-move "
-        INNOBACKUP="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF} $disver $iopts \$tmpopts \$INNOEXTRA \$keyringbackupopt --backup --galera-info  --binlog-info=ON --stream=\$sfmt --target-dir=\$itmpdir 2> >(logger -p daemon.err -t ${ssystag}innobackupex-backup)"
+        INNOBACKUP="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF} $disver $iopts \$INNOEXTRA \$keyringbackupopt --backup --galera-info  --binlog-info=ON --stream=\$sfmt --target-dir=\$itmpdir 2> >(logger -p daemon.err -t ${ssystag}innobackupex-backup)"
     fi
 else
     INNOAPPLY="${INNOBACKUPEX_BIN} $disver $iapts --prepare --binlog-info=ON \$rebuildcmd \$keyringapplyopt --target-dir=\${DATA} &>\${DATA}/innobackup.prepare.log"
     INNOMOVE="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF}  --defaults-group=mysqld${WSREP_SST_OPT_CONF_SUFFIX} --datadir=\${TDATA} $disver $impts  --move-back --binlog-info=ON --force-non-empty-directories --target-dir=\${DATA} &>\${DATA}/innobackup.move.log"
-    INNOBACKUP="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF}  --defaults-group=mysqld${WSREP_SST_OPT_CONF_SUFFIX} $disver $iopts \$tmpopts \$INNOEXTRA \$keyringbackupopt --backup --galera-info --binlog-info=ON --stream=\$sfmt --target-dir=\$itmpdir 2>\${DATA}/innobackup.backup.log"
+    INNOBACKUP="${INNOBACKUPEX_BIN} --defaults-file=${WSREP_SST_OPT_CONF}  --defaults-group=mysqld${WSREP_SST_OPT_CONF_SUFFIX} $disver $iopts \$INNOEXTRA \$keyringbackupopt --backup --galera-info --binlog-info=ON --stream=\$sfmt --target-dir=\$itmpdir 2>\${DATA}/innobackup.backup.log"
 fi
 
 #
@@ -1176,14 +1204,10 @@ then
             exit 93
         fi
 
-        if [[ -z $(parse_cnf mysqld tmpdir "") && -z $(parse_cnf xtrabackup tmpdir "") ]]; then
-            xtmpdir=$(mktemp -d)
-            tmpopts=" --tmpdir=$xtmpdir "
-            wsrep_log_info "Using $xtmpdir as xtrabackup temporary directory"
-        fi
+        initialize_tmpdir
 
-        itmpdir=$(mktemp -d)
-        wsrep_log_info "Using $itmpdir as innobackupex temporary directory"
+        # main temp directory for xtrabackup (target-dir)
+        itmpdir=$(mktemp -p "${tmpdirbase}" -dt donor_xb_XXXXXXXX)
 
         if [[ -n "${WSREP_SST_OPT_USER:-}" && "$WSREP_SST_OPT_USER" != "(null)" ]]; then
            INNOEXTRA+=" --user=$WSREP_SST_OPT_USER"
@@ -1285,9 +1309,6 @@ then
             exit 22
         fi
 
-        # innobackupex implicitly writes PID to fixed location in $xtmpdir
-        XTRABACKUP_PID="$xtmpdir/xtrabackup_pid"
-
     else # BYPASS FOR IST
 
         wsrep_log_info "Bypassing SST. Can work it through IST"
@@ -1368,7 +1389,9 @@ then
             strmcmd=" $sdecomp | $strmcmd"
     fi
 
-    STATDIR=$(mktemp -d)
+    initialize_tmpdir
+
+    STATDIR=$(mktemp -p "${tmpdirbase}" -dt joiner_XXXXXXXX)
     XB_GTID_INFO_FILE_PATH="${STATDIR}/${XB_GTID_INFO_FILE}"
     recv_data_from_donor_to_joiner $STATDIR "${stagemsg}-gtid" $stimeout 1
 


### PR DESCRIPTION
Issue:
wsrep_sst_xtrabackup-v2.sh does not use the tmpdir option (either [xtrabackup] or [mysqld]).
It creates any needed temporary directories via "mktemp -d").

Solution:
Change the script so that it uses the tmpdir (if in [sst], [xtrabackup] or [mysqld], in
that order).

Additionally:
Test cases fixes for : MW-328A, galera_as_master_and_slave