### PR TITLE
- PXC#823: Donor node enters permanent DESYNCED state after short net…

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1423,7 +1423,8 @@ extern "C" void unireg_abort(int exit_code)
     wsrep_wait_appliers_close(NULL);
     WSREP_INFO("Service disconnected.");
 
-    sleep(3); /* so give some time to exit for those which can */
+    WSREP_INFO("Waiting to close threads......");
+    sleep(5); /* so give some time to exit for those which can */
     WSREP_INFO("Some threads may fail to exit.");
   }
 #endif // WITH_WSREP


### PR DESCRIPTION
…work

  failure duing SST

  Let's understand the problem through a use-case
  * 2 node cluster with nodes n1, n2
  * 3rd node is trying to join say n3.
  * n1 is acting as DONOR and n3 is acting as JOINER
  * n1 looses n/w connectivity.
  * n2 and n3 forms a primary but n3 can't keep itself up
    in half-cooked state so it needs to leave.
  * n3 leaving should be graceful but it was abrupt shutdown
    and so n2 turns into non-primary as it loose quorum.
  * Even though n1 re-joins the cluster n1 and n2 both
    non-primary wait for n3 to come up which doesn't happen.
  * Also, as per the flow, n1 resumes original state that
    it maintained before it turned non-primary. (DONOR)
  * Since sst_sent action fails join process is not completed.

  Fix:
  ---

  * Ensure that if the sst fails on JOINER it does graceful shutdown
    (and not abrupt assert)
  * DONOR on restore should resume join state if sst_sent fails.