### PR TITLE
- PXC#878: Threads stuck in permanent statistics state with innodb_th…

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1767,10 +1767,6 @@ innobase_srv_conc_enter_innodb(
 	}
 
 	trx_t*	trx	= prebuilt->trx;
-#ifdef WITH_WSREP
-	if (wsrep_on(trx->mysql_thd) && 
-	    wsrep_thd_is_BF(trx->mysql_thd, FALSE)) return;
-#endif /* WITH_WSREP */
 	if (srv_thread_concurrency) {
 		if (trx->n_tickets_to_enter_innodb > 0) {
 

--- a/storage/innobase/srv/srv0conc.cc
+++ b/storage/innobase/srv/srv0conc.cc
@@ -322,13 +322,6 @@ srv_conc_force_exit_innodb(
 
 		return;
 	}
-#ifdef WITH_WSREP
-	if (wsrep_on(trx->mysql_thd) && 
-	    wsrep_trx_is_aborting(trx->mysql_thd)) {
-		srv_conc_force_enter_innodb(trx);
-		return;
-	}
-#endif /* WITH_WSREP */
 
 	srv_conc_exit_innodb_with_atomics(trx);
 


### PR DESCRIPTION
…read_concurrency>0

  * Upstream merge accidentally got a wrong code that looks like a copy-paste
    mistake.

  * When the threads leaves InnoDB it should mark exit from innodb server
    concurrency. It was doing exactly opposite.