### PR TITLE
- PXC#879: Wrong count if LOAD DATA used with GTIDs

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -9888,7 +9888,11 @@ commit_stage:
    */
   if (DBUG_EVALUATE_IF("force_rotate", 1, 0) ||
       (do_rotate && thd->commit_error == THD::CE_NONE &&
-       !is_rotating_caused_by_incident))
+       !is_rotating_caused_by_incident
+#ifdef WITH_WSREP
+       && !thd->wsrep_split_trx
+#endif /* WITH_WSREP */
+      ))
   {
     /*
       Do not force the rotate as several consecutive groups may

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -852,7 +852,10 @@ extern "C" void wsrep_thd_set_conflict_state(
     if (lock) mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
   }
 }
-
+extern "C" void wsrep_thd_mark_split_trx(THD *thd, bool split_trx)
+{
+  thd->wsrep_split_trx= split_trx;
+}
 
 extern "C" enum wsrep_exec_mode wsrep_thd_exec_mode(THD *thd)
 {
@@ -1533,6 +1536,7 @@ THD::THD(bool enable_plugins)
   wsrep_affected_rows     = 0;
   wsrep_replicate_GTID    = false;
   wsrep_skip_wsrep_GTID   = false;
+  wsrep_split_trx         = false;
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;
 #endif /* WITH_WSREP */
   /* Call to init() below requires fully initialized Open_tables_state. */
@@ -1929,6 +1933,7 @@ void THD::init(void)
   wsrep_affected_rows     = 0;
   wsrep_replicate_GTID    = false;
   wsrep_skip_wsrep_GTID   = false;
+  wsrep_split_trx         = false;
   wsrep_gtid_event_buf    = NULL;
   wsrep_gtid_event_buf_len = 0;
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3384,6 +3384,21 @@ public:
   bool                      wsrep_replicate_GTID;
   bool                      wsrep_skip_wsrep_GTID;
 
+  /* This field is set when wsrep try to do an intermediate special
+  commit while processing LOAD DATA INFILE statement by breaking it
+  into 10K rows mini transactions.
+
+  If this variable is set then binlog rotation is not performed
+  while mini transaction try to commit. Why ?
+  a. From logical perspective LDI is still a single transaction
+  b. rotation will cause unregistration of binlog/innodb handler.
+     On resuming the flow binlog handler is re-register but innodb
+     isn't this eventually causes replication of last chunk (< 10K)
+     rows to skip. Infact, this is logical issue that exist in
+     MySQL/InnoDB world but it just work for them as InnoDB
+     then commit the said transaction as part of external_lock(UNLOCK). */
+  bool                      wsrep_split_trx;
+
   /*
     Transaction id:
     * m_next_wsrep_trx_id is assigned on the first query after

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -193,6 +193,7 @@ extern "C" void wsrep_thd_set_query_state(
         THD *thd, enum wsrep_query_state state);
 extern "C" void wsrep_thd_set_conflict_state(
         THD *thd, bool lock, enum wsrep_conflict_state state);
+extern "C" void wsrep_thd_mark_split_trx(THD* thd, bool mini_trx);
 
 extern "C" void wsrep_thd_set_trx_to_replay(THD *thd, uint64 trx_id);
 

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -616,6 +616,7 @@ extern "C" void wsrep_thd_set_query_state(
 	THD *thd, enum wsrep_query_state state);
 extern "C" void wsrep_thd_set_conflict_state(
         THD *thd, bool lock, enum wsrep_conflict_state state);
+extern "C" void wsrep_thd_mark_split_trx(THD* thd, bool mini_trx);
 
 extern "C" void wsrep_thd_set_trx_to_replay(THD *thd, uint64 trx_id);
 


### PR DESCRIPTION
  * wsrep splits LOAD DATA INFILE into 10K bucket (except last)
    and commits each bucket independently.

  * While committing such bucket if the bin-log
    reaches its max size then bin-log is switched over.
    Existing binlog is closed and GTIDs are saved.

    As part of this process commit action is invoked
    that causes clearing of registered storage engine
    plugin given that commit is last step.

  * But in this use-case it is not the last step but an intermediate
    commit of 10K bucket and so degistration of storage engine plugin
    shouldn't happen.

  * Also, LDI being a logical single command or big transaction
    all binlogs related information for it should be logged
    to same bin-log file. wsrep optimization for 10K commit
    shouldn't affect the split of binlog information.

  So we worked it out by skipping switch-over (or rotate as code
  name it) of binlogs if the wsrep is processing intermediate commit.