### PR TITLE
- PXC#883: ROLLBACK to SAVEPOINT does not rollback correctly on slaves

### DIFF
--- a/mysql-test/suite/galera/r/galera_rollback_to_savepoint.result
+++ b/mysql-test/suite/galera/r/galera_rollback_to_savepoint.result
@@ -1,0 +1,41 @@
+#node-1
+use test;
+CREATE TABLE example (id INT NOT NULL PRIMARY KEY, name VARCHAR(64));
+INSERT INTO example VALUES(0, 'zero');
+BEGIN;
+INSERT INTO example VALUES(1, 'first!');
+SAVEPOINT savepoint001;
+ROLLBACK TO SAVEPOINT savepoint001;
+INSERT INTO example VALUES(2, 'second');
+COMMIT;
+SELECT * FROM example;
+id	name
+0	zero
+1	first!
+2	second
+#node-2
+SELECT * FROM example;
+id	name
+0	zero
+1	first!
+2	second
+#node-1
+DROP TABLE example;
+#node-1
+use test;
+CREATE TABLE example (id INT NOT NULL PRIMARY KEY, name VARCHAR(64));
+BEGIN;
+SAVEPOINT savepoint001;
+INSERT INTO example VALUES(2, 'second');
+SELECT * FROM example;
+id	name
+2	second
+ROLLBACK TO SAVEPOINT savepoint001;
+COMMIT;
+SELECT * FROM example;
+id	name
+#node-2
+SELECT * FROM example;
+id	name
+#node-1
+DROP TABLE example;

--- a/mysql-test/suite/galera/t/galera_rollback_to_savepoint.cnf
+++ b/mysql-test/suite/galera/t/galera_rollback_to_savepoint.cnf
@@ -1,0 +1,8 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+skip_log_bin
+
+[mysqld.2]
+skip_log_bin
+

--- a/mysql-test/suite/galera/t/galera_rollback_to_savepoint.test
+++ b/mysql-test/suite/galera/t/galera_rollback_to_savepoint.test
@@ -1,0 +1,56 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+#
+# ROLLBACK to savepoint should only rollback the said action.
+#
+
+--connection node_1
+--echo #node-1
+use test;
+
+CREATE TABLE example (id INT NOT NULL PRIMARY KEY, name VARCHAR(64));
+INSERT INTO example VALUES(0, 'zero');
+
+BEGIN;
+INSERT INTO example VALUES(1, 'first!');
+SAVEPOINT savepoint001;
+ROLLBACK TO SAVEPOINT savepoint001;
+INSERT INTO example VALUES(2, 'second');
+COMMIT;
+
+SELECT * FROM example;
+
+--connection node_2
+--echo #node-2
+SELECT * FROM example;
+
+--connection node_1
+--echo #node-1
+DROP TABLE example;
+
+#
+# ROLLBACK to savepoint leading to empty transaction
+#
+--connection node_1
+--echo #node-1
+use test;
+
+CREATE TABLE example (id INT NOT NULL PRIMARY KEY, name VARCHAR(64));
+
+BEGIN;
+SAVEPOINT savepoint001;
+INSERT INTO example VALUES(2, 'second');
+SELECT * FROM example;
+ROLLBACK TO SAVEPOINT savepoint001;
+COMMIT;
+
+SELECT * FROM example;
+
+--connection node_2
+--echo #node-2
+SELECT * FROM example;
+
+--connection node_1
+--echo #node-1
+DROP TABLE example;

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -706,7 +706,11 @@ bool trans_rollback_to_savepoint(THD *thd, LEX_STRING name)
                 (!((WSREP_EMULATE_BINLOG(thd) ||  mysql_bin_log.is_open()) 
                    && thd->variables.sql_log_bin) ||
                  ha_rollback_to_savepoint_can_release_mdl(thd));
-  wsrep_register_hton(thd, TRUE);
+  /* No need to register wsrep plugin while rolling back to savepoint.
+  There is no action for wsrep plugin for savepoint rollback.
+  Action is associated with binlog to clearup/truncate till said point
+  and innodb.
+  wsrep_register_hton(thd, TRUE); */
 #else
   bool mdl_can_safely_rollback_to_savepoint=
                 (!(mysql_bin_log.is_open() && thd->variables.sql_log_bin) ||


### PR DESCRIPTION
  * ROLLBACK to savepoint involves 2 main actions:
    - truncate binlog to the said position
    - rollback at innodb storage engine level.

    wsrep plugin has no role to play in savepoint rollback and
    call to wsrep plugin should be avoided in such case.

  * What would happen if we call wsrep plugin rollback action
    for savepoint rollback ?
    * wsrep plugin doesn't differentiate between normal and savepoint
      rollback and so will cause complete transaction rollback there-by
      discarding valid action even befor the savepoint.
    * this drawback currently is limited to log-bin=0 but ideal solution
      is to avoid calling wsrep plugin for savepoint rollback as it doesn't
      have role to play.