### PR TITLE
PXC-851: Avoid doing SST from lower version (5.7 node trying to get S…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -1060,7 +1060,7 @@ normalize_version()
 # Compares two version strings
 # The first parameter is the version to be checked
 # The second parameter is the minimum version required
-# Returns 1 (failure) if $1 >= $2, 0 (success) otherwise
+# Returns 0 (success) if $1 >= $2, 1 (failure) otherwise
 check_for_version()
 {
     local local_version_str="$( normalize_version $1 )"
@@ -1188,6 +1188,9 @@ if ! check_for_version $XB_VERSION $XB_REQUIRED_VERSION; then
 fi
 
 wsrep_log_debug "The $INNOBACKUPEX_BIN version is $XB_VERSION"
+
+# Get our MySQL version
+MYSQL_VERSION=$($(dirname $0)/mysqld --version 2>&1 | grep -oe '[0-9]\.[0-9][\.0-9]*' | head -n1)
 
 rm -f "${XB_GTID_INFO_FILE_PATH}"
 
@@ -1339,6 +1342,7 @@ then
     echo "[sst]" > "$sst_info_file_path"
     echo "galera-gtid=$WSREP_SST_OPT_GTID" >> "$sst_info_file_path"
     echo "binlog-name=$(basename "$WSREP_SST_OPT_BINLOG")" >> "$sst_info_file_path"
+    echo "mysql-version=$MYSQL_VERSION" >> "$sst_info_file_path"
 
     #
     # SST is not needed. IST would suffice. By-pass SST.
@@ -1546,6 +1550,35 @@ then
     parse_sst_info "$sst_file_info_path" sst galera-gtid "" > "$XB_GTID_INFO_FILE_PATH"
 
     DONOR_BINLOGNAME=$(parse_sst_info "$sst_file_info_path" sst binlog-name "")
+    DONOR_MYSQL_VERSION=$(parse_sst_info "$sst_file_info_path" sst mysql-version "")
+
+    if [[ -n "$DONOR_MYSQL_VERSION" ]]; then
+        local_version_str=""
+        donor_version_str=""
+
+        # Truncate the version numbers (we want the major.minor version like "5.6", not "5.6.35-...")
+        local_version_str=$(expr match "$MYSQL_VERSION" '\([0-9]\+\.[0-9]\+\)')
+        donor_version_str=$(expr match "$DONOR_MYSQL_VERSION" '\([0-9]\+\.[0-9]\+\)')
+
+        # Is this node's pxc version < donor's pxc version?
+        if ! check_for_version $local_version_str $donor_version_str; then
+            wsrep_log_error "******************* FATAL ERROR ********************** "
+            wsrep_log_error "FATAL: PXC is receiving an SST from a node with a higher version."
+            wsrep_log_error "This node's PXC version is $local_version_str.  The donor's PXC version is $donor_version_str."
+            wsrep_log_error "Upgrade this node before joining the cluster."
+            wsrep_log_error "****************************************************** "
+            exit 2
+        fi
+
+        # Is the donor's pxc version < this node's pxc version?
+        if ! check_for_version $donor_version_str $local_version_str; then
+            wsrep_log_warning "WARNING: PXC is receiving an SST from a node with a lower version."
+            wsrep_log_warning "This node's PXC version is $local_version_str. The donor's PXC version is $donor_version_str."
+            wsrep_log_warning "Run mysql_upgrade in non-cluster (standalone mode) to upgrade."
+            wsrep_log_warning "Check the upgrade process here:"
+            wsrep_log_warning "    https://www.percona.com/doc/percona-xtradb-cluster/LATEST/howtos/upgrade_guide.html"
+        fi
+    fi
 
     # server-id is already part of backup-my.cnf so avoid appending it.
     # server-id is the id of the node that is acting as donor and not joiner node.


### PR DESCRIPTION
…ST from 5.6)

Issue:
Currently, PXC does not check the versions between the donor and the joiner.
Thus, we will clean the datadir and then receive the donor's datadir which will
probably be incompatible (thus erasing the datadir for no good reason).

Solution:
Pass the version from the donor to the joiner and let the joiner reject
the SST if the version is a higher version.