### PR TITLE
- PXC#479: Setting wsrep_desync=1 after FTWRL blocks a node

### DIFF
--- a/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
+++ b/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
@@ -39,10 +39,12 @@ show status like 'wsrep_desync_count';
 Variable_name	Value
 wsrep_desync_count	2
 SET GLOBAL wsrep_desync=0;
+ERROR HY000: Explictly desync/resync of already desynced/paused node is prohibited
 show status like 'wsrep_desync_count';
 Variable_name	Value
-wsrep_desync_count	1
+wsrep_desync_count	2
 UNLOCK TABLES;
+SET GLOBAL wsrep_desync=0;
 show status like 'wsrep_desync_count';
 Variable_name	Value
 wsrep_desync_count	0

--- a/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
+++ b/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
@@ -50,10 +50,11 @@ SET GLOBAL wsrep_desync=1;
 show status like 'wsrep_desync_count';
 FLUSH TABLE WITH READ LOCK;
 show status like 'wsrep_desync_count';
-# this shouldn't resync the cluster as flush table is still active.
+--error ER_UNKNOWN_ERROR
 SET GLOBAL wsrep_desync=0;
 show status like 'wsrep_desync_count';
 UNLOCK TABLES;
+SET GLOBAL wsrep_desync=0;
 show status like 'wsrep_desync_count';
 DROP TABLE t1;
 


### PR DESCRIPTION
  accidentally got removed as part of merge. Re-adding.