### PR TITLE
PXC-865: Tests: galera_flush and galera_flush_gtid failing more often

### DIFF
--- a/mysql-test/suite/galera/include/galera_load_provider.inc
+++ b/mysql-test/suite/galera/include/galera_load_provider.inc
@@ -2,7 +2,12 @@
 
 --disable_query_log
 --eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
+
+# Changing wsrep_cluster_address will cause the client connection to be shutdown
+# Depending on timing, it may trigger 2013 (CR_SERVER_LOST) on the client side
+--error 0,2013
 --eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
+
 --enable_query_log
 
 --enable_reconnect

--- a/mysql-test/suite/galera/r/MW-44.result
+++ b/mysql-test/suite/galera/r/MW-44.result
@@ -1,5 +1,4 @@
 TRUNCATE TABLE mysql.general_log;
-TRUNCATE TABLE mysql.general_log;
 SET SESSION wsrep_osu_method=TOI;
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 SET SESSION wsrep_osu_method=RSU;

--- a/mysql-test/suite/galera/r/lp1376747-4.result
+++ b/mysql-test/suite/galera/r/lp1376747-4.result
@@ -2,7 +2,7 @@ CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET session wsrep_sync_wait=0;
 SET session wsrep_causal_reads=OFF;
-FLUSH TABLE WITH READ LOCK;
+FLUSH TABLES WITH READ LOCK;
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;
 INSERT INTO t1 VALUES (2,3);
 SET session wsrep_sync_wait=0;

--- a/mysql-test/suite/galera/t/MW-329.test
+++ b/mysql-test/suite/galera/t/MW-329.test
@@ -41,7 +41,7 @@ DELIMITER ;|
 #
 
 --connection node_2
---let $count = 10
+--let $count = 20
 while ($count)
 {
 	--let $signature = `SELECT LEFT(MD5(RAND()), 10)`

--- a/mysql-test/suite/galera/t/MW-336.test
+++ b/mysql-test/suite/galera/t/MW-336.test
@@ -10,6 +10,11 @@ CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 
 --connection node_1
 SET GLOBAL wsrep_slave_threads = 10;
+
+# ensure that the threads have actually started running
+--let $wait_condition = SELECT COUNT(*) = 11 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
+--source include/wait_condition.inc
+
 SET GLOBAL wsrep_slave_threads = 1;
 
 --connection node_2

--- a/mysql-test/suite/galera/t/MW-44.test
+++ b/mysql-test/suite/galera/t/MW-44.test
@@ -8,7 +8,10 @@
 TRUNCATE TABLE mysql.general_log;
 
 --connection node_2
-TRUNCATE TABLE mysql.general_log;
+--sleep 0.5
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.general_log WHERE argument NOT LIKE '%mysql.general_log%'
+--let $wait_condition_on_error_output = SELECT * FROM mysql.general_log
+--source include/wait_condition_with_debug.inc
 
 --connection node_1
 SET SESSION wsrep_osu_method=TOI;

--- a/mysql-test/suite/galera/t/galera_admin.test
+++ b/mysql-test/suite/galera/t/galera_admin.test
@@ -44,7 +44,8 @@ ANALYZE TABLE t1, t2;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT $wsrep_last_committed_before AS 'BEFORE', VARIABLE_VALUE AS 'AFTER', $wsrep_last_committed_before+1 AS 'EXPECTED' FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition_with_debug.inc
 
 
 
@@ -57,7 +58,8 @@ OPTIMIZE TABLE t1, t2;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT $wsrep_last_committed_before AS 'BEFORE', VARIABLE_VALUE AS 'AFTER', $wsrep_last_committed_before+1 AS 'EXPECTED' FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition_with_debug.inc
 
 
 
@@ -70,7 +72,8 @@ REPAIR TABLE x1, x2;
 
 --connection node_2
 --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT $wsrep_last_committed_before AS 'BEFORE', VARIABLE_VALUE AS 'AFTER', $wsrep_last_committed_before+1 AS 'EXPECTED' FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition_with_debug.inc
 
 
 

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid.test
@@ -39,7 +39,14 @@ SELECT LENGTH(@@global.gtid_executed) > 1;
 --eval SELECT '$gtid_executed_node1' = @@global.gtid_executed AS gtid_executed_equal;
 --enable_query_log
 
+
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
 SELECT COUNT(*) = 1 FROM t1;
 
 --disable_query_log

--- a/mysql-test/suite/galera/t/galera_flush.test
+++ b/mysql-test/suite/galera/t/galera_flush.test
@@ -15,7 +15,13 @@ DROP TABLE IF EXISTS t1, t2;
 # The following FLUSH statements should be replicated
 #
 
+#
+# Test: FLUSH DES_KEY_FILE
+#
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME IN  ('t1', 't2');
+--source include/wait_condition.inc
+
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
 --connection node_1
@@ -27,6 +33,9 @@ FLUSH DES_KEY_FILE;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH HOSTS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -39,6 +48,9 @@ FLUSH HOSTS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH PRIVILEGES
+#
 --connection node_1
 SET SESSION wsrep_replicate_myisam = TRUE;
 INSERT INTO mysql.user VALUES('localhost','user1',PASSWORD('pass1'), 'Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','','','','',0,0,0,0,'mysql_native_password','','N');
@@ -56,6 +68,9 @@ SET SESSION wsrep_replicate_myisam = FALSE;
 FLUSH PRIVILEGES;
 
 
+#
+# Test: FLUSH QUERY_CACHE
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -68,6 +83,9 @@ FLUSH QUERY CACHE;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH STATUS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -80,6 +98,9 @@ FLUSH STATUS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH USER_RESOURCES
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -92,6 +113,9 @@ FLUSH USER_RESOURCES;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH TABLES
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -104,10 +128,15 @@ FLUSH TABLES;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH TABLES
+#
 --connection node_1
 CREATE TABLE t2 (f1 INTEGER);
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
 --connection node_1
@@ -119,6 +148,9 @@ FLUSH TABLES t2;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH ERROR_LOGS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -131,6 +163,9 @@ FLUSH ERROR LOGS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH SLOW_LOGS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -143,6 +178,9 @@ FLUSH SLOW LOGS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH GENERAL_LOGS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -155,6 +193,9 @@ FLUSH GENERAL LOGS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH ENGINE_LOGS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -167,6 +208,9 @@ FLUSH ENGINE LOGS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH RELAY_LOGS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -179,6 +223,12 @@ FLUSH RELAY LOGS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH CLIENT_STATISTICS
+#       FLUSH INDEX_STATISTICS
+#       FLUSH TABLE_STATISTICS
+#       FLUSH USER_STATISTICS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -194,6 +244,9 @@ FLUSH USER_STATISTICS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH THREAD_STATISTICS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -206,6 +259,9 @@ FLUSH THREAD_STATISTICS;
 --source include/wait_condition_with_debug.inc
 
 
+#
+# Test: FLUSH CHANGED_PAGE_BITMAPS
+#
 --connection node_2
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
@@ -228,6 +284,12 @@ CREATE TABLE t1 (f1 INTEGER);
 --connection node_2
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
+
+# In addition, wait until we have seen the create table
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 2 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 2 as EXPECTED_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
 --let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
 --connection node_1
@@ -245,6 +307,11 @@ RESET QUERY CACHE;
 --connection node_2
 --sleep 5
 --disable_query_log
+--let $wsrep_last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+if ($wsrep_last_committed_before != $wsrep_last_committed_after)
+{
+	--echo "before:$wsrep_last_committed_before after:$wsrep_last_committed_after expected:$wsrep_last_committed_before"
+}
 --eval SELECT VARIABLE_VALUE = $wsrep_last_committed_before AS wsrep_last_committed_diff FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
 --enable_query_log
 

--- a/mysql-test/suite/galera/t/galera_many_indexes.test
+++ b/mysql-test/suite/galera/t/galera_many_indexes.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 CREATE TABLE t1 (f1 VARCHAR(767) PRIMARY KEY) ENGINE=InnoDB;
 

--- a/mysql-test/suite/galera/t/galera_transaction_replay.test
+++ b/mysql-test/suite/galera/t/galera_transaction_replay.test
@@ -97,6 +97,11 @@ set session wsrep_sync_wait = 0;
 # Issue a conflicting update on node #2
 --connection node_2
 --echo #node_2
+
+# Wait for the first transaction to be applied
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE c = 'b';
+--source include/wait_condition.inc
+
 insert into t1 values (3, 'a');
 
 # Wait for both transactions to be blocked

--- a/mysql-test/suite/galera/t/galera_var_slave_threads.test
+++ b/mysql-test/suite/galera/t/galera_var_slave_threads.test
@@ -61,6 +61,9 @@ while ($count)
 }
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 64 FROM t2;
+--source include/wait_condition.inc
+
 SELECT COUNT(*) = 64 FROM t2;
 
 SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';

--- a/mysql-test/suite/galera/t/lp1376747-4.test
+++ b/mysql-test/suite/galera/t/lp1376747-4.test
@@ -18,7 +18,7 @@ INSERT INTO t1 VALUES (1);
 --connection node_2
 SET session wsrep_sync_wait=0;
 SET session wsrep_causal_reads=OFF;
-FLUSH TABLE WITH READ LOCK;
+FLUSH TABLES WITH READ LOCK;
 
 --connection node_1
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;
@@ -35,8 +35,11 @@ SHOW CREATE TABLE t1;
 # let the flush table wait in pause state before we unlock
 # table otherwise there is window where-in flush table is
 # yet to wait in pause and unlock allows alter table to proceed.
-# this is because send in asynchronous.
---sleep 3
+# this is because send is asynchronous.
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE Info LIKE 'FLUSH TABLES t1 WITH READ LOCK';
+--let $wait_condition_on_error_output = SHOW PROCESSLIST
+--source include/wait_condition_with_debug.inc
+
 # this will release existing lock but will not resume
 # the cluster as there is new FTRL that is still pausing it.
 UNLOCK TABLES;

--- a/mysql-test/suite/galera/t/mysql-wsrep#31.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#31.test
@@ -11,6 +11,9 @@ CREATE DATABASE db;
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'db';
 --source include/wait_condition.inc
 
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1
+--source include/wait_condition.inc
+
 --let $expected_position_uuid = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_state_uuid'`
 --let $expected_position_seqno = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 

--- a/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
+++ b/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
@@ -18,21 +18,21 @@ wsrep_node_address=127.0.0.1
 
 [mysqld.1]
 wsrep_cluster_address='gcomm://'
-wsrep_provider_options='base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S'
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.1.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.1.port
 
 [mysqld.2]
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
-wsrep_provider_options='base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S'
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.2.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.2.port
 
 [mysqld.3]
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
-wsrep_provider_options='base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S'
+wsrep_provider_options='base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.3.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.3.port

--- a/mysql-test/suite/galera_3nodes/t/galera_ipv6_mysqldump.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_ipv6_mysqldump.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_ipv6.inc
+--source include/force_restart.inc
 
 --connection node_1
 GRANT ALL PRIVILEGES ON *.* TO 'sst';

--- a/mysql-test/suite/galera_3nodes/t/galera_pc_weight.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_pc_weight.test
@@ -6,6 +6,7 @@
 --source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 --connection node_1
 SET GLOBAL wsrep_provider_options = 'pc.weight=3';
@@ -56,7 +57,8 @@ SHOW STATUS LIKE 'wsrep_local_state_comment';
 # For Node #1, we expect a primary component of size 1
 
 --let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME,VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME LIKE 'wsrep_%'
+--source include/wait_condition_with_debug.inc
 
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 SELECT VARIABLE_VALUE = 'ON' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_connected';


### PR DESCRIPTION
Issue:
galera_flush and galera_flush_gtid are failing more often, may be
due to improved Jenkins performance which may lead to timing flaws
in the tests.

Solution:
Correct some of the tests to wait until changes are replicated.