### PR TITLE
Remove service Alias from mysql@.service unit file

### DIFF
--- a/build-ps/rpm/mysql@.service
+++ b/build-ps/rpm/mysql@.service
@@ -37,7 +37,6 @@ After=network.target syslog.target
 
 [Install]
 WantedBy=multi-user.target
-Alias=mysql.service
 
 [Service]
 # Needed to create system tables etc.


### PR DESCRIPTION
This affects the RPM build of PXC. The Alias in the mysql@.service unit file creates issues if you are running multiple instances on the same host. 
```
$ sudo systemctl enable mysql@custom
Failed to execute operation: File exists
```
In the above instance, a symlink is correctly created in multiuser.target.wants:
```
lrwxrwxrwx. 1 root root 38 Dec 14 14:08 multi-user.target.wants/mysql@custom.service -> /usr/lib/systemd/system/mysql@.service
```
So the service will actually start and work, but the systemctl command exited with status 1 because it was unable to create the mysql.service symlink in /etc/systemd/system (because in this case the symlink was already there for another PXC instance).

It also doesn't appear to work even if there is no preexisting mysql.service symlink. If `systemctl enable mysql@custom` is run, it creates both symlinks and exits successfully:
```
$ sudo systemctl enable mysql@custom
Created symlink from /etc/systemd/system/mysql.service to /usr/lib/systemd/system/mysql@.service.
Created symlink from /etc/systemd/system/multi-user.target.wants/mysql@custom.service to /usr/lib/systemd/system/mysql@.service.
```
However, mysql.service can't start because it it can't find the unit:
```
$ sudo systemctl start mysql.service
Failed to start mysql.service: Unit not found.
```
