### PR TITLE
Fix PXC-813: correct timezone for sst script

### DIFF
--- a/mysql-test/suite/galera/t/galera_log_bin.test
+++ b/mysql-test/suite/galera/t/galera_log_bin.test
@@ -22,6 +22,12 @@ INSERT INTO t2 VALUES (1);
 INSERT INTO t2 VALUES (1);
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t2
+--source include/wait_condition.inc
+
 SELECT COUNT(*) = 1 FROM t1;
 SELECT COUNT(*) = 2 FROM t2;
 

--- a/mysql-test/suite/galera/t/lp1376747-2.test
+++ b/mysql-test/suite/galera/t/lp1376747-2.test
@@ -5,6 +5,12 @@ CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1
+--source include/wait_condition.inc
+
 FLUSH TABLES t1 FOR EXPORT;
 
 --connection node_1


### PR DESCRIPTION
Issue:
The SST script (when printing output) does not show the TZ in the same
format as the rest of the error log.

Solution:
Change the format to match what MySQL is doing. Change the script
to use the same format (see --log-timestamps for supported TZs).

Also, some additional test case fixes.