### PR TITLE
Do not alter gtid on startup

### DIFF
--- a/build-ps/debian/extra/mysql-systemd-start
+++ b/build-ps/debian/extra/mysql-systemd-start
@@ -30,16 +30,6 @@ sanity () {
                 install -d -m 0750 -o mysql -g mysql ${MYSQLDATA}/mysql
 	fi
 
-	if [ ! "$(ls -A ${MYSQLDATA}/mysql)" ];
-	then
-		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on 2>&1 > /dev/null"
-		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --log_error_verbosity=2 2>&1 > /dev/null &"
-		pinger
-		mysql -e "INSTALL PLUGIN auth_socket SONAME 'auth_socket.so'"
-		mysql -e "USE mysql; UPDATE user SET plugin='auth_socket' WHERE user='root'"
-		mysqladmin shutdown
-	fi
-
 	if [ -x /usr/bin/mysql_ssl_rsa_setup -a ! -e "${MYSQLDATA}/server-key.pem" ];
 	then
 		/usr/bin/mysql_ssl_rsa_setup --datadir="${MYSQLDATA}" --uid=mysql >/dev/null 2>&1


### PR DESCRIPTION
When a node is joining a cluster and if root is not using 'auth_socket' plugin, the gtidset is locally changed on the local data (just out of xtrabackup) without running in the cluster (and thus not altering data in other members of the cluster).

This is effectively dangerous, because it alters the local gtid. If a slave comes to this master via async replication, it will have an extraneous component in the gtid set and won't be able to replicate from any other member of the cluster anymore.

I believe it is safer to remove any instruction that alters local data while not in the cluster altogether.

Please let me know what you think