### PR TITLE
- PXC#816: Regression in GTID consistency when parallel applying used…

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -302,7 +302,7 @@ export MAKE_JFLAG="${MAKE_JFLAG:--j$PROCESSORS}"
 
 export DEBIAN_VERSION="$(lsb_release -sc)"
 echo $DEBIAN_VERSION
-if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]] && [[ "$DEBIAN_VERSION" == "yakkety" ]]; then
+if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]] && ([[ "$DEBIAN_VERSION" == "yakkety" ]] || [[ "$DEBIAN_VERSION" == "zesty" ]]); then
     export CFLAGS=" $CFLAGS -fno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-error=nonnull-compare -Wno-error=shift-negative-value -Wno-error=misleading-indentation -Wno-error=literal-suffix -Wno-error=virtual-move-assign"
     export CXXFLAGS=" $CFLAGS -fno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-error=nonnull-compare -Wno-error=shift-negative-value -Wno-error=misleading-indentation -Wno-error=literal-suffix -Wno-error=virtual-move-assign"
 fi

--- a/mysql-test/suite/galera/r/galera_as_master_and_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_master_and_slave.result
@@ -45,6 +45,83 @@ i	c
 3	cccccc
 4	dddddd
 5	eeeeee
+select @@slave_parallel_workers;
+@@slave_parallel_workers
+0
+set global slave_parallel_workers=2;
+select @@slave_parallel_workers;
+@@slave_parallel_workers
+2
+STOP SLAVE;
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+#node-1 (independent master)
+use test;
+insert into t values (1000, 'aaaaaa');
+insert into t values (2000, 'bbbbbb');
+select locate(':1-4', @@global.gtid_executed);
+locate(':1-4', @@global.gtid_executed)
+VALID_POS
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+1000	aaaaaa
+2000	bbbbbb
+#node-2 (galera-cluster-node acting as slave to an independent master)
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+1000	aaaaaa
+2000	bbbbbb
+select left(@@global.gtid_executed, 36) = '<master_id>';;
+left(@@global.gtid_executed, 36) = '<master_id>'
+1
+#node-3 (galera-cluster-node-2 that act as master to independent slave)
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+1000	aaaaaa
+2000	bbbbbb
+select left(@@global.gtid_executed, 36) = '<master_id>';;
+left(@@global.gtid_executed, 36) = '<master_id>'
+1
+#node-4 (independent slave replicating from galera-node-2)
+select * from t;
+i	c
+1	aaaaaa
+2	bbbbbb
+3	cccccc
+4	dddddd
+5	eeeeee
+1000	aaaaaa
+2000	bbbbbb
+select left(@@global.gtid_executed, 36) = '<master_id>';;
+left(@@global.gtid_executed, 36) = '<master_id>'
+1
+select @@slave_parallel_workers;
+@@slave_parallel_workers
+2
+set global slave_parallel_workers=0;
+select @@slave_parallel_workers;
+@@slave_parallel_workers
+0
+STOP SLAVE;
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
 #node-2 (galera-cluster-node acting as slave to an independent master)
 delete from t where i = 2;
 update t set c = 'zzzzzz' where i = 4;
@@ -55,6 +132,8 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
+1000	aaaaaa
+2000	bbbbbb
 select locate(':1-3', @@global.gtid_executed);
 locate(':1-3', @@global.gtid_executed)
 VALID_POS
@@ -65,6 +144,8 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
+1000	aaaaaa
+2000	bbbbbb
 select locate(':1-3', @@global.gtid_executed);
 locate(':1-3', @@global.gtid_executed)
 VALID_POS
@@ -78,8 +159,10 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate(':1-5', @@global.gtid_executed);
-locate(':1-5', @@global.gtid_executed)
+1000	aaaaaa
+2000	bbbbbb
+select locate(':1-7', @@global.gtid_executed);
+locate(':1-7', @@global.gtid_executed)
 VALID_POS
 #node-2 (galera-cluster-node acting as slave to an independent master)
 select * from t;
@@ -88,8 +171,10 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate(':1-5', @@global.gtid_executed);
-locate(':1-5', @@global.gtid_executed)
+1000	aaaaaa
+2000	bbbbbb
+select locate(':1-7', @@global.gtid_executed);
+locate(':1-7', @@global.gtid_executed)
 VALID_POS
 #node-3 (galera-cluster-node-2 that act as master to independent slave)
 select * from t;
@@ -98,8 +183,10 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate(':1-5', @@global.gtid_executed);
-locate(':1-5', @@global.gtid_executed)
+1000	aaaaaa
+2000	bbbbbb
+select locate(':1-7', @@global.gtid_executed);
+locate(':1-7', @@global.gtid_executed)
 VALID_POS
 #node-4 (independent slave replicating from galera-node-2)
 select * from t;
@@ -108,8 +195,10 @@ i	c
 3	cccccc
 4	zzzzzz
 50	pppppp
-select locate(':1-5', @@global.gtid_executed);
-locate(':1-5', @@global.gtid_executed)
+1000	aaaaaa
+2000	bbbbbb
+select locate(':1-7', @@global.gtid_executed);
+locate(':1-7', @@global.gtid_executed)
 VALID_POS
 #node-1 (independent master)
 update t set c = 'kkkkk' where i = 1;
@@ -120,8 +209,10 @@ i	c
 4	zzzzzz
 50	pppppp
 100	k2
-select locate(':1-7', @@global.gtid_executed);
-locate(':1-7', @@global.gtid_executed)
+1000	aaaaaa
+2000	bbbbbb
+select locate(':1-9', @@global.gtid_executed);
+locate(':1-9', @@global.gtid_executed)
 VALID_POS
 #node-3 (galera-cluster-node-2 that act as master to independent slave)
 select * from t;
@@ -130,8 +221,10 @@ i	c
 4	zzzzzz
 50	pppppp
 100	k2
-select locate(':1-7', @@global.gtid_executed);
-locate(':1-7', @@global.gtid_executed)
+1000	aaaaaa
+2000	bbbbbb
+select locate(':1-9', @@global.gtid_executed);
+locate(':1-9', @@global.gtid_executed)
 VALID_POS
 #node-1 (independent master)
 DROP TABLE t;

--- a/mysql-test/suite/galera/t/galera_as_master_and_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_master_and_slave.test
@@ -52,38 +52,94 @@ select * from t;
 # ensure remaining nodes has the needed data.
 --connection node_2
 --echo #node-2 (galera-cluster-node acting as slave to an independent master)
-
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
 --source include/wait_condition.inc
-
 --let $wait_condition = SELECT COUNT(*) = 5 FROM t;
 --source include/wait_condition.inc
-
 select * from t;
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
-
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
 --source include/wait_condition.inc
-
 --let $wait_condition = SELECT COUNT(*) = 5 FROM t;
 --source include/wait_condition.inc
-
 select * from t;
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
-
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
 --source include/wait_condition.inc
-
 --let $wait_condition = SELECT COUNT(*) = 5 FROM t;
 --source include/wait_condition.inc
-
 select * from t;
 
+
+#
+# Step-2a: Initiate some seed workload on independent master
+#          with slave-parallel-workers > 0 on slave.
+#
+
+--connection node_2
+select @@slave_parallel_workers;
+set global slave_parallel_workers=2;
+select @@slave_parallel_workers;
+#
+STOP SLAVE;
+START SLAVE USER='root';
+
+--connection node_1
+--echo #node-1 (independent master)
+use test;
+insert into t values (1000, 'aaaaaa');
+insert into t values (2000, 'bbbbbb');
+--replace_regex /[1-9][0-9]+/VALID_POS/
+select locate(':1-4', @@global.gtid_executed);
+--let $master_id=`select left(@@global.gtid_executed, 36)`
+select * from t;
+# replication lag
+--sleep 1
+
+#
+# ensure remaining nodes has the needed data.
+--connection node_2
+--echo #node-2 (galera-cluster-node acting as slave to an independent master)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 7 FROM t;
+--source include/wait_condition.inc
+select * from t;
+--replace_result $master_id <master_id>
+--eval select left(@@global.gtid_executed, 36) = '$master_id';
+
+--connection node_3
+--echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 7 FROM t;
+--source include/wait_condition.inc
+select * from t;
+--replace_result $master_id <master_id>
+--eval select left(@@global.gtid_executed, 36) = '$master_id';
+
+--connection node_4
+--echo #node-4 (independent slave replicating from galera-node-2)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 7 FROM t;
+--source include/wait_condition.inc
+select * from t;
+--replace_result $master_id <master_id>
+--eval select left(@@global.gtid_executed, 36) = '$master_id';
+
+--connection node_2
+select @@slave_parallel_workers;
+set global slave_parallel_workers=0;
+select @@slave_parallel_workers;
+#
+STOP SLAVE;
+START SLAVE USER='root';
 
 #
 # Step-3: Try to perform some DML directly on galera-node-1 which is slave
@@ -103,7 +159,6 @@ select locate(':1-3', @@global.gtid_executed);
 --echo #node-4 (independent slave replicating from galera-node-2)
 --let $wait_condition = SELECT COUNT(*) = 1 FROM t WHERE i = 50
 --source include/wait_condition.inc
-
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
 select locate(':1-3', @@global.gtid_executed);
@@ -119,7 +174,7 @@ update t set c = 'zzzzzz' where i = 4;
 update t set c = 'pppppp', i = 50 where i = 5;
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate(':1-5', @@global.gtid_executed);
+select locate(':1-7', @@global.gtid_executed);
 # replication lag
 sleep 1;
 
@@ -128,19 +183,19 @@ sleep 1;
 --echo #node-2 (galera-cluster-node acting as slave to an independent master)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate(':1-5', @@global.gtid_executed);
+select locate(':1-7', @@global.gtid_executed);
 
 --connection node_3
 --echo #node-3 (galera-cluster-node-2 that act as master to independent slave)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate(':1-5', @@global.gtid_executed);
+select locate(':1-7', @@global.gtid_executed);
 
 --connection node_4
 --echo #node-4 (independent slave replicating from galera-node-2)
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate(':1-5', @@global.gtid_executed);
+select locate(':1-7', @@global.gtid_executed);
 
 #
 # do some more transaction to rule-out existence of GTID gaps.
@@ -151,7 +206,7 @@ update t set c = 'kkkkk' where i = 1;
 update t set c = 'k2', i = 100 where i = 1;
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate(':1-7', @@global.gtid_executed);
+select locate(':1-9', @@global.gtid_executed);
 # replication lag
 --sleep 1
 
@@ -161,7 +216,7 @@ select locate(':1-7', @@global.gtid_executed);
 --source include/wait_condition.inc
 select * from t;
 --replace_regex /[1-9][0-9]+/VALID_POS/
-select locate(':1-7', @@global.gtid_executed);
+select locate(':1-9', @@global.gtid_executed);
 
 #
 # Step-n: Remove seed table and break all replication links as part of cleanup.

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -5410,38 +5410,6 @@ static int exec_relay_log_event(THD* thd, Relay_log_info* rli)
       if (ev->get_type_code() != binary_log::FORMAT_DESCRIPTION_EVENT &&
           ev->get_type_code() != binary_log::ROWS_QUERY_LOG_EVENT)
       {
-#ifdef WITH_WSREP
-        if (ev->get_type_code() == binary_log::GTID_LOG_EVENT &&
-            WSREP_ON && !wsrep_preordered_opt)
-        {
-          assert (!thd->wsrep_applier);
-          if (thd->wsrep_gtid_event_buf)
-          {
-            WSREP_WARN("Pending to replicate MySQL GTID event"
-                       " (probably a stale event). Discarding it now.");
-            my_free((uchar*)thd->wsrep_gtid_event_buf);
-            thd->wsrep_gtid_event_buf     = NULL;
-            thd->wsrep_gtid_event_buf_len = 0;
-          }
-
-          ulong len= thd->wsrep_gtid_event_buf_len=
-            uint4korr(ev->temp_buf + EVENT_LEN_OFFSET);
-          thd->wsrep_gtid_event_buf= (void*)my_realloc(
-              key_memory_wsrep,
-              thd->wsrep_gtid_event_buf,
-              thd->wsrep_gtid_event_buf_len,
-              MYF(0));
-          if (!thd->wsrep_gtid_event_buf)
-          {
-            WSREP_WARN("GTID event allocation for slave failed");
-            thd->wsrep_gtid_event_buf_len= 0;
-          }
-          else
-          {
-            memcpy(thd->wsrep_gtid_event_buf, ev->temp_buf, len);
-          }
-        }
-#endif /* WITH_WSREP */
         DBUG_PRINT("info", ("Deleting the event after it has been executed"));
         delete ev;
         ev= NULL;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4529,6 +4529,10 @@ end_with_restore_list:
   {
     List<set_var_base> *lex_var_list= &lex->var_list;
 
+#ifdef WITH_WSREP
+    ulong cached_pxc_maint_mode= pxc_maint_mode;
+#endif /* WITH_WSREP */
+
     if ((check_table_access(thd, SELECT_ACL, all_tables, FALSE, UINT_MAX, FALSE)
          || open_and_lock_tables(thd, all_tables, 0)))
       goto error;
@@ -4545,6 +4549,16 @@ end_with_restore_list:
         my_error(ER_WRONG_ARGUMENTS,MYF(0),"SET");
       goto error;
     }
+
+#ifdef WITH_WSREP
+    if (cached_pxc_maint_mode != pxc_maint_mode
+        && pxc_maint_mode == PXC_MAINT_MODE_MAINTENANCE)
+    {
+      WSREP_INFO ("Sleep for %lu secs while switching to maintenance mode",
+                  pxc_maint_transition_period);
+      sleep(pxc_maint_transition_period);
+    }
+#endif /* WITH_WSREP */
 
     break;
   }

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -1008,12 +1008,5 @@ bool pxc_maint_mode_check(sys_var *self, THD* thd, set_var* var)
 
 bool pxc_maint_mode_update(sys_var *self, THD* thd, enum_var_type type)
 {
-   if (pxc_maint_mode == PXC_MAINT_MODE_MAINTENANCE)
-   {
-     WSREP_INFO ("Sleep for %lu secs while switching to maintenance mode",
-                  pxc_maint_transition_period);
-     sleep(pxc_maint_transition_period);
-   }
-
    return false;
 }


### PR DESCRIPTION
… for async replication

  - GTID event generated from MASTER is processed by SLAVE.
  - SLAVE can process this event using master-thread if slave-parallel-workers=0
    or assign it to slave worker is slave-parallel-workers > 0.
  - Starting 5.7, MySQL has stopped writing this event to bin-log but PXC need
    this event for proper creation of write-set so PXC has logic to cache this event.
  - Hook to cache this event was wrongly placed that was triggered only if
    GTID event is being processed by master-thread (that is slave-parallel-workers=0)

  Fix:
  - Corrected hook such that the thread that is processing this event will
    cache the event.

------------------------

- PXC#820: unable to query pxc_maint_mode while switching to maintenance

  - After updating pxc_maint_mode mode, flow use to trigger a sleep for
    pxc_maint_transition_period so that ProxySQL can detect the change
    and update the state of the node while user still wait for node change.

  - Unfortunately, MySQL holds global-variable locks longer than expected.
    on_update routine is called after the variable is updated and theortically
    global-variable lock should not be held during on_update as update action
    is already complete by MySQL continue to hold locks and correcting it
    looks difficult now as legacy variable's on_update routine continue to
    update the variable even though semantically it should use on_update
    function for follow-up action.

  To get around this we now handles pxc_maint_mode case specially by checking
  if there is change in pxc_maint_mode post update. If the new mode is
  maintenance then trigger sleep.