### PR TITLE
* PXC#2039: Node consistency compromized for simple

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1852,7 +1852,6 @@ int ha_commit_trans(THD *thd, bool all, bool ignore_global_read_lock)
         (WSREP(thd) && thd->lex->sql_command == SQLCOM_CREATE_TABLE &&
          !trans_has_updated_trans_table(thd)))
     {
-      WSREP_DEBUG("handler prepare for CTAS");
 #else
     if (!trn_ctx->no_2pc(trx_scope) && (trn_ctx->rw_ha_count(trx_scope) > 1))
 #endif /* WITH_WSREP */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -22310,10 +22310,11 @@ wsrep_innobase_kill_one_trx(void * const bf_thd_ptr,
 		} else {
 			WSREP_DEBUG("Abort transaction in pre-commit state"
                                     " bearing trx-id: %lu, next-trx-id: %lu"
-                                    " query-id: %lld",
+                                    " query-id: %lld (seqno: %lld)",
                               (long unsigned int) wsrep_thd_trx_id(thd),
                               (long unsigned int) wsrep_thd_next_trx_id(thd),
-                              wsrep_thd_query_id(thd));
+                              wsrep_thd_query_id(thd),
+                              (long long)wsrep_thd_trx_seqno(thd));
 			rcode = wsrep->abort_pre_commit(
 				wsrep, bf_seqno,
 				(wsrep_trx_id_t)wsrep_thd_trx_id(thd)


### PR DESCRIPTION
  INSERT INTO ... ON DUPLICATE KEY UPDATE workload

  - A high priority (read replicated) transaction can cause
    existing local transaction to get aborted.

  - Generally if a local transaction is aborted due to lock-conflict
    then the said transaction needs to be evaluated for certification
    conflict and accordingly decision to replay or abort needs to be
    called out.

    This logic went missing (from pre-commit hook) when replicate_pre_commit
    hook was split into 2 different actions (as part of performance).

  - Corrected the logic to handle the said condition in pre-commit hook.