### PR TITLE
- PXC#885: IST hangs when keyring_file_data is set

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
@@ -49,5 +49,32 @@ INSERT INTO e1(text) VALUES('bbbbb');
 
 select * from e1;
 
+#
+# test IST with keyring enabled.
+#
+--connection node_2
+--echo #shutting down node-2
+--source include/shutdown_mysqld.inc
+
 --connection node_1
+--echo #node-1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+INSERT INTO e1(text) VALUES('aaaaa2');
+INSERT INTO e1(text) VALUES('bbbbb2');
+
+--connection node_2
+--echo #restarting node-2
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from e1;
+
+--connection node_1
+--echo #node-1
 drop table e1;
+
+


### PR DESCRIPTION
  * When a node joins the cluster depending on existing
    state it is synced using SST or IST.

  * If SST is done then keyring needs is sent from DONOR
    to JOINER.

  * If IST is done only write-sets are send. keyring
    sync is not needed.

  bug was caused as the JOINER flow expected keyring
  even in IST flow.