### PR TITLE
Fix PXC-758: Debug status output is misleading

### DIFF
--- a/mysql-test/suite/galera/r/MW-328A.result
+++ b/mysql-test/suite/galera/r/MW-328A.result
@@ -18,4 +18,4 @@ have_deadlocks
 Got one of the listed errors
 DROP PROCEDURE proc_update;
 DROP TABLE t1, t2;
-CALL mtr.add_suppression("conflict state 3 after post commit");
+CALL mtr.add_suppression("conflict state ABORTED after post commit");

--- a/mysql-test/suite/galera/r/MW-328B.result
+++ b/mysql-test/suite/galera/r/MW-328B.result
@@ -14,4 +14,4 @@ SET SESSION wsrep_retry_autocommit = 0;
 Got one of the listed errors
 DROP PROCEDURE proc_update;
 DROP TABLE t1, t2;
-CALL mtr.add_suppression("conflict state 3 after post commit");
+CALL mtr.add_suppression("conflict state ABORTED after post commit");

--- a/mysql-test/suite/galera/r/MW-328C.result
+++ b/mysql-test/suite/galera/r/MW-328C.result
@@ -14,4 +14,4 @@ SET SESSION wsrep_retry_autocommit = 10000;
 Got one of the listed errors
 DROP PROCEDURE proc_update;
 DROP TABLE t1, t2;
-CALL mtr.add_suppression("conflict state 3 after post commit");
+CALL mtr.add_suppression("conflict state ABORTED after post commit");

--- a/mysql-test/suite/galera/r/galera_gcache_recover_manytrx.result
+++ b/mysql-test/suite/galera/r/galera_gcache_recover_manytrx.result
@@ -100,7 +100,7 @@ DROP PROCEDURE insert_transaction;
 DROP PROCEDURE update_simple;
 DROP PROCEDURE insert_1k;
 DROP PROCEDURE insert_1m;
-CALL mtr.add_suppression("conflict state 7 after post commit");
+CALL mtr.add_suppression("conflict state RETRY_AUTOCOMMIT after post commit");
 CALL mtr.add_suppression("Skipped GCache ring buffer recovery");
 include/assert_grep.inc [async IST sender starting to serve]
 CALL mtr.add_suppression("Skipped GCache ring buffer recovery");

--- a/mysql-test/suite/galera/t/MW-328-footer.inc
+++ b/mysql-test/suite/galera/t/MW-328-footer.inc
@@ -15,4 +15,4 @@
 DROP PROCEDURE proc_update;
 DROP TABLE t1, t2;
 
-CALL mtr.add_suppression("conflict state 3 after post commit");
+CALL mtr.add_suppression("conflict state ABORTED after post commit");

--- a/mysql-test/suite/galera/t/galera_gcache_recover_manytrx.test
+++ b/mysql-test/suite/galera/t/galera_gcache_recover_manytrx.test
@@ -193,7 +193,7 @@ DROP PROCEDURE insert_1k;
 DROP PROCEDURE insert_1m;
 
 --connection node_1
-CALL mtr.add_suppression("conflict state 7 after post commit");
+CALL mtr.add_suppression("conflict state RETRY_AUTOCOMMIT after post commit");
 
 # Warning happens when the cluster is started for the first time
 CALL mtr.add_suppression("Skipped GCache ring buffer recovery");

--- a/mysql-test/suite/galera/t/galera_parallel_apply_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_parallel_apply_lock_table.test
@@ -35,7 +35,7 @@ SET SESSION wsrep_sync_wait=0;
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Waiting for table metadata lock%';
 --source include/wait_condition.inc
 
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'wsrep: applied write-set%';
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'wsrep: applied write set%';
 --source include/wait_condition.inc
 
 SELECT COUNT(*) = 0 FROM t1;

--- a/mysql-test/suite/galera/t/galera_parallel_simple.test
+++ b/mysql-test/suite/galera/t/galera_parallel_simple.test
@@ -40,7 +40,7 @@ SET SESSION wsrep_sync_wait = 0;
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Waiting for table metadata lock%';
 --source include/wait_condition.inc
 
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'wsrep: applied write-set%';
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'wsrep: applied write set%';
 --source include/wait_condition.inc
 
 UNLOCK TABLES;

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -59,7 +59,7 @@ cpat=""
 ib_home_dir=""
 ib_log_dir=""
 ib_undo_dir=""
-sfmt="tar"
+sfmt=""
 strmcmd=""
 tfmt=""
 tcmd=""
@@ -403,6 +403,11 @@ get_transfer()
             fi
         fi
 
+        # prepend a comma if it's not already there
+        if [[ -n "${sockopt}" ]] && [[ "${sockopt}" != ","* ]]; then
+            sockopt=",${sockopt}"
+        fi
+
         if [[ $encrypt -eq 2 ]]; then
             wsrep_log_warning "**** WARNING **** encrypt=2 is deprecated and will be removed in a future release"
             wsrep_log_debug "Using openssl based encryption with socat: with crt and ca"
@@ -601,6 +606,11 @@ read_cnf()
         if [[ -n "$bufferpoolsize" ]]; then
             iapts="$iapts --use-memory=$bufferpoolsize"
         fi
+    fi
+
+    # Setup # of threads (if not already specified)
+    if ! [[ "$iopts" =~ --parallel= ]]; then
+        iopts+=" --parallel=4"
     fi
 
 }

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -253,7 +253,7 @@ wsrep_cb_status_t wsrep_apply_cb(void* const             ctx,
   thd->wsrep_trx_meta = *meta;
 
   THD_STAGE_INFO(thd, stage_wsrep_applying_writeset);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
            "wsrep: applying write-set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
@@ -281,8 +281,10 @@ wsrep_cb_status_t wsrep_apply_cb(void* const             ctx,
   wsrep_cb_status_t rcode(wsrep_apply_events(thd, buf, buf_len));
 
   THD_STAGE_INFO(thd, stage_wsrep_applied_writeset);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
-           "wsrep: applied write-set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
+           "wsrep: %s write set (%lld)",
+           rcode == WSREP_CB_SUCCESS ? "applied" : "failed to apply",
+           (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
 
@@ -307,7 +309,7 @@ wsrep_cb_status_t wsrep_apply_cb(void* const             ctx,
 static wsrep_cb_status_t wsrep_commit(THD* const thd)
 {
   THD_STAGE_INFO(thd, stage_wsrep_committing);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
            "wsrep: committing write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
@@ -316,8 +318,10 @@ static wsrep_cb_status_t wsrep_commit(THD* const thd)
                                 WSREP_CB_FAILURE : WSREP_CB_SUCCESS);
 
   THD_STAGE_INFO(thd, stage_wsrep_committed);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
-           "wsrep: committed write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
+           "wsrep: %s write set (%lld)",
+           (rcode == WSREP_CB_SUCCESS ? "committed" : "failed to commit"),
+           (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
 
@@ -338,7 +342,7 @@ static wsrep_cb_status_t wsrep_commit(THD* const thd)
 static wsrep_cb_status_t wsrep_rollback(THD* const thd)
 {
   THD_STAGE_INFO(thd, stage_wsrep_rolling_back);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
            "wsrep: rolling back write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
@@ -350,8 +354,10 @@ static wsrep_cb_status_t wsrep_rollback(THD* const thd)
                                 WSREP_CB_FAILURE : WSREP_CB_SUCCESS);
 
   THD_STAGE_INFO(thd, stage_wsrep_rolled_back);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
-           "wsrep: rolled back write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
+           "wsrep: %s write set (%lld)",
+           rcode == WSREP_CB_SUCCESS ? "rolled back" : "failed to rollback",
+           (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
 

--- a/sql/wsrep_hton.cc
+++ b/sql/wsrep_hton.cc
@@ -374,7 +374,7 @@ wsrep_run_wsrep_commit(THD *thd, handlerton *hton, bool all)
   }
 
   THD_STAGE_INFO(thd, stage_wsrep_replicating_commit);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
            "wsrep: replicating commit (%lld)", (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
@@ -400,7 +400,7 @@ wsrep_run_wsrep_commit(THD *thd, handlerton *hton, bool all)
     mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
 
     THD_STAGE_INFO(thd, stage_wsrep_waiting_on_replaying);
-    snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+    snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
              "wsrep: waiting to replay write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
     WSREP_DEBUG("%s", thd->wsrep_info);
     thd_proc_info(thd, thd->wsrep_info);
@@ -522,7 +522,7 @@ wsrep_run_wsrep_commit(THD *thd, handlerton *hton, bool all)
     if (WSREP_OK == rcode) {
 
       THD_STAGE_INFO(thd, stage_wsrep_pre_commit);
-      snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+      snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
               "wsrep: initiating pre-commit for write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
       WSREP_DEBUG("%s", thd->wsrep_info);
       thd_proc_info(thd, thd->wsrep_info);

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1814,7 +1814,7 @@ static int wsrep_TOI_begin(THD *thd, const char *db_, const char *table_,
                 wsrep_get_exec_mode(thd->wsrep_exec_mode));
 
     THD_STAGE_INFO(thd, stage_wsrep_preparing_for_TO_isolation);
-    snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+    snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
              "wsrep: initiating TOI for write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
     WSREP_DEBUG("%s", thd->wsrep_info);
     thd_proc_info(thd, thd->wsrep_info);
@@ -1869,7 +1869,7 @@ static void wsrep_TOI_end(THD *thd)
 #endif
 
   THD_STAGE_INFO(thd, stage_wsrep_completed_TO_isolation);
-  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+  snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
            "wsrep: completed TOI write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -242,7 +242,7 @@ void wsrep_replay_transaction(THD *thd)
       thd->m_digest= NULL;
 
       THD_STAGE_INFO(thd, stage_wsrep_replaying_trx);
-      snprintf(thd->wsrep_info, sizeof(thd->wsrep_info) - 1,
+      snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
                "wsrep: replaying write set (%lld)", (long long)wsrep_thd_trx_seqno(thd));
       WSREP_DEBUG("%s", thd->wsrep_info);
       thd_proc_info(thd, thd->wsrep_info);


### PR DESCRIPTION
    PXC-794: PXC SST: usability, prepend ',' to sockopt if needed
    PXC-795: PXC SST: set "--parallel=4" as default option to wsrep_sst_xtrabackup-v2

Issue:
PXC-758: status output does not check the result code before reporting result.
PXC-794: make the "sockopt" less error-prone
PXC-795: perf, increase use of threads when backing up on the donor

Solution:
PXC-758: check the result code and output the according output
PXC-794: prepend a comma (",") to the sockopt before using
PXC-795: add the "--parallel=4" to socat as a default