### PR TITLE
PXC-875:  [Warning] WSREP: Unsupported protocol downgrade: incrementa…

### DIFF
--- a/mysql-test/suite/galera/r/MW-44.result
+++ b/mysql-test/suite/galera/r/MW-44.result
@@ -4,10 +4,6 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 SET SESSION wsrep_osu_method=RSU;
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;
 SET SESSION wsrep_osu_method=TOI;
-SELECT COUNT(*) = 2 FROM mysql.general_log WHERE argument LIKE 'CREATE%' OR argument LIKE 'ALTER%';
-COUNT(*) = 2
-1
-SELECT COUNT(*) = 0 FROM mysql.general_log WHERE argument NOT LIKE 'SELECT%';
-COUNT(*) = 0
-1
+include/assert.inc [General log should have 2 queries for ALTER and CREATE]
+include/assert.inc [General log should have no queries which don't have SELECT]
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MW-44.test
+++ b/mysql-test/suite/galera/t/MW-44.test
@@ -20,19 +20,15 @@ SET SESSION wsrep_osu_method=RSU;
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;
 SET SESSION wsrep_osu_method=TOI;
 
-SELECT COUNT(*) = 2 FROM mysql.general_log WHERE argument LIKE 'CREATE%' OR argument LIKE 'ALTER%';
---let $general_log_count = `SELECT COUNT(*) FROM mysql.general_log WHERE argument LIKE 'CREATE%' OR argument LIKE 'ALTER%'`
-if ($general_log_count != 2)
-{
-	SELECT * FROM mysql.general_log;
-}
+--let $assert_text= General log should have 2 queries for ALTER and CREATE
+--let $assert_cond= COUNT(*) = 2 FROM mysql.general_log WHERE argument LIKE "CREATE%" OR argument LIKE "ALTER%"
+--let $assert_debug= SELECT * FROM mysql.general_log
+--source include/assert.inc
 
 --connection node_2
-SELECT COUNT(*) = 0 FROM mysql.general_log WHERE argument NOT LIKE 'SELECT%';
---let $general_log_count = `SELECT COUNT(*) FROM mysql.general_log WHERE argument NOT LIKE 'SELECT%'`
-if ($general_log_count != 0)
-{
-	SELECT * FROM mysql.general_log;
-}
+--let $assert_text= General log should have no queries which don't have SELECT
+--let $assert_cond= COUNT(*) = 0 FROM mysql.general_log WHERE argument NOT LIKE "SELECT%"
+--let $assert_debug= SELECT * FROM mysql.general_log
+--source include/assert.inc
 
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -1,5 +1,4 @@
 galera_wsrep_provider_unset_set : lp1379204 'Unsupported protocol downgrade: incremental data collection disabled. Expect abort.'
-pxc-421 : lp1379204 'Unsupported protocol downgrade: incremental data collection disabled. Expect abort.'
 galera_bf_abort_for_update : mysql-wsrep#26 SELECT FOR UPDATE sometimes allowed to proceed in the face of a concurrent update
 galera_toi_ddl_fk_insert : qa#39 galera_toi_ddl_fk_insert fails sporadically
 galera_toi_ddl_online : fails randomly with "deadlock error" as sequence of action is causing an issue.

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -454,6 +454,9 @@ int wsrep_init()
   wsrep_ready_set(FALSE);
   assert(wsrep_provider);
 
+  // Reset global settings
+  wsrep_incremental_data_collection= FALSE;
+
   wsrep_init_position();
 
   if ((rcode= wsrep_load(wsrep_provider, &wsrep, wsrep_log_cb)) != WSREP_OK)


### PR DESCRIPTION
…l data collection disabled. Expect abort.

Issue:
Some tests would fail with the warning message: Unsupported protocol downgrade: incremental...
This was happening because the servers start with version -1 and then get established
at version 7.  During some tests, wsrep_provider is turned off which resets the version to -1,
but the internal variable for incremental data collection is still set to 1 and is enabled.
So upon wsrep restart, we get the error, since we see the version going from 7 to -1.

Solution:
Clear the use of the incremental data collection settings upon wsrep initialization.