### PR TITLE
PXC-833: SST fails if donor has to send keyring file

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -639,6 +639,11 @@ read_cnf()
         done
     fi
 
+    # Retry the connection 30 times (at 1-second intervals)
+    if [[ ! "$sockopt" =~ retry= ]]; then
+        sockopt+=",retry=30"
+    fi
+
 }
 
 #


### PR DESCRIPTION
Issue
The SST would sometimes fail because the joiner was slower than the donor.
The donor would have tried to connect to the joiner (but it wasn't ready),
so the donor would then shutdown the SST process.  The joiner would then
fail the SST and abort the process.

Solution
Have the donor retry the connection if it fails (to make the process more
robust).  We set the retry to 30 times (with the default 1-second intervals),
thus we give the joiner 30 seconds to get socat setup.