### PR TITLE
Fix PXC-749: Assertion `pool_.size() == allocd_' failed in gu::MemPoo…

### DIFF
--- a/mysql-test/suite/galera/t/galera_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_lock_table.test
@@ -12,6 +12,9 @@ CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 CREATE TABLE t2 (id INT PRIMARY KEY) ENGINE=InnoDB;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+
 LOCK TABLE t1 READ;
 
 --connection node_1

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -10705,7 +10705,8 @@ ha_innobase::wsrep_append_keys(
 
 			/* !hasPK == table with no PK, 
                            must append all non-unique keys */
-			if (!hasPK || key_info->flags & HA_NOSAME ||
+			if ((!hasPK && wsrep_certify_nonPK) ||
+				key_info->flags & HA_NOSAME ||
 			    ((tab && wsrep_is_FK_index(tab, idx)) ||
 			     (!tab && referenced_by_foreign_key()))) {
 


### PR DESCRIPTION
…l<thread_safe>::~MemPool() [with bool thread_safe = false]

Issue:
Code asserts when wsrep-certify-nonPK=0 is set and an INSERT is tried on a no-PK table.
The code results in a memory leak (which causes the assert)

Solution:
If the table does not have a PK, and wsrep-certify-nonPK is set to 0, do not
append non-unique keys to the row.