### PR TITLE
Fix PXC-827: MySQL GTID metadata not synced upon full SST

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_binlog.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_binlog.result
@@ -1,0 +1,21 @@
+SET GLOBAL wsrep_provider_options="pc.weight=1";
+SET GLOBAL wsrep_provider_options="pc.weight=0";
+SELECT 1;
+1
+1
+CREATE TABLE t1 (
+id INT NOT NULL AUTO_INCREMENT,
+text VARCHAR(10) DEFAULT NULL,
+PRIMARY KEY (id)
+);
+INSERT INTO t1(text) VALUES('aaaaa');
+INSERT INTO t1(text) VALUES('bbbbb');
+Restarting node 2 ...
+# restart
+select * from t1;
+id	text
+1	aaaaa
+2	bbbbb
+gtid_executed_equal
+1
+drop table t1;

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_binlog.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_binlog.cnf
@@ -1,0 +1,15 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_sst_auth="root:"
+gtid-mode=ON
+enforce-gtid-consistency=1
+log-slave-updates
+binlog-format=ROW
+
+[mysqld.1]
+log-bin=pxc1
+
+[mysqld.2]
+log-bin=@ENV.MYSQLTEST_VARDIR/mysqld.2/pxc2-binlog

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_binlog.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_binlog.test
@@ -1,0 +1,97 @@
+#
+# This test looks into doing an SST with nodes that have differing binlog names.
+#
+# The initial SST happens on startup, so we can't test it there (since there
+# are no transactions, so we have to shutdown node 2, do some transactions, and
+# then start it up and force an SST).
+#
+--source include/big_test.inc
+--source include/have_gtid.inc
+--source include/have_binlog_format_row.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+# Force a restart at the end of the test
+--source include/force_restart.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+#
+# Set this up so that node 1 stays PRIMARY, no split-brain
+#
+--connection node_1
+--let $wsrep_provider_options_orig1 = `SELECT @@global.wsrep_provider_options`
+SET GLOBAL wsrep_provider_options="pc.weight=1";
+
+--connection node_2
+--let $wsrep_provider_options_orig2 = `SELECT @@global.wsrep_provider_options`
+SET GLOBAL wsrep_provider_options="pc.weight=0";
+
+--connection node_1
+SELECT 1;
+
+
+#
+# Shutdown node 2, to get it out of sync with node 1
+#
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+# Wait until the node is confirmed as being down
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+#
+# Perform some transactions so that there are some GTIDs in the
+# gtid_executed table
+#
+CREATE TABLE t1 (
+  id INT NOT NULL AUTO_INCREMENT,
+  text VARCHAR(10) DEFAULT NULL,
+  PRIMARY KEY (id)
+);
+
+INSERT INTO t1(text) VALUES('aaaaa');
+INSERT INTO t1(text) VALUES('bbbbb');
+
+--let $gtid_executed_node1 = `SELECT @@global.gtid_executed;`
+
+# Restart the server
+--connection node_2
+--echo Restarting node 2 ...
+--source include/start_mysqld.inc
+
+--connection node_1
+--source include/wait_until_connected_again.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_2
+--source include/wait_until_connected_again.inc
+select * from t1;
+
+--disable_query_log
+--eval SELECT '$gtid_executed_node1' = @@global.gtid_executed AS gtid_executed_equal;
+--enable_query_log
+
+#
+# Restore state back to the original
+#
+--connection node_2
+--disable_query_log
+--eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_orig2';
+--enable_query_log
+
+--connection node_1
+--disable_query_log
+--eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_orig1';
+--enable_query_log
+
+drop table t1;
+
+


### PR DESCRIPTION
Issue:
The SST did not handle correctly the case when binlog names on the
donor/joiner are different (it was assumed they are the same).
On 5.6, with GTIDs enabled, this would lead to differences in the
gtid_executed table.  Note that 5.7 does not rely on the binlog,
but just restores the gtid_executed table.

Solution:
XtraBackup only copies the last binlog (to recover the GTIDs). So
we ensure that the binlog is renamed and copied correctly.  This
requires that we send over the name of the binlog on the donor. To
enable this, a change was made to how this data is sent over (instead
of a pure one-line data file, we send a cnf-like file that is parsed
on the joiner to recover the values).