### PR TITLE
PXC-890: PXC 5.7 MTR: ASAN failure for galera.mysql-wsrep#31

### DIFF
--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -535,6 +535,9 @@ static void wsrep_rollback_process(THD *thd)
                   wsrep_get_conflict_state(aborting->wsrep_conflict_state));
       mysql_mutex_unlock(&aborting->LOCK_wsrep_thd);
 
+      /* Clear the thread state, since the rollback thread is done with it */
+      aborting->restore_globals();
+
       mysql_mutex_lock(&LOCK_wsrep_rollback);
     }
   }


### PR DESCRIPTION
Issue:
ASAN reported an error accessing a variable in an object that had
been deleted.  This was due to a BF abort which caused the
rollbacker thread to maintain a reference to a THD object which
was deleted on another thread.

Note that this can occur with any test that causes a BF abort and
is then followed by a test that restarts the server.

Solution:
Have the rollbacker thread clear the reference to the THD object.