### PR TITLE
Fix PXC-794 : PXC SST: usability, prepend ',' to sockopt if needed

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -330,6 +330,11 @@ get_transfer()
             fi
         fi
 
+        # prepend a comma if it's not already there
+        if [[ -n "${sockopt}" ]] && [[ "${sockopt}" != ","* ]]; then
+            sockopt=",${sockopt}"
+        fi
+
         if [[ $encrypt -eq 2 ]]; then
             wsrep_log_warning "**** WARNING **** encrypt=2 is deprecated and will be removed in a future release"
             wsrep_log_info "Using openssl based encryption with socat: with crt and ca"


### PR DESCRIPTION
Issue
The sockopt option requires the option to start with a comma(",").
This is easily missed and makes it harder to set than necessary.

Solution
If there is no comma, prepend it to the option before using it.