### PR TITLE
- PXC#806: Early read of query-id result in stale trx handle assignment.

### DIFF
--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -790,6 +790,8 @@ bool sp_head::execute(THD *thd, bool merge_da_on_success)
 #ifdef WITH_WSREP
     if (thd->wsrep_next_trx_id() == WSREP_UNDEFINED_TRX_ID)
     {
+      if (thd->query_id == 0)
+        thd->set_query_id(next_query_id());
       thd->set_wsrep_next_trx_id(thd->query_id);
       WSREP_DEBUG("Assigned new next trx-id (%lu) to Store-Procedure execution",
                   (long unsigned int) thd->wsrep_next_trx_id());


### PR DESCRIPTION
  * During an execution of a Stored Procedure (SP) as a background
    action (say through event scheduler), query-id get assigned at
    later stage, before PXC captures it to derive wsrep_next_trx_id.

  * PXC uses this wsrep_next_trx_id as unique id to maintain
    TrxHandle and thread mapping.

  * This early capture of query-id resulted in assigning an invalid
    wsrep_next_trx_id (read 0). Problem starts if multiple threads
    gets the same invalid (read 0) id as their unique id to look
    for TrxHandle that eventually cause sharing of TrxHandle.

  Solution:
  --------

  * Fixed by ensuring that when PXC reads query_id, it is a valid id.
    If not, then a valid query_id is generated.
    (MySQL flow anyway generates it but at later stage).

  * We could have also corrected it by skipping setting of
    wsrep_next_trx_id at the said stage and waiting for MySQL to
    generate it but that means a drill-down code inside
    the main logic. So keeping it at outer layer
    makes it more manageable.