### PR TITLE
- PXC#841: DDL is replicated even when sql_log_bin=0, and GTID is

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
@@ -27,4 +27,5 @@ ERROR 23000: Duplicate entry '0' for key 'c1'
 set @@global.wsrep_drupal_282555_workaround = 0;
 set @@session.sql_log_bin = 1;
 set @@sql_mode = default;
+CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query");
 drop table t1;

--- a/mysql-test/suite/galera/r/galera_mysqlpump.result
+++ b/mysql-test/suite/galera/r/galera_mysqlpump.result
@@ -6,6 +6,7 @@ INSERT INTO db1.t1 SELECT 1 FROM test.ten AS a1, test.ten AS a2, test.ten AS a3;
 CREATE DATABASE db2;
 CREATE TABLE db2.t2 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO db2.t2 SELECT 1 FROM test.ten AS a1, test.ten AS a2, test.ten AS a3;
+call mtr.add_suppression("Slave SQL: Error 'Can't drop database");
 DROP DATABASE db1;
 DROP DATABASE db2;
 SELECT COUNT(*) = 1000 FROM db1.t1;

--- a/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
+++ b/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
@@ -1,12 +1,24 @@
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 SET SESSION sql_log_bin = 0;
+CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
+CREATE USER 'demo'@'localhost' IDENTIFIED BY 's3kr3t';
 SET SESSION sql_log_bin = 1;
 INSERT INTO t1 VALUES (2);
+SELECT @@global.gtid_executed;
+@@global.gtid_executed
+
+CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
 SELECT COUNT(*) = 0 FROM t1 WHERE f1 = 1;
 COUNT(*) = 0
 1
+SHOW TABLES;
+Tables_in_test
+t1
+DROP USER 'demo'@'localhost';
+ERROR HY000: Operation DROP USER failed for 'demo'@'localhost'
 DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/galera_bf_abort_get_lock.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_get_lock.test
@@ -69,5 +69,8 @@ insert into t1 values ('a');
 #
 disconnect con_node_1a;
 
+--connection node_2
+CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query");
+
 --connection node_1
 drop table t1;

--- a/mysql-test/suite/galera/t/galera_mysqlpump.test
+++ b/mysql-test/suite/galera/t/galera_mysqlpump.test
@@ -15,6 +15,9 @@ CREATE DATABASE db2;
 CREATE TABLE db2.t2 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO db2.t2 SELECT 1 FROM test.ten AS a1, test.ten AS a2, test.ten AS a3;
 
+--connection node_2
+call mtr.add_suppression("Slave SQL: Error 'Can't drop database");
+
 # As a single transaction
 --exec $MYSQL_PUMP --include-databases=db1,db2 --default-parallelism=1 --single-transaction > $MYSQLTEST_VARDIR/tmp/mysqlpump1.sql
 
@@ -24,6 +27,7 @@ INSERT INTO db2.t2 SELECT 1 FROM test.ten AS a1, test.ten AS a2, test.ten AS a3;
 # Parallel
 --exec $MYSQL_PUMP --parallel-schemas=2:db1,db2 --default-parallelism=2 --include-databases=db1,db2 > $MYSQLTEST_VARDIR/tmp/mysqlpump3.sql
 
+--connection node_1
 DROP DATABASE db1;
 DROP DATABASE db2;
 

--- a/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
+++ b/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
@@ -10,16 +10,26 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 
 SET SESSION sql_log_bin = 0;
 
+CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
+
 INSERT INTO t1 VALUES (1);
+
+CREATE USER 'demo'@'localhost' IDENTIFIED BY 's3kr3t';
 
 SET SESSION sql_log_bin = 1;
 
 INSERT INTO t1 VALUES (2);
 
+SELECT @@global.gtid_executed;
 
 --connection node_2
+CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
 SELECT COUNT(*) = 1 FROM t1;
 SELECT COUNT(*) = 0 FROM t1 WHERE f1 = 1;
+SHOW TABLES;
+--error ER_CANNOT_USER
+DROP USER 'demo'@'localhost';
 
 --connection node_1
 DROP TABLE t1;
+DROP TABLE t2;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -24,6 +24,7 @@
 #include "wsrep_var.h"
 #include "wsrep_binlog.h"
 #include "wsrep_applier.h"
+#include <binlog.h>
 #include "wsrep_xid.h"
 #include <cstdio>
 #include <cstdlib>
@@ -1799,6 +1800,10 @@ static bool wsrep_can_run_in_toi(THD *thd, const char *db, const char *table,
 {
   DBUG_ASSERT(!table || db);
   DBUG_ASSERT(table_list || db);
+
+  /* Only if binlog is enabled and user try to set sql_log_bin=0. */
+  if (mysql_bin_log.is_open() && !(thd->variables.option_bits & OPTION_BIN_LOG))
+    return false;
 
   LEX* lex= thd->lex;
   SELECT_LEX* select_lex= lex->select_lex;


### PR DESCRIPTION
  incremented in remote node

  sql_log_bin=0 will stop generation of binary logs data.
  In turn it will also stop replication and GTID increment.

  PXC executes DDL through TOI and DML through normal replication.
  Since binary log is not-generated DML replication was already blocked.
  DDL path didn't had a check for sql_log_bin.
  Added the needed check.

(cherry picked from commit 183043e54f41d2dd607bcae5e28fd6dc53b031e8)