### PR TITLE
[BLD-725] Cannot start garbd

### DIFF
--- a/build-ps/debian/percona-xtradb-cluster-garbd-5.7.garbd.init
+++ b/build-ps/debian/percona-xtradb-cluster-garbd-5.7.garbd.init
@@ -47,7 +47,7 @@ log_failure() {
 
 if grep -q -E '^# REMOVE' $config; then
 	log_failure "Garbd config $config is not configured yet"
-	exit 0
+	exit 1
 fi
 
 PIDFILE=/var/run/garbd

--- a/build-ps/debian/percona-xtradb-cluster-garbd-5.7.postinst
+++ b/build-ps/debian/percona-xtradb-cluster-garbd-5.7.postinst
@@ -1,12 +1,13 @@
 #!/bin/sh
-
-#DEBHELPER#
-
-set -e
-case "$1" in
-    configure)
-	invoke-rc.d garbd stop || exit $?
-	sed -i "s/exit 0/exit 1/" /etc/init.d/garbd
-	;;
-    esac
-exit 0
+config=/etc/default/garbd
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+  if [ -x "/etc/init.d/garbd" ]; then
+    update-rc.d garbd defaults >/dev/null
+    if grep -q -E '^# REMOVE' $config; then
+      echo  "Garbd config $config is not configured yet"
+      exit 0
+    else
+      invoke-rc.d garbd start || exit $?
+    fi
+  fi
+fi

--- a/build-ps/debian/percona-xtradb-cluster-garbd-5.7.preinst
+++ b/build-ps/debian/percona-xtradb-cluster-garbd-5.7.preinst
@@ -10,7 +10,3 @@ if [ ! -d "/var/lib/galera" ]; then
     chown nobody:nogroup /var/lib/galera
   fi
 fi
-
-if [ -f "/etc/init.d/garbd" ]; then
-  sed -i "s/exit 1/exit 0/" /etc/init.d/garbd
-fi

--- a/build-ps/debian/percona-xtradb-cluster-garbd-5.7.prerm
+++ b/build-ps/debian/percona-xtradb-cluster-garbd-5.7.prerm
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-if [ -e "/etc/init.d/garbd" ]; then
-  sed -i "s/exit 1/exit 0/" /etc/init.d/garbd
-fi
-#DEBHELPER#

--- a/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.garbd.init
+++ b/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.garbd.init
@@ -47,7 +47,7 @@ log_failure() {
 
 if grep -q -E '^# REMOVE' $config; then
 	log_failure "Garbd config $config is not configured yet"
-	exit 0
+	exit 1
 fi
 
 PIDFILE=/var/run/garbd

--- a/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.postinst
+++ b/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.postinst
@@ -1,12 +1,13 @@
 #!/bin/sh
-
-#DEBHELPER#
-
-set -e
-case "$1" in
-    configure)
-	invoke-rc.d garbd stop || exit $?
-	sed -i "s/exit 0/exit 1/" /etc/init.d/garbd
-	;;
-    esac
-exit 0
+config=/etc/default/garbd
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+  if [ -x "/etc/init.d/garbd" ]; then
+    update-rc.d garbd defaults >/dev/null
+    if grep -q -E '^# REMOVE' $config; then
+      echo  "Garbd config $config is not configured yet"
+      exit 0
+    else
+      invoke-rc.d garbd start || exit $?
+    fi
+  fi
+fi

--- a/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.preinst
+++ b/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.preinst
@@ -10,7 +10,3 @@ if [ ! -d "/var/lib/galera" ]; then
     chown nobody:nogroup /var/lib/galera
   fi
 fi
-
-if [ -f "/etc/init.d/garbd" ]; then
-  sed -i "s/exit 1/exit 0/" /etc/init.d/garbd
-fi

--- a/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.prerm
+++ b/build-ps/ubuntu/percona-xtradb-cluster-garbd-5.7.prerm
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-if [ -e "/etc/init.d/garbd" ]; then
-  sed -i "s/exit 1/exit 0/" /etc/init.d/garbd
-fi
-#DEBHELPER#


### PR DESCRIPTION
ubuntu@ubuntu-zesty:~$ sudo dpkg -i percona-xtradb-cluster-garbd-5.7_5.7.18-29.20-1.zesty_amd64.deb 
(Reading database ... 56780 files and directories currently installed.)
Preparing to unpack percona-xtradb-cluster-garbd-5.7_5.7.18-29.20-1.zesty_amd64.deb ...
Unpacking percona-xtradb-cluster-garbd-5.7 (5.7.18-29.20-1.zesty) over (5.7.18-29.20-1.zesty) ...
Setting up percona-xtradb-cluster-garbd-5.7 (5.7.18-29.20-1.zesty) ...
Garbd config /etc/default/garbd is not configured yet
Processing triggers for ureadahead (0.100.0-19) ...
Processing triggers for systemd (232-21ubuntu3) ...
ubuntu@ubuntu-zesty:~$ sudo service garbd status
● garbd.service - LSB: Galera Arbitrator Daemon
   Loaded: loaded (/etc/init.d/garbd; generated; vendor preset: enabled)
   Active: inactive (dead)
     Docs: man:systemd-sysv-generator(8)

May 30 22:39:57 ubuntu-zesty systemd[1]: Stopping LSB: Galera Arbitrator Daemon...
May 30 22:39:57 ubuntu-zesty garbd[8708]: start-stop-daemon: warning: failed to kill 8355: No such process
May 30 22:39:57 ubuntu-zesty garbd[8708]:    ...done.
May 30 22:39:57 ubuntu-zesty systemd[1]: Stopped LSB: Galera Arbitrator Daemon.
May 30 22:47:46 ubuntu-zesty systemd[1]: Starting LSB: Galera Arbitrator Daemon...
May 30 22:47:46 ubuntu-zesty garbd[9443]:  * Garbd config /etc/default/garbd is not configured yet
May 30 22:47:46 ubuntu-zesty systemd[1]: Started LSB: Galera Arbitrator Daemon.
May 30 22:48:03 ubuntu-zesty systemd[1]: Stopping LSB: Galera Arbitrator Daemon...
May 30 22:48:03 ubuntu-zesty garbd[9508]:  * Garbd config /etc/default/garbd is not configured yet
May 30 22:48:03 ubuntu-zesty systemd[1]: Stopped LSB: Galera Arbitrator Daemon.


So everything works