### PR TITLE
[BLD-697] upgrade fails with -full meta package (part 2)

### DIFF
--- a/build-ps/debian/percona-xtradb-cluster-garbd-5.7.prerm
+++ b/build-ps/debian/percona-xtradb-cluster-garbd-5.7.prerm
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+if [ -e "/etc/init.d/garbd" ]; then
+  sed -i "s/exit 1/exit 0/" /etc/init.d/garbd
+fi
+#DEBHELPER#

--- a/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.prerm
+++ b/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.prerm
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+if [ -e "/etc/init.d/garbd" ]; then
+  sed -i "s/exit 1/exit 0/" /etc/init.d/garbd
+fi
+#DEBHELPER#


### PR DESCRIPTION
The error appear on prerm stage of garbd package. now everything works well:

`Unpacking replacement percona-xtradb-cluster-garbd-debug-5.7 ...
Preparing to replace percona-xtradb-cluster-garbd-5.7 5.7.17-27.20-2.wheezy (using .../percona-xtradb-cluster-garbd-5.7_5.7.17-29.20-3.wheezy_amd64.deb) ...
[FAIL] Garbd config /etc/default/garbd is not configured yet ... failed!
invoke-rc.d: initscript garbd, action "stop" failed.
dpkg: warning: subprocess old pre-removal script returned error exit status 1
dpkg: trying script from the new package instead ...
[FAIL] Garbd config /etc/default/garbd is not configured yet ... failed!
dpkg: ... it looks like that went OK
Unpacking replacement percona-xtradb-cluster-garbd-5.7 ...
Preparing to replace percona-xtradb-cluster-full-57 5.7.17-27.20-2.wheezy (using .../percona-xtradb-cluster-full-57_5.7.17-29.20-3.wheezy_amd64.deb) ...
Unpacking replacement percona-xtradb-cluster-full-57 ...
Processing triggers for man-db ...
locale: Cannot set LC_ALL to default locale: No such file or directory
Setting up percona-xtradb-cluster-client-5.7 (5.7.17-29.20-3.wheezy) ...
Setting up percona-xtradb-cluster-server-5.7 (5.7.17-29.20-3.wheezy) ...
locale: Cannot set LC_ALL to default locale: No such file or directory


 * Percona XtraDB Cluster is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
 * Run the following commands to create these functions:

        mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
        mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
        mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"

 * See http://www.percona.com/doc/percona-server/5.7/management/udf_percona_toolkit.html for more details


[ ok ] Starting MySQL (Percona XtraDB Cluster) database server: mysqld ..
Setting up percona-xtradb-cluster-5.7-dbg (5.7.17-29.20-3.wheezy) ...
Setting up percona-xtradb-cluster-test-5.7 (5.7.17-29.20-3.wheezy) ...
Setting up percona-xtradb-cluster-garbd-5.7 (5.7.17-29.20-3.wheezy) ...
[FAIL] Garbd config /etc/default/garbd is not configured yet ... failed!
[FAIL] Garbd config /etc/default/garbd is not configured yet ... failed!
Setting up percona-xtradb-cluster-garbd-debug-5.7 (5.7.17-29.20-3.wheezy) ...
Setting up percona-xtradb-cluster-full-57 (5.7.17-29.20-3.wheezy) ...
vagrant@wheezy:~$ echo $?
0
`