### PR TITLE
PXC-853: When nodes all go non-primary, PXC can recover, but does not…

### DIFF
--- a/mysql-test/suite/galera/r/galera_migrate.result
+++ b/mysql-test/suite/galera/r/galera_migrate.result
@@ -11,14 +11,14 @@ INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 SET GLOBAL wsrep_cluster_address='gcomm://';
 INSERT INTO t1 VALUES (5);
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-VARIABLE_VALUE = 'Synced'
-1
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-VARIABLE_VALUE = 'Primary'
-1
-SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-VARIABLE_VALUE = 1
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+VARIABLE_VALUE
+Synced
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+VARIABLE_VALUE
+Primary
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+VARIABLE_VALUE
 1
 INSERT INTO t1 VALUES (6);
 CREATE USER 'sst';
@@ -26,15 +26,15 @@ GRANT ALL PRIVILEGES ON *.* TO 'sst';
 SET GLOBAL wsrep_sst_auth = 'sst:';
 CREATE USER 'sst';
 GRANT ALL PRIVILEGES ON *.* TO 'sst';
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-VARIABLE_VALUE = 'Synced'
-1
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-VARIABLE_VALUE = 'Primary'
-1
-SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-VARIABLE_VALUE = 2
-1
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+VARIABLE_VALUE
+Synced
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+VARIABLE_VALUE
+Primary
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+VARIABLE_VALUE
+2
 STOP SLAVE;
 RESET SLAVE ALL;
 STOP SLAVE;
@@ -44,27 +44,27 @@ INSERT INTO t1 VALUES (8);
 SELECT COUNT(*) = 8 FROM t1;
 COUNT(*) = 8
 1
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-VARIABLE_VALUE = 'Synced'
-1
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-VARIABLE_VALUE = 'Primary'
-1
-SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-VARIABLE_VALUE = 2
-1
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+VARIABLE_VALUE
+Synced
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+VARIABLE_VALUE
+Primary
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+VARIABLE_VALUE
+2
 SELECT COUNT(*) = 8 FROM t1;
 COUNT(*) = 8
 1
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-VARIABLE_VALUE = 'Synced'
-1
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-VARIABLE_VALUE = 'Primary'
-1
-SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-VARIABLE_VALUE = 2
-1
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+VARIABLE_VALUE
+Synced
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+VARIABLE_VALUE
+Primary
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+VARIABLE_VALUE
+2
 DROP TABLE t1;
 DROP TABLE t1;
 SET GLOBAL wsrep_provider = 'none';

--- a/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
+++ b/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
@@ -89,8 +89,6 @@ t1	CREATE TABLE `t1` (
   `f2` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
 Variable_name	Value
-wsrep_desync	ON
-Variable_name	Value
 wsrep_desync_count	1
 SET GLOBAL wsrep_desync=0;
 Variable_name	Value

--- a/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_autoinc.test
@@ -67,6 +67,11 @@ SELECT @@auto_increment_offset = (SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.
 --enable_warnings
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1;
+--source include/wait_condition.inc
 
 select * from t1;
 

--- a/mysql-test/suite/galera/t/galera_migrate.test
+++ b/mysql-test/suite/galera/t/galera_migrate.test
@@ -15,6 +15,7 @@
 --source include/big_test.inc
 --source include/have_innodb.inc
 --source include/have_log_bin.inc
+--source include/force_restart.inc
 
 #
 # Step #1 Begin with a single server
@@ -91,9 +92,9 @@ INSERT INTO t1 VALUES (5);
 --let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
 --source include/wait_condition.inc
 
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 
 --connection node_1
 INSERT INTO t1 VALUES (6);
@@ -137,9 +138,9 @@ GRANT ALL PRIVILEGES ON *.* TO 'sst';
 --let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
 --source include/wait_condition.inc
 
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 
 
 #
@@ -170,9 +171,9 @@ SELECT COUNT(*) = 8 FROM t1;
 --let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
 --source include/wait_condition.inc
 
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 
 --connection node_3a
 SELECT COUNT(*) = 8 FROM t1;
@@ -180,9 +181,9 @@ SELECT COUNT(*) = 8 FROM t1;
 --let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
 --source include/wait_condition.inc
 
-SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
-SELECT VARIABLE_VALUE = 'Primary'  FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
-SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 
 #
 # Teardown

--- a/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
+++ b/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
@@ -154,7 +154,10 @@ SET DEBUG_SYNC= 'now SIGNAL continue';
 SHOW CREATE TABLE t1;
 
 --disable_query_log
-SHOW VARIABLES LIKE 'wsrep_desync';
+# The actual value of wsrep_desync is dependent on the timing
+# between the 'ALTER TABLE' and the 'SET GLOBAL wsrep_desync=1'
+# call.  So we don't check the value here since it could be ON/OFF.
+#SHOW VARIABLES LIKE 'wsrep_desync';
 show status like 'wsrep_desync_count';
 --enable_query_log
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -651,7 +651,8 @@ wsrep_view_handler_cb (void*                    app_ctx,
              wsrep_cluster_size, wsrep_local_index, view->proto_ver);
 
   /* Proceed further only if view is PRIMARY */
-  if (WSREP_VIEW_PRIMARY != view->status) {
+  if (WSREP_VIEW_PRIMARY != view->status)
+  {
     wsrep_ready_set(FALSE);
     new_status= WSREP_MEMBER_UNDEFINED;
     /* Always record local_uuid and local_seqno in non-prim since this
@@ -663,6 +664,8 @@ wsrep_view_handler_cb (void*                    app_ctx,
     // local_seqno= view->first - 1;
     goto out;
   }
+
+  wsrep_ready_set(TRUE);
 
   switch (view->proto_ver)
   {
@@ -788,7 +791,7 @@ out:
 
 void wsrep_ready_set (my_bool x)
 {
-  WSREP_DEBUG("Setting wsrep_ready to %s", (x ? "true" : "false"));
+  WSREP_INFO("Setting wsrep_ready to %s", (x ? "true" : "false"));
   if (mysql_mutex_lock (&LOCK_wsrep_ready)) abort();
   if (wsrep_ready != x)
   {
@@ -818,6 +821,7 @@ static void wsrep_synced_cb(void* app_ctx)
   if (mysql_mutex_lock (&LOCK_wsrep_ready)) abort();
   if (!wsrep_ready)
   {
+    WSREP_INFO("This node is synced, setting wsrep_ready to true");
     wsrep_ready= TRUE;
     mysql_cond_signal (&COND_wsrep_ready);
     signal_main= true;


### PR DESCRIPTION
… set wsrep_ready

Issue:
There are times, during the MTR run, when all the nodes can go NON-PRIMARY
due to timing issues.  The cluster can recover, but in this case the cluster
goes straight from OPEN -> DONOR/DESYNCED, and thus does not re-enable
wsrep_ready.

Solution:
Enable wsrep_ready whenever we go PRIMARY.

Also, test case fixes