### PR TITLE
PXC-889: Fallback when wsrep_provider cannot load the library allows …

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -461,12 +461,21 @@ int wsrep_init()
 
   if ((rcode= wsrep_load(wsrep_provider, &wsrep, wsrep_log_cb)) != WSREP_OK)
   {
-    if (strcasecmp(wsrep_provider, WSREP_NONE))
+    if (strlen(wsrep_provider) == 0)
     {
-      WSREP_ERROR("wsrep_load(%s) failed: %s (%d). Reverting to no provider.",
+      WSREP_ERROR("wsrep_load() failed to load the provider('%s'): %s (%d). Reverting to no provider.",
                   wsrep_provider, strerror(rcode), rcode);
-      strcpy((char*)wsrep_provider, WSREP_NONE); // damn it's a dirty hack
+
+      if (wsrep_provider) my_free((void *)wsrep_provider);
+      wsrep_provider = my_strdup(WSREP_NONE, MYF(0)); // damn it's a dirty hack
+
       return wsrep_init();
+    }
+    else if (strcasecmp(wsrep_provider, WSREP_NONE))
+    {
+      WSREP_ERROR("wsrep_load() failed to load the provider('%s'): %s (%d). Need to abort.",
+                  wsrep_provider, strerror(rcode), rcode);
+      unireg_abort(1);
     }
     else /* this is for recursive call above */
     {


### PR DESCRIPTION
…writes

Issue:
When we fail to load the WSREP provider (wsrep-provider option), due to a
problem with the shared library (either a code problem or the location is
not entered correctly), an error is logged, but the server is allowed to
start as a non-cluster node (and still allows writes).
This can lead to a problem if this is not detected, since this standalone
server will not represent the true cluster state.

Solution:
Have the node fail if the wsrep_provider fails to load.  Note that
the special case of an empty wsrep_provider will still continue to start.