### PR TITLE
- PXC#842: Deadlocks and duplicate Entries Load Data Infile

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_load_data_splitting2.result
+++ b/mysql-test/suite/galera/r/galera_var_load_data_splitting2.result
@@ -1,0 +1,9 @@
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET GLOBAL wsrep_load_data_splitting = TRUE;
+SELECT COUNT(*) = 95000 FROM t1;
+COUNT(*) = 95000
+1
+wsrep_last_committed_diff
+1
+SET GLOBAL wsrep_load_data_splitting = 1;;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_var_load_data_splitting2-master.opt
+++ b/mysql-test/suite/galera/t/galera_var_load_data_splitting2-master.opt
@@ -1,0 +1,1 @@
+--skip-log-bin

--- a/mysql-test/suite/galera/t/galera_var_load_data_splitting2.test
+++ b/mysql-test/suite/galera/t/galera_var_load_data_splitting2.test
@@ -1,0 +1,42 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/big_test.inc
+
+--let $wsrep_load_data_splitting_orig = `SELECT @@wsrep_load_data_splitting`
+
+# Create a file for LOAD DATA with 95K entries
+--perl
+open(FILE, ">", "$ENV{'MYSQLTEST_VARDIR'}/tmp/galera_var_load_data_splitting.csv") or die;
+foreach  my $i (1..95000) {
+	print FILE "$i\n";
+}
+EOF
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
+# Record wsrep_last_committed as it was before LOAD DATA
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+SET GLOBAL wsrep_load_data_splitting = TRUE;
+--disable_query_log
+--eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/galera_var_load_data_splitting.csv' INTO TABLE t1;
+--enable_query_log
+
+--connection node_2
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+SELECT COUNT(*) = 95000 FROM t1;
+
+# LOAD-ing 95K rows causes 10 commits to be registered
+--disable_query_log
+--eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 10 AS wsrep_last_committed_diff;
+--enable_query_log
+
+--connection node_1
+--eval SET GLOBAL wsrep_load_data_splitting = $wsrep_load_data_splitting_orig;
+
+DROP TABLE t1;


### PR DESCRIPTION
  Problem:
  -------

  * Load Data Infile (LDI) with log-bin=0 fails.
  * LDI with > 10K rows is split into mini transactions, each having
    10K rows (except the last bucket). Each mini transaction is committed
    independently once the bucket is full.
    A new transaction is started before processing next set of bucket.
  * New transaction should be started after the transaction is committed
    in wsrep and innodb world but the exsiting flow tried start new
    transaction before innodb commit was complete.
  * Recent change for performance optimization has tweaked innodb
    code to invoke post-commit that committed newly started transaction.
    In turn followup bucket is processed without active transaction.

  Solution:
  ---------

  * Ensure that new transaction starts only after the existing mini
    transaction is committed in wsrep and innodb world.