### PR TITLE
PXC-870, PXC-880

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_ddl_access_checking.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_ddl_access_checking.result
@@ -113,7 +113,7 @@ INSERT INTO counter(count) VALUES(8);;
 # connection node_1
 include/assert.inc [Database testdbother still does not exist on node 1]
 # connection node_2
-include/assert.inc [Database testdbother still does not exist on node 1]
+include/assert.inc [Database testdbother still does not exist on node 2]
 #
 # SQLCOM_DROP_DB access test
 #
@@ -218,34 +218,12 @@ include/assert_grep.inc [OPTIMIZE TABLE did not execute on node 1]
 # connection node_2
 include/assert_grep.inc [OPTIMIZE TABLE did not execute on node 2]
 #
-# SQLCOM_CHECK access test
-#
-# connection node_1
-CREATE DATABASE testdb_notouch;
-USE testdb_notouch;
-CREATE TABLE notouch(id INT PRIMARY KEY AUTO_INCREMENT, f2 CHAR(16));
-CREATE TABLE a1(id INT PRIMARY KEY);
-GRANT SELECT ON testdb_notouch.a1 TO 'testme'@'%';
-USE testdb;
-# connection node_testme
-USE testdb_notouch;
-CHECK TABLE notouch;
-ERROR 42000: SELECT command denied to user 'testme'@'localhost' for table 'notouch'
-USE testdb;
-INSERT INTO counter(count) VALUES(15);;
-# connection node_1
-include/assert_grep.inc [CHECK TABLE did not execute on node 1]
-# connection node_2
-include/assert_grep.inc [CHECK TABLE did not execute on node 2]
-# connection node_1
-DROP DATABASE testdb_notouch;
-#
 # SQLCOM_ANALYZE access test
 #
 # connection node_testme
 ANALYZE TABLE t1;
 ERROR 42000: INSERT command denied to user 'testme'@'localhost' for table 't1'
-INSERT INTO counter(count) VALUES(16);;
+INSERT INTO counter(count) VALUES(15);;
 # connection node_1
 include/assert_grep.inc [ANALYZE TABLE did not execute on node 1]
 # connection node_2
@@ -256,7 +234,7 @@ include/assert_grep.inc [ANALYZE TABLE did not execute on node 2]
 # connection node_testme
 RENAME TABLE t1 to t2;
 ERROR 42000: DROP, ALTER command denied to user 'testme'@'localhost' for table 't1'
-INSERT INTO counter(count) VALUES(17);;
+INSERT INTO counter(count) VALUES(16);;
 # connection node_1
 include/assert.inc [Table t1 was not renamed on node 1]
 # connection node_2
@@ -267,7 +245,7 @@ include/assert.inc [Table t1 was not renamed on node 2]
 # connection node_testme
 CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
 ERROR 42000: Access denied; you need (at least one of) the CREATE USER privilege(s) for this operation
-INSERT INTO counter(count) VALUES(18);;
+INSERT INTO counter(count) VALUES(17);;
 # connection node_1
 include/assert.inc [User foo was not created on node 1]
 # connection node_2
@@ -278,7 +256,7 @@ include/assert.inc [User foo was not created on node 2]
 # connection node_testme
 DROP USER 'testother'@'%';
 ERROR 42000: Access denied; you need (at least one of) the CREATE USER privilege(s) for this operation
-INSERT INTO counter(count) VALUES(19);;
+INSERT INTO counter(count) VALUES(18);;
 # connection node_1
 include/assert.inc [User testother still exists on node 1]
 # connection node_2
@@ -289,7 +267,7 @@ include/assert.inc [User testother still exists on node 2]
 # connection node_testme
 RENAME USER 'testother'@'%' TO 'testwho'@'%';
 ERROR 42000: Access denied; you need (at least one of) the CREATE USER privilege(s) for this operation
-INSERT INTO counter(count) VALUES(20);;
+INSERT INTO counter(count) VALUES(19);;
 # connection node_1
 include/assert.inc [User testother still exists on node 1]
 # connection node_2
@@ -313,7 +291,7 @@ GRANT SELECT ON `testdb`.`t1` TO 'testother'@'%'
 # connection node_testme
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'testother'@'%';
 ERROR 42000: Access denied; you need (at least one of) the CREATE USER privilege(s) for this operation
-INSERT INTO counter(count) VALUES(21);;
+INSERT INTO counter(count) VALUES(20);;
 # connection node_1
 SHOW GRANTS FOR 'testother';
 Grants for testother@%
@@ -332,7 +310,7 @@ CREATE PROCEDURE hellop (OUT ver_param VARCHAR(64), INOUT incr_param INT)
 BEGIN
 END;
 ERROR 42000: Access denied for user 'testme'@'%' to database 'testdb'
-INSERT INTO counter(count) VALUES(22);;
+INSERT INTO counter(count) VALUES(21);;
 # connection node_1
 include/assert.inc [The hellop procedure should not exist on node 1]
 # connection node_2
@@ -343,7 +321,7 @@ include/assert.inc [The hellop function should not exist on node 2]
 # connection node_testme
 CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello, ',s,'!');
 ERROR 42000: Access denied for user 'testme'@'%' to database 'testdb'
-INSERT INTO counter(count) VALUES(23);;
+INSERT INTO counter(count) VALUES(22);;
 # connection node_1
 include/assert.inc [The hello function should not exist on node 1]
 # connection node_2
@@ -362,7 +340,7 @@ include/assert.inc [The hellop procedure should exist on node 2]
 # connection node_testme
 DROP PROCEDURE hellop;
 ERROR 42000: alter routine command denied to user 'testme'@'%' for routine 'testdb.hellop'
-INSERT INTO counter(count) VALUES(24);;
+INSERT INTO counter(count) VALUES(23);;
 # connection node_1
 include/assert.inc [The hellop procedure should still exist on node 1]
 # connection node_2
@@ -386,7 +364,7 @@ hellop	DEFINER
 # connection node_testme
 ALTER PROCEDURE hellop SQL SECURITY INVOKER;
 ERROR 42000: alter routine command denied to user 'testme'@'%' for routine 'testdb.hellop'
-INSERT INTO counter(count) VALUES(25);;
+INSERT INTO counter(count) VALUES(24);;
 # connection node_1
 include/assert.inc [The hellop procedure should still use the definer on node 1]
 # connection node_2
@@ -408,7 +386,7 @@ hellof	DEFINER
 # connection node_testme
 ALTER FUNCTION hellof SQL SECURITY INVOKER;
 ERROR 42000: alter routine command denied to user 'testme'@'%' for routine 'testdb.hellof'
-INSERT INTO counter(count) VALUES(26);;
+INSERT INTO counter(count) VALUES(25);;
 # connection node_1
 include/assert.inc [The hellof function should still use the definer on node 1]
 # connection node_2
@@ -421,7 +399,7 @@ DROP FUNCTION hellof;
 # connection node_testme
 CREATE VIEW testview AS SELECT * FROM t1;
 ERROR 42000: CREATE VIEW command denied to user 'testme'@'localhost' for table 'testview'
-INSERT INTO counter(count) VALUES(27);;
+INSERT INTO counter(count) VALUES(26);;
 # connection node_1
 include/assert.inc [The testview VIEW should not exist on node 1]
 # connection node_2
@@ -438,7 +416,7 @@ include/assert.inc [The helloview VIEW should exist on node 2]
 # connection node_testme
 DROP VIEW helloview;
 ERROR 42000: DROP command denied to user 'testme'@'localhost' for table 'helloview'
-INSERT INTO counter(count) VALUES(28);;
+INSERT INTO counter(count) VALUES(27);;
 # connection node_1
 include/assert.inc [The helloview VIEW should still exist on node 1]
 # connection node_2
@@ -451,7 +429,7 @@ DROP VIEW helloview;
 # connection node_testme
 CREATE TRIGGER testtrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1;
 ERROR 42000: TRIGGER command denied to user 'testme'@'localhost' for table 't1'
-INSERT INTO counter(count) VALUES(29);;
+INSERT INTO counter(count) VALUES(28);;
 # connection node_1
 include/assert.inc [The testtrigger TRIGGER should not exist on node 1]
 # connection node_2
@@ -468,9 +446,9 @@ include/assert.inc [The hellotrigger TRIGGER should exist on node 2]
 # connection node_testme
 DROP TRIGGER hellotrigger;
 ERROR 42000: TRIGGER command denied to user 'testme'@'localhost' for table 't1'
-INSERT INTO counter(count) VALUES(30);;
+INSERT INTO counter(count) VALUES(29);;
 # connection node_1
-include/assert.inc [The hellotrigger TRIGGER should still exist on node 2]
+include/assert.inc [The hellotrigger TRIGGER should still exist on node 1]
 # connection node_2
 include/assert.inc [The hellotrigger TRIGGER should still exist on node 2]
 # connection node_1
@@ -481,7 +459,7 @@ DROP TRIGGER hellotrigger;
 # connection node_testme
 INSTALL PLUGIN audit_log SONAME "audit_log.so";
 ERROR 42000: INSERT command denied to user 'testme'@'localhost' for table 'plugin'
-INSERT INTO counter(count) VALUES(31);;
+INSERT INTO counter(count) VALUES(30);;
 # connection node_1
 include/assert.inc [The audit_log PLUGIN should not be installed on node 1]
 # connection node_2
@@ -496,7 +474,7 @@ include/assert.inc [The audit_log PLUGIN should be installed on node 1]
 # connection node_testme
 UNINSTALL PLUGIN audit_log;
 ERROR 42000: DELETE command denied to user 'testme'@'localhost' for table 'plugin'
-INSERT INTO counter(count) VALUES(32);;
+INSERT INTO counter(count) VALUES(31);;
 # connection node_1
 include/assert.inc [The audit_log PLUGIN should still be installed on node 1]
 # connection node_2
@@ -513,7 +491,7 @@ CREATE EVENT testevent
 ON SCHEDULE EVERY 1 HOUR
 DO INSERT INTO t1(f2) VALUES(3);
 ERROR 42000: Access denied for user 'testme'@'%' to database 'testdb'
-INSERT INTO counter(count) VALUES(33);;
+INSERT INTO counter(count) VALUES(32);;
 # connection node_1
 include/assert.inc [The testevent EVENT should not exist on node 1]
 # connection node_2
@@ -532,7 +510,7 @@ include/assert.inc [The helloevent EVENT should exist on node 2]
 # connection node_testme
 ALTER EVENT helloevent ON SCHEDULE EVERY '2:3' DAY_HOUR;
 ERROR 42000: Access denied for user 'testme'@'%' to database 'testdb'
-INSERT INTO counter(count) VALUES(34);;
+INSERT INTO counter(count) VALUES(33);;
 # connection node_1
 include/assert.inc [The helloevent EVENT should still exist on node 1]
 # connection node_2
@@ -543,7 +521,7 @@ include/assert.inc [The helloevent EVENT should still exist on node 2]
 # connection node_testme
 DROP EVENT helloevent;
 ERROR 42000: Access denied for user 'testme'@'%' to database 'testdb'
-INSERT INTO counter(count) VALUES(35);;
+INSERT INTO counter(count) VALUES(34);;
 # connection node_1
 include/assert.inc [The helloevent EVENT should still exist on node 1]
 # connection node_2
@@ -554,7 +532,7 @@ include/assert.inc [The helloevent EVENT should still exist on node 2]
 # connection node_testme
 ALTER USER 'testother'@'%' PASSWORD EXPIRE;
 ERROR 42000: Access denied; you need (at least one of) the CREATE USER privilege(s) for this operation
-INSERT INTO counter(count) VALUES(36);;
+INSERT INTO counter(count) VALUES(35);;
 # connection node_1
 include/assert.inc [User testother should be unexpired on node 1]
 # connection node_2

--- a/mysql-test/suite/galera/r/galera_wsrep_ddl_access_checking2.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_ddl_access_checking2.result
@@ -1,0 +1,1118 @@
+CREATE DATABASE testdb;
+USE testdb;
+CREATE TABLE counter(id INT PRIMARY KEY AUTO_INCREMENT, count INT);
+CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT, f2 CHAR(64));
+INSERT INTO t1(f2) VALUES(1);
+CREATE USER 'testme'@'%' IDENTIFIED BY 'secret';
+GRANT SELECT ON testdb.* TO 'testme'@'%';
+GRANT INSERT ON testdb.counter TO 'testme'@'%';
+CREATE USER 'testother'@'%' IDENTIFIED BY 'secret2';
+FLUSH PRIVILEGES;
+# connection node_1
+use testdb;
+SET GLOBAL debug= 'd,sql_cmd.before_toi_begin.log_command';
+# connection node_2
+use testdb;
+SET GLOBAL debug= 'd,sql_cmd.before_toi_begin.log_command';
+# connection node_testme
+use testdb;
+#
+# SQLCOM_CREATE_TABLE access test
+#
+# connection node_1
+GRANT CREATE ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, CREATE ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE TABLE t2(id INT PRIMARY KEY AUTO_INCREMENT);
+INSERT INTO counter(count) VALUES(1);;
+# connection node_1
+include/assert.inc [Table t2 should exist on node 1]
+# connection node_2
+include/assert.inc [Table t2 should exist on node 2]
+# connection node_1
+REVOKE CREATE ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+DROP TABLE t2;
+#
+# SQLCOM_CREATE_INDEX access test
+#
+# connection node_1
+GRANT INDEX ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, INDEX ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE INDEX index_t1_f2 ON t1(f2);
+INSERT INTO counter(count) VALUES(2);;
+# connection node_1
+include/assert.inc [Index t1_f2 should exist on node 1]
+# connection node_2
+include/assert.inc [Index t1_f2 should exist on node 2]
+# connection node_1
+REVOKE INDEX ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+DROP INDEX index_t1_f2 ON t1;
+#
+# SQLCOM_ALTER_TABLE access test
+#
+# connection node_1
+GRANT ALTER ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, ALTER ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+ALTER TABLE t1 ADD COLUMN f3 LONGBLOB;
+INSERT INTO counter(count) VALUES(3);;
+# connection node_1
+include/assert.inc [Column f3 on table t1 should exist on node 1]
+# connection node_2
+include/assert.inc [Column f3 on table t1 should exist on node 2]
+# connection node_1
+REVOKE ALTER ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+ALTER TABLE t1 DROP COLUMN f3;
+#
+# SQLCOM_TRUNCATE access test
+#
+# connection node_1
+GRANT DROP ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, DROP ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+TRUNCATE TABLE t1;
+INSERT INTO counter(count) VALUES(4);;
+# connection node_1
+include/assert.inc [Table t1 was truncated on node 1]
+# connection node_2
+include/assert.inc [Table t1 was truncated on node 2]
+# connection node_1
+REVOKE DROP ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+INSERT INTO t1(f2) VALUES(1);
+#
+# SQLCOM_DROP_TABLE access test
+#
+# connection node_1
+GRANT DROP ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, DROP ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP TABLE t1;
+INSERT INTO counter(count) VALUES(5);;
+# connection node_1
+include/assert.inc [Table t1 was dropped on node 1]
+# connection node_2
+include/assert.inc [Table t1 was dropped on node 2]
+# connection node_1
+REVOKE DROP ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT, f2 CHAR(64));
+INSERT INTO t1(f2) VALUES(1);
+#
+# SQLCOM_DROP_INDEX access test
+#
+# connection node_1
+CREATE INDEX t1_f2 ON t1(f2);
+include/assert.inc [Index t1_f2 should exist on node 1]
+# connection node_1
+GRANT INDEX ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, INDEX ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP INDEX t1_f2 ON t1;
+INSERT INTO counter(count) VALUES(6);;
+# connection node_1
+include/assert.inc [Index t1_f2 should not exist on node 1]
+# connection node_2
+include/assert.inc [Index t1_f2 should not exist on node 2]
+# connection node_1
+REVOKE INDEX ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_GRANT access test
+#
+# connection node_1
+GRANT GRANT OPTION ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%' WITH GRANT OPTION
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+GRANT SELECT ON testdb.* TO 'testother'@'%';
+INSERT INTO counter(count) VALUES(7);;
+# connection node_1
+SHOW GRANTS FOR 'testother';
+Grants for testother@%
+GRANT USAGE ON *.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.* TO 'testother'@'%'
+# connection node_2
+SHOW GRANTS FOR 'testother';
+Grants for testother@%
+GRANT USAGE ON *.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.* TO 'testother'@'%'
+# connection node_1
+REVOKE GRANT OPTION ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_CREATE_DB access test
+#
+# connection node_testme
+include/assert.inc [Database testdbother does not exist on node 1]
+# connection node_1
+GRANT CREATE ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT CREATE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE DATABASE testdbother;
+INSERT INTO counter(count) VALUES(8);;
+# connection node_1
+include/assert.inc [Database testdbother should exist on node 1]
+# connection node_2
+include/assert.inc [Database testdbother should exist on node 2]
+# connection node_1
+REVOKE CREATE ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+DROP DATABASE testdbother;
+#
+# SQLCOM_DROP_DB access test
+#
+# connection node_1
+CREATE DATABASE testdbother;
+# connection node_2
+# connection node_1
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+GRANT DROP ON *.* TO 'testme'@'%';
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP DATABASE testdbother;
+INSERT INTO counter(count) VALUES(9);;
+# connection node_1
+include/assert.inc [Database testdbother should not exist on node 1]
+# connection node_2
+include/assert.inc [Database testdbother shoutl not exist on node 2]
+# connection node_1
+REVOKE DROP ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_ALTER_DB access test
+#
+# connection node_1
+GRANT ALTER ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT ALTER ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+CREATE DATABASE testdbother;
+SHOW CREATE DATABASE testdbother;
+Database	Create Database
+testdbother	CREATE DATABASE `testdbother` /*!40100 DEFAULT CHARACTER SET latin1 */
+# connection node_testme
+use testdb;
+ALTER DATABASE testdbother CHARACTER SET latin7;
+INSERT INTO counter(count) VALUES(10);;
+# connection node_1
+SHOW CREATE DATABASE testdbother;
+Database	Create Database
+testdbother	CREATE DATABASE `testdbother` /*!40100 DEFAULT CHARACTER SET latin7 */
+# connection node_2
+SHOW CREATE DATABASE testdbother;
+Database	Create Database
+testdbother	CREATE DATABASE `testdbother` /*!40100 DEFAULT CHARACTER SET latin7 */
+# connection node_1
+DROP DATABASE testdbother;
+REVOKE ALTER ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_REPAIR access test
+#
+# connection node_1
+GRANT INSERT ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, INSERT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+REPAIR TABLE t1;
+Table	Op	Msg_type	Msg_text
+testdb.t1	repair	note	The storage engine for the table doesn't support repair
+INSERT INTO counter(count) VALUES(11);;
+# connection node_1
+include/assert_grep.inc [REPAIR TABLE did execute on node 1]
+# connection node_2
+include/assert_grep.inc [REPAIR TABLE did execute on node 2]
+# connection node_1
+REVOKE INSERT ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_DROP_FUNCTION access test
+#
+# connection node_1
+CREATE FUNCTION hello2 (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello again, ',s,'!');
+# connection node_1
+include/assert.inc [The hello2 function should exist on node 1]
+# connection node_2
+include/assert.inc [The hello2 function should exist on node 2]
+# connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, ALTER ROUTINE ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP FUNCTION hello2;
+INSERT INTO counter(count) VALUES(12);;
+# connection node_1
+include/assert.inc [The hello2 function should not exist on node 1]
+# connection node_2
+include/assert.inc [The hello2 function should not exist on node 2]
+# connection node_1
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_REVOKE access test
+#
+# connection node_1
+GRANT SELECT ON testdb.t1 TO 'testother'@'%';
+FLUSH PRIVILEGES;
+# connection node_1
+SHOW GRANTS FOR 'testother';
+Grants for testother@%
+GRANT USAGE ON *.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.`t1` TO 'testother'@'%'
+# connection node_2
+SHOW GRANTS FOR 'testother';
+Grants for testother@%
+GRANT USAGE ON *.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.`t1` TO 'testother'@'%'
+# connection node_1
+GRANT GRANT OPTION ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%' WITH GRANT OPTION
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+REVOKE SELECT ON testdb.t1 FROM 'testother'@'%';
+INSERT INTO counter(count) VALUES(13);;
+# connection node_1
+SHOW GRANTS FOR 'testother';
+Grants for testother@%
+GRANT USAGE ON *.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.* TO 'testother'@'%'
+# connection node_2
+SHOW GRANTS FOR 'testother';
+Grants for testother@%
+GRANT USAGE ON *.* TO 'testother'@'%'
+GRANT SELECT ON `testdb`.* TO 'testother'@'%'
+# connection node_1
+REVOKE GRANT OPTION ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_OPTIMIZE access test
+#
+# connection node_1
+GRANT INSERT ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, INSERT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+testdb.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+testdb.t1	optimize	status	OK
+INSERT INTO counter(count) VALUES(14);;
+# connection node_1
+include/assert_grep.inc [OPTIMIZE TABLE did execute on node 1]
+# connection node_2
+include/assert_grep.inc [OPTIMIZE TABLE did execute on node 2]
+# connection node_1
+REVOKE INSERT ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_ANALYZE access test
+#
+# connection node_1
+GRANT INSERT ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, INSERT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+testdb.t1	analyze	status	OK
+INSERT INTO counter(count) VALUES(15);;
+# connection node_1
+include/assert_grep.inc [ANALYZE TABLE did execute on node 1]
+# connection node_2
+include/assert_grep.inc [ANALYZE TABLE did execute on node 2]
+# connection node_1
+REVOKE INSERT ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_RENAME_TABLE access test
+#
+# connection node_1
+GRANT ALTER,DROP,CREATE,INSERT ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, INSERT, CREATE, DROP, ALTER ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+RENAME TABLE t1 to t2;
+INSERT INTO counter(count) VALUES(16);;
+# connection node_1
+include/assert.inc [Table t1 was renamed on node 1]
+# connection node_2
+include/assert.inc [Table t1 was renamed on node 2]
+# connection node_1
+RENAME TABLE t2 to t1;
+REVOKE ALTER,DROP,CREATE,INSERT ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_CREATE_USER access test
+#
+# connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT CREATE USER ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
+INSERT INTO counter(count) VALUES(17);;
+# connection node_1
+include/assert.inc [User foo was created on node 1]
+# connection node_2
+include/assert.inc [User foo was created on node 2]
+# connection node_1
+DROP USER foo;
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_DROP_USER access test
+#
+CREATE USER 'testdbother'@'%' IDENTIFIED BY 'secret2';
+# connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT CREATE USER ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP USER 'testdbother'@'%';
+INSERT INTO counter(count) VALUES(18);;
+# connection node_1
+include/assert.inc [User testdbother does not exist on node 1]
+# connection node_2
+include/assert.inc [User testdbother does not exist on node 2]
+# connection node_1
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_RENAME_USER access test
+#
+# connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT CREATE USER ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+RENAME USER 'testother'@'%' TO 'testwho'@'%';
+INSERT INTO counter(count) VALUES(19);;
+# connection node_1
+include/assert.inc [User testother does not exist on node 1]
+include/assert.inc [User testwho exists on node 1]
+# connection node_2
+include/assert.inc [User testother does not exist on node 2]
+include/assert.inc [User testwho exists on node 2]
+# connection node_1
+RENAME USER 'testwho'@'%' TO 'testother'@'%';
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_REVOKE_ALL access test
+#
+# connection node_1
+CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
+GRANT SELECT ON testdb.t1 TO 'foo'@'%';
+SHOW GRANTS FOR 'foo';
+Grants for foo@%
+GRANT USAGE ON *.* TO 'foo'@'%'
+GRANT SELECT ON `testdb`.`t1` TO 'foo'@'%'
+FLUSH PRIVILEGES;
+# connection node_1
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'foo'@'%';
+INSERT INTO counter(count) VALUES(20);;
+# connection node_1
+SHOW GRANTS FOR 'foo';
+Grants for foo@%
+GRANT USAGE ON *.* TO 'foo'@'%'
+# connection node_2
+SHOW GRANTS FOR 'foo';
+Grants for foo@%
+GRANT USAGE ON *.* TO 'foo'@'%'
+# connection node_1
+DROP USER foo;
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_CREATE_PROCEDURE access test
+#
+# connection node_1
+GRANT CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, EXECUTE, CREATE ROUTINE, ALTER ROUTINE ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE PROCEDURE hellop (OUT ver_param VARCHAR(64), INOUT incr_param INT)
+BEGIN
+END;
+INSERT INTO counter(count) VALUES(21);;
+# connection node_1
+include/assert.inc [The hellop procedure should exist on node 1]
+# connection node_2
+include/assert.inc [The hellop function should exist on node 2]
+# connection node_1
+DROP PROCEDURE hellop;
+REVOKE CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_CREATE_SPFUNCTION access test
+#
+# connection node_1
+GRANT CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, EXECUTE, CREATE ROUTINE, ALTER ROUTINE ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello, ',s,'!');
+INSERT INTO counter(count) VALUES(22);;
+# connection node_1
+include/assert.inc [The hello function should exist on node 1]
+# connection node_2
+include/assert.inc [The hello function should exist on node 2]
+# connection node_1
+DROP FUNCTION hello;
+REVOKE CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_DROP_PROCEDURE access test
+#
+# connection node_1
+CREATE PROCEDURE hellop (OUT ver_param VARCHAR(25), INOUT incr_param INT)
+BEGIN
+END;
+# connection node_1
+include/assert.inc [The hellop procedure should exist on node 1]
+# connection node_2
+include/assert.inc [The hellop procedure should exist on node 2]
+# connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, ALTER ROUTINE ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP PROCEDURE hellop;
+INSERT INTO counter(count) VALUES(23);;
+# connection node_1
+include/assert.inc [The hellop procedure should not exist on node 1]
+# connection node_2
+include/assert.inc [The hellop procedure should not exist on node 2]
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_ALTER_PROCEDURE access test
+#
+# connection node_1
+CREATE PROCEDURE hellop (OUT ver_param VARCHAR(25), INOUT incr_param INT)
+BEGIN
+END;
+# connection node_1
+include/assert.inc [The hellop procedure should exist on node 1]
+# connection node_2
+include/assert.inc [The hellop procedure should exist on node 2]
+SELECT name, security_type FROM mysql.proc WHERE name = "hellop";
+name	security_type
+hellop	DEFINER
+# connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, ALTER ROUTINE ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+ALTER PROCEDURE hellop SQL SECURITY INVOKER;
+INSERT INTO counter(count) VALUES(24);;
+# connection node_1
+include/assert.inc [The hellop procedure should use the invoker on node 1]
+# connection node_2
+include/assert.inc [The hellop procedure should use the invoker on node 2]
+# connection node_1
+DROP PROCEDURE hellop;
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_ALTER_FUNCTION access test
+#
+# connection node_1
+CREATE FUNCTION hellof (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello again, ',s,'!');
+# connection node_1
+include/assert.inc [The hellof function should exist on node 1]
+# connection node_2
+include/assert.inc [The hellof function should exist on node 2]
+SELECT name, security_type FROM mysql.proc WHERE name = "hellof";
+name	security_type
+hellof	DEFINER
+# connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, ALTER ROUTINE ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+ALTER FUNCTION hellof SQL SECURITY INVOKER;
+INSERT INTO counter(count) VALUES(25);;
+# connection node_1
+include/assert.inc [The hellof function should use the invoker on node 1]
+# connection node_2
+include/assert.inc [The hellof function should use the invoker on node 2]
+# connection node_1
+DROP FUNCTION hellof;
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_CREATE_VIEW access test
+#
+# connection node_1
+GRANT CREATE VIEW ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, CREATE VIEW ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE VIEW testview AS SELECT * FROM t1;
+INSERT INTO counter(count) VALUES(26);;
+# connection node_1
+include/assert.inc [The testview VIEW should exist on node 1]
+# connection node_2
+include/assert.inc [The testview VIEW should exist on node 2]
+DROP VIEW testview;
+REVOKE CREATE VIEW ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_DROP_VIEW access test
+#
+# connection node_1
+CREATE VIEW helloview AS SELECT * FROM t1;
+# connection node_1
+include/assert.inc [The helloview VIEW should exist on node 1]
+# connection node_2
+include/assert.inc [The helloview VIEW should exist on node 2]
+# connection node_1
+GRANT DROP ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, DROP ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP VIEW helloview;
+INSERT INTO counter(count) VALUES(27);;
+# connection node_1
+include/assert.inc [The helloview VIEW should not exist on node 1]
+# connection node_2
+include/assert.inc [The helloview VIEW should not exist on node 2]
+# connection node_1
+REVOKE DROP ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_CREATE_TRIGGER access test
+#
+# connection node_1
+GRANT TRIGGER ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, TRIGGER ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE TRIGGER testtrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1;
+INSERT INTO counter(count) VALUES(28);;
+# connection node_1
+include/assert.inc [The testtrigger TRIGGER should exist on node 1]
+# connection node_2
+include/assert.inc [The testtrigger TRIGGER should exist on node 2]
+# connection node_1
+DROP TRIGGER testtrigger;
+REVOKE TRIGGER ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_DROP_TRIGGER access test
+#
+# connection node_1
+CREATE TRIGGER hellotrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1;
+# connection node_1
+include/assert.inc [The hellotrigger TRIGGER should exist on node 1]
+# connection node_2
+include/assert.inc [The hellotrigger TRIGGER should exist on node 2]
+# connection node_1
+GRANT TRIGGER ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, TRIGGER ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP TRIGGER hellotrigger;
+INSERT INTO counter(count) VALUES(29);;
+# connection node_1
+include/assert.inc [The hellotrigger TRIGGER should not exist on node 1]
+# connection node_2
+include/assert.inc [The hellotrigger TRIGGER should not exist on node 2]
+# connection node_1
+REVOKE TRIGGER ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_INSTALL_PLUGIN access test
+#
+# connection node_1
+GRANT INSERT ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT INSERT ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+INSTALL PLUGIN audit_log SONAME "audit_log.so";
+INSERT INTO counter(count) VALUES(30);;
+# connection node_1
+include/assert.inc [The audit_log PLUGIN should be installed on node 1]
+# connection node_2
+include/assert.inc [The audit_log PLUGIN should be installed on node 2]
+# connection node_1
+UNINSTALL PLUGIN audit_log;
+REVOKE INSERT ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_UNINSTALL_PLUGIN access test
+#
+# connection node_1
+INSTALL PLUGIN null_audit SONAME "adt_null.so";
+include/assert.inc [The null_audit PLUGIN should be installed on node 1]
+# connection node_2
+# connection node_1
+GRANT DELETE ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT DELETE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+UNINSTALL PLUGIN null_audit;
+INSERT INTO counter(count) VALUES(31);;
+# connection node_1
+include/assert.inc [The null_audit PLUGIN should not be installed on node 1]
+# connection node_2
+include/assert.inc [The null_audit PLUGIN should not be installed on node 2]
+# connection node_1
+REVOKE DELETE ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_CREATE_EVENT access test
+#
+# connection node_1
+GRANT EVENT ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, EVENT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE EVENT testevent
+ON SCHEDULE EVERY 1 HOUR
+DO INSERT INTO t1(f2) VALUES(3);
+INSERT INTO counter(count) VALUES(32);;
+# connection node_1
+include/assert.inc [The testevent EVENT should exist on node 1]
+# connection node_2
+include/assert.inc [The testevent EVENT should exist on node 2]
+# connection node_1
+DROP EVENT testevent;
+REVOKE EVENT ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_ALTER_EVENT access test
+#
+# connection node_1
+CREATE EVENT helloevent
+ON SCHEDULE EVERY 1 HOUR
+DO INSERT INTO t1(f2) VALUES(3);
+# connection node_1
+include/assert.inc [The helloevent EVENT should exist on node 1]
+# connection node_2
+include/assert.inc [The helloevent EVENT should exist on node 2]
+# connection node_1
+GRANT EVENT ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, EVENT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+ALTER EVENT helloevent ON SCHEDULE EVERY '2:3' DAY_HOUR;
+INSERT INTO counter(count) VALUES(33);;
+# connection node_1
+include/assert.inc [The helloevent EVENT should still exist on node 1]
+# connection node_2
+include/assert.inc [The helloevent EVENT should still exist on node 2]
+# connection node_1
+REVOKE EVENT ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_DROP_EVENT access test
+#
+# connection node_1
+GRANT EVENT ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT, EVENT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+DROP EVENT helloevent;
+INSERT INTO counter(count) VALUES(34);;
+# connection node_1
+include/assert.inc [The helloevent EVENT should not exist on node 1]
+# connection node_2
+include/assert.inc [The helloevent EVENT should not exist on node 2]
+# connection node_1
+REVOKE EVENT ON testdb.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# SQLCOM_ALTER_USER access test
+#
+# connection node_1
+include/assert.inc [User testother should not be expired on node 1]
+# connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT CREATE USER ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+ALTER USER 'testother'@'%' PASSWORD EXPIRE;
+INSERT INTO counter(count) VALUES(35);;
+# connection node_1
+include/assert.inc [User testother should be expired on node 1]
+# connection node_2
+include/assert.inc [User testother should be expired on node 2]
+# connection node_1
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO 'testme'@'%'
+GRANT SELECT ON `testdb`.* TO 'testme'@'%'
+GRANT INSERT ON `testdb`.`counter` TO 'testme'@'%'
+FLUSH PRIVILEGES;
+#
+# cleanup
+#
+DROP USER 'testother';
+DROP USER 'testme';
+DROP DATABASE testdb;
+SET GLOBAL debug= '';
+SET GLOBAL debug= '';

--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -26,11 +26,13 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ADMIN command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend changing storage engine of a table ");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of INSERT");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of DML command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of TRUNCATE command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ADMIN command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits changing storage engine of a table");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of INSERT");
 call mtr.add_suppression("WSREP doesn't support XA transaction");
 set global pxc_strict_mode='ENFORCING';
 #node-2
@@ -1231,6 +1233,96 @@ drop table t;
 1
 "Try restarting node-2 with default options"
 # restart:
+#node-1
+CREATE TABLE tbl_w_pk(id INT PRIMARY KEY) engine=innodb;
+CREATE TABLE tbl_wo_pk(id INT) engine=innodb;
+CREATE VIEW  view_w_pk AS SELECT * FROM tbl_w_pk;
+CREATE VIEW  view_wo_pk AS SELECT * FROM tbl_wo_pk;
+INSERT INTO tbl_w_pk VALUES (1), (2);
+SELECT * FROM tbl_w_pk;
+id
+1
+2
+SELECT * FROM tbl_wo_pk;
+id
+#node-1
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
+#node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
+#node-1
+INSERT INTO view_w_pk VALUES(3);
+SELECT * FROM view_w_pk;
+id
+1
+2
+3
+INSERT INTO view_wo_pk VALUES (3);
+SELECT * FROM view_wo_pk;
+id
+3
+#node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-1
+INSERT INTO view_w_pk VALUES(4);
+SELECT * FROM view_w_pk;
+id
+1
+2
+3
+4
+INSERT INTO view_wo_pk VALUES (4);
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of INSERT on a view (test.view_wo_pk) that writes to a table with no explicit primary key with pxc_strict_mode = PERMISSIVE
+SELECT * FROM view_wo_pk;
+id
+3
+4
+include/assert_grep.inc [pxc_strict_mode issued warning about no primary keys]
+#node-1
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
+#node-2
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
+#node-1
+INSERT INTO view_w_pk VALUES(5);
+SELECT * FROM view_w_pk;
+id
+1
+2
+3
+4
+5
+INSERT INTO view_wo_pk VALUES (5);
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of INSERT on a view (test.view_wo_pk) that writes to a table with no explicit primary key with pxc_strict_mode = ENFORCING or MASTER
+SELECT * FROM view_wo_pk;
+id
+3
+4
+include/assert_grep.inc [pxc_strict_mode issued error about no primary keys]
+#node-1
+DROP VIEW view_wo_pk;
+DROP VIEW view_w_pk;
+DROP TABLE tbl_wo_pk;
+DROP TABLE tbl_w_pk;
 #node-1
 set global pxc_strict_mode = DISABLED;;
 #node-2

--- a/mysql-test/suite/galera/t/galera_wsrep_ddl_access_checking2.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_ddl_access_checking2.test
@@ -1,6 +1,9 @@
 #
 # Test access checks for DDL
-# Test that DDL statements are not replicated if the access checks fail.
+#
+# This is the complement of galera_wsrep_ddl_access_checking.test
+# This tests that if the user has the appropriate privileges, the statement
+# will succeed and will be replicated.
 #
 #
 # The following commands are not tested since they are not replicated.
@@ -40,7 +43,6 @@
 # SQLCOM_SHOW_CREATE_FUNC
 # SQLCOM_SHOW_CREATE_PROC
 # SQLCOM_SHOW_CREATE_TRIGGER
-# SQLCOM_SHOW_CREATE_USER
 # SQLCOM_SHOW_DATABASES
 # SQLCOM_SHOW_ENGINE_LOGS
 # SQLCOM_SHOW_ENGINE_STATUS
@@ -62,6 +64,7 @@
 # SQLCOM_SHOW_PROFILES
 # SQLCOM_SHOW_RELAYLOG_EVENTS
 # SQLCOM_SHOW_SLAVE_HOSTS
+# SQLCOM_SHOW_SLAVE_NOLOCK_STAT
 # SQLCOM_SHOW_SLAVE_STAT
 # SQLCOM_SHOW_STATUS
 # SQLCOM_SHOW_STATUS_FUNC
@@ -95,7 +98,6 @@
 #
 # Other unreplicated statements
 #
-# SQLCOM_ALTER_INSTANCE
 # SQLCOM_ALTER_SERVER
 # SQLCOM_ALTER_TABLESPACE
 # SQLCOM_ASSIGN_TO_KEYCACHE
@@ -103,7 +105,6 @@
 # SQLCOM_CALL
 # SQLCOM_CHANGE_DB
 # SQLCOM_CHANGE_MASTER
-# SQLCOM_CHANGE_REPLICATION_FILTER
 # SQLCOM_CHECK
 # SQLCOM_CHECKSUM
 # SQLCOM_CREATE_COMPRESSION_DICTIONARY
@@ -114,7 +115,6 @@
 # SQLCOM_DROP_SERVER
 # SQLCOM_EMPTY_QUERY
 # SQLCOM_EXECUTE
-# SQLCOM_EXPLAIN_OTHER
 # SQLCOM_FLUSH
 # SQLCOM_GET_DIAGNOSTICS
 # SQLCOM_HA_OPEN
@@ -129,16 +129,15 @@
 # SQLCOM_PRELOAD_KEYS
 # SQLCOM_PREPARE
 # SQLCOM_PURGE
+# SQLCOM_PURGE_ARCHIVE
+# SQLCOM_PURGE_ARCHIVE_BEFORE
 # SQLCOM_PURGE_BEFORE
 # SQLCOM_RESET
 # SQLCOM_RESIGNAL
 # SQLCOM_SET_OPTION
-# SQLCOM_SHUTDOWN
 # SQLCOM_SIGNAL
 # SQLCOM_SLAVE_START
 # SQLCOM_SLAVE_STOP
-# SQLCOM_START_GROUP_REPLICATION
-# SQLCOM_STOP_GROUP_REPLICATION
 # SQLCOM_UNLOCK_BINLOG
 # SQLCOM_UNLOCK_TABLES
 #
@@ -161,6 +160,8 @@ GRANT INSERT ON testdb.counter TO 'testme'@'%';
 CREATE USER 'testother'@'%' IDENTIFIED BY 'secret2';
 
 FLUSH PRIVILEGES;
+
+--let $rpl_debug= 0
 
 --connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 
@@ -189,10 +190,19 @@ use testdb;
 --echo # SQLCOM_CREATE_TABLE access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT CREATE ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE TABLE t2(id INT PRIMARY KEY AUTO_INCREMENT);
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -202,8 +212,8 @@ CREATE TABLE t2(id INT PRIMARY KEY AUTO_INCREMENT);
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Table t2 should not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME="t2"
+--let $assert_text = Table t2 should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME="t2"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -211,9 +221,18 @@ CREATE TABLE t2(id INT PRIMARY KEY AUTO_INCREMENT);
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Table t2 should not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME="t2"
+--let $assert_text = Table t2 should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME="t2"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE CREATE ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+DROP TABLE t2;
 
 
 #
@@ -225,11 +244,247 @@ CREATE TABLE t2(id INT PRIMARY KEY AUTO_INCREMENT);
 --echo # SQLCOM_CREATE_INDEX access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT INDEX ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE INDEX index_t1_f2 ON t1(f2);
+
+--eval INSERT INTO counter(count) VALUES($test_id);
+
+--echo # connection node_1
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Index t1_f2 should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.statistics WHERE table_schema="testdb" AND table_name="t1" AND index_name != "PRIMARY"
+--let $assert_debug = SHOW INDEX FROM testdb.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Index t1_f2 should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.statistics WHERE table_schema="testdb" AND table_name="t1" AND index_name != "PRIMARY"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE INDEX ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+DROP INDEX index_t1_f2 ON t1;
+
+
+#
+# SQLCOM_ALTER_TABLE
+#
+--inc $test_id
+
+--echo #
+--echo # SQLCOM_ALTER_TABLE access test
+--echo #
+
+--echo # connection node_1
+--connection node_1
+GRANT ALTER ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
+ALTER TABLE t1 ADD COLUMN f3 LONGBLOB;
+
+--eval INSERT INTO counter(count) VALUES($test_id);
+
+--echo # connection node_1
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Column f3 on table t1 should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.columns WHERE table_schema="testdb" AND table_name="t1" AND column_name = "f3"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Column f3 on table t1 should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.columns WHERE table_schema="testdb" AND table_name="t1" AND column_name = "f3"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE ALTER ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+ALTER TABLE t1 DROP COLUMN f3;
+
+
+#
+# SQLCOM_TRUNCATE
+#
+--inc $test_id
+
+--echo #
+--echo # SQLCOM_TRUNCATE access test
+--echo #
+
+--echo # connection node_1
+--connection node_1
+GRANT DROP ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
+TRUNCATE TABLE t1;
+
+--eval INSERT INTO counter(count) VALUES($test_id);
+
+--echo # connection node_1
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Table t1 was truncated on node 1
+--let $assert_cond = COUNT(*) = 0 FROM t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Table t1 was truncated on node 2
+--let $assert_cond = COUNT(*) = 0 FROM t1
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE DROP ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+INSERT INTO t1(f2) VALUES(1);
+
+
+#
+# SQLCOM_DROP_TABLE
+#
+--inc $test_id
+
+--echo #
+--echo # SQLCOM_DROP_TABLE access test
+--echo #
+
+--echo # connection node_1
+--connection node_1
+GRANT DROP ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
+DROP TABLE t1;
+
+--eval INSERT INTO counter(count) VALUES($test_id);
+
+--echo # connection node_1
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Table t1 was dropped on node 1
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.tables WHERE table_name = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = Table t1 was dropped on node 2
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.tables WHERE table_name = "t1"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE DROP ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT, f2 CHAR(64));
+INSERT INTO t1(f2) VALUES(1);
+
+
+#
+# SQLCOM_DROP_INDEX
+#
+--inc $test_id
+
+--echo #
+--echo # SQLCOM_DROP_INDEX access test
+--echo #
+
+--echo # connection node_1
+--connection node_1
+CREATE INDEX t1_f2 ON t1(f2);
+
+--let $assert_text = Index t1_f2 should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.statistics WHERE table_schema="testdb" AND table_name="t1" AND index_name != "PRIMARY"
+--let $assert_debug = SHOW INDEX FROM testdb.t1
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+GRANT INDEX ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
+DROP INDEX t1_f2 ON t1;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
 
@@ -252,165 +507,12 @@ CREATE INDEX index_t1_f2 ON t1(f2);
 --let $assert_cond = COUNT(*) = 0 FROM information_schema.statistics WHERE table_schema="testdb" AND table_name="t1" AND index_name != "PRIMARY"
 --source include/assert.inc
 
-
-#
-# SQLCOM_ALTER_TABLE
-#
---inc $test_id
-
---echo #
---echo # SQLCOM_ALTER_TABLE access test
---echo #
-
---echo # connection node_testme
---connection node_testme
-
---error ER_TABLEACCESS_DENIED_ERROR
-ALTER TABLE t1 ADD COLUMN f3 LONGBLOB;
-
---eval INSERT INTO counter(count) VALUES($test_id);
-
 --echo # connection node_1
 --connection node_1
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Column f3 on table t1 should not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM information_schema.columns WHERE table_schema="testdb" AND table_name="t1" AND column_name = "f3"
---source include/assert.inc
-
---echo # connection node_2
---connection node_2
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Column f3 on table t1 should not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM information_schema.columns WHERE table_schema="testdb" AND table_name="t1" AND column_name = "f3"
---source include/assert.inc
-
-
-#
-# SQLCOM_TRUNCATE
-#
---inc $test_id
-
---echo #
---echo # SQLCOM_TRUNCATE access test
---echo #
-
---echo # connection node_testme
---connection node_testme
-
---error ER_TABLEACCESS_DENIED_ERROR
-TRUNCATE TABLE t1;
-
---eval INSERT INTO counter(count) VALUES($test_id);
-
---echo # connection node_1
---connection node_1
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Table t1 was not truncated on node 1
---let $assert_cond = COUNT(*) = 1 FROM t1
---source include/assert.inc
-
---echo # connection node_2
---connection node_2
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Table t1 was not truncated on node 2
---let $assert_cond = COUNT(*) = 1 FROM t1
---source include/assert.inc
-
-
-#
-# SQLCOM_DROP_TABLE
-#
---inc $test_id
-
---echo #
---echo # SQLCOM_DROP_TABLE access test
---echo #
-
---echo # connection node_testme
---connection node_testme
-
---error ER_TABLEACCESS_DENIED_ERROR
-DROP TABLE t1;
-
---eval INSERT INTO counter(count) VALUES($test_id);
-
---echo # connection node_1
---connection node_1
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Table t1 was not dropped on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t1"
---source include/assert.inc
-
---echo # connection node_2
---connection node_2
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Table t1 was not dropped on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t1"
---source include/assert.inc
-
-
-#
-# SQLCOM_DROP_INDEX
-#
---inc $test_id
-
---echo #
---echo # SQLCOM_DROP_INDEX access test
---echo #
-
---echo # connection node_1
---connection node_1
-CREATE INDEX t1_f2 ON t1(f2);
-
---let $assert_text = Index t1_f2 should exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.statistics WHERE table_schema="testdb" AND table_name="t1" AND index_name != "PRIMARY"
---let $assert_debug = SHOW INDEX FROM testdb.t1
---source include/assert.inc
-
---echo # connection node_testme
---connection node_testme
-
---error ER_TABLEACCESS_DENIED_ERROR
-DROP INDEX t1_f2 ON t1;
-
---eval INSERT INTO counter(count) VALUES($test_id);
-
---echo # connection node_1
---connection node_1
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Index t1_f2 should still exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.statistics WHERE table_schema="testdb" AND table_name="t1" AND index_name != "PRIMARY"
---let $assert_debug = SHOW INDEX FROM testdb.t1
---source include/assert.inc
-
---echo # connection node_2
---connection node_2
---let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
---source include/wait_condition.inc
-
---let $assert_text = Index t1_f2 should still exist on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.statistics WHERE table_schema="testdb" AND table_name="t1" AND index_name != "PRIMARY"
---source include/assert.inc
-
-# test cleanup
-#
---echo # connection node_1
---connection node_1
-DROP INDEX t1_f2 ON t1;
+REVOKE INDEX ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -422,10 +524,19 @@ DROP INDEX t1_f2 ON t1;
 --echo # SQLCOM_GRANT access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT GRANT OPTION ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_DBACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 GRANT SELECT ON testdb.* TO 'testother'@'%';
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -446,6 +557,13 @@ SHOW GRANTS FOR 'testother';
 --replace_regex /\*[0-9A-Z]+/<SECRET>/
 SHOW GRANTS FOR 'testother';
 
+--echo # connection node_1
+--connection node_1
+REVOKE GRANT OPTION ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
 
 #
 # SQLCOM_CREATE_DB
@@ -463,7 +581,19 @@ SHOW GRANTS FOR 'testother';
 --let $assert_cond = COUNT(*) = 0 FROM information_schema.schemata WHERE schema_name="testdbother"
 --source include/assert.inc
 
---error ER_DBACCESS_DENIED_ERROR
+--echo # connection node_1
+--connection node_1
+GRANT CREATE ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE DATABASE testdbother;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -473,8 +603,8 @@ CREATE DATABASE testdbother;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Database testdbother still does not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM information_schema.schemata WHERE schema_name="testdbother"
+--let $assert_text = Database testdbother should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.schemata WHERE schema_name="testdbother"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -482,9 +612,18 @@ CREATE DATABASE testdbother;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Database testdbother still does not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM information_schema.schemata WHERE schema_name="testdbother"
+--let $assert_text = Database testdbother should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.schemata WHERE schema_name="testdbother"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE CREATE ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+DROP DATABASE testdbother;
 
 
 #
@@ -496,15 +635,29 @@ CREATE DATABASE testdbother;
 --echo # SQLCOM_DROP_DB access test
 --echo #
 
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE testdbother;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.schemata WHERE schema_name="testdbother";
+--source include/wait_condition.inc
+
+--echo # connection node_1
+--connection node_1
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+GRANT DROP ON *.* TO 'testme'@'%';
+FLUSH PRIVILEGES;
+
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---let $assert_text = Database testdb exists on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.schemata WHERE schema_name="testdb"
---source include/assert.inc
-
---error ER_DBACCESS_DENIED_ERROR
-DROP DATABASE testdb;
+DROP DATABASE testdbother;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
 
@@ -513,8 +666,8 @@ DROP DATABASE testdb;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Database testdb still exists on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.schemata WHERE schema_name="testdb"
+--let $assert_text = Database testdbother should not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.schemata WHERE schema_name="testdbother"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -522,9 +675,16 @@ DROP DATABASE testdb;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Database testdb still exists on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.schemata WHERE schema_name="testdb"
+--let $assert_text = Database testdbother shoutl not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.schemata WHERE schema_name="testdbother"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE DROP ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -536,13 +696,23 @@ DROP DATABASE testdb;
 --echo # SQLCOM_ALTER_DB access test
 --echo #
 
+--echo # connection node_1
+--connection node_1
+GRANT ALTER ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+CREATE DATABASE testdbother;
+SHOW CREATE DATABASE testdbother;
+
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
-SHOW CREATE DATABASE testdb;
-
---error ER_DBACCESS_DENIED_ERROR
-ALTER DATABASE testdb CHARACTER SET latin7;
+--connection node_testme
+ALTER DATABASE testdbother CHARACTER SET latin7;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
 
@@ -551,14 +721,23 @@ ALTER DATABASE testdb CHARACTER SET latin7;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
-SHOW CREATE DATABASE testdb;
+SHOW CREATE DATABASE testdbother;
 
 --echo # connection node_2
 --connection node_2
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
-SHOW CREATE DATABASE testdb;
+SHOW CREATE DATABASE testdbother;
+
+--echo # connection node_1
+--connection node_1
+DROP DATABASE testdbother;
+
+REVOKE ALTER ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -570,10 +749,20 @@ SHOW CREATE DATABASE testdb;
 --echo # SQLCOM_REPAIR access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+# testme already has SELECT access
+GRANT INSERT ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 REPAIR TABLE t1;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -583,9 +772,9 @@ REPAIR TABLE t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = REPAIR TABLE did not execute on node 1
+--let $assert_text = REPAIR TABLE did execute on node 1
 --let $assert_select = Sql_cmd_repair_table::execute
---let $assert_count = 0
+--let $assert_count = 1
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc
@@ -595,12 +784,19 @@ REPAIR TABLE t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = REPAIR TABLE did not execute on node 2
+--let $assert_text = REPAIR TABLE did execute on node 2
 --let $assert_select = Sql_cmd_repair_table::execute
---let $assert_count = 0
+--let $assert_count = 1
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE INSERT ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -630,11 +826,19 @@ CREATE FUNCTION hello2 (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT
 --let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hello2"
 --source include/assert.inc
 
+--echo # connection node_1
+--connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_PROCACCESS_DENIED_ERROR
 DROP FUNCTION hello2;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -644,8 +848,8 @@ DROP FUNCTION hello2;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hello2 function should still exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hello2"
+--let $assert_text = The hello2 function should not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hello2"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -653,15 +857,18 @@ DROP FUNCTION hello2;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hello2 function should still exist on node 2
---let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hello2"
+--let $assert_text = The hello2 function should not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hello2"
 --source include/assert.inc
 
 # cleanup
 #
 --echo # connection node_1
 --connection node_1
-DROP FUNCTION hello2;
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -690,11 +897,19 @@ SHOW GRANTS FOR 'testother';
 --replace_regex /\*[0-9A-Z]+/<SECRET>/
 SHOW GRANTS FOR 'testother';
 
+--echo # connection node_1
+--connection node_1
+GRANT GRANT OPTION ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_TABLEACCESS_DENIED_ERROR
 REVOKE SELECT ON testdb.t1 FROM 'testother'@'%';
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -719,7 +934,10 @@ SHOW GRANTS FOR 'testother';
 #
 --echo # connection node_1
 --connection node_1
-REVOKE SELECT ON testdb.t1 FROM 'testother'@'%';
+REVOKE GRANT OPTION ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -731,10 +949,20 @@ REVOKE SELECT ON testdb.t1 FROM 'testother'@'%';
 --echo # SQLCOM_OPTIMIZE access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+# testme already has SELECT access
+GRANT INSERT ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 OPTIMIZE TABLE t1;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -744,9 +972,9 @@ OPTIMIZE TABLE t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = OPTIMIZE TABLE did not execute on node 1
+--let $assert_text = OPTIMIZE TABLE did execute on node 1
 --let $assert_select = Sql_cmd_optimize_table::execute
---let $assert_count = 0
+--let $assert_count = 1
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc
@@ -756,12 +984,19 @@ OPTIMIZE TABLE t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = OPTIMIZE TABLE did not execute on node 2
+--let $assert_text = OPTIMIZE TABLE did execute on node 2
 --let $assert_select = Sql_cmd_optimize_table::execute
---let $assert_count = 0
+--let $assert_count = 1
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE INSERT ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -773,10 +1008,20 @@ OPTIMIZE TABLE t1;
 --echo # SQLCOM_ANALYZE access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+# testme already has SELECT access
+GRANT INSERT ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 ANALYZE TABLE t1;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -786,9 +1031,9 @@ ANALYZE TABLE t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = ANALYZE TABLE did not execute on node 1
+--let $assert_text = ANALYZE TABLE did execute on node 1
 --let $assert_select = Sql_cmd_analyze_table::execute
---let $assert_count = 0
+--let $assert_count = 1
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc
@@ -798,12 +1043,19 @@ ANALYZE TABLE t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = ANALYZE TABLE did not execute on node 2
+--let $assert_text = ANALYZE TABLE did execute on node 2
 --let $assert_select = Sql_cmd_analyze_table::execute
---let $assert_count = 0
+--let $assert_count = 1
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE INSERT ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -814,10 +1066,20 @@ ANALYZE TABLE t1;
 --echo #
 --echo # SQLCOM_RENAME_TABLE access test
 --echo #
---echo # connection node_testme
---connection node_testme
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_1
+--connection node_1
+GRANT ALTER,DROP,CREATE,INSERT ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 RENAME TABLE t1 to t2;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -827,8 +1089,8 @@ RENAME TABLE t1 to t2;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Table t1 was not renamed on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t1"
+--let $assert_text = Table t1 was renamed on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t2"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -836,9 +1098,18 @@ RENAME TABLE t1 to t2;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = Table t1 was not renamed on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t1"
+--let $assert_text = Table t1 was renamed on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t2"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+RENAME TABLE t2 to t1;
+
+REVOKE ALTER,DROP,CREATE,INSERT ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -849,10 +1120,20 @@ RENAME TABLE t1 to t2;
 --echo #
 --echo # SQLCOM_CREATE_USER access test
 --echo #
---echo # connection node_testme
---connection node_testme
 
---error ER_SPECIFIC_ACCESS_DENIED_ERROR
+--echo # connection node_1
+--connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -862,8 +1143,8 @@ CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User foo was not created on node 1
---let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo"
+--let $assert_text = User foo was created on node 1
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -871,9 +1152,18 @@ CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User foo was not created on node 2
---let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo"
+--let $assert_text = User foo was created on node 2
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+DROP USER foo;
+
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -884,11 +1174,28 @@ CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
 --echo #
 --echo # SQLCOM_DROP_USER access test
 --echo #
---echo # connection node_testme
---connection node_testme
 
---error ER_SPECIFIC_ACCESS_DENIED_ERROR
-DROP USER 'testother'@'%';
+--connection node_1
+CREATE USER 'testdbother'@'%' IDENTIFIED BY 'secret2';
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE user = "testdbother";
+--source include/wait_condition.inc
+
+--echo # connection node_1
+--connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
+DROP USER 'testdbother'@'%';
 
 --eval INSERT INTO counter(count) VALUES($test_id);
 
@@ -897,8 +1204,8 @@ DROP USER 'testother'@'%';
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User testother still exists on node 1
---let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother"
+--let $assert_text = User testdbother does not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "testdbother"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -906,9 +1213,16 @@ DROP USER 'testother'@'%';
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User testother still exists on node 2
---let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother"
+--let $assert_text = User testdbother does not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "testdbother"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -919,10 +1233,20 @@ DROP USER 'testother'@'%';
 --echo #
 --echo # SQLCOM_RENAME_USER access test
 --echo #
---echo # connection node_testme
---connection node_testme
 
---error ER_SPECIFIC_ACCESS_DENIED_ERROR
+--echo # connection node_1
+--connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 RENAME USER 'testother'@'%' TO 'testwho'@'%';
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -932,8 +1256,12 @@ RENAME USER 'testother'@'%' TO 'testwho'@'%';
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User testother still exists on node 1
---let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother"
+--let $assert_text = User testother does not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "testother"
+--source include/assert.inc
+
+--let $assert_text = User testwho exists on node 1
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testwho"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -941,9 +1269,23 @@ RENAME USER 'testother'@'%' TO 'testwho'@'%';
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User testother still exists on node 2
---let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother"
+--let $assert_text = User testother does not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "testother"
 --source include/assert.inc
+
+--let $assert_text = User testwho exists on node 2
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testwho"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+RENAME USER 'testwho'@'%' TO 'testother'@'%';
+
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
 
 #
 # SQLCOM_REVOKE_ALL
@@ -958,25 +1300,30 @@ RENAME USER 'testother'@'%' TO 'testwho'@'%';
 #
 --echo # connection node_1
 --connection node_1
-GRANT SELECT ON testdb.t1 TO 'testother'@'%';
+CREATE USER 'foo'@'%' IDENTIFIED BY 'secret';
+GRANT SELECT ON testdb.t1 TO 'foo'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'foo';
 FLUSH PRIVILEGES;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE User = 'foo';
+--source include/wait_condition.inc
 
 --echo # connection node_1
 --connection node_1
 --replace_regex /\*[0-9A-Z]+/<SECRET>/
-SHOW GRANTS FOR 'testother';
-
---echo # connection node_2
---connection node_2
---replace_regex /\*[0-9A-Z]+/<SECRET>/
-SHOW GRANTS FOR 'testother';
-
+SHOW GRANTS FOR 'testme';
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_SPECIFIC_ACCESS_DENIED_ERROR
-REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'testother'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'foo'@'%';
 
 --eval INSERT INTO counter(count) VALUES($test_id);
 
@@ -986,7 +1333,7 @@ REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'testother'@'%';
 --source include/wait_condition.inc
 
 --replace_regex /\*[0-9A-Z]+/<SECRET>/
-SHOW GRANTS FOR 'testother';
+SHOW GRANTS FOR 'foo';
 
 --echo # connection node_2
 --connection node_2
@@ -994,7 +1341,16 @@ SHOW GRANTS FOR 'testother';
 --source include/wait_condition.inc
 
 --replace_regex /\*[0-9A-Z]+/<SECRET>/
-SHOW GRANTS FOR 'testother';
+SHOW GRANTS FOR 'foo';
+
+--echo # connection node_1
+--connection node_1
+DROP USER foo;
+
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1006,10 +1362,19 @@ SHOW GRANTS FOR 'testother';
 --echo # SQLCOM_CREATE_PROCEDURE access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_DBACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE PROCEDURE hellop (OUT ver_param VARCHAR(64), INOUT incr_param INT)
 BEGIN
 END;
@@ -1021,8 +1386,8 @@ END;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellop procedure should not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hellop"
+--let $assert_text = The hellop procedure should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hellop"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1030,9 +1395,18 @@ END;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellop function should not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hellop"
+--let $assert_text = The hellop function should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hellop"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+DROP PROCEDURE hellop;
+
+REVOKE CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1044,10 +1418,19 @@ END;
 --echo # SQLCOM_CREATE_SPFUNCTION access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_DBACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello, ',s,'!');
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1057,8 +1440,8 @@ CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT(
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hello function should not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hello"
+--let $assert_text = The hello function should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hello"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1066,9 +1449,18 @@ CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT(
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hello function should not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hello"
+--let $assert_text = The hello function should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hello"
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+DROP FUNCTION hello;
+
+REVOKE CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1100,11 +1492,19 @@ END;
 --let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hellop"
 --source include/assert.inc
 
+--echo # connection node_1
+--connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_PROCACCESS_DENIED_ERROR
 DROP PROCEDURE hellop;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1114,8 +1514,8 @@ DROP PROCEDURE hellop;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellop procedure should still exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hellop"
+--let $assert_text = The hellop procedure should not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hellop"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1123,15 +1523,17 @@ DROP PROCEDURE hellop;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellop procedure should still exist on node 2
---let $assert_cond = COUNT(*) = 1 FROM mysql.proc WHERE name="hellop"
+--let $assert_text = The hellop procedure should not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM mysql.proc WHERE name="hellop"
 --source include/assert.inc
 
 # cleanup
 #
---echo # connection node_1
 --connection node_1
-DROP PROCEDURE hellop;
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1165,10 +1567,19 @@ END;
 
 SELECT name, security_type FROM mysql.proc WHERE name = "hellop";
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_PROCACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 ALTER PROCEDURE hellop SQL SECURITY INVOKER;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1178,8 +1589,8 @@ ALTER PROCEDURE hellop SQL SECURITY INVOKER;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellop procedure should still use the definer on node 1
---let $assert_cond = security_type = "definer" FROM mysql.proc WHERE name = "hellop";
+--let $assert_text = The hellop procedure should use the invoker on node 1
+--let $assert_cond = security_type = "invoker" FROM mysql.proc WHERE name = "hellop";
 --let $assert_debug = SELECT * FROM mysql.proc WHERE name = "hellop";
 --source include/assert.inc
 
@@ -1188,8 +1599,8 @@ ALTER PROCEDURE hellop SQL SECURITY INVOKER;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellop procedure should still use the definer on node 2
---let $assert_cond = security_type = "definer" FROM mysql.proc WHERE name = "hellop";
+--let $assert_text = The hellop procedure should use the invoker on node 2
+--let $assert_cond = security_type = "invoker" FROM mysql.proc WHERE name = "hellop";
 --source include/assert.inc
 
 # cleanup
@@ -1197,6 +1608,12 @@ ALTER PROCEDURE hellop SQL SECURITY INVOKER;
 --echo # connection node_1
 --connection node_1
 DROP PROCEDURE hellop;
+
+--connection node_1
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1228,10 +1645,19 @@ CREATE FUNCTION hellof (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT
 
 SELECT name, security_type FROM mysql.proc WHERE name = "hellof";
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT ALTER ROUTINE ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_PROCACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 ALTER FUNCTION hellof SQL SECURITY INVOKER;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1241,8 +1667,8 @@ ALTER FUNCTION hellof SQL SECURITY INVOKER;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellof function should still use the definer on node 1
---let $assert_cond = security_type = "definer" FROM mysql.proc WHERE name = "hellof";
+--let $assert_text = The hellof function should use the invoker on node 1
+--let $assert_cond = security_type = "invoker" FROM mysql.proc WHERE name = "hellof";
 --let $assert_debug = SELECT * FROM mysql.proc WHERE name = "hellof";
 --source include/assert.inc
 
@@ -1251,8 +1677,8 @@ ALTER FUNCTION hellof SQL SECURITY INVOKER;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellof function should still use the definer on node 2
---let $assert_cond = security_type = "definer" FROM mysql.proc WHERE name = "hellof";
+--let $assert_text = The hellof function should use the invoker on node 2
+--let $assert_cond = security_type = "invoker" FROM mysql.proc WHERE name = "hellof";
 --source include/assert.inc
 
 # cleanup
@@ -1260,6 +1686,12 @@ ALTER FUNCTION hellof SQL SECURITY INVOKER;
 --echo # connection node_1
 --connection node_1
 DROP FUNCTION hellof;
+
+--connection node_1
+REVOKE ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1271,10 +1703,19 @@ DROP FUNCTION hellof;
 --echo # SQLCOM_CREATE_VIEW access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT CREATE VIEW ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE VIEW testview AS SELECT * FROM t1;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1284,8 +1725,8 @@ CREATE VIEW testview AS SELECT * FROM t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The testview VIEW should not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "testview";
+--let $assert_text = The testview VIEW should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "testview";
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1293,9 +1734,17 @@ CREATE VIEW testview AS SELECT * FROM t1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The testview VIEW should not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "testview";
+--let $assert_text = The testview VIEW should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "testview";
 --source include/assert.inc
+
+--connection node_1
+DROP VIEW testview;
+
+REVOKE CREATE VIEW ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1330,11 +1779,19 @@ CREATE VIEW helloview AS SELECT * FROM t1;
 --let $assert_debug = SELECT * FROM information_schema.tables WHERE table_type = "VIEW";
 --source include/assert.inc
 
+--echo # connection node_1
+--connection node_1
+GRANT DROP ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_TABLEACCESS_DENIED_ERROR
 DROP VIEW helloview;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1344,8 +1801,8 @@ DROP VIEW helloview;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The helloview VIEW should still exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "helloview";
+--let $assert_text = The helloview VIEW should not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "helloview";
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1353,15 +1810,18 @@ DROP VIEW helloview;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The helloview VIEW should still exist on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "helloview";
+--let $assert_text = The helloview VIEW should not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.tables WHERE table_type = "VIEW" and table_name = "helloview";
 --source include/assert.inc
 
 # cleanup
 #
 --echo # connection node_1
 --connection node_1
-DROP VIEW helloview;
+REVOKE DROP ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1373,10 +1833,19 @@ DROP VIEW helloview;
 --echo # SQLCOM_CREATE_TRIGGER access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT TRIGGER ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE TRIGGER testtrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1386,8 +1855,8 @@ CREATE TRIGGER testtrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The testtrigger TRIGGER should not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM information_schema.triggers WHERE trigger_name = "testtrigger" AND event_object_table = "t1";
+--let $assert_text = The testtrigger TRIGGER should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.triggers WHERE trigger_name = "testtrigger" AND event_object_table = "t1";
 --let $assert_debug = SELECT * FROM information_schema.triggers;
 --source include/assert.inc
 
@@ -1396,9 +1865,18 @@ CREATE TRIGGER testtrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The testtrigger TRIGGER should not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM information_schema.triggers WHERE trigger_name = "testtrigger" AND event_object_table = "t1";
+--let $assert_text = The testtrigger TRIGGER should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.triggers WHERE trigger_name = "testtrigger" AND event_object_table = "t1";
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+DROP TRIGGER testtrigger;
+
+REVOKE TRIGGER ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1428,11 +1906,19 @@ CREATE TRIGGER hellotrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1
 --let $assert_cond = COUNT(*) = 1 FROM information_schema.triggers WHERE trigger_name = "hellotrigger" AND event_object_table = "t1";
 --source include/assert.inc
 
+--echo # connection node_1
+--connection node_1
+GRANT TRIGGER ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_TABLEACCESS_DENIED_ERROR
 DROP TRIGGER hellotrigger;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1442,8 +1928,8 @@ DROP TRIGGER hellotrigger;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellotrigger TRIGGER should still exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.triggers WHERE trigger_name = "hellotrigger" AND event_object_table = "t1";
+--let $assert_text = The hellotrigger TRIGGER should not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.triggers WHERE trigger_name = "hellotrigger" AND event_object_table = "t1";
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1451,15 +1937,18 @@ DROP TRIGGER hellotrigger;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The hellotrigger TRIGGER should still exist on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.triggers WHERE trigger_name = "hellotrigger" AND event_object_table = "t1";
+--let $assert_text = The hellotrigger TRIGGER should not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.triggers WHERE trigger_name = "hellotrigger" AND event_object_table = "t1";
 --source include/assert.inc
 
 # cleanup
 #
 --echo # connection node_1
 --connection node_1
-DROP TRIGGER hellotrigger;
+REVOKE TRIGGER ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1471,10 +1960,19 @@ DROP TRIGGER hellotrigger;
 --echo # SQLCOM_INSTALL_PLUGIN access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT INSERT ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_TABLEACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 INSTALL PLUGIN audit_log SONAME "audit_log.so";
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1484,8 +1982,8 @@ INSTALL PLUGIN audit_log SONAME "audit_log.so";
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The audit_log PLUGIN should not be installed on node 1
---let $assert_cond = COUNT(*) = 0 FROM information_schema.plugins WHERE plugin_name = "audit_log";
+--let $assert_text = The audit_log PLUGIN should be installed on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "audit_log" AND plugin_status = "ACTIVE";
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1493,9 +1991,20 @@ INSTALL PLUGIN audit_log SONAME "audit_log.so";
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The audit_log PLUGIN should not be installed on node 2
---let $assert_cond = COUNT(*) = 0 FROM information_schema.plugins WHERE plugin_name = "audit_log";
+--let $assert_text = The audit_log PLUGIN should be installed on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "audit_log" AND plugin_status = "ACTIVE";
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+--disable_warnings
+UNINSTALL PLUGIN audit_log;
+--enable_warnings
+
+REVOKE INSERT ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1511,24 +2020,40 @@ INSTALL PLUGIN audit_log SONAME "audit_log.so";
 #
 --echo # connection node_1
 --connection node_1
-INSTALL PLUGIN audit_log SONAME "audit_log.so";
+--disable_warnings
+--error 0,1125
+INSTALL PLUGIN null_audit SONAME "adt_null.so";
+--enable_warnings
 
---let $assert_text = The audit_log PLUGIN should be installed on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "audit_log" AND plugin_status = "ACTIVE";
+--let $assert_text = The null_audit PLUGIN should be installed on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "null_audit" AND plugin_status = "ACTIVE";
 --let $assert_debug = SELECT plugin_name, plugin_status FROM information_schema.plugins;
 --source include/assert.inc
 
 --echo # connection node_2
 --connection node_2
---let $assert_text = The audit_log PLUGIN should be installed on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "audit_log" AND plugin_status = "ACTIVE";
+--let $assert_text = The null_audit PLUGIN should be installed on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "null_audit" AND plugin_status = "ACTIVE";
 
+--echo # connection node_1
+--connection node_1
+GRANT DELETE ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_TABLEACCESS_DENIED_ERROR
-UNINSTALL PLUGIN audit_log;
+--disable_warnings
+UNINSTALL PLUGIN null_audit;
+--enable_warnings
+
+# Give the system some time to remove the plugin entirely
+--sleep 5
 
 --eval INSERT INTO counter(count) VALUES($test_id);
 
@@ -1537,8 +2062,8 @@ UNINSTALL PLUGIN audit_log;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The audit_log PLUGIN should still be installed on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "audit_log" AND plugin_status = "ACTIVE";
+--let $assert_text = The null_audit PLUGIN should not be installed on node 1
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.plugins WHERE plugin_name = "null_audit" AND plugin_status = "ACTIVE";
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1546,16 +2071,18 @@ UNINSTALL PLUGIN audit_log;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The audit_log PLUGIN should still be installed on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.plugins WHERE plugin_name = "audit_log" AND plugin_status = "ACTIVE";
+--let $assert_text = The null_audit PLUGIN should not be installed on node 2
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.plugins WHERE plugin_name = "null_audit" AND plugin_status = "ACTIVE";
 --source include/assert.inc
-
 
 # Test cleanup
 #
 --echo # connection node_1
 --connection node_1
-UNINSTALL plugin audit_log;
+REVOKE DELETE ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1567,10 +2094,19 @@ UNINSTALL plugin audit_log;
 --echo # SQLCOM_CREATE_EVENT access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT EVENT ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_DBACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 CREATE EVENT testevent
   ON SCHEDULE EVERY 1 HOUR
   DO INSERT INTO t1(f2) VALUES(3);
@@ -1582,8 +2118,8 @@ CREATE EVENT testevent
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The testevent EVENT should not exist on node 1
---let $assert_cond = COUNT(*) = 0 FROM information_schema.events WHERE event_name = "testevent";
+--let $assert_text = The testevent EVENT should exist on node 1
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "testevent";
 --let $assert_debug = SELECT * FROM information_schema.events;
 --source include/assert.inc
 
@@ -1592,9 +2128,18 @@ CREATE EVENT testevent
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The testevent EVENT should not exist on node 2
---let $assert_cond = COUNT(*) = 0 FROM information_schema.events WHERE event_name = "testevent";
+--let $assert_text = The testevent EVENT should exist on node 2
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "testevent";
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+DROP EVENT testevent;
+
+REVOKE EVENT ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1626,11 +2171,19 @@ CREATE EVENT helloevent
 --let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "helloevent" AND interval_value = 1;
 --source include/assert.inc
 
+--echo # connection node_1
+--connection node_1
+GRANT EVENT ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
 --connection node_testme
+use testdb;
 
---error ER_DBACCESS_DENIED_ERROR
 ALTER EVENT helloevent ON SCHEDULE EVERY '2:3' DAY_HOUR;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1641,7 +2194,8 @@ ALTER EVENT helloevent ON SCHEDULE EVERY '2:3' DAY_HOUR;
 --source include/wait_condition.inc
 
 --let $assert_text = The helloevent EVENT should still exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "helloevent" AND interval_value = 1;
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "helloevent" AND interval_value LIKE "%2 3%";
+--let $assert_debug = SHOW EVENTS;
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1650,12 +2204,18 @@ ALTER EVENT helloevent ON SCHEDULE EVERY '2:3' DAY_HOUR;
 --source include/wait_condition.inc
 
 --let $assert_text = The helloevent EVENT should still exist on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "helloevent" AND interval_value = 1;
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "helloevent" AND interval_value LIKE "%2 3%";
 --source include/assert.inc
 
 # No cleanup
 # Have the follwing test case use the same event
 #
+--echo # connection node_1
+--connection node_1
+REVOKE EVENT ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1667,10 +2227,19 @@ ALTER EVENT helloevent ON SCHEDULE EVERY '2:3' DAY_HOUR;
 --echo # SQLCOM_DROP_EVENT access test
 --echo #
 
---echo # connection node_testme
---connection node_testme
+--echo # connection node_1
+--connection node_1
+GRANT EVENT ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
---error ER_DBACCESS_DENIED_ERROR
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 DROP EVENT helloevent;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1680,8 +2249,8 @@ DROP EVENT helloevent;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The helloevent EVENT should still exist on node 1
---let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "helloevent";
+--let $assert_text = The helloevent EVENT should not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.events WHERE event_name = "helloevent";
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1689,9 +2258,16 @@ DROP EVENT helloevent;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = The helloevent EVENT should still exist on node 2
---let $assert_cond = COUNT(*) = 1 FROM information_schema.events WHERE event_name = "helloevent";
+--let $assert_text = The helloevent EVENT should not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.events WHERE event_name = "helloevent";
 --source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+REVOKE EVENT ON testdb.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 
 #
@@ -1706,10 +2282,26 @@ DROP EVENT helloevent;
 --echo #
 --echo # SQLCOM_ALTER_USER access test
 --echo #
---echo # connection node_testme
---connection node_testme
 
---error ER_SPECIFIC_ACCESS_DENIED_ERROR
+--echo # connection node_1
+--connection node_1
+--let $assert_text = User testother should not be expired on node 1
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother" AND password_expired = "N"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+GRANT CREATE USER ON *.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
 ALTER USER 'testother'@'%' PASSWORD EXPIRE;
 
 --eval INSERT INTO counter(count) VALUES($test_id);
@@ -1719,8 +2311,8 @@ ALTER USER 'testother'@'%' PASSWORD EXPIRE;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User testother should be unexpired on node 1
---let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother" AND password_expired = "N"
+--let $assert_text = User testother should be expired on node 1
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother" AND password_expired = "Y"
 --source include/assert.inc
 
 --echo # connection node_2
@@ -1728,11 +2320,17 @@ ALTER USER 'testother'@'%' PASSWORD EXPIRE;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
 --source include/wait_condition.inc
 
---let $assert_text = User testother should be unlocked on node 2
---let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother" AND password_expired = "N"
+--let $assert_text = User testother should be expired on node 2
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "testother" AND password_expired = "Y"
 --source include/assert.inc
 
 
+--echo # connection node_1
+--connection node_1
+REVOKE CREATE USER ON *.* FROM 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
 
 --echo #
 --echo # cleanup

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -59,12 +59,14 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ADMIN command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend changing storage engine of a table ");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of INSERT");
 
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of DML command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of TRUNCATE command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ADMIN command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits changing storage engine of a table");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of INSERT");
 
 
 call mtr.add_suppression("WSREP doesn't support XA transaction");
@@ -1318,6 +1320,116 @@ drop table t;
 --source include/start_mysqld.inc
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
 --source include/wait_condition.inc
+
+#-------------------------------------------------------------------------------
+#
+# Scenario-9: Test effect of pxc-strict-mode on view with underlying table
+#             without explicit primary key
+#
+
+#
+--connection node_1
+--echo #node-1
+CREATE TABLE tbl_w_pk(id INT PRIMARY KEY) engine=innodb;
+CREATE TABLE tbl_wo_pk(id INT) engine=innodb;
+
+CREATE VIEW  view_w_pk AS SELECT * FROM tbl_w_pk;
+CREATE VIEW  view_wo_pk AS SELECT * FROM tbl_wo_pk;
+
+INSERT INTO tbl_w_pk VALUES (1), (2);
+
+SELECT * FROM tbl_w_pk;
+SELECT * FROM tbl_wo_pk;
+
+#----------------------------
+#
+# DISABLED
+--connection node_1
+--echo #node-1
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'DISABLED';
+select @@pxc_strict_mode;
+
+#
+--connection node_1
+--echo #node-1
+INSERT INTO view_w_pk VALUES(3);
+SELECT * FROM view_w_pk;
+
+INSERT INTO view_wo_pk VALUES (3);
+SELECT * FROM view_wo_pk;
+
+#----------------------------
+#
+# PERMISSIVE
+--connection node_1
+--echo #node-1
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'PERMISSIVE';
+select @@pxc_strict_mode;
+
+#
+--connection node_1
+--echo #node-1
+INSERT INTO view_w_pk VALUES(4);
+SELECT * FROM view_w_pk;
+
+INSERT INTO view_wo_pk VALUES (4);
+SELECT * FROM view_wo_pk;
+
+--let $assert_text = pxc_strict_mode issued warning about no primary keys
+--let $assert_select = no explicit primary key with pxc_strict_mode = PERMISSIVE
+--let $assert_count = 1
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+#----------------------------
+#
+# ENFORCING
+--connection node_1
+--echo #node-1
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+set global pxc_strict_mode = 'ENFORCING';
+select @@pxc_strict_mode;
+
+#
+--connection node_1
+--echo #node-1
+INSERT INTO view_w_pk VALUES(5);
+SELECT * FROM view_w_pk;
+
+--error ER_UNKNOWN_ERROR
+INSERT INTO view_wo_pk VALUES (5);
+SELECT * FROM view_wo_pk;
+
+--let $assert_text = pxc_strict_mode issued error about no primary keys
+--let $assert_select = no explicit primary key with pxc_strict_mode = ENFORCING
+--let $assert_count = 1
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+#
+--connection node_1
+--echo #node-1
+DROP VIEW view_wo_pk;
+DROP VIEW view_w_pk;
+DROP TABLE tbl_wo_pk;
+DROP TABLE tbl_w_pk;
+
 
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
PXC-870: User without Create View privileges get "ERROR 1142" but VIEW definition still gets replicated to other attached nodes!
PXC-880: INSERT to table without PK possible with insertable VIEW when pxc_strict_mode=ENFORCING Edit

Additional tests added for PXC-870 to ensure that allowed actions are replicated.
Views with an underlying table that does not have a primary key, do not allow inserts if pxc_strict_mode is enabled.