### PR TITLE
- PXC#895: Transaction lost after recovery

### DIFF
--- a/mysql-test/suite/galera/r/galera_trx_lost.result
+++ b/mysql-test/suite/galera/r/galera_trx_lost.result
@@ -1,0 +1,27 @@
+#node-2
+#shutdown node-2.
+#node-1
+select @@sync_binlog;
+@@sync_binlog
+1
+#node-1
+create table t1 (i int, primary key pk(i)) engine=innodb;
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+set debug="+d,crash_before_trx_commit_in_memory";
+insert into t1 values (4);
+ERROR HY000: Lost connection to MySQL server during query
+#node-1
+#waiting to restart node-1
+# restart:
+select * from t1;
+i
+1
+2
+3
+4
+drop table t1;
+#node-2
+# restart:
+call mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer.*");

--- a/mysql-test/suite/galera/t/galera_trx_lost.cnf
+++ b/mysql-test/suite/galera/t/galera_trx_lost.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+sync_binlog=1

--- a/mysql-test/suite/galera/t/galera_trx_lost.test
+++ b/mysql-test/suite/galera/t/galera_trx_lost.test
@@ -1,0 +1,67 @@
+
+#
+# this test exercise recovery feature. Prior to PXC#895 trx was
+# was being lost on recovery.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/force_restart.inc
+
+--connection node_2
+--echo #node-2
+--echo #shutdown node-2.
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--echo #node-1
+select @@sync_binlog;
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+#-------------------------------------------------------------------------------
+#
+# Execute some workload on node-1 with induce crash.
+#
+--connection node_1
+--echo #node-1
+
+create table t1 (i int, primary key pk(i)) engine=innodb;
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+set debug="+d,crash_before_trx_commit_in_memory";
+--error 2013
+insert into t1 values (4);
+
+--connection node_1
+--echo #node-1
+--echo #waiting to restart node-1
+--sleep 3
+
+--let $restart_parameters="restart:"
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+select * from t1;
+drop table t1;
+
+--connection node_2
+--echo #node-2
+
+--let $restart_parameters="restart:"
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
+call mtr.add_suppression("WSREP: Failed to prepare for incremental state transfer.*");

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5140,7 +5140,19 @@ a file name for --log-bin-index option", opt_binlog_index_name);
   }
 #endif /* WITH_WSREP */
 
+#ifdef WITH_WSREP
+  /* Don't spawn a new binlog file during wsrep-recovery. Why ?
+  - Recovery flow is only going to read existing wsrep saved co-ordinate
+    from sys_header. No other action is performed that needs binlogging.
+
+  - Existing server flow looks at last binlog to set gtid_executed if server
+    was shutdown abruptly. Newly create binlog will not have any such
+    information and so restart post wsrep_recover will result in gtid_executed
+    to be empty. */
+  if (opt_bin_log && !wsrep_recovery)
+#else
   if (opt_bin_log)
+#endif /* WITH_WSREP */
   {
     /*
       Configures what object is used by the current log to store processed

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -19502,6 +19502,7 @@ innobase_commit_by_xid(
 
 	if (trx != NULL) {
 		TrxInInnoDB	trx_in_innodb(trx);
+		trx->wsrep_recover_xid = xid;
 
 		innobase_commit_low(trx);
                 ut_ad(trx->mysql_thd == NULL);

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -1326,6 +1326,15 @@ struct trx_t {
 #endif /* WITH_WSREP */
 	bool		take_stats;
 	ulint		magic_n;
+
+#ifdef WITH_WSREP
+	/* During recovery, prepare state transaction may be committed
+	or rollback. If a transaction is committed then xid of such
+	transaction should be persisted to sys_header under wsrep-xid
+	section to record successful commit-recovery of the said
+	transaction. */
+	XID*		wsrep_recover_xid;
+#endif /* WITH_WSREP */
 };
 
 /**


### PR DESCRIPTION
    If binlog is enabled then SE will persist redo at following stages:
    - during prepare
    - during binlog write
    - during innodb-commit
    3rd stage (fsync) can be skipped as transaction can be recovered
    from binlog.

    During 3rd stage, commit co-ordinates are also recorded in sysheader
    under wsrep placeholder. These co-ordinates are then used to stop
    binlog scan (in addition to get recovery position in case of node-crash).

    Since fsync of 3rd stage is delayed (as transaction can be recovered
    using binlog) it is possible that even though transaction is reported
    as success to end-user said co-ordinates are not persisted to disk.

    On restart, a prepare state transaction could be recovered and committed
    but since wsrep co-ordinates are not persisted a successfully committed
    transaction recovery is skipped causing data inconsistency from end-user
    application perspective.

    This behavior is now changed to let recovery proceed independent of
    wsrep co-ordinates and wsrep co-ordinates are updated to reflect
    the recovery committed transaction.

- PXC#897: gitd_executed is empty post wsrep_recover

  Don't spawn a new binlog file during wsrep-recovery. Why ?
  - Recovery flow is only going to read existing wsrep saved co-ordinate
    from sys_header. No other action is performed that needs binlogging.

  - Existing server flow looks at last binlog to set gtid_executed if server
    was shutdown abruptly. Newly created binlog will not have any such
    information and so restart post wsrep_recover will result in gtid_executed
    to be empty.

(cherry picked from commit ade0ef10cc83692468cf853ee276b1bece5644dd)