### PR TITLE
- PXC#874: PXC with async slave reporting Rolling back unfinished tra…

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_without_gtid.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_without_gtid.result
@@ -1,0 +1,22 @@
+# pxc-slave
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+# master
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+INSERT INTO t1 VALUES(3);
+INSERT INTO t1 VALUES(4);
+INSERT INTO t1 VALUES(5);
+# pxc-slave
+select @@gtid_mode;
+@@gtid_mode
+OFF
+# pxc-replicating-node
+include/assert_grep.inc [Rolling back unfinished transaction]
+# master
+DROP TABLE t1;
+# pxc-slave
+STOP SLAVE;
+RESET SLAVE ALL;

--- a/mysql-test/suite/galera/t/galera_as_slave_without_gtid.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_without_gtid.cnf
@@ -1,0 +1,11 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+gtid-mode=OFF
+log-bin=mysqld-bin
+enforce-gtid-consistency=OFF
+binlog-format=ROW
+log-slave-updates=0
+
+[mysqld.2]
+log-slave-updates

--- a/mysql-test/suite/galera/t/galera_as_slave_without_gtid.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_without_gtid.test
@@ -1,0 +1,69 @@
+#
+# Test Galera as a slave to a MySQL master with gitd-mode=OFF
+#
+#
+
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster.inc
+
+--connection node_2
+--echo # pxc-slave
+--disable_query_log
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START SLAVE USER='root';
+
+--connection node_1
+--echo # master
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+INSERT INTO t1 VALUES(3);
+INSERT INTO t1 VALUES(4);
+INSERT INTO t1 VALUES(5);
+
+--connection node_2
+--echo # pxc-slave
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1;
+--source include/wait_condition.inc
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_3
+
+select @@gtid_mode;
+--echo # pxc-replicating-node
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_3
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.3.err
+--let $assert_only_after = CURRENT_TEST
+
+--let $assert_text = Rolling back unfinished transaction
+--let $assert_select = Rolling back unfinished transaction
+--let $assert_count = 0
+--source include/assert_grep.inc
+
+--connection node_1
+--echo # master
+DROP TABLE t1;
+
+--connection node_2
+--echo # pxc-slave
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+STOP SLAVE;
+RESET SLAVE ALL;
+

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -13622,8 +13622,8 @@ bool Gtid_log_event::write_data_header(IO_CACHE *file)
 #if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)
 
 #ifdef WITH_WSREP
-/* Starting 5.7 gtid event is not logged to binary log and so this event
-needs to be captured so that PXC can append it as part of write-set. */
+/* Capture GTID event if PXC node is acting as ASYNC-SLAVE.
+This GTID event is appended as part of write-set creation in wsrep_replicate */
 static void wsrep_capture_gtid_event(THD* thd, Gtid_log_event* ev)
 {
   /* GTID events are also processed by applier but avoid capturing

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -123,7 +123,9 @@ static wsrep_cb_status_t wsrep_apply_events(THD*        thd,
     case binary_log::FORMAT_DESCRIPTION_EVENT:
       wsrep_set_apply_format(thd, (Format_description_log_event*)ev);
       continue;
+    /* If gtid_mode=OFF then async master-slave will generate ANONYMOUS GTID. */
     case binary_log::GTID_LOG_EVENT:
+    case binary_log::ANONYMOUS_GTID_LOG_EVENT:
     {
       Gtid_log_event* gev= (Gtid_log_event*)ev;
       if (gev->get_gno() == 0)


### PR DESCRIPTION
…nsaction

  Issue:
  ------

  PXC acting as async slave will replicate an event that is not handled
  by wsrep-applier causing erroneous messages in the replicated node.

  setup: async-master (could be pxc node) replicating to
         async-slave (pxc node that further replicates the said traffic in
                      its cluster group channel).

  If async master has gtid_mode=OFF it will emit GTID_NEXT="ANONYMOUS" event.
  PXC node acting as async slave can handle this event as it is done by
  MySQL async replication applier/worker thread but when the same event is
  further replicated on group channel PXC applier thread doesn't have logic
  to handle this event causing erroneous messages.

  Solution:
  --------

  Add logic in wsrep-applier to handle said event.