### PR TITLE
- PXC#895: Transaction lost after recovery

### DIFF
--- a/mysql-test/suite/galera/r/galera_trx_lost.result
+++ b/mysql-test/suite/galera/r/galera_trx_lost.result
@@ -1,0 +1,25 @@
+#node-2
+#shutdown node-2.
+#node-1
+select @@sync_binlog;
+@@sync_binlog
+1
+#node-1
+create table t1 (i int, primary key pk(i)) engine=innodb;
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+set debug="+d,crash_before_trx_commit_in_memory";
+insert into t1 values (4);
+ERROR HY000: Lost connection to MySQL server during query
+#node-1
+#waiting to restart node-1
+select * from t1;
+i
+1
+2
+3
+4
+drop table t1;
+#node-2
+call mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer.*");

--- a/mysql-test/suite/galera/t/galera_trx_lost.cnf
+++ b/mysql-test/suite/galera/t/galera_trx_lost.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+sync_binlog=1

--- a/mysql-test/suite/galera/t/galera_trx_lost.test
+++ b/mysql-test/suite/galera/t/galera_trx_lost.test
@@ -1,0 +1,67 @@
+
+#
+# this test exercise recovery feature. Prior to PXC#895 trx was
+# was being lost on recovery.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/force_restart.inc
+
+--connection node_2
+--echo #node-2
+--echo #shutdown node-2.
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--echo #node-1
+select @@sync_binlog;
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+#-------------------------------------------------------------------------------
+#
+# Execute some workload on node-1 with induce crash.
+#
+--connection node_1
+--echo #node-1
+
+create table t1 (i int, primary key pk(i)) engine=innodb;
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+set debug="+d,crash_before_trx_commit_in_memory";
+--error 2013
+insert into t1 values (4);
+
+--connection node_1
+--echo #node-1
+--echo #waiting to restart node-1
+--sleep 3
+
+--let $restart_parameters="restart:"
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+select * from t1;
+drop table t1;
+
+--connection node_2
+--echo #node-2
+
+--let $restart_parameters="restart:"
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+call mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer.*");

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -7854,18 +7854,40 @@ int MYSQL_BIN_LOG::recover(IO_CACHE *log, Format_description_log_event *fdle,
 
 #ifdef WITH_WSREP
   /*
-    Read current wsrep position from storage engines to have consistent
-    end position for binlog scan.
+    If binlog is enabled then SE will persist redo at following stages:
+    - during prepare
+    - during binlog write
+    - during innodb-commit
+    3rd stage (fsync) can be skipped as transaction can be recovered
+    from binlog.
+
+    During 3rd stage, commit co-ordinates are also recorded in sysheader
+    under wsrep placeholder. These co-ordinates are then used to stop
+    binlog scan (in addition to get recovery position in case of node-crash).
+
+    Since fsync of 3rd stage is delayed (as transaction can be recovered
+    using binlog) it is possible that even though transaction is reported
+    as success to end-user said co-ordinates are not persisted to disk.
+
+    On restart, a prepare state transaction could be recovered and committed
+    but since wsrep co-ordinates are not persisted a successfully committed
+    transaction recovery is skipped causing data inconsistency from end-user
+    application perspective.
+
+    This behavior is now changed to let recovery proceed independent of
+    wsrep co-ordinates and wsrep co-ordinates are updated to reflect
+    the recovery committed transaction.
   */
-  wsrep_uuid_t uuid;
-  wsrep_seqno_t seqno;
-  wsrep_get_SE_checkpoint(uuid, seqno);
-  char uuid_str[40];
-  wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
-  WSREP_INFO("Binlog recovery, found wsrep position %s:%lld", uuid_str,
-             (long long)seqno);
-  const wsrep_seqno_t last_xid_seqno= seqno;
-  wsrep_seqno_t cur_xid_seqno=WSREP_SEQNO_UNDEFINED;
+  if (WSREP_ON)
+  {
+    wsrep_uuid_t uuid;
+    wsrep_seqno_t seqno;
+    wsrep_get_SE_checkpoint(uuid, seqno);
+    char uuid_str[40];
+    wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
+    WSREP_INFO("Before binlog recovery (wsrep position %s:%lld)", uuid_str,
+               (long long)seqno);
+  }
 #endif /* WITH_WSREP */
 
 
@@ -7878,10 +7900,6 @@ int MYSQL_BIN_LOG::recover(IO_CACHE *log, Format_description_log_event *fdle,
 
   while ((ev= Log_event::read_log_event(log, 0, fdle, TRUE))
          && ev->is_valid()
-#ifdef WITH_WSREP
-         && (last_xid_seqno == WSREP_SEQNO_UNDEFINED ||
-             last_xid_seqno != cur_xid_seqno)
-#endif
       )
   {
     if (ev->get_type_code() == QUERY_EVENT &&
@@ -7903,9 +7921,6 @@ int MYSQL_BIN_LOG::recover(IO_CACHE *log, Format_description_log_event *fdle,
                                       sizeof(xev->xid));
       if (!x || my_hash_insert(&xids, x))
         goto err2;
-#ifdef WITH_WSREP
-      cur_xid_seqno= xev->xid;
-#endif /* WITH_WSREP */
     }
 
     /*
@@ -7950,13 +7965,21 @@ int MYSQL_BIN_LOG::recover(IO_CACHE *log, Format_description_log_event *fdle,
     delete ev;
   }
 
-#ifdef WITH_WSREP
-  WSREP_INFO("Binlog recovery scan stopped at Xid event %lld",
-             (long long)cur_xid_seqno);
-#endif /* WITH_WSREP */
-
   if (ha_recover(&xids))
     goto err2;
+
+#ifdef WITH_WSREP
+  if (WSREP_ON)
+  {
+    wsrep_uuid_t uuid;
+    wsrep_seqno_t seqno;
+    wsrep_get_SE_checkpoint(uuid, seqno);
+    char uuid_str[40];
+    wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
+    WSREP_INFO("After binlog recovery (wsrep position %s:%lld)", uuid_str,
+               (long long)seqno);
+  }
+#endif /* WITH_WSREP */
 
   free_root(&mem_root, MYF(0));
   my_hash_free(&xids);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -16497,6 +16497,7 @@ innobase_commit_by_xid(
 	DBUG_ASSERT(hton == innodb_hton_ptr);
 
 	trx = trx_get_trx_by_xid(xid);
+	trx->wsrep_recover_xid = xid;
 
 	if (trx) {
 		innobase_commit_low(trx);

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -1073,6 +1073,16 @@ struct trx_t{
 #ifdef WITH_WSREP
 	os_event_t	wsrep_event;	/* event waited for in srv_conc_slot */
 #endif /* WITH_WSREP */
+
+#ifdef WITH_WSREP
+	/* During recovery, prepare state transaction may be committed
+	or rollback. If a transaction is committed then xid of such
+	transaction should be persisted to sys_header under wsrep-xid
+	section to record successful commit-recovery of the said
+	transaction. */
+	XID*		wsrep_recover_xid;
+#endif /* WITH_WSREP */
+
 };
 
 /* Transaction isolation levels (trx->isolation_level) */


### PR DESCRIPTION
    If binlog is enabled then SE will persist redo at following stages:
    - during prepare
    - during binlog write
    - during innodb-commit
    3rd stage (fsync) can be skipped as transaction can be recovered
    from binlog.

    During 3rd stage, commit co-ordinates are also recorded in sysheader
    under wsrep placeholder. These co-ordinates are then used to stop
    binlog scan (in addition to get recovery position in case of node-crash).

    Since fsync of 3rd stage is delayed (as transaction can be recovered
    using binlog) it is possible that even though transaction is reported
    as success to end-user said co-ordinates are not persisted to disk.

    On restart, a prepare state transaction could be recovered and committed
    but since wsrep co-ordinates are not persisted a successfully committed
    transaction recovery is skipped causing data inconsistency from end-user
    application perspective.

    This behavior is now changed to let recovery proceed independent of
    wsrep co-ordinates and wsrep co-ordinates are updated to reflect
    the recovery committed transaction.

- PXC#897: gitd_executed is empty post wsrep_recover

  Don't spawn a new binlog file during wsrep-recovery. Why ?
  - Recovery flow is only going to read existing wsrep saved co-ordinate
    from sys_header. No other action is performed that needs binlogging.

  - Existing server flow looks at last binlog to set gtid_executed if server
    was shutdown abruptly. Newly created binlog will not have any such
    information and so restart post wsrep_recover will result in gtid_executed
    to be empty.