### PR TITLE
PXC-861: Improving galera/galera_3nodes test suites

### DIFF
--- a/mysql-test/include/wait_condition_with_debug.inc
+++ b/mysql-test/include/wait_condition_with_debug.inc
@@ -1,0 +1,69 @@
+# include/wait_condition_with_debug.inc
+#
+# SUMMARY
+#
+#    Waits until the passed statement returns true, or the operation
+#    times out.  If the operation times out, the additional error
+#    statement will be executed.
+#
+# USAGE
+#
+#    let $wait_condition=
+#      SELECT c = 3 FROM t;
+#    let $wait_condition_on_error_output= select count(*) from t;
+#    [let $explicit_default_wait_timeout= N] # to override the default reset
+#    --source include/wait_condition_with_debug.inc
+#
+#   OR
+#
+#    let $wait_timeout= 60; # Override default 30 seconds with 60.
+#    let $wait_condition=
+#      SELECT c = 3 FROM t;
+#    let $wait_condition_on_error_output= select count(*) from t;
+#    --source include/wait_condition_with_debug.inc
+#    --echo Executed the test condition $wait_condition_reps times
+#
+#
+# EXAMPLE
+#    events_bugs.test, events_time_zone.test
+#
+
+let $wait_counter= 300;
+if ($wait_timeout)
+{
+  let $wait_counter= `SELECT $wait_timeout * 10`;
+}
+# Reset $wait_timeout so that its value won't be used on subsequent
+# calls, and default will be used instead.
+if ($explicit_default_wait_timeout)
+{
+  --let $wait_timeout= $explicit_default_wait_timeout
+}
+if (!$explicit_default_wait_timeout)
+{
+  --let $wait_timeout= 0
+}
+
+# Keep track of how many times the wait condition is tested
+# This is used by some tests (e.g., main.status)
+let $wait_condition_reps= 0;
+while ($wait_counter)
+{
+    --error 0,ER_NO_SUCH_TABLE,ER_LOCK_WAIT_TIMEOUT,ER_UNKNOWN_COM_ERROR,ER_LOCK_DEADLOCK
+    let $success= `$wait_condition`;
+    inc $wait_condition_reps;
+    if ($success)
+    {
+        let $wait_counter= 0;
+    }
+    if (!$success)
+    {
+        real_sleep 0.1;
+        dec $wait_counter;
+    }
+}
+if (!$success)
+{
+  echo Timeout in wait_condition.inc for $wait_condition;
+  --eval $wait_condition_on_error_output
+}

--- a/mysql-test/suite/galera/r/galera_log_output_csv.result
+++ b/mysql-test/suite/galera/r/galera_log_output_csv.result
@@ -1,3 +1,7 @@
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SELECT COUNT(*) > 0 FROM mysql.general_log;

--- a/mysql-test/suite/galera/r/galera_wsrep_desync_wsrep_on.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_desync_wsrep_on.result
@@ -38,5 +38,4 @@ call mtr.add_suppression("Aborting");
 "Restart with wsrep_desync=1"
 "Restart with default options"
 # restart
-"grep --count "Can't desync a non-synced node""
-1
+include/assert_grep.inc [Can't desync a non-synced node]

--- a/mysql-test/suite/galera/r/mysql-wsrep#216.result
+++ b/mysql-test/suite/galera/r/mysql-wsrep#216.result
@@ -3,8 +3,8 @@ CREATE USER u1 IDENTIFIED BY 'plaintext_password';
 CREATE USER u1 IDENTIFIED BY 'plaintext_password';
 ERROR HY000: Operation CREATE USER failed for 'u1'@'%'
 DROP USER u1;
-0
-0
-5
-1
+include/assert_grep.inc [plaintext_password]
+include/assert_grep.inc [plaintext_password]
+include/assert_grep.inc ['mysql_native_password' AS '<secret>']
+include/assert_grep.inc ['mysql_native_password' AS '<secret>']
 CALL mtr.add_suppression('Operation CREATE USER failed');

--- a/mysql-test/suite/galera/t/MW-329.test
+++ b/mysql-test/suite/galera/t/MW-329.test
@@ -3,6 +3,7 @@
 #
 
 --source include/galera_cluster.inc
+--source include/force_restart.inc
 
 CREATE TABLE t1 (f1 INTEGER, f2 CHAR(20) DEFAULT 'abc') ENGINE=InnoDB;
 
@@ -40,7 +41,7 @@ DELIMITER ;|
 #
 
 --connection node_2
---let $count = 10
+--let $count = 20
 while ($count)
 {
 	--let $signature = `SELECT LEFT(MD5(RAND()), 10)`

--- a/mysql-test/suite/galera/t/MW-336.test
+++ b/mysql-test/suite/galera/t/MW-336.test
@@ -4,6 +4,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 
@@ -19,13 +20,15 @@ INSERT INTO t1 VALUES (1);
 SET GLOBAL wsrep_slave_threads = 10;
 
 --let $wait_condition = SELECT COUNT(*) = 11 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT COUNT(*), 11 as EXPECTED_VALUE FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user'; show processlist
+--source include/wait_condition_with_debug.inc
 SELECT COUNT(*) = 11 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
 
 SET GLOBAL wsrep_slave_threads = 20;
 
 --let $wait_condition = SELECT COUNT(*) = 21 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT COUNT(*), 21 as EXPECTED_VALUE FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user'; show processlist
+--source include/wait_condition_with_debug.inc
 SELECT COUNT(*) = 21 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
 
 SET GLOBAL wsrep_slave_threads = 1;
@@ -60,9 +63,9 @@ INSERT INTO t1 VALUES (19);
 INSERT INTO t1 VALUES (20);
 
 --connection node_1
---sleep 0.5
 --let $wait_condition = SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT COUNT(*), 2 as EXPECTED_VALUE FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user'; show processlist
+--source include/wait_condition_with_debug.inc
 SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
 
 SET GLOBAL wsrep_slave_threads = 1;

--- a/mysql-test/suite/galera/t/MW-44.test
+++ b/mysql-test/suite/galera/t/MW-44.test
@@ -18,7 +18,18 @@ ALTER TABLE t1 ADD COLUMN f2 INTEGER;
 SET SESSION wsrep_osu_method=TOI;
 
 SELECT COUNT(*) = 2 FROM mysql.general_log WHERE argument LIKE 'CREATE%' OR argument LIKE 'ALTER%';
+--let $general_log_count = `SELECT COUNT(*) FROM mysql.general_log WHERE argument LIKE 'CREATE%' OR argument LIKE 'ALTER%'`
+if ($general_log_count != 2)
+{
+	SELECT * FROM mysql.general_log;
+}
 
 --connection node_2
 SELECT COUNT(*) = 0 FROM mysql.general_log WHERE argument NOT LIKE 'SELECT%';
+--let $general_log_count = `SELECT COUNT(*) FROM mysql.general_log WHERE argument NOT LIKE 'SELECT%'`
+if ($general_log_count != 0)
+{
+	SELECT * FROM mysql.general_log;
+}
+
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_as_master_and_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_master_and_slave.test
@@ -7,6 +7,7 @@
 
 --source include/have_innodb.inc
 --source include/have_log_bin.inc
+--source include/force_restart.inc
 
 #
 # Starting galera cluster

--- a/mysql-test/suite/galera/t/galera_as_master_gtid.test
+++ b/mysql-test/suite/galera/t/galera_as_master_gtid.test
@@ -11,6 +11,7 @@
 --source include/have_innodb.inc
 --source include/have_log_bin.inc
 --source include/galera_cluster.inc
+--source include/force_restart.inc
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --disable_query_log

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid.test
@@ -9,6 +9,7 @@
 
 --source include/have_innodb.inc
 --source include/have_log_bin.inc
+--source include/force_restart.inc
 
 # As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -23,7 +23,8 @@ FLUSH DES_KEY_FILE;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -34,7 +35,8 @@ FLUSH HOSTS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_1
@@ -62,7 +64,8 @@ FLUSH QUERY CACHE;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -73,7 +76,8 @@ FLUSH STATUS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -84,7 +88,8 @@ FLUSH USER_RESOURCES;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -95,7 +100,8 @@ FLUSH TABLES;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_1
@@ -109,7 +115,8 @@ FLUSH TABLES t2;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -120,7 +127,8 @@ FLUSH ERROR LOGS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -131,7 +139,8 @@ FLUSH SLOW LOGS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -142,7 +151,8 @@ FLUSH GENERAL LOGS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -153,7 +163,8 @@ FLUSH ENGINE LOGS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -164,7 +175,8 @@ FLUSH RELAY LOGS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -178,6 +190,8 @@ FLUSH USER_STATISTICS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 4 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 4 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 --source include/wait_condition.inc
 
 
@@ -189,7 +203,8 @@ FLUSH THREAD_STATISTICS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -200,7 +215,8 @@ FLUSH CHANGED_PAGE_BITMAPS;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 #
@@ -251,7 +267,8 @@ UNLOCK TABLES;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_2
@@ -277,7 +294,8 @@ FLUSH TABLES t1;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
 
 
 --connection node_1

--- a/mysql-test/suite/galera/t/galera_flush_local.test
+++ b/mysql-test/suite/galera/t/galera_flush_local.test
@@ -170,7 +170,8 @@ REPAIR TABLE x1, x2;
 --source include/wait_condition.inc
 
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 9 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed';
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 9 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition_with_debug.inc
 
 
 SELECT COUNT(*) = 10 FROM t1;

--- a/mysql-test/suite/galera/t/galera_gcache_pagestore.test
+++ b/mysql-test/suite/galera/t/galera_gcache_pagestore.test
@@ -10,6 +10,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 --connection node_1
 

--- a/mysql-test/suite/galera/t/galera_log_bin.test
+++ b/mysql-test/suite/galera/t/galera_log_bin.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 #
 # Test Galera with --log-bin --log-slave-updates .

--- a/mysql-test/suite/galera/t/galera_log_output_csv.test
+++ b/mysql-test/suite/galera/t/galera_log_output_csv.test
@@ -5,6 +5,15 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
+--connection node_1
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+
+--connection node_2
+TRUNCATE TABLE mysql.general_log;
+TRUNCATE TABLE mysql.slow_log;
+
+--connection node_1
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 

--- a/mysql-test/suite/galera/t/galera_migrate.test
+++ b/mysql-test/suite/galera/t/galera_migrate.test
@@ -84,12 +84,15 @@ SET GLOBAL wsrep_cluster_address='gcomm://';
 INSERT INTO t1 VALUES (5);
 
 --connection node_3
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--source include/wait_condition.inc
+
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 --let $wait_condition = SELECT COUNT(*) = 5 FROM t1;
---source include/wait_condition.inc
-
---let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
 --source include/wait_condition.inc
 
 SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
@@ -104,7 +107,7 @@ INSERT INTO t1 VALUES (6);
 #
 
 --connection node_3
-# We need a user with a n empty password for mysqldump SST
+# We need a user with an empty password for mysqldump SST
 # non-empty passwords will not work since there is already an empty 'password=' directive in the [client] section of my.cnf
 CREATE USER 'sst';
 GRANT ALL PRIVILEGES ON *.* TO 'sst';
@@ -120,8 +123,14 @@ GRANT ALL PRIVILEGES ON *.* TO 'sst';
 --eval SET GLOBAL wsrep_provider='$WSREP_PROVIDER'
 --eval SET GLOBAL wsrep_provider_options='base_port=$NODE_GALERAPORT_4'
 --eval SET GLOBAL wsrep_sst_receive_address = '127.0.0.1:$NODE_MYPORT_4';
+
+# Changing wsrep_cluster_address will cause the client connection to be shutdown
+# Depending on timing, it may trigger 2013 (CR_SERVER_LOST) on the client side
+--error 0,2013
 --eval SET GLOBAL wsrep_cluster_address='gcomm://127.0.0.1:$NODE_GALERAPORT_3'
+
 --enable_query_log
+
 --sleep 60
 
 --connection node_3
@@ -130,13 +139,16 @@ GRANT ALL PRIVILEGES ON *.* TO 'sst';
 
 --connect node_4a, 127.0.0.1, root, , test, $NODE_MYPORT_4
 --connection node_4a
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--source include/wait_condition.inc
+
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 
 --let $wait_condition = SELECT COUNT(*) = 6 FROM t1;
---source include/wait_condition.inc
-
---let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';
 --source include/wait_condition.inc
 
 SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';

--- a/mysql-test/suite/galera/t/galera_performance_schema.test
+++ b/mysql-test/suite/galera/t/galera_performance_schema.test
@@ -5,6 +5,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 --connection node_1
 --echo #node-1

--- a/mysql-test/suite/galera/t/galera_sst_mysqldump.test
+++ b/mysql-test/suite/galera/t/galera_sst_mysqldump.test
@@ -1,6 +1,7 @@
 --source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 --source suite/galera/include/galera_sst_set_mysqldump.inc
 

--- a/mysql-test/suite/galera/t/galera_transaction_read_only.test
+++ b/mysql-test/suite/galera/t/galera_transaction_read_only.test
@@ -26,6 +26,10 @@ COMMIT;
 --sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
+if ($wsrep_last_committed_before != $wsrep_last_committed_after)
+{
+	--echo "wsrep_last_committed_before:$wsrep_last_committed_before  wsrep_last_committed_after:$wsrep_last_committed_after"
+}
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
 --enable_query_log
 
@@ -43,6 +47,10 @@ COMMIT;
 --sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
+if ($wsrep_last_committed_before != $wsrep_last_committed_after)
+{
+	--echo "wsrep_last_committed_before:$wsrep_last_committed_before  wsrep_last_committed_after:$wsrep_last_committed_after"
+}
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
 --enable_query_log
 
@@ -57,6 +65,10 @@ COMMIT;
 --sleep 1
 --let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 --disable_query_log
+if ($wsrep_last_committed_before != $wsrep_last_committed_after)
+{
+	--echo "wsrep_last_committed_before:$wsrep_last_committed_before  wsrep_last_committed_after:$wsrep_last_committed_after"
+}
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before AS wsrep_last_committed_diff;
 --enable_query_log
 

--- a/mysql-test/suite/galera/t/galera_var_load_data_splitting.test
+++ b/mysql-test/suite/galera/t/galera_var_load_data_splitting.test
@@ -1,6 +1,7 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/big_test.inc
+--source include/force_restart.inc
 
 --let $wsrep_load_data_splitting_orig = `SELECT @@wsrep_load_data_splitting`
 
@@ -33,6 +34,13 @@ SELECT COUNT(*) = 95000 FROM t1;
 
 # LOAD-ing 95K rows causes 10 commits to be registered
 --disable_query_log
+
+--let $wsrep_last_committed_total = `SELECT $wsrep_last_committed_before + 10`
+if ($wsrep_last_committed_after != $wsrep_last_committed_total)
+{
+	--echo "before:$wsrep_last_committed_before after:$wsrep_last_committed_after expected:$wsrep_last_committed_total"
+}
+
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 10 AS wsrep_last_committed_diff;
 --enable_query_log
 

--- a/mysql-test/suite/galera/t/galera_var_load_data_splitting2.test
+++ b/mysql-test/suite/galera/t/galera_var_load_data_splitting2.test
@@ -1,6 +1,7 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/big_test.inc
+--source include/force_restart.inc
 
 --let $wsrep_load_data_splitting_orig = `SELECT @@wsrep_load_data_splitting`
 
@@ -33,6 +34,13 @@ SELECT COUNT(*) = 95000 FROM t1;
 
 # LOAD-ing 95K rows causes 10 commits to be registered
 --disable_query_log
+
+--let $wsrep_last_committed_total = `SELECT $wsrep_last_committed_before + 10`
+if ($wsrep_last_committed_after != $wsrep_last_committed_total)
+{
+	--echo "before:$wsrep_last_committed_before after:$wsrep_last_committed_after expected:$wsrep_last_committed_total"
+}
+
 --eval SELECT $wsrep_last_committed_after = $wsrep_last_committed_before + 10 AS wsrep_last_committed_diff;
 --enable_query_log
 

--- a/mysql-test/suite/galera/t/galera_var_notify_cmd.test
+++ b/mysql-test/suite/galera/t/galera_var_notify_cmd.test
@@ -5,6 +5,7 @@
 
 --source include/have_innodb.inc
 --source include/galera_cluster.inc
+--source include/force_restart.inc
 
 --connection node_1
 SELECT COUNT(DISTINCT uuid) = 2 FROM mtr_wsrep_notify.membership;

--- a/mysql-test/suite/galera/t/galera_var_slave_threads.test
+++ b/mysql-test/suite/galera/t/galera_var_slave_threads.test
@@ -38,6 +38,9 @@ INSERT INTO t1 VALUES (1);
 --connection node_2
 SELECT COUNT(*) = 1 FROM t1;
 
+# Wait until we know that all threads have been started in MySQL
+--let $wait_condition = SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user'
+--source include/wait_condition.inc
 SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
 SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep: aborter%';
 

--- a/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
@@ -84,6 +84,10 @@ call mtr.add_suppression("Aborting");
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
 --source include/wait_condition.inc
 
---echo "grep --count \"Can't desync a non-synced node\""
---exec grep --count "Can't desync a non-synced node" $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_text = Can't desync a non-synced node
+--let $assert_select = Can't desync a non-synced node
+--let $assert_count = 1
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
 

--- a/mysql-test/suite/galera/t/mysql-wsrep#216.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#216.test
@@ -27,16 +27,38 @@ DROP USER u1;
 
 --connection node_1
 # Check that the plaintext password does not appear in the logs
---exec grep --count plaintext_password $MYSQLTEST_VARDIR/log/mysqld.1.err || true
---exec grep --count plaintext_password $MYSQLTEST_VARDIR/log/mysqld.2.err || true
+
+--let $assert_text = plaintext_password
+--let $assert_select = plaintext_password
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+--let $assert_text = plaintext_password
+--let $assert_select = plaintext_password
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
 
 # Check that the obfuscated password appears in the logs
 
-# Four times for the first node, in the various wsrep_debug messages
---exec grep --count "'mysql_native_password' AS '<secret>'" $MYSQLTEST_VARDIR/log/mysqld.1.err
+# Five times for the first node, in the various wsrep_debug messages
+--let $assert_text = 'mysql_native_password' AS '<secret>'
+--let $assert_select = 'mysql_native_password' AS '<secret>'
+--let $assert_count = 5
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
 
 # Once for the second node, in the 'Slave SQL' error
---exec grep --count "'mysql_native_password' AS '<secret>'" $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_text = 'mysql_native_password' AS '<secret>'
+--let $assert_select = 'mysql_native_password' AS '<secret>'
+--let $assert_count = 1
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
 
 --disable_query_log
 --eval SET GLOBAL wsrep_debug = $wsrep_debug_orig

--- a/mysql-test/suite/galera/t/mysql-wsrep#31.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#31.test
@@ -25,7 +25,8 @@ CREATE DATABASE db;
 
 if ($galera_wsrep_start_position != $expected_position)
 {
-  die(Expected position: $expected_position, found $galera_wsrep_start_position);
+  --echo "Expected position: $expected_position, found $galera_wsrep_start_position"
+  die(The expected position does not match the wsrep_recover position);
 }
 
 #
@@ -41,7 +42,8 @@ if ($galera_wsrep_start_position != $expected_position)
 # This should give the same result as before, it should ignore the use of this special value
 if ($galera_wsrep_start_position != $expected_position)
 {
-  die(Expected position: $expected_position, found $galera_wsrep_start_position);
+  --echo "Expected position: $expected_position, found $galera_wsrep_start_position"
+  die(The expected position does not match the wsrep_recover position);
 }
 
 --echo Restarting server ...

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -5,6 +5,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 
 #-------------------------------------------------------------------------------

--- a/mysql-test/suite/galera_3nodes/t/galera_ipv6_xtrabackup-v2.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_ipv6_xtrabackup-v2.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_ipv6.inc
+--source include/force_restart.inc
 
 # Confirm that initial handshake happened over ipv6
 

--- a/mysql-test/suite/galera_3nodes/t/galera_pc_bootstrap.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_pc_bootstrap.test
@@ -22,12 +22,12 @@ SET GLOBAL wsrep_provider_options = 'gmcast.isolate=1';
 --sleep 10
 
 # Node #2 should be non-primary
+--connection node_2
 SET SESSION wsrep_sync_wait = 0;
 --let $wait_condition = SELECT variable_value = 'non-Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE variable_name = 'wsrep_cluster_status';
 --source include/wait_condition.inc
 
 # Signal node #2 to bootstrap
---connection node_2
 SET GLOBAL wsrep_provider_options = 'pc.bootstrap=1';
 
 # Wait until node becomes available for queries again


### PR DESCRIPTION
Issue:
Too many test failures

Solution:
Some test case fixes (such as galera.galera_migrate, galera.galera_var_slave_threads,
and galera_3nodes.galera_pc_bootstrap)
A lot of test case fixes so they can run with --repeat=2
Additional output, in some cases, so that we can debug the failures