### PR TITLE
- PXC#824: shutdown of pxc doesn't wait for applier thread to finish.

### DIFF
--- a/mysql-test/suite/galera/r/galera_migrate.result
+++ b/mysql-test/suite/galera/r/galera_migrate.result
@@ -80,6 +80,7 @@ SET GLOBAL wsrep_sst_receive_address = 'AUTO';
 DROP TABLE t1;
 DROP USER sst;
 CALL mtr.add_suppression("Read non-wsrep XID from storage engines");
+CALL mtr.add_suppression("WSREP: Pending to replicate MySQL GTID event.*");
 CALL mtr.add_suppression("Read non-wsrep XID from storage engines");
 CALL mtr.add_suppression("`innodb_index_stats` not found");
 CALL mtr.add_suppression("`innodb_table_stats` not found");

--- a/mysql-test/suite/galera/t/galera_migrate.test
+++ b/mysql-test/suite/galera/t/galera_migrate.test
@@ -212,6 +212,7 @@ DROP USER sst;
 
 --connection node_3
 CALL mtr.add_suppression("Read non-wsrep XID from storage engines");
+CALL mtr.add_suppression("WSREP: Pending to replicate MySQL GTID event.*");
 
 --connection node_4a
 CALL mtr.add_suppression("Read non-wsrep XID from storage engines");

--- a/sql/mysqld_thd_manager.h
+++ b/sql/mysqld_thd_manager.h
@@ -49,6 +49,10 @@ public:
   Do_THD_Impl();
   virtual ~Do_THD_Impl() {}
   virtual void operator()(THD*) = 0;
+#ifdef WITH_WSREP
+  virtual void reset() {}
+  virtual bool done(int) { return(true); }
+#endif /* WITH_WSREP */
 };
 
 
@@ -216,6 +220,15 @@ public:
     get_thd_count to become zero.
   */
   void wait_till_no_thd();
+
+#ifdef WITH_WSREP
+  /**
+    Waits until total wsrep thd count fails below the set threshold.
+    wsrep thd to considered is filtered using func functor.
+  */
+  void wait_till_wsrep_thd_eq(Do_THD_Impl* func, int threshold_count);
+#endif /* WITH_WSREP */
+
 
   /**
     This function calls func() for all thds in thd list after


### PR DESCRIPTION
  When the node is gracefully shutdown it should wait for applier
  to finish the assigned work (this is how 5.6 operates).

  In recent ported 5.7 the flow didn't wait for applier to finish,
  instead notified applier about server shutdown.

  Applier on getting notification fails to apply the write-set.
  Failure to apply write-set is treated as catastrophic error
  there-by causing applier thread to abort with fatal error
  about node-consistency compromised.

  Fix:
  ---
  * shutdown flow should wait for applier to finish.
  * applier will not see new workload as the group communication
    channel has been disconnected but applier should finish up
    existing work. (this is now in sync with 5.6 logic).