### PR TITLE
- PXC#479: Setting wsrep_desync=1 after FTWRL blocks a node

### DIFF
--- a/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
+++ b/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
@@ -39,10 +39,12 @@ show status like 'wsrep_desync_count';
 Variable_name	Value
 wsrep_desync_count	2
 SET GLOBAL wsrep_desync=0;
+ERROR HY000: Explictly desync/resync of already desynced/paused node is prohibited
 show status like 'wsrep_desync_count';
 Variable_name	Value
-wsrep_desync_count	1
+wsrep_desync_count	2
 UNLOCK TABLES;
+SET GLOBAL wsrep_desync=0;
 show status like 'wsrep_desync_count';
 Variable_name	Value
 wsrep_desync_count	0

--- a/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
+++ b/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
@@ -50,10 +50,11 @@ SET GLOBAL wsrep_desync=1;
 show status like 'wsrep_desync_count';
 FLUSH TABLE WITH READ LOCK;
 show status like 'wsrep_desync_count';
-# this shouldn't resync the cluster as flush table is still active.
+--error ER_UNKNOWN_ERROR
 SET GLOBAL wsrep_desync=0;
 show status like 'wsrep_desync_count';
 UNLOCK TABLES;
+SET GLOBAL wsrep_desync=0;
 show status like 'wsrep_desync_count';
 DROP TABLE t1;
 

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -634,6 +634,22 @@ bool wsrep_desync_check (sys_var *self, THD* thd, set_var* var)
     }
     return false;
   }
+
+  /* Setting desync to on/off signals participation of node in flow control.
+  It doesn't turn-off recieval of write-sets.
+  If the node is already in paused state due to some previous action like FTWRL
+  then avoid desync as superset action of pausing the node is already active. */
+
+  if (!thd->global_read_lock.provider_resumed())
+  {
+    char message[1024];
+    sprintf(message,
+            "Explictly desync/resync of already desynced/paused node"
+            " is prohibited");
+    my_message(ER_UNKNOWN_ERROR, message, MYF(0));
+    return true;
+  }
+
   wsrep_status_t ret(WSREP_WARNING);
   if (new_wsrep_desync) {
     ret = wsrep->desync (wsrep);


### PR DESCRIPTION
  accidentally got removed as part of merge. Re-adding.