### PR TITLE
PXC-873: gtid/keyring stage: No such file or directory

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -967,8 +967,7 @@ recv_data_from_donor_to_joiner()
 
     if [[ ${RC[0]} -eq 124 ]]; then
         wsrep_log_error "******************* FATAL ERROR ********************** "
-        wsrep_log_error "Possible timeout in receving first data from donor in "
-                        "gtid/keyring stage"
+        wsrep_log_error "Possible timeout in receving first data from donor in gtid/keyring stage"
         wsrep_log_error "****************************************************** "
         exit 32
     fi


### PR DESCRIPTION
Issue:
Text was cut-off, leaving to a partial error message

Solution:
Make the error text appear on the same line