### PR TITLE
* PXC#915: InnoDB: Failing assertion: trx_is_registered_for_2pc(trx) in

### DIFF
--- a/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
+++ b/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
@@ -22,3 +22,21 @@ DROP USER 'demo'@'localhost';
 ERROR HY000: Operation DROP USER failed for 'demo'@'localhost'
 DROP TABLE t1;
 DROP TABLE t2;
+use test;
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1);
+set sql_log_bin=0;
+alter table t add column j int;
+set sql_log_bin=1;
+set sql_log_bin=0;
+insert into t values (2, 2);
+set sql_log_bin=1;
+select * from t;
+i	j
+1	NULL
+2	2
+use test;
+select * from t;
+i
+1
+drop table t;

--- a/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
+++ b/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
@@ -33,3 +33,28 @@ DROP USER 'demo'@'localhost';
 --connection node_1
 DROP TABLE t1;
 DROP TABLE t2;
+
+
+#-------------------------------------------------------------------------------
+#
+# Setting sql_log_bin = 0 use to block DML replication but allow DDL replication
+# After fixing PXC#841 we ensure that sql_log_bin also blocks DDL replication
+# PXC#915 is regression caused during implementation of PXC#841.
+#
+
+--connection node_1
+use test;
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1);
+set sql_log_bin=0;
+alter table t add column j int;
+set sql_log_bin=1;
+set sql_log_bin=0;
+insert into t values (2, 2);
+set sql_log_bin=1;
+select * from t;
+
+--connection node_2
+use test;
+select * from t;
+drop table t;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1334,6 +1334,7 @@ THD::THD(bool enable_plugins)
   wsrep_affected_rows     = 0;
   wsrep_replicate_GTID    = false;
   wsrep_skip_wsrep_GTID   = false;
+  wsrep_skip_wsrep_hton   = false;
 #endif
   /* Call to init() below requires fully initialized Open_tables_state. */
   reset_open_tables_state();
@@ -1761,6 +1762,7 @@ void THD::init(void)
   wsrep_affected_rows     = 0;
   wsrep_replicate_GTID    = false;
   wsrep_skip_wsrep_GTID   = false;
+  wsrep_skip_wsrep_hton   = false;
 #endif
   binlog_row_event_extra_data= 0;
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3591,6 +3591,11 @@ public:
   Galera GTID. */
   bool                      wsrep_skip_wsrep_GTID;
 
+  /* DDL statement. skip registering wsrep_hton handler.
+  This is normally blocked by checking wsrep_exec_state != TOTAL_ORDER
+  but if sql_log_bin = 0 then the state is not set and DDL should is expected
+  not be replicated. This variable helps identify situation like these. */
+  bool                      wsrep_skip_wsrep_hton;
 #endif /* WITH_WSREP */
   /**
     Internal parser state.

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1344,6 +1344,7 @@ static int wsrep_TOI_begin(THD *thd, char *db_, char *table_,
   size_t buf_len(0);
   int buf_err;
 
+  thd->wsrep_skip_wsrep_hton= true;
   if (wsrep_can_run_in_toi(thd, db_, table_, table_list) == false)
   {
     WSREP_DEBUG("No TOI for %s", WSREP_QUERY(thd));
@@ -1428,7 +1429,6 @@ static int wsrep_TOI_begin(THD *thd, char *db_, char *table_,
                 ret, WSREP_QUERY(thd));
     if (buf) my_free(buf);
     wsrep_keys_free(&key_arr);
-    wsrep_cleanup_transaction(thd);
     return 1;
   }
   return 0;
@@ -1660,6 +1660,9 @@ void wsrep_to_isolation_end(THD *thd)
     }
     wsrep_cleanup_transaction(thd);
   }
+
+  if (thd->wsrep_skip_wsrep_hton)
+    wsrep_cleanup_transaction(thd);
 }
 
 #define WSREP_MDL_LOG(severity, msg, schema, schema_len, req, gra)             \


### PR DESCRIPTION
  file ha_innodb.cc line 19502

  As part of PXC#841 we tried suppressing DDL/TOI replication
  if sql_log_bin = 0. While the approach worked it missed an important
  condition where-in the if the DDL statement modifies existing table
  say using ALTER TABLE, OPTIMIZE TABLE, etc.... then transaction
  for this operation is registered with MySQL 2PC co-ordinator
  that will eventually invoke sequence to prepare -> commit the given
  transaction.

  prepare stage will try to register wsrep-hton handler which is not
  expected for any DDL/TOI statement. This erroneous action eventually
  resulted in the said error/assert.