### PR TITLE
PXC-904 : Replication filters not working with account management sta…

### DIFF
--- a/mysql-test/suite/galera/r/galera_repl_filtersA.result
+++ b/mysql-test/suite/galera/r/galera_repl_filtersA.result
@@ -1,0 +1,1753 @@
+# connection node_2 : starting async slave
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+#
+# Test preparation
+#
+# connection node_1
+CREATE DATABASE db;
+USE db;
+CREATE TABLE db.counter(id INT PRIMARY KEY AUTO_INCREMENT, count INT);
+# connection node_1
+CREATE DATABASE dbx;
+# connection node_2
+CREATE DATABASE dbx;
+#
+# Test async.db.ddl.1.1 : CREATE DATABASE
+#
+# connection node_1
+USE db;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(1);
+include/assert.inc ["db1 is on node_1"]
+# connection node_2
+include/assert.inc ["db1 is on node_2"]
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+#
+# Test async.db.ddl.1.2 : ALTER DATABASE
+#
+# connection node_1
+USE db;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(2);
+include/assert.inc ['db1 was altered on node 1']
+# connection node_2
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 3']
+# connection node_1
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.1.3 : DROP DATABASE
+#
+# connection node_1
+USE db;
+DROP database db1;
+INSERT INTO db.counter(count) VALUES(3);
+include/assert.inc ['db1 is not on node_1']
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test async.db.ddl.2.1 : CREATE DATABASE
+#
+# connection node_1
+USE db;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(4);
+include/assert.inc ['dbx2 is on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# Test preparation for async.db.ddl.2.2
+#
+# connection node_2
+USE db;
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test async.db.ddl.2.2 : ALTER DATABASE
+#
+# connection node_1
+USE db;
+ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(5);
+include/assert.inc ['dbx2 was altered on node 1']
+# connection node_2
+include/assert.inc ['dbx2 was not altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was not altered on node 3']
+# connection node_1
+USE db;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.2.3 : DROP DATABASE
+#
+# connection node_1
+USE db;
+DROP database dbx2;
+INSERT INTO db.counter(count) VALUES(6);
+include/assert.inc ['dbx2 is not on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+# Test async.db.ddl.2 cleanup
+# connection node_2
+DROP DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# Test async.db.ddl.3.1 : CREATE DATABASE
+#
+# connection node_1
+USE dbx;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(7);
+include/assert.inc ['db1 is on node_1']
+# connection node_2
+include/assert.inc ['db1 is on node_2']
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+#
+# Test async.db.ddl.3.2 : ALTER DATABASE
+#
+# connection node_1
+USE dbx;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(8);
+include/assert.inc ['db1 was altered on node 1']
+# connection node_2
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 3']
+# connection node_1
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.3.3 : DROP DATABASE
+#
+# connection node_1
+USE dbx;
+DROP DATABASE db1;
+INSERT INTO db.counter(count) VALUES(9);
+include/assert.inc ['db1 is not on node_1']
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test async.db.ddl.4.1 : CREATE DATABASE
+#
+# connection node_1
+USE dbx;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(10);
+include/assert.inc ['dbx2 is on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+# prepare for next tests
+# connection node_2
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ["dbx2 is on node_3"]
+#
+# Test async.db.ddl.4.2 : ALTER DATABASE
+#
+# connection node_1
+USE dbx;
+ALTER database dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(11);
+include/assert.inc ['dbx2 was altered on node 1']
+# connection node_2
+include/assert.inc ['dbx2 was not altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was not altered on node 3']
+# connection node_1
+USE dbx;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.4.3 : DROP DATABASE
+#
+# connection node_1
+USE dbx;
+DROP DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(12);
+include/assert.inc ['dbx2 is not on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test async.db.ddl.4 cleanup
+#
+# connection node_1
+include/assert.inc ['dbx2 is not on node_1']
+# connection node_2
+DROP DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# async.tbl.ddl test preparation
+#
+# connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_2
+include/assert.inc ["db1 is on node_2"]
+CREATE DATABASE dbx1;
+include/assert.inc ["dbx1 is on node_2"]
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+include/assert.inc ["dbx1 is on node_3"]
+#
+# Test async.tbl.ddl.1.1 : CREATE TABLE
+#
+# connection node_1
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(13);
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test async.tbl.ddl.1.2 : ALTER TABLE
+#
+# connection node_1
+USE db;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(14);
+# connection node_2
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test async.tbl.ddl.1.3 : RENAME TABLE
+#
+# connection node_1
+USE db;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(15);
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# async.tbl.ddl.1.4 test preparation
+#
+# connection node_1
+USE db;
+INSERT INTO db1.t2(id) VALUES(1);
+# connection node_2
+include/assert.inc ["db1.t2 has a row on node_2"]
+# connection node_3
+include/assert.inc ["db1.t2 has a row on node_3"]
+#
+# Test async.tbl.ddl.1.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE db;
+TRUNCATE TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(16);
+# connection node_2
+include/assert.inc ['db1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t2 is truncated on node_3']
+#
+# Test async.tbl.ddl.1.5 : DROP TABLE
+#
+# connection node_1
+USE db;
+DROP TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(17);
+# connection node_2
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# Test async.tbl.ddl.2.1 : CREATE TABLE
+#
+# connection node_1
+USE db;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+INSERT INTO db.counter(count) VALUES(18);
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test async.tbl.ddl.2.2 : ALTER TABLE
+#
+# connection node_1
+USE db;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(19);
+# connection node_2
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test async.tbl.ddl.2.3 : RENAME TABLE
+#
+# connection node_1
+USE db;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(20);
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test preparation for async.tbl.ddl.2.4
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+#
+# Test async.tbl.ddl.2.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE db;
+TRUNCATE TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(21);
+# connection node_2
+include/assert.inc ['dbx1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is truncated on node_3']
+#
+# Test async.tbl.ddl.2.5 : DROP TABLE
+#
+# connection node_1
+USE db;
+DROP TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(22);
+# connection node_2
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# Test async.tbl.ddl.3.1 : CREATE TABLE
+#
+# connection node_1
+USE dbx;
+CREATE TABLE db1.t1(id INT PRIMARY KEY);
+INSERT INTO db.counter(count) VALUES(23);
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# Test preparation
+#
+# connection node_1
+USE dbx;
+DROP TABLE db1.t1;
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY);
+# connection node_2
+include/assert.inc ["t1 is on node_2"]
+# connection node_3
+include/assert.inc ["t1 is on node_3"]
+#
+# Test async.tbl.ddl.3.2 : ALTER TABLE
+#
+# connection node_1
+USE dbx;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(24);
+# connection node_2
+include/assert.inc ['t1.x3 is not on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is not on node_3']
+#
+# Test async.tbl.ddl.3.3 : RENAME TABLE
+#
+# connection node_1
+USE dbx;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(25);
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+include/assert.inc ['t2 is not on node_3']
+# restore table to original name
+# connection node_1
+USE dbx;
+RENAME TABLE db1.t2 TO db1.t1;
+#
+# Test preparation for async.tbl.ddl.3.4
+#
+# connection node_1
+USE db;
+INSERT INTO db1.t1(id) VALUES(99);
+# connection node_2
+include/assert.inc ["Row added to db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["Row added to db1.t1 on node_3"]
+#
+# Test async.tbl.ddl.3.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE dbx;
+TRUNCATE TABLE db1.t1;
+INSERT INTO db.counter(count) VALUES(26);
+# connection node_2
+include/assert.inc ['db1.t1 is not truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t1 is not truncated on node_3']
+#
+# Test async.tbl.ddl.3.5 : DROP TABLE
+#
+# connection node_1
+USE dbx;
+DROP TABLE db1.t1;
+INSERT INTO db.counter(count) VALUES(27);
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# async.tbl.ddl.3.5 test cleanup
+#
+# connection node_2
+DROP TABLE db1.t1;
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# Test async.tbl.ddl.4.1 : CREATE TABLE
+#
+# connection node_1
+USE dbx;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(28);
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# Test preparation for async.tbl.ddl.4.2
+#
+# connection node_1
+USE dbx;
+DROP TABLE dbx1.t1;
+USE db;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_2
+include/assert.inc ["t1 is on node_2"]
+# connection node_3
+include/assert.inc ["t1 is on node_3"]
+#
+# Test async.tbl.ddl.4.2 : ALTER TABLE
+#
+# connection node_1
+USE dbx;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(29);
+# connection node_2
+include/assert.inc ['t1.x3 is not on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is not on node_3']
+#
+# Test async.tbl.ddl.4.3 : RENAME TABLE
+#
+# connection node_1
+USE dbx;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(30);
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+include/assert.inc ['t2 is not on node_3']
+# restore table to original name
+# connection node_1
+USE dbx;
+RENAME TABLE dbx1.t2 TO dbx1.t1;
+#
+# Test preparation for async.tbl.ddl.4.4
+#
+# connection node_1
+INSERT INTO dbx1.t1(id) VALUES(99);
+# connection node_2
+INSERT INTO dbx1.t1(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t1(id) VALUES(99);
+#
+# Test async.tbl.ddl.4.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE dbx;
+TRUNCATE TABLE dbx1.t1;
+INSERT INTO db.counter(count) VALUES(31);
+# connection node_2
+include/assert.inc ['dbx1.t1 is not truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t1 is not truncated on node_3']
+#
+# Test async.tbl.ddl.4.5 : DROP TABLE
+#
+# connection node_1
+USE dbx;
+DROP TABLE dbx1.t1;
+INSERT INTO db.counter(count) VALUES(32);
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test cleanup
+#
+# connection node_2
+DROP TABLE dbx1.t1;
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# async.tbl.ddl test cleanup
+#
+# connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_2
+include/assert.inc ["db1 is not on node_2"]
+DROP DATABASE dbx1;
+include/assert.inc ["dbx1 is not on node_2"]
+# connection node_3
+include/assert.inc ["db1 is not on node_3"]
+include/assert.inc ["dbx1 is not on node_3"]
+#
+# async.tbl.dml test preparation
+#
+# connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_2
+include/assert.inc ['db1 is on node_2']
+CREATE DATABASE dbx1;
+include/assert.inc ['dbx1 is on node_2']
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+include/assert.inc ['dbx1 is on node_3']
+# connection node_1
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db;
+CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_2
+include/assert.inc ["db1.t1 is on node_2"]
+include/assert.inc ["dbx1.t2 is on node_2"]
+# connection node_3
+include/assert.inc ["db1.t1 is on node_3"]
+include/assert.inc ["dbx1.t2 is on node_3"]
+#
+# Test async.tbl.dml.1.1 : INSERT
+#
+# connection node_1
+USE db;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(33);
+# connection node_2
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert succeeded on node_3"]
+#
+# Test async.tbl.dml.1.2 : UPDATE
+#
+# connection node_1
+USE db;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(34);
+# connection node_2
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update succeeded on node_3"]
+#
+# Test async.tbl.dml.1.3 : DELETE
+#
+# connection node_1
+USE db;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(35);
+# connection node_2
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete succeeded on node_3"]
+#
+# Testcase async.tbl.dml.1 cleanup
+#
+# connection node_1
+USE db;
+TRUNCATE TABLE db1.t1;
+#
+# Test async.tbl.dml.2.1 : INSERT
+#
+# connection node_1
+USE db;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(36);
+# connection node_2
+include/assert.inc ["Insert not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test async.tbl.dml.2 test preparation
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test async.tbl.dml.2.2 : UPDATE
+#
+# connection node_1
+USE db;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(37);
+# connection node_2
+include/assert.inc ["Update not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test async.tbl.dml.2.3 : DELETE
+#
+# connection node_1
+USE db;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(38);
+# connection node_2
+include/assert.inc ["Delete not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase async.tbl.dml.2.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# Test async.tbl.dml.3.1 : INSERT
+#
+# connection node_1
+USE dbx;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(39);
+# connection node_2
+include/assert.inc ["Insert replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert replicated to node_3"]
+#
+# Test async.tbl.dml.3.2 : UPDATE
+#
+# connection node_1
+USE dbx;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(40);
+# connection node_2
+include/assert.inc ["Update replicated to node_2"]
+# connection node_3
+include/assert.inc ["Update replicated to node_3"]
+#
+# Test async.tbl.dml.3.3 : DELETE
+#
+# connection node_1
+USE dbx;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(41);
+# connection node_2
+include/assert.inc ["Delete replicated to node_2"]
+# connection node_3
+include/assert.inc ["Delete replicated to node_3"]
+#
+# Test async.tbl.dml.4.1 : INSERT
+#
+# connection node_1
+USE dbx;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(42);
+# connection node_2
+include/assert.inc ["Insert not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test async.tbl.dml.4 test preparation
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test async.tbl.dml.4.2 : UPDATE
+#
+# connection node_1
+USE dbx;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(43);
+# connection node_2
+include/assert.inc ["Update not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test async.tbl.dml.4.3 : DELETE
+#
+# connection node_1
+USE dbx;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(44);
+# connection node_2
+include/assert.inc ["Delete not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase async.tbl.dml.4.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# async.tbl.dml test cleanup
+#
+# connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+DROP DATABASE dbx1;
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+include/assert.inc ['dbx1 is not on node_3']
+#
+# async.acct.mgmt test preparation
+#
+# connection node_1
+CREATE DATABASE db1;
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_2
+include/assert.inc ['db1.t1 is on node_2']
+# connection node_3
+include/assert.inc ['db1.t1 is on node_3']
+#
+# Test async.acct.mgmt.1.1 : CREATE USER
+#
+# connection node_1
+USE db;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(45);
+include/assert.inc ["User foo is on node_1"]
+# connection node_2
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test async.acct.mgmt.1.2 : CHANGE PASSWORD
+#
+# connection node_1
+USE db;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(46);
+include/assert.inc ["User foo is altered on node_1"]
+# connection node_2
+include/assert.inc ["User foo is altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is altered on node_3"]
+#
+# Test async.acct.mgmt.1.3 : ALTER USER
+#
+# connection node_1
+include/assert.inc ["User foo is not expired on node_1"]
+USE db;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is altered on node_1"]
+INSERT INTO db.counter(count) VALUES(47);
+# connection node_2
+include/assert.inc ["User foo is altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is altered on node_3"]
+#
+# Test async.acct.mgmt.1.4 : GRANT
+#
+# connection node_1
+USE db;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(48);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.1.5 : REVOKE
+#
+# connection node_1
+USE db;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(49);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.1.6 : GRANT ALL
+#
+# connection node_1
+USE db;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(50);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.1.7 : REVOKE ALL
+#
+# connection node_1
+USE db;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(51);
+include/assert.inc ["User foo has no access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has no access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has no access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.1.8 : DROP USER
+#
+# connection node_1
+USE db;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(52);
+# connection node_2
+include/assert.inc ["User foo is not on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3"]
+#
+# Test async.acct.mgmt.2.1 : CREATE USER
+#
+# connection node_1
+USE dbx;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(53);
+include/assert.inc ["User foo is on node_1"]
+# connection node_2
+include/assert.inc ["User foo is not on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3"]
+#
+# Test preparation for async.acct.mgmt.2
+#
+# connection node_2
+USE db;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test async.acct.mgmt.2.2 : CHANGE PASSWORD
+#
+# connection node_1
+USE dbx;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(54);
+include/assert.inc ["User foo is altered on node_1"]
+# connection node_2
+include/assert.inc ["User foo is not altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not altered on node_3"]
+#
+# Test async.acct.mgmt.2.3 : ALTER USER
+#
+# connection node_1
+include/assert.inc ["User foo is not expired on node_1"]
+USE dbx;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is altered on node_1"]
+INSERT INTO db.counter(count) VALUES(55);
+# connection node_2
+include/assert.inc ["User foo is not altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not altered on node_3"]
+#
+# Test async.acct.mgmt.2.4 : GRANT
+#
+# connection node_1
+USE dbx;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(56);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test preparation for async.acct.mgmt.2.5
+#
+# connection node_2
+USE db;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.5 : REVOKE
+#
+# connection node_1
+USE dbx;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(57);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test cleanup for async.acct.mgmt.2.5
+#
+# connection node_2
+USE db;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.6 : GRANT ALL
+#
+# connection node_1
+USE dbx;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(58);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo does not have ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have ALL access on db1.t1 on node_3"]
+#
+# Test preparation for async.acct.mgmt.2.7
+#
+# connection node_2
+USE db;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.7 : REVOKE ALL
+#
+# connection node_1
+USE dbx;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(59);
+include/assert.inc ["User foo does not have access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.8 : DROP USER
+#
+# connection node_1
+USE dbx;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(60);
+include/assert.inc ["User foo is not on node_1"]
+# connection node_2
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# async.acct.mgmt test cleanup
+#
+# connection node_1
+DROP DATABASE db1;
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+USE db;
+DROP USER "foo";
+include/assert.inc ["user foo is not on node_2"]
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+include/assert.inc ["user foo is not on node_3"]
+#
+# Test galera.db.ddl.1.1 : CREATE DATABASE
+#
+# connection node_2
+USE db;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(61);
+include/assert.inc ["db1 is on node_2"]
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+#
+# Test galera.db.ddl.1.2 : ALTER DATABASE
+#
+# connection node_2
+USE db;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(62);
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 3']
+# connection node_2
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test galera.db.ddl.1.3 : DROP DATABASE
+#
+# connection node_2
+USE db;
+DROP database db1;
+INSERT INTO db.counter(count) VALUES(63);
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test galera.db.ddl.2.1 : CREATE DATABASE
+#
+# connection node_2
+USE db;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(64);
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+# connection node_2
+DROP DATABASE dbx2;
+#
+# galera.db.ddl.2.2 test preparation
+#
+# connection node_2
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ["dbx2 is on node_3"]
+#
+# Test galera.db.ddl.2.2 : DROP DATABASE
+#
+USE db;
+DROP database dbx2;
+INSERT INTO db.counter(count) VALUES(65);
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# Test preparation for galera.db.ddl.2.3
+#
+# connection node_2
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test galera.db.ddl.2.3 : ALTER DATABASE
+#
+# connection node_2
+USE db;
+ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(66);
+include/assert.inc ['dbx2 was altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was altered on node 3']
+# connection node_2
+USE db;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+# Test galera.db.ddl.2 cleanup
+# connection node_2
+DROP DATABASE dbx2;
+# connection node_3
+#
+# Test galera.db.ddl.3.1 : CREATE DATABASE
+#
+# connection node_2
+USE dbx;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(67);
+include/assert.inc ['db1 is on node_2']
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+#
+# Test galera.db.ddl.3.2 : ALTER DATABASE
+#
+# connection node_2
+USE dbx;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(68);
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 2']
+# connection node_2
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test galera.db.ddl.3.3 : DROP DATABASE
+#
+# connection node_2
+USE dbx;
+DROP DATABASE db1;
+INSERT INTO db.counter(count) VALUES(69);
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test galera.db.ddl.4.1 : CREATE DATABASE
+#
+# connection node_2
+USE dbx;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(70);
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test galera.db.ddl.4.2 : ALTER DATABASE
+#
+# connection node_2
+USE dbx;
+ALTER database dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(71);
+include/assert.inc ['dbx2 was altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was altered on node 3']
+# connection node_2
+USE dbx;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+#
+# Test galera.db.ddl.4.3 : DROP DATABASE
+#
+# connection node_2
+USE dbx;
+DROP DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(72);
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# galera.tbl.ddl test preparation
+#
+# connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+include/assert.inc ["dbx1 is on node_3"]
+#
+# Test galera.tbl.ddl.1.1 : CREATE TABLE
+#
+# connection node_2
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(73);
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test galera.tbl.ddl.1.2 : ALTER TABLE
+#
+# connection node_2
+USE db;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(74);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.1.3 : RENAME TABLE
+#
+# connection node_2
+USE db;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(75);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test galera.tbl.ddl.1.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(76);
+include/assert.inc ['db1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.1.5 : DROP TABLE
+#
+# connection node_2
+USE db;
+DROP TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(77);
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# Test galera.tbl.ddl.2.1 : CREATE TABLE
+#
+# connection node_2
+USE db;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+INSERT INTO db.counter(count) VALUES(78);
+include/assert.inc ['dbx1.t1 is on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t1 is on node_3']
+#
+# Test galera.tbl.ddl.2.2 : ALTER TABLE
+#
+# connection node_2
+USE db;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(79);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.2.3 : RENAME TABLE
+#
+# connection node_2
+USE db;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(80);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test preparation for galera.tbl.ddl.2.4
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+#
+# Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(81);
+include/assert.inc ['dbx1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.2.5 : DROP TABLE
+#
+# connection node_2
+USE db;
+DROP TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(82);
+include/assert.inc ['dbx1.t2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is not on node_3']
+#
+# Test galera.tbl.ddl.3.1 : CREATE TABLE
+#
+# connection node_2
+USE dbx;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(83);
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test galera.tbl.ddl.3.2 : ALTER TABLE
+#
+# connection node_2
+USE dbx;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(84);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.3.3 : RENAME TABLE
+#
+# connection node_2
+USE dbx;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(85);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test preparation for galera.tbl.ddl.3.4
+#
+# connection node_2
+USE db;
+INSERT INTO db1.t2(id) VALUES(99);
+# connection node_3
+include/assert.inc ["Row added to db1.t2 on node_3"]
+#
+# Test galera.tbl.ddl.3.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE dbx;
+TRUNCATE TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(86);
+include/assert.inc ['db1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.3.5 : DROP TABLE
+#
+# connection node_2
+USE dbx;
+DROP TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(87);
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# Test galera.tbl.ddl.4.1 : CREATE TABLE
+#
+# connection node_2
+USE dbx;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(88);
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test galera.tbl.ddl.4.2 : ALTER TABLE
+#
+# connection node_2
+USE dbx;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(89);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.4.3 : RENAME TABLE
+#
+# connection node_2
+USE dbx;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(90);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test preparation for galera.tbl.ddl.4.4
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+#
+# Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE dbx;
+TRUNCATE TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(91);
+include/assert.inc ['dbx1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.4.5 : DROP TABLE
+#
+# connection node_2
+USE dbx;
+DROP TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(92);
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# galera.tbl.ddl test cleanup
+#
+# connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_3
+include/assert.inc ["db1 is not on node_3"]
+include/assert.inc ["dbx1 is not on node_3"]
+#
+# galera.tbl.dml test preparation
+#
+# connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+include/assert.inc ['dbx1 is on node_3']
+# connection node_2
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db;
+CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_3
+include/assert.inc ["db1.t1 is on node_3"]
+include/assert.inc ["dbx1.t2 is on node_3"]
+#
+# Test galera.tbl.dml.1.1 : INSERT
+#
+# connection node_2
+USE db;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(93);
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert succeeded on node_3"]
+#
+# Test galera.tbl.dml.1.2 : UPDATE
+#
+# connection node_2
+USE db;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(94);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update succeeded on node_3"]
+#
+# Test galera.tbl.dml.1.3 : DELETE
+#
+# connection node_2
+USE db;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(95);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete succeeded on node_3"]
+#
+# Test galera.tbl.dml.2.1 : INSERT
+#
+# connection node_2
+USE db;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(96);
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test galera.tbl.dml.2 test preparation
+#
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test galera.tbl.dml.2.2 : UPDATE
+#
+# connection node_2
+USE db;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(97);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test galera.tbl.dml.2.3 : DELETE
+#
+# connection node_2
+USE db;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(98);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase galera.tbl.dml.2.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# Test galera.tbl.dml.3.1 : INSERT
+#
+# connection node_2
+USE dbx;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(99);
+include/assert.inc ["Insert replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert replicated to node_3"]
+#
+# Test galera.tbl.dml.3.2 : UPDATE
+#
+# connection node_2
+USE dbx;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(100);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update replicated to node_3"]
+#
+# Test galera.tbl.dml.3.3 : DELETE
+#
+# connection node_2
+USE dbx;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(101);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete replicated to node_3"]
+#
+# Test galera.tbl.dml.4.1 : INSERT
+#
+# connection node_2
+USE dbx;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(102);
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test galera.tbl.dml.4 test preparation
+#
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test galera.tbl.dml.4.2 : UPDATE
+#
+# connection node_2
+USE dbx;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(103);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test galera.tbl.dml.4.3 : DELETE
+#
+# connection node_2
+USE dbx;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(104);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase galera.tbl.dml.4.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# galera.tbl.dml test cleanup
+#
+# connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+include/assert.inc ['dbx1 is not on node_3']
+#
+# galera.acct.mgmt test preparation
+#
+# connection node_2
+CREATE DATABASE db1;
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_3
+include/assert.inc ['db1.t1 is on node_3']
+#
+# Test galera.acct.mgmt.1.1 : CREATE USER
+#
+# connection node_2
+USE db;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(105);
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test galera.acct.mgmt.1.2 : CHANGE PASSWORD
+#
+# connection node_2
+USE db;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(106);
+include/assert.inc ["User foo is altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is altered on node_3"]
+#
+# Test galera.acct.mgmt.1.3 : ALTER USER
+#
+# connection node_2
+include/assert.inc ["User foo is not expired on node_2"]
+USE db;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is expired on node_2"]
+INSERT INTO db.counter(count) VALUES(107);
+# connection node_3
+include/assert.inc ["User foo is expired on node_3"]
+#
+# Test galera.acct.mgmt.1.4 : GRANT
+#
+# connection node_2
+USE db;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(108);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.5 : REVOKE
+#
+# connection node_2
+USE db;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(109);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.6 : GRANT ALL
+#
+# connection node_2
+USE db;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(110);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.7 : REVOKE ALL
+#
+# connection node_2
+USE db;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(111);
+include/assert.inc ["User foo has no access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has no access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.8 : DROP USER
+#
+# connection node_2
+USE db;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(112);
+include/assert.inc ["User foo is not on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3"]
+#
+# Test galera.acct.mgmt.2.1 : CREATE USER
+#
+# connection node_2
+USE dbx;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(113);
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test galera.acct.mgmt.2.2 : CHANGE PASSWORD
+#
+# connection node_2
+USE dbx;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(114);
+include/assert.inc ["User foo is altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is altered on node_3"]
+#
+# Test galera.acct.mgmt.2.3 : ALTER USER
+#
+# connection node_2
+include/assert.inc ["User foo is not expired on node_2"]
+USE dbx;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is expired on node_2"]
+INSERT INTO db.counter(count) VALUES(115);
+# connection node_3
+include/assert.inc ["User foo is expired on node_3"]
+#
+# Test galera.acct.mgmt.2.4 : GRANT
+#
+# connection node_2
+USE dbx;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(116);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.5 : REVOKE
+#
+# connection node_2
+USE dbx;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(117);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.6 : GRANT ALL
+#
+# connection node_2
+USE dbx;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(118);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.7 : REVOKE ALL
+#
+# connection node_2
+USE dbx;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(119);
+include/assert.inc ["User foo does not have access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.8 : DROP USER
+#
+# connection node_2
+USE dbx;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(120);
+include/assert.inc ["User foo is not on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3"]
+#
+# galera.acct.mgmt test cleanup
+#
+# connection node_2
+DROP DATABASE db1;
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Overall cleanup
+#
+# connection node_1
+DROP DATABASE db;
+# connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+# connection node_1
+RESET MASTER;

--- a/mysql-test/suite/galera/r/galera_repl_filtersB.result
+++ b/mysql-test/suite/galera/r/galera_repl_filtersB.result
@@ -1,0 +1,1837 @@
+# connection node_2 : starting async slave
+START SLAVE USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+#
+# Test preparation
+#
+# connection node_1
+CREATE DATABASE db;
+USE db;
+CREATE TABLE db.counter(id INT PRIMARY KEY AUTO_INCREMENT, count INT);
+# connection node_1
+CREATE DATABASE dbx;
+# connection node_2
+CREATE DATABASE dbx;
+#
+# Test async.db.ddl.1.1 : CREATE DATABASE
+#
+# connection node_1
+USE db;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(1);
+include/assert.inc ["db1 is on node_1"]
+# connection node_2
+include/assert.inc ["db1 is on node_2"]
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+#
+# Test async.db.ddl.1.2 : ALTER DATABASE
+#
+# connection node_1
+USE db;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(2);
+include/assert.inc ['db1 was altered on node 1']
+# connection node_2
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 3']
+# connection node_1
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.1.3 : DROP DATABASE
+#
+# connection node_1
+USE db;
+DROP database db1;
+INSERT INTO db.counter(count) VALUES(3);
+include/assert.inc ['db1 is not on node_1']
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test async.db.ddl.2.1 : CREATE DATABASE
+#
+# connection node_1
+USE db;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(4);
+include/assert.inc ['dbx2 is on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# Test preparation for async.db.ddl.2.2
+#
+# connection node_2
+USE db;
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test async.db.ddl.2.2 : ALTER DATABASE
+#
+# connection node_1
+USE db;
+ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(5);
+include/assert.inc ['dbx2 was altered on node 1']
+# connection node_2
+include/assert.inc ['dbx2 was not altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was not altered on node 3']
+# connection node_1
+USE db;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.2.3 : DROP DATABASE
+#
+# connection node_1
+USE db;
+DROP database dbx2;
+INSERT INTO db.counter(count) VALUES(6);
+include/assert.inc ['dbx2 is not on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+# Test async.db.ddl.2 cleanup
+# connection node_2
+DROP DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# Test async.db.ddl.3.1 : CREATE DATABASE
+#
+# connection node_1
+USE dbx;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(7);
+include/assert.inc ['db1 is on node_1']
+# connection node_2
+include/assert.inc ['db1 is on node_2']
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+#
+# Test async.db.ddl.3.2 : ALTER DATABASE
+#
+# connection node_1
+USE dbx;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(8);
+include/assert.inc ['db1 was altered on node 1']
+# connection node_2
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 3']
+# connection node_1
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.3.3 : DROP DATABASE
+#
+# connection node_1
+USE dbx;
+DROP DATABASE db1;
+INSERT INTO db.counter(count) VALUES(9);
+include/assert.inc ['db1 is not on node_1']
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test async.db.ddl.4.1 : CREATE DATABASE
+#
+# connection node_1
+USE dbx;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(10);
+include/assert.inc ['dbx2 is on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+# prepare for next tests
+# connection node_2
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ["dbx2 is on node_3"]
+#
+# Test async.db.ddl.4.2 : ALTER DATABASE
+#
+# connection node_1
+USE dbx;
+ALTER database dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(11);
+include/assert.inc ['dbx2 was altered on node 1']
+# connection node_2
+include/assert.inc ['dbx2 was not altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was not altered on node 3']
+# connection node_1
+USE dbx;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+#
+# Test async.db.ddl.4.3 : DROP DATABASE
+#
+# connection node_1
+USE dbx;
+DROP DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(12);
+include/assert.inc ['dbx2 is not on node_1']
+# connection node_2
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test async.db.ddl.4 cleanup
+#
+# connection node_1
+include/assert.inc ['dbx2 is not on node_1']
+# connection node_2
+DROP DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# async.tbl.ddl test preparation
+#
+# connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+CREATE DATABASE dbx1;
+# connection node_2
+include/assert.inc ["db1 is on node_2"]
+include/assert.inc ["dbx1 is on node_2"]
+#
+# Test async.tbl.ddl.1.1 : CREATE TABLE
+#
+# connection node_1
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(13);
+include/assert.inc ['t1 is on node_1']
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test async.tbl.ddl.1.2 : ALTER TABLE
+#
+# connection node_1
+USE db;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(14);
+include/assert.inc ['t1.x3 is on node_1']
+# connection node_2
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test async.tbl.ddl.1.3 : RENAME TABLE
+#
+# connection node_1
+USE db;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(15);
+include/assert.inc ['db1.t1 is not on node_1']
+include/assert.inc ['db1.t2 is on node_1']
+# connection node_2
+include/assert.inc ['db1.t1 is not on node_2']
+include/assert.inc ['db1.t2 is on node_2']
+# connection node_3
+include/assert.inc ['db1.t1 is not on node_3']
+include/assert.inc ['db1.t2 is on node_3']
+#
+# async.tbl.ddl.1.4 test preparation
+#
+# connection node_1
+USE db;
+INSERT INTO db1.t2(id) VALUES(1);
+include/assert.inc ["db1.t2 has a row on node_1"]
+# connection node_3
+include/assert.inc ["db1.t2 has a row on node_3"]
+# connection node_2
+include/assert.inc ["db1.t2 has a row on node_2"]
+#
+# Test async.tbl.ddl.1.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE db;
+TRUNCATE TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(16);
+include/assert.inc ['db1.t2 is truncated on node_1']
+# connection node_2
+include/assert.inc ['db1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t2 is truncated on node_3']
+#
+# Test async.tbl.ddl.1.5 : DROP TABLE
+#
+# connection node_1
+USE db;
+DROP TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(17);
+include/assert.inc ['t2 is not on node_1']
+# connection node_2
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# Test async.tbl.ddl.2.1 : CREATE TABLE
+#
+# connection node_1
+USE db;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+INSERT INTO db.counter(count) VALUES(18);
+include/assert.inc ['t1 is on node_1']
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# async.tbl.dll.2.2 test preparation
+#
+# connection node_2
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test async.tbl.ddl.2.2 : ALTER TABLE
+#
+# connection node_1
+USE db;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(19);
+include/assert.inc ['t1.x3 is on node_1']
+# connection node_2
+include/assert.inc ['t1.x3 is not on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is not on node_3']
+#
+# Test async.tbl.ddl.2.3 : RENAME TABLE
+#
+# connection node_1
+USE db;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(20);
+include/assert.inc ['t1 is not on node_1']
+include/assert.inc ['t2 is on node_1']
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+include/assert.inc ['t2 is not on node_3']
+#
+# Test preparation for async.tbl.ddl.2.4
+#
+# connection node_2
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+# connection node_3
+include/assert.inc ['t2 is on node_3']
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+#
+# Test async.tbl.ddl.2.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE db;
+TRUNCATE TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(21);
+include/assert.inc ['dbx1.t2 is truncated on node_2']
+# connection node_2
+include/assert.inc ['dbx1.t2 is not truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is not truncated on node_3']
+#
+# Test async.tbl.ddl.2.5 : DROP TABLE
+#
+# connection node_1
+USE db;
+DROP TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(22);
+include/assert.inc ['t2 is not on node_2']
+# connection node_2
+include/assert.inc ['t2 is on node_2 (DROP did not replicate)']
+# connection node_3
+include/assert.inc ['t2 is on node_3 (DROP did not replicate)']
+#
+# async.tbl.ddl.2 test cleanup
+#
+# connection node_2
+DROP TABLE dbx1.t2;
+# connection node_2
+include/assert.inc ['t2 is not on node_3']
+#
+# Test async.tbl.ddl.3.1 : CREATE TABLE
+#
+# connection node_1
+USE dbx;
+CREATE TABLE db1.t1(id INT PRIMARY KEY);
+INSERT INTO db.counter(count) VALUES(23);
+include/assert.inc ['t1 is on node_1']
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test async.tbl.ddl.3.2 : ALTER TABLE
+#
+# connection node_1
+USE dbx;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(24);
+include/assert.inc ['t1.x3 is on node_1']
+# connection node_2
+include/assert.inc ['t1.x3 is on node_2 (replicated)']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3 (replicated)']
+#
+# Test async.tbl.ddl.3.3 : RENAME TABLE
+#
+# connection node_1
+USE dbx;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(25);
+include/assert.inc ['t1 is not on node_1']
+include/assert.inc ['t2 is on node_1']
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+# restore table to original name
+# connection node_1
+USE db;
+RENAME TABLE db1.t2 TO db1.t1;
+# connection node_3
+include/assert.inc ["t1 is on node_3"]
+# connection node_2
+include/assert.inc ["t1 is on node_2"]
+#
+# Test preparation for async.tbl.ddl.3.4
+#
+# connection node_1
+USE db;
+INSERT INTO db1.t1(id) VALUES(99);
+# connection node_3
+include/assert.inc ["Row added to db1.t1 on node_3"]
+# connection node_2
+include/assert.inc ["Row added to db1.t1 on node_2"]
+#
+# Test async.tbl.ddl.3.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE dbx;
+TRUNCATE TABLE db1.t1;
+INSERT INTO db.counter(count) VALUES(26);
+include/assert.inc ['db1.t1 is truncated on node_1']
+# connection node_2
+include/assert.inc ['db1.t1 is truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t1 is truncated on node_3']
+#
+# Test async.tbl.ddl.3.5 : DROP TABLE
+#
+# connection node_1
+USE dbx;
+DROP TABLE db1.t1;
+INSERT INTO db.counter(count) VALUES(27);
+include/assert.inc ['t1 is not on node_1']
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# Test async.tbl.ddl.4.1 : CREATE TABLE
+#
+# connection node_1
+USE dbx;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(28);
+include/assert.inc ['t1 is on node_1']
+# connection node_2
+include/assert.inc ['t1 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# Test preparation for async.tbl.ddl.4.2
+#
+# connection node_2
+USE db;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_3
+include/assert.inc ["t1 is on node_3"]
+#
+# Test async.tbl.ddl.4.2 : ALTER TABLE
+#
+# connection node_1
+USE dbx;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(29);
+include/assert.inc ['t1.x3 is on node_1']
+# connection node_2
+include/assert.inc ['t1.x3 is not on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is not on node_3']
+#
+# Test async.tbl.ddl.4.3 : RENAME TABLE
+#
+# connection node_1
+USE dbx;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(30);
+include/assert.inc ['t1 is not on node_1']
+include/assert.inc ['t2 is on node_1']
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+include/assert.inc ['t2 is not on node_3']
+# restore table to original name
+# connection node_1
+USE dbx;
+RENAME TABLE dbx1.t2 TO dbx1.t1;
+#
+# Test preparation for async.tbl.ddl.4.4
+#
+# connection node_1
+INSERT INTO dbx1.t1(id) VALUES(99);
+# connection node_2
+INSERT INTO dbx1.t1(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t1(id) VALUES(99);
+#
+# Test async.tbl.ddl.4.4 : TRUNCATE TABLE
+#
+# connection node_1
+USE dbx;
+TRUNCATE TABLE dbx1.t1;
+INSERT INTO db.counter(count) VALUES(31);
+include/assert.inc ['dbx1.t1 is truncated on node_1']
+# connection node_2
+include/assert.inc ['dbx1.t1 is not truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t1 is not truncated on node_3']
+#
+# Test async.tbl.ddl.4.5 : DROP TABLE
+#
+# connection node_1
+USE dbx;
+DROP TABLE dbx1.t1;
+INSERT INTO db.counter(count) VALUES(32);
+include/assert.inc ['t1 is not on node_1']
+# connection node_2
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test cleanup
+#
+# connection node_2
+DROP TABLE dbx1.t1;
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+#
+# async.tbl.ddl test cleanup
+#
+# connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_3
+include/assert.inc ["db1 is not on node_3"]
+DROP DATABASE dbx1;
+# connection node_2
+include/assert.inc ["db1 is not on node_2"]
+include/assert.inc ["dbx1 is not on node_2"]
+#
+# async.tbl.dml test preparation
+#
+# connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+CREATE DATABASE dbx1;
+# connection node_2
+include/assert.inc ['db1 is on node_2']
+include/assert.inc ['dbx1 is on node_2']
+# connection node_1
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db;
+CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_3
+include/assert.inc ["db1.t1 is on node_3"]
+USE db;
+CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_2
+include/assert.inc ["db1.t1 is on node_2"]
+include/assert.inc ["dbx1.t2 is on node_2"]
+#
+# Test async.tbl.dml.1.1 : INSERT
+#
+# connection node_1
+USE db;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(33);
+include/assert.inc ["Insert succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert succeeded on node_3"]
+#
+# Test async.tbl.dml.1.2 : UPDATE
+#
+# connection node_1
+USE db;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(34);
+include/assert.inc ["Update succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update succeeded on node_3"]
+#
+# Test async.tbl.dml.1.3 : DELETE
+#
+# connection node_1
+USE db;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(35);
+include/assert.inc ["Delete succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete succeeded on node_3"]
+#
+# Testcase async.tbl.dml.1 cleanup
+#
+# connection node_1
+USE db;
+TRUNCATE TABLE db1.t1;
+#
+# Test async.tbl.dml.2.1 : INSERT
+#
+# connection node_1
+USE db;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(36);
+include/assert.inc ["Insert succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Insert not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test async.tbl.dml.2 test preparation
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test async.tbl.dml.2.2 : UPDATE
+#
+# connection node_1
+USE db;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(37);
+include/assert.inc ["Update succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Update not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test async.tbl.dml.2.3 : DELETE
+#
+# connection node_1
+USE db;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(38);
+include/assert.inc ["Delete succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Delete not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase async.tbl.dml.2.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# Test async.tbl.dml.3.1 : INSERT
+#
+# connection node_1
+USE dbx;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(39);
+include/assert.inc ["Insert succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Insert replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert replicated to node_3"]
+#
+# Test async.tbl.dml.3.2 : UPDATE
+#
+# connection node_1
+USE dbx;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(40);
+include/assert.inc ["Update succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Update replicated to node_2"]
+# connection node_3
+include/assert.inc ["Update replicated to node_3"]
+#
+# Test async.tbl.dml.3.3 : DELETE
+#
+# connection node_1
+USE dbx;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(41);
+include/assert.inc ["Delete succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Delete replicated to node_2"]
+# connection node_3
+include/assert.inc ["Delete replicated to node_3"]
+#
+# Test async.tbl.dml.4.1 : INSERT
+#
+# connection node_1
+USE dbx;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(42);
+include/assert.inc ["Insert succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Insert not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test async.tbl.dml.4 test preparation
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test async.tbl.dml.4.2 : UPDATE
+#
+# connection node_1
+USE dbx;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(43);
+include/assert.inc ["Update succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Update not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test async.tbl.dml.4.3 : DELETE
+#
+# connection node_1
+USE dbx;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(44);
+include/assert.inc ["Delete succeeded on node_1"]
+# connection node_2
+include/assert.inc ["Delete not replicated to node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase async.tbl.dml.4.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# async.tbl.dml test cleanup
+#
+# connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+DROP DATABASE dbx1;
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+include/assert.inc ['dbx1 is not on node_3']
+#
+# async.acct.mgmt test preparation
+#
+# connection node_1
+CREATE DATABASE db1;
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_3
+include/assert.inc ['db1.t1 is on node_3']
+# connection node_2
+include/assert.inc ['db1.t1 is on node_2']
+#
+# Test async.acct.mgmt.1.1 : CREATE USER
+#
+# connection node_1
+USE db;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(45);
+include/assert.inc ["User foo is on node_1"]
+# connection node_2
+include/assert.inc ["User foo is not on node_2 (did not replicate)"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3 (did not replicate)"]
+#
+# async.acct.mgmt.1.2 test preparation
+#
+# connection node_2
+USE db;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test async.acct.mgmt.1.2 : CHANGE PASSWORD
+#
+# connection node_1
+USE db;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(46);
+include/assert.inc ["User foo is altered on node_1"]
+# connection node_2
+include/assert.inc ["User foo is not altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not altered on node_3"]
+#
+# Test async.acct.mgmt.1.3 : ALTER USER
+#
+# connection node_1
+include/assert.inc ["User foo is not expired on node_1"]
+USE db;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is altered on node_1"]
+INSERT INTO db.counter(count) VALUES(47);
+# connection node_2
+include/assert.inc ["User foo is not altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not altered on node_3"]
+#
+# Test async.acct.mgmt.1.4 : GRANT
+#
+# connection node_1
+USE db;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(48);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# async.acct.mgmt.1.5 test preparation
+#
+# connection node_2
+USE db;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.1.5 : REVOKE
+#
+# connection node_1
+USE db;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(49);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test cleanup for async.acct.mgmt.1.5
+#
+# connection node_2
+USE db;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.1.6 : GRANT ALL
+#
+# connection node_1
+USE db;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(50);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has NO access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has NO access on db1.t1 on node_3"]
+#
+# async.acct.mgmt.1.6 test preparation
+#
+# connection node_2
+USE db;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.1.7 : REVOKE ALL
+#
+# connection node_1
+USE db;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(51);
+include/assert.inc ["User foo has no access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2 (did not replicate)"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3 (did not replicate)"]
+#
+# Test async.acct.mgmt.1.8 : DROP USER
+#
+# connection node_1
+USE db;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(52);
+include/assert.inc ["User foo is not on node_1"]
+# connection node_2
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# async.acct.mgmt.1.7 test cleanup
+#
+# connection node_2
+USE db;
+DROP USER "foo";
+include/assert.inc ['User foo is not on node_2']
+# connection node_3
+include/assert.inc ["user foo is not on node_3"]
+#
+# Test async.acct.mgmt.2.1 : CREATE USER
+#
+# connection node_1
+USE dbx;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(53);
+include/assert.inc ["User foo is on node_1"]
+# connection node_2
+include/assert.inc ["User foo is not on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3"]
+#
+# Test preparation for async.acct.mgmt.2
+#
+# connection node_2
+USE db;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test async.acct.mgmt.2.2 : CHANGE PASSWORD
+#
+# connection node_1
+USE dbx;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(54);
+include/assert.inc ["User foo is altered on node_1"]
+# connection node_2
+include/assert.inc ["User foo is not altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not altered on node_3"]
+#
+# Test async.acct.mgmt.2.3 : ALTER USER
+#
+# connection node_1
+include/assert.inc ["User foo is not expired on node_1"]
+USE dbx;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is altered on node_1"]
+INSERT INTO db.counter(count) VALUES(55);
+# connection node_2
+include/assert.inc ["User foo is not altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not altered on node_3"]
+#
+# Test async.acct.mgmt.2.4 : GRANT
+#
+# connection node_1
+USE dbx;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(56);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test preparation for async.acct.mgmt.2.5
+#
+# connection node_2
+USE db;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.5 : REVOKE
+#
+# connection node_1
+USE dbx;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(57);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test cleanup for async.acct.mgmt.2.5
+#
+# connection node_2
+USE db;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.6 : GRANT ALL
+#
+# connection node_1
+USE dbx;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(58);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo does not have ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have ALL access on db1.t1 on node_3"]
+#
+# Test preparation for async.acct.mgmt.2.7
+#
+# connection node_2
+USE db;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.7 : REVOKE ALL
+#
+# connection node_1
+USE dbx;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(59);
+include/assert.inc ["User foo does not have access on db1.t1 on node_1"]
+# connection node_2
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test async.acct.mgmt.2.8 : DROP USER
+#
+# connection node_1
+USE dbx;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(60);
+include/assert.inc ["User foo is not on node_1"]
+# connection node_2
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# async.acct.mgmt.2.8 test cleanup
+#
+# connection node_2
+USE db;
+DROP USER "foo";
+include/assert.inc ["user foo is not on node_2"]
+# connection node_3
+include/assert.inc ["user foo is not on node_3"]
+#
+# async.acct.mgmt test cleanup
+#
+# connection node_1
+DROP DATABASE db1;
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+# connection node_2
+include/assert.inc ['db1 is not on node_2']
+#
+# Test galera.db.ddl.1.1 : CREATE DATABASE
+#
+# connection node_2
+USE db;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(61);
+include/assert.inc ["db1 is on node_2"]
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+#
+# Test galera.db.ddl.1.2 : ALTER DATABASE
+#
+# connection node_2
+USE db;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(62);
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 3']
+# connection node_2
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test galera.db.ddl.1.3 : DROP DATABASE
+#
+# connection node_2
+USE db;
+DROP database db1;
+INSERT INTO db.counter(count) VALUES(63);
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test galera.db.ddl.2.1 : CREATE DATABASE
+#
+# connection node_2
+USE db;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(64);
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+# connection node_2
+DROP DATABASE dbx2;
+#
+# galera.db.ddl.2.2 test preparation
+#
+# connection node_2
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ["dbx2 is on node_3"]
+#
+# Test galera.db.ddl.2.2 : DROP DATABASE
+#
+USE db;
+DROP database dbx2;
+INSERT INTO db.counter(count) VALUES(65);
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# Test preparation for galera.db.ddl.2.3
+#
+# connection node_2
+CREATE DATABASE dbx2;
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test galera.db.ddl.2.3 : ALTER DATABASE
+#
+# connection node_2
+USE db;
+ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(66);
+include/assert.inc ['dbx2 was altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was altered on node 3']
+# connection node_2
+USE db;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+# Test galera.db.ddl.2 cleanup
+# connection node_2
+DROP DATABASE dbx2;
+# connection node_3
+#
+# Test galera.db.ddl.3.1 : CREATE DATABASE
+#
+# connection node_2
+USE dbx;
+CREATE DATABASE db1;
+INSERT INTO db.counter(count) VALUES(67);
+include/assert.inc ['db1 is on node_2']
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+#
+# Test galera.db.ddl.3.2 : ALTER DATABASE
+#
+# connection node_2
+USE dbx;
+ALTER database db1 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(68);
+include/assert.inc ['db1 was altered on node 2']
+# connection node_3
+include/assert.inc ['db1 was altered on node 2']
+# connection node_2
+USE db1;
+ALTER database db1 CHARACTER SET = 'latin1';
+#
+# Test galera.db.ddl.3.3 : DROP DATABASE
+#
+# connection node_2
+USE dbx;
+DROP DATABASE db1;
+INSERT INTO db.counter(count) VALUES(69);
+include/assert.inc ['db1 is not on node_2']
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Test galera.db.ddl.4.1 : CREATE DATABASE
+#
+# connection node_2
+USE dbx;
+CREATE DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(70);
+include/assert.inc ['dbx2 is on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is on node_3']
+#
+# Test galera.db.ddl.4.2 : ALTER DATABASE
+#
+# connection node_2
+USE dbx;
+ALTER database dbx2 CHARACTER SET = "latin7";
+INSERT INTO db.counter(count) VALUES(71);
+include/assert.inc ['dbx2 was altered on node 2']
+# connection node_3
+include/assert.inc ['dbx2 was altered on node 3']
+# connection node_2
+USE dbx;
+ALTER database dbx2 CHARACTER SET = 'latin1';
+#
+# Test galera.db.ddl.4.3 : DROP DATABASE
+#
+# connection node_2
+USE dbx;
+DROP DATABASE dbx2;
+INSERT INTO db.counter(count) VALUES(72);
+include/assert.inc ['dbx2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx2 is not on node_3']
+#
+# galera.tbl.ddl test preparation
+#
+# connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_3
+include/assert.inc ["db1 is on node_3"]
+include/assert.inc ["dbx1 is on node_3"]
+#
+# Test galera.tbl.ddl.1.1 : CREATE TABLE
+#
+# connection node_2
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(73);
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test galera.tbl.ddl.1.2 : ALTER TABLE
+#
+# connection node_2
+USE db;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(74);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.1.3 : RENAME TABLE
+#
+# connection node_2
+USE db;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(75);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test galera.tbl.ddl.1.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(76);
+include/assert.inc ['db1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.1.5 : DROP TABLE
+#
+# connection node_2
+USE db;
+DROP TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(77);
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# Test galera.tbl.ddl.2.1 : CREATE TABLE
+#
+# connection node_2
+USE db;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+INSERT INTO db.counter(count) VALUES(78);
+include/assert.inc ['dbx1.t1 is on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t1 is on node_3']
+#
+# Test galera.tbl.ddl.2.2 : ALTER TABLE
+#
+# connection node_2
+USE db;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(79);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.2.3 : RENAME TABLE
+#
+# connection node_2
+USE db;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(80);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test preparation for galera.tbl.ddl.2.4
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+#
+# Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(81);
+include/assert.inc ['dbx1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.2.5 : DROP TABLE
+#
+# connection node_2
+USE db;
+DROP TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(82);
+include/assert.inc ['dbx1.t2 is not on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is not on node_3']
+#
+# Test galera.tbl.ddl.3.1 : CREATE TABLE
+#
+# connection node_2
+USE dbx;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(83);
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test galera.tbl.ddl.3.2 : ALTER TABLE
+#
+# connection node_2
+USE dbx;
+ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(84);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.3.3 : RENAME TABLE
+#
+# connection node_2
+USE dbx;
+RENAME TABLE db1.t1 TO db1.t2;
+INSERT INTO db.counter(count) VALUES(85);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test preparation for galera.tbl.ddl.3.4
+#
+# connection node_2
+USE db;
+INSERT INTO db1.t2(id) VALUES(99);
+# connection node_3
+include/assert.inc ["Row added to db1.t2 on node_3"]
+#
+# Test galera.tbl.ddl.3.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE dbx;
+TRUNCATE TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(86);
+include/assert.inc ['db1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['db1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.3.5 : DROP TABLE
+#
+# connection node_2
+USE dbx;
+DROP TABLE db1.t2;
+INSERT INTO db.counter(count) VALUES(87);
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# Test galera.tbl.ddl.4.1 : CREATE TABLE
+#
+# connection node_2
+USE dbx;
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db.counter(count) VALUES(88);
+include/assert.inc ['t1 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is on node_3']
+#
+# Test galera.tbl.ddl.4.2 : ALTER TABLE
+#
+# connection node_2
+USE dbx;
+ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+INSERT INTO db.counter(count) VALUES(89);
+include/assert.inc ['t1.x3 is on node_2']
+# connection node_3
+include/assert.inc ['t1.x3 is on node_3']
+#
+# Test galera.tbl.ddl.4.3 : RENAME TABLE
+#
+# connection node_2
+USE dbx;
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+INSERT INTO db.counter(count) VALUES(90);
+include/assert.inc ['t1 is not on node_2']
+include/assert.inc ['t2 is on node_2']
+# connection node_3
+include/assert.inc ['t1 is not on node_3']
+include/assert.inc ['t2 is on node_3']
+#
+# Test preparation for galera.tbl.ddl.4.4
+#
+# connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+#
+# Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
+#
+# connection node_2
+USE dbx;
+TRUNCATE TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(91);
+include/assert.inc ['dbx1.t2 is truncated on node_2']
+# connection node_3
+include/assert.inc ['dbx1.t2 is truncated on node_3']
+#
+# Test galera.tbl.ddl.4.5 : DROP TABLE
+#
+# connection node_2
+USE dbx;
+DROP TABLE dbx1.t2;
+INSERT INTO db.counter(count) VALUES(92);
+include/assert.inc ['t2 is not on node_2']
+# connection node_3
+include/assert.inc ['t2 is not on node_3']
+#
+# galera.tbl.ddl test cleanup
+#
+# connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_3
+include/assert.inc ["db1 is not on node_3"]
+include/assert.inc ["dbx1 is not on node_3"]
+#
+# galera.tbl.dml test preparation
+#
+# connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+# connection node_3
+include/assert.inc ['db1 is on node_3']
+include/assert.inc ['dbx1 is on node_3']
+# connection node_2
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db;
+CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_3
+include/assert.inc ["db1.t1 is on node_3"]
+include/assert.inc ["dbx1.t2 is on node_3"]
+#
+# Test galera.tbl.dml.1.1 : INSERT
+#
+# connection node_2
+USE db;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(93);
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert succeeded on node_3"]
+#
+# Test galera.tbl.dml.1.2 : UPDATE
+#
+# connection node_2
+USE db;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(94);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update succeeded on node_3"]
+#
+# Test galera.tbl.dml.1.3 : DELETE
+#
+# connection node_2
+USE db;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(95);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete succeeded on node_3"]
+#
+# Test galera.tbl.dml.2.1 : INSERT
+#
+# connection node_2
+USE db;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(96);
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test galera.tbl.dml.2 test preparation
+#
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test galera.tbl.dml.2.2 : UPDATE
+#
+# connection node_2
+USE db;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(97);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test galera.tbl.dml.2.3 : DELETE
+#
+# connection node_2
+USE db;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(98);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase galera.tbl.dml.2.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# Test galera.tbl.dml.3.1 : INSERT
+#
+# connection node_2
+USE dbx;
+INSERT INTO db1.t1(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(99);
+include/assert.inc ["Insert replicated to node_2"]
+# connection node_3
+include/assert.inc ["Insert replicated to node_3"]
+#
+# Test galera.tbl.dml.3.2 : UPDATE
+#
+# connection node_2
+USE dbx;
+UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(100);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update replicated to node_3"]
+#
+# Test galera.tbl.dml.3.3 : DELETE
+#
+# connection node_2
+USE dbx;
+DELETE FROM db1.t1 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(101);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete replicated to node_3"]
+#
+# Test galera.tbl.dml.4.1 : INSERT
+#
+# connection node_2
+USE dbx;
+INSERT INTO dbx1.t2(id) VALUES(1);
+INSERT INTO db.counter(count) VALUES(102);
+include/assert.inc ["Insert succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Insert not replicated to node_3"]
+#
+# Test galera.tbl.dml.4 test preparation
+#
+# connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+#
+# Test galera.tbl.dml.4.2 : UPDATE
+#
+# connection node_2
+USE dbx;
+UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(103);
+include/assert.inc ["Update succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Update not replicated to node_3"]
+#
+# Test galera.tbl.dml.4.3 : DELETE
+#
+# connection node_2
+USE dbx;
+DELETE FROM dbx1.t2 WHERE id = 1;
+INSERT INTO db.counter(count) VALUES(104);
+include/assert.inc ["Delete succeeded on node_2"]
+# connection node_3
+include/assert.inc ["Delete not replicated to node_3"]
+#
+# Testcase galera.tbl.dml.4.3 cleanup
+#
+# connection node_2
+USE db;
+TRUNCATE TABLE dbx1.t2;
+# connection node_3
+USE db;
+TRUNCATE TABLE dbx1.t2;
+#
+# galera.tbl.dml test cleanup
+#
+# connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+include/assert.inc ['dbx1 is not on node_3']
+#
+# galera.acct.mgmt test preparation
+#
+# connection node_2
+CREATE DATABASE db1;
+USE db;
+CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+# connection node_3
+include/assert.inc ['db1.t1 is on node_3']
+#
+# Test galera.acct.mgmt.1.1 : CREATE USER
+#
+# connection node_2
+USE db;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(105);
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test galera.acct.mgmt.1.2 : CHANGE PASSWORD
+#
+# connection node_2
+USE db;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(106);
+include/assert.inc ["User foo is altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is altered on node_3"]
+#
+# Test galera.acct.mgmt.1.3 : ALTER USER
+#
+# connection node_2
+include/assert.inc ["User foo is not expired on node_2"]
+USE db;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is expired on node_2"]
+INSERT INTO db.counter(count) VALUES(107);
+# connection node_3
+include/assert.inc ["User foo is expired on node_3"]
+#
+# Test galera.acct.mgmt.1.4 : GRANT
+#
+# connection node_2
+USE db;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(108);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.5 : REVOKE
+#
+# connection node_2
+USE db;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(109);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.6 : GRANT ALL
+#
+# connection node_2
+USE db;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(110);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.7 : REVOKE ALL
+#
+# connection node_2
+USE db;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(111);
+include/assert.inc ["User foo has no access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has no access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.1.8 : DROP USER
+#
+# connection node_2
+USE db;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(112);
+include/assert.inc ["User foo is not on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3"]
+#
+# Test galera.acct.mgmt.2.1 : CREATE USER
+#
+# connection node_2
+USE dbx;
+CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+INSERT INTO db.counter(count) VALUES(113);
+include/assert.inc ["User foo is on node_2"]
+# connection node_3
+include/assert.inc ["User foo is on node_3"]
+#
+# Test galera.acct.mgmt.2.2 : CHANGE PASSWORD
+#
+# connection node_2
+USE dbx;
+SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+INSERT INTO db.counter(count) VALUES(114);
+include/assert.inc ["User foo is altered on node_2"]
+# connection node_3
+include/assert.inc ["User foo is altered on node_3"]
+#
+# Test galera.acct.mgmt.2.3 : ALTER USER
+#
+# connection node_2
+include/assert.inc ["User foo is not expired on node_2"]
+USE dbx;
+ALTER USER "foo"@"%" PASSWORD EXPIRE;
+include/assert.inc ["User foo is expired on node_2"]
+INSERT INTO db.counter(count) VALUES(115);
+# connection node_3
+include/assert.inc ["User foo is expired on node_3"]
+#
+# Test galera.acct.mgmt.2.4 : GRANT
+#
+# connection node_2
+USE dbx;
+GRANT SELECT ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(116);
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.5 : REVOKE
+#
+# connection node_2
+USE dbx;
+REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(117);
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have SELECT access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.6 : GRANT ALL
+#
+# connection node_2
+USE dbx;
+GRANT ALL ON db1.t1 TO "foo"@"%";
+INSERT INTO db.counter(count) VALUES(118);
+include/assert.inc ["User foo has ALL access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo has ALL access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.7 : REVOKE ALL
+#
+# connection node_2
+USE dbx;
+REVOKE ALL ON db1.t1 FROM "foo"@"%";
+INSERT INTO db.counter(count) VALUES(119);
+include/assert.inc ["User foo does not have access on db1.t1 on node_2"]
+# connection node_3
+include/assert.inc ["User foo does not have access on db1.t1 on node_3"]
+#
+# Test galera.acct.mgmt.2.8 : DROP USER
+#
+# connection node_2
+USE dbx;
+DROP USER "foo"@"%";
+INSERT INTO db.counter(count) VALUES(120);
+include/assert.inc ["User foo is not on node_2"]
+# connection node_3
+include/assert.inc ["User foo is not on node_3"]
+#
+# galera.acct.mgmt test cleanup
+#
+# connection node_2
+DROP DATABASE db1;
+# connection node_3
+include/assert.inc ['db1 is not on node_3']
+#
+# Overall cleanup
+#
+# connection node_1
+DROP DATABASE db;
+# connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+# connection node_1
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_repl_filtersA.cnf
+++ b/mysql-test/suite/galera/t/galera_repl_filtersA.cnf
@@ -1,0 +1,10 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+replicate-do-db=db
+
+[mysqld.2]
+replicate-do-db=db1
+
+[mysqld.3]
+replicate-do-db=db1

--- a/mysql-test/suite/galera/t/galera_repl_filtersA.test
+++ b/mysql-test/suite/galera/t/galera_repl_filtersA.test
@@ -1,0 +1,6744 @@
+#
+# Test how replication filters affects Galera replication
+# This test tests the behavior of the repliate-do-db filter.
+#
+# The galera/galera_2node_slave.cnf describes the setup of the nodes
+#
+# async master
+# PXC node 2 and async slave
+# PXC node 3
+#
+# All nodes are configured the same:
+#	[mysqld]
+#	replicate-do-db=db
+#	replicate-do-db=db1
+#
+# We are testing to see that nodes 2 and 3 (which are PXC nodes),
+# maintain consistency when the async slave node is using replication filters.
+#
+# Database 'db' is allowed by the filters but is meant for tracking the PXC cluster
+# Database 'db1' is allowed by the filter
+# Database 'dbx' is not allowed by the filter
+# Database 'dbx1' is not allowed by the filter
+#
+# db and dbx are meant to be used for allowed/not allowed databases.
+# db also holds some test information and should not be deleted.
+#
+# db1 and dbx1 can be used for TABLE/DATABASE testing.
+#
+
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+--let $test_id = 0
+--let $show_rpl_debug_info = 0
+
+# Cluster setup
+# As node #1 is not a Galera node, we connect to node #2 in order to run
+# include/galera_cluster.inc
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--source include/galera_cluster.inc
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--disable_query_log
+--echo # connection node_2 : starting async slave
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START SLAVE USER='root';
+
+#
+# Create a database called db to hold various test case tracking tables.
+#
+--echo #
+--echo # Test preparation
+--echo #
+
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db;
+USE db; CREATE TABLE db.counter(id INT PRIMARY KEY AUTO_INCREMENT, count INT);
+# Also need to reset the test_id (since we had to drop the db database)
+--let $test_id = 0
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db" AND TABLE_NAME = "counter";
+-- source include/wait_condition.inc
+
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db" AND TABLE_NAME = "counter";
+-- source include/wait_condition.inc
+
+
+#
+# Create a separate database on all nodes, this database is not allowed to replicate
+#
+--connection node_1
+--echo # connection node_1
+CREATE DATABASE dbx;
+
+--connection node_2
+--echo # connection node_2
+CREATE DATABASE dbx;
+
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx";
+--source include/wait_condition.inc
+
+
+#==============================================================
+#
+# ASYNC-GALERA replication testing
+#
+# The tests below involve async replication and galera replication.
+# The intent is to test the affect of replication filters on
+# galera replication (when a PXC node is acting as an async slave).
+#
+#==============================================================
+
+
+#
+# Database DDL
+#
+
+
+#
+# Testcases async.db.ddl.1
+#	The default database (db) is allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+#
+# Test async.db.ddl.1.1 : CREATE DATABASE
+#		The default database is allowed.
+#		The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.1.1 : CREATE DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "db1 is on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test async.db.ddl.1.2 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.1.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test async.db.ddl.1.3 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.1.3 : DROP DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DROP database db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'db1';
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'db1';
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.db.ddl.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx, db1, etc...)
+#
+
+#
+# Test async.db.ddl.2.1 : CREATE DATABASE
+#		   The default database is allowed.
+#		   The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.2.1 : CREATE DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+--echo #
+--echo # Test preparation for async.db.ddl.2.2
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+#
+# Test async.db.ddl.2.2 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.2.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE db;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+
+
+#
+# Test async.db.ddl.2.3 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.2.3 : DROP DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; DROP database dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+#
+# Test async.db.ddl.2 cleanup
+#
+--echo # Test async.db.ddl.2 cleanup
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.db.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1)
+#
+
+#
+# Test async.db.ddl.3.1 : CREATE DATABASE
+#		   The default database is not allowed.
+#		   The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.3.1 : CREATE DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test async.db.ddl.3.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.3.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test async.db.ddl.3.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.3.3 : DROP DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; DROP DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.db.ddl.4
+#	The default database (dbx, db1) is not allowed.
+#	All operations are performed on an unallowed database (dbx, db1, db2, ...)
+#
+
+#
+# Test async.db.ddl.4.1 : CREATE DATABASE
+#		   The default database is not allowed.
+#		   The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.4.1 : CREATE DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+# prepare for next test
+--echo # prepare for next tests
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx2 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+#
+# Test async.db.ddl.4.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.4.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; ALTER database dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE dbx;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test async.db.ddl.4.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.4.3 : DROP DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DROP DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+--echo #
+--echo # Test async.db.ddl.4 cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+--let $assert_text = 'dbx2 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+
+#
+# Table DDL
+#	CREATE TABLE
+#	DROP TABLE
+#	ALTER TABLE
+#	RENAME TABLE
+#	TRUNCATE TABLE
+#
+
+#
+# Test preparation
+# 	Create db1 and dbx1 on all nodes
+#
+--echo #
+--echo # async.tbl.ddl test preparation
+--echo #
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+CREATE DATABASE dbx1;
+
+--let $assert_text = "dbx1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+#
+# Testcases async.tbl.ddl.1
+#	The default database (dbx, db1) is allowed.
+#	All operations are performed on a table in an allowed database (db)
+#
+
+#
+# Test async.tbl.ddl.1.1 : CREATE TABLE
+#		The default database is allowed.
+#		The database of the table being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test async.tbl.ddl.1.2 : ALTER TABLE
+#		The default database is allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+#
+# Test async.tbl.ddl.1.3 : RENAME TABLE
+#		The default database is allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.1.4 : TRUNCATE TABLE
+#		The default database is allowed.
+#		The database of the table being truncated is allowed.
+#
+--inc $test_id
+
+# Test preparation
+--echo #
+--echo # async.tbl.ddl.1.4 test preparation
+--echo #
+--echo # connection node_1
+--connection node_1
+USE db; INSERT INTO db1.t2(id) VALUES(1);
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM db1.t2
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t2 has a row on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM db1.t2
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t2 has a row on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t2
+--source include/assert.inc
+
+
+--echo #
+--echo # Test async.tbl.ddl.1.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; TRUNCATE TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.1.5 : DROP TABLE
+#		The default database is allowed.
+#		The database of the table being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DROP TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.ddl.2
+#	The default database (db) is allowed.
+#	All operations are performed on a table in a database that is not allowed (dbx1)
+#
+
+#
+# Test async.tbl.ddl.2.1 : CREATE TABLE
+#		The default database is allowed.
+#		The database of the table being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.2.2 : ALTER TABLE
+#		The default database is allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.2.3 : RENAME TABLE
+#		The default database is allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.2.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+
+#
+# Test async.tbl.ddl.2.4 : TRUNCATE TABLE
+#		The default database is allowed.
+#		The database of the table being truncated is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test async.tbl.ddl.2.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.2.5 : DROP TABLE
+#		The default database is allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the statement will
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DROP TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is allowed (db1)
+#
+
+#
+# Test async.tbl.ddl.3.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; CREATE TABLE db1.t1(id INT PRIMARY KEY);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Prepare for the rest of the tests by creating this table on all nodes
+#
+--echo #
+--echo # Test preparation
+--echo #
+--echo # connection node_1
+--connection node_1
+USE dbx; DROP TABLE db1.t1;
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY);
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1";
+--source include/wait_condition.inc
+
+--let $assert_text = "t1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1";
+--source include/wait_condition.inc
+
+--let $assert_text = "t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # restore table to original name
+--echo # connection node_1
+--connection node_1
+# Still use dbx since we don't want this command to replicate
+USE dbx; RENAME TABLE db1.t2 TO db1.t1;
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.3.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_1
+--connection node_1
+USE db; INSERT INTO db1.t1(id) VALUES(99);
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT MAX(id) = 99 FROM db1.t1
+--source include/wait_condition.inc
+
+--let $assert_text = "Row added to db1.t1 on node_2"
+--let $assert_cond = MAX(id) = 99 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT MAX(id) = 99 FROM db1.t1
+--source include/wait_condition.inc
+
+--let $assert_text = "Row added to db1.t1 on node_3"
+--let $assert_cond = MAX(id) = 99 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being truncated is allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test async.tbl.ddl.3.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; TRUNCATE TABLE db1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is not truncated on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is not truncated on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DROP TABLE db1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test cleanup
+#
+--echo #
+--echo # async.tbl.ddl.3.5 test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP TABLE db1.t1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1";
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.ddl.4
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is not allowed (dbx)
+#
+
+#
+# Test async.tbl.ddl.4.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Prepare for the rest of the tests by creating this table on all nodes
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.4.2
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# This will drop the table only on node_1
+USE dbx; DROP TABLE dbx1.t1;
+
+# Recreate the table on all nodes
+USE db; CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1";
+--source include/wait_condition.inc
+
+--let $assert_text = "t1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1";
+--source include/wait_condition.inc
+
+--let $assert_text = "t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.4.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "dbx1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "dbx1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.4.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # restore table to original name
+--echo # connection node_1
+--connection node_1
+# Still use dbx since we don't want this command to replicate
+USE dbx; RENAME TABLE dbx1.t2 TO dbx1.t1;
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.4.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_1
+--connection node_1
+INSERT INTO dbx1.t1(id) VALUES(99);
+
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t1(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t1(id) VALUES(99);
+
+
+#
+# Test async.tbl.ddl.4.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test async.tbl.ddl.4.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; TRUNCATE TABLE dbx1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t1 is not truncated on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t1 is not truncated on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t1
+--source include/assert.inc
+
+
+
+#
+# Test async.tbl.ddl.4.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the statement will not
+# replicate.
+# NOTE: The default database decides whether or not the statement
+# ia accepted by the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DROP TABLE dbx1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo #
+--echo # Test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP TABLE dbx1.t1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1" AND TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test cleanup
+#
+--echo #
+--echo # async.tbl.ddl test cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+DROP DATABASE dbx1;
+
+--let $assert_text = "dbx1 is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx1 is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Table DML (default db allowed, default db not allowed)
+#	Insert
+#	Update
+#	Delete
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # async.tbl.dml test preparation
+--echo #
+
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+CREATE DATABASE dbx1;
+
+--let $assert_text = 'dbx1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+--echo # connection node_1
+--connection node_1
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db; CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx1.t2 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx1.t2 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.dml.1
+#	The default database (db) is allowed.
+#	All table operations are performed on an allowed database (db1).
+#
+
+#
+# Test async.tbl.dml.1.1 : INSERT
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.1.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the table's database, db1, is allowed, so the statement will
+# replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.1.2 : UPDATE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.1.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the table's database, db1, is allowed, so the statement will
+# replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.1.3 : DELETE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.1.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the table's database, db1, is allowed, so the statement will
+# replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete succeeded on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo #
+--echo # Testcase async.tbl.dml.1 cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+USE db; TRUNCATE TABLE db1.t1;
+
+
+
+#
+# Testcases async.tbl.dml.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test async.tbl.dml.2.1 : INSERT
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.2.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the table's database, dbx1, is not allowed, so the operations will
+# not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+# NOTE: node_3 never receives the operation because node_2 is filtering
+# out the transaction on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test async.tbl.dml.2 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test async.tbl.dml.2.2 : UPDATE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.2.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the table's database, dbx1, is not allowed, so the operations will
+# not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+# NOTE: node_3 never receives the operation because node_2 is filtering
+# out the transaction on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.2.3 : DELETE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.2.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the table's database, dbx1, is not allowed, so the operations will
+# not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+# NOTE: node_3 never receives the operation because node_2 is filtering
+# out the transaction on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase async.tbl.dml.2.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+
+#
+# Testcases async.tbl.dml.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+#
+# Test async.tbl.dml.3.1 : INSERT
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.3.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the table's database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.3.2 : UPDATE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.3.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the table's database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.3.3 : DELETE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.3.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the table's database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.dml.4
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test async.tbl.dml.4.1 : INSERT
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.4.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the table's database, dbx1, is not allowed, so the operations will
+# not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+# NOTE: node_3 never receives the operation because node_2 is filtering
+# out the transaction on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test async.tbl.dml.4 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test async.tbl.dml.4.2 : UPDATE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.4.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the table's database, dbx1, is not allowed, so the operations will
+# not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+# NOTE: node_3 never receives the operation because node_2 is filtering
+# out the transaction on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.4.3 : DELETE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.4.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the table's database, dbx1, is not allowed, so the operations will
+# not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+# NOTE: node_3 never receives the operation because node_2 is filtering
+# out the transaction on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase async.tbl.dml.4.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+#
+# async.tbl.dml cleanup
+#
+--echo #
+--echo # async.tbl.dml test cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+DROP DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = 'dbx1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Account Management (default db allowed, default db not allowed)
+#	Create user
+#	Alter user
+#	Grant
+#	Revoke
+#	Grant all
+#	Revoke all
+#	Drop user
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # async.acct.mgmt test preparation
+--echo #
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db1;
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Testcases async.acct.mgmt.1
+#	The default database is allowed.
+#
+
+#
+# Test async.acct.mgmt.1.1 : CREATE USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.1 : CREATE USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--let $assert_debug = SELECT USER,HOST,PASSWORD FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_2"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_3"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.3 : ALTER USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.3 : ALTER USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $assert_text = "User foo is not expired on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.4 : GRANT
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.4 : GRANT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.5 : REVOKE
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.5 : REVOKE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.6 : GRANT ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.6 : GRANT ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.7 : REVOKE ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has no access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has no access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--let $assert_debug = SELECT * FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AD USER = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has no access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.8 : DROP USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.8 : DROP USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3 because
+# the default database, db1, is allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+
+#
+# Testcases async.acct.mgmt.2
+#	The default database (dbx) is not allowed.
+#
+
+#
+# Test async.acct.mgmt.2.1 : CREATE USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.1 : CREATE USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+#
+# Test prep for the rest of the test cases
+#
+--echo #
+--echo # Test preparation for async.acct.mgmt.2
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+
+#
+# Test async.acct.mgmt.2.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--let $assert_debug = SELECT USER,HOST,PASSWORD FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_2"
+--let $assert_cond = password = "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_3"
+--let $assert_cond = password = "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+
+#
+# Test async.acct.mgmt.2.3 : ALTER USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.3 : ALTER USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $assert_text = "User foo is not expired on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.4 : GRANT
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.4 : GRANT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+# Test preparation
+--echo #
+--echo # Test preparation for async.acct.mgmt.2.5
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; GRANT SELECT ON db1.t1 TO "foo"@"%";
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.5 : REVOKE
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.5 : REVOKE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+#
+# Test cleanup
+#
+--echo #
+--echo # Test cleanup for async.acct.mgmt.2.5
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--echo # connection node_3
+--connection node_3
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.6 : GRANT ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.6 : GRANT ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+# Test preparation
+--echo #
+--echo # Test preparation for async.acct.mgmt.2.7
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--echo # connection node_3
+--connection node_3
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.7 : REVOKE ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.8 : DROP USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.8 : DROP USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 because
+# the default database, dbx, is not allowed, so the operations will
+# replicate.
+#
+# NOTE: The default database decides whether or not the statement
+# is accepted by the async thread. Table filters will also apply.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is not on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test cleanup
+#
+--echo #
+--echo # async.acct.mgmt test cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db1;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+USE db; DROP USER "foo";
+
+--let $assert_text = "user foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/wait_condition.inc
+
+--let $assert_text = "user foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/assert.inc
+
+
+
+#==============================================================
+#
+# GALERA-GALERA replication testing
+# The tests from here down do not involve async replication.
+# The purpose is to test the affect of the replication filters
+# on galera replication.
+#
+#==============================================================
+
+
+#
+# Database DDL
+#
+
+
+#
+# Testcases galera.db.ddl.1
+#	The default database (db) is allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+
+#
+# Test galera.db.ddl.1.1 : CREATE DATABASE
+#		The default database is allowed.
+#		The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.1.1 : CREATE DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "db1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.1.2 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.1.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test galera.db.ddl.1.3 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.1.3 : DROP DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP database db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+
+#
+# Testcases galera.db.ddl.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx, db1, etc...)
+#
+
+#
+# Test galera.db.ddl.2.1 : CREATE DATABASE
+#		   The default database is allowed.
+#		   The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.2.1 : CREATE DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+#
+# Test galera.db.ddl.2.2 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is not allowed.
+#
+--inc $test_id
+
+#
+# This setup requires that the database exist on all nodes.
+#
+--echo #
+--echo # galera.db.ddl.2.2 test preparation
+--echo #
+
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx2 is on node_3"
+--let $assert_cond = COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+--echo #
+--echo # Test galera.db.ddl.2.2 : DROP DATABASE
+--echo #
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP database dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+#
+# Recreate database dbx2 for the next test
+#
+--echo #
+--echo # Test preparation for galera.db.ddl.2.3
+--echo #
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.2.3 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.2.3 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE db;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+#
+# Test galera.db.ddl.2 cleanup
+#
+--echo # Test galera.db.ddl.2 cleanup
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+
+
+#
+# Testcases galera.db.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1)
+#
+
+#
+# Test galera.db.ddl.3.1 : CREATE DATABASE
+#	The default database is not allowed.
+#	The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.3.1 : CREATE DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.3.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.3.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+
+#
+# Test galera.db.ddl.3.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.3.3 : DROP DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.db.ddl.4
+#	The default database (dbx, db1) is not allowed.
+#	All operations are performed on an unallowed database (dbx, db1, db2, ...)
+#
+
+#
+# Test galera.db.ddl.4.1 : CREATE DATABASE
+#	The default database is not allowed.
+#	The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.4.1 : CREATE DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.4.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.4.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER database dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE dbx;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test galera.db.ddl.4.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.4.3 : DROP DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+
+#
+# Table DDL
+#	CREATE TABLE
+#	DROP TABLE
+#	ALTER TABLE
+#	RENAME TABLE
+#	TRUNCATE TABLE
+#
+
+#
+# Test preparation
+# 	Create db1 and dbx1 on all nodes
+#
+--echo #
+--echo # galera.tbl.ddl test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+#
+# Testcases galera.tbl.ddl.1
+#	The default database (dbx, db1) is allowed.
+#	All operations are performed on a table in an allowed database (db)
+#
+
+#
+# Test galera.tbl.ddl.1.1 : CREATE TABLE
+#		The default database is allowed.
+#		The database of the table being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test galera.tbl.ddl.1.2 : ALTER TABLE
+#		The default database is allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+#
+# Test galera.tbl.ddl.1.3 : RENAME TABLE
+#		The default database is allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.1.4 : TRUNCATE TABLE
+#		The default database is allowed.
+#		The database of the table being truncated is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; TRUNCATE TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.1.5 : DROP TABLE
+#		The default database is allowed.
+#		The database of the table being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.ddl.2
+#	The default database (db) is allowed.
+#	All operations are performed on a table in a database that is not allowed (dbx1)
+#
+
+#
+# Test galera.tbl.ddl.2.1 : CREATE TABLE
+#		The default database is allowed.
+#		The database of the table being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.2.2 : ALTER TABLE
+#		The default database is allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.2.3 : RENAME TABLE
+#		The default database is allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for galera.tbl.ddl.2.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+
+#
+# Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
+#		The default database is allowed.
+#		The database of the table being truncated is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.2.5 : DROP TABLE
+#		The default database is allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is allowed (db1)
+#
+
+#
+# Test galera.tbl.ddl.3.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for galera.tbl.ddl.3.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+USE db; INSERT INTO db1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT MAX(id) = 99 FROM db1.t2
+--source include/wait_condition.inc
+
+--let $assert_text = "Row added to db1.t2 on node_3"
+--let $assert_cond = MAX(id) = 99 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being truncated is allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test galera.tbl.ddl.3.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; TRUNCATE TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.ddl.4
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is not allowed (dbx)
+#
+
+#
+# Test galera.tbl.ddl.4.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.4.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.4.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for galera.tbl.ddl.4.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+
+#
+# Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; TRUNCATE TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.4.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test cleanup
+#
+--echo #
+--echo # galera.tbl.ddl test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1 is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Table DML (default db allowed, default db not allowed)
+#	Insert
+#	Update
+#	Delete
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # galera.tbl.dml test preparation
+--echo #
+
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = 'dbx1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+--echo # connection node_2
+--connection node_2
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db; CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1.t2 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Testcases galera.tbl.dml.1
+#	The default database (db) is allowed.
+#	All table operations are performed on an allowed database (db1).
+#
+
+#
+# Test galera.tbl.dml.1.1 : INSERT
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.1.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate node_3 because the table's database, db1,
+# is allowed, so the statement will replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.1.2 : UPDATE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.1.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate node_3 because the table's database, db1,
+# is allowed, so the statement will replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.1.3 : DELETE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.1.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate node_3 because the table's database, db1,
+# is allowed, so the statement will replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete succeeded on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.dml.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test galera.tbl.dml.2.1 : INSERT
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.2.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
+# is not allowed, so the operation will not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE db; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test galera.tbl.dml.2 test preparation
+--echo #
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test galera.tbl.dml.2.2 : UPDATE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.2.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
+# is not allowed, so the operation will not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.2.3 : DELETE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.2.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
+# is not allowed, so the operation will not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE db; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase galera.tbl.dml.2.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+
+#
+# Testcases galera.tbl.dml.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+#
+# Test galera.tbl.dml.3.1 : INSERT
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.3.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate node_3 because the table's database, db1,
+# is allowed, so the statement will replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.3.2 : UPDATE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.3.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate node_3 because the table's database, db1,
+# is allowed, so the statement will replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.3.3 : DELETE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.3.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate node_3 because the table's database, db1,
+# is allowed, so the statement will replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.dml.4
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test galera.tbl.dml.4.1 : INSERT
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.4.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
+# is not allowed, so the operation will not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test galera.tbl.dml.4 test preparation
+--echo #
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test galera.tbl.dml.4.2 : UPDATE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.4.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
+# is not allowed, so the operation will not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.4.3 : DELETE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.4.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
+# is not allowed, so the operation will not replicate.
+#
+# NOTE: The default database does not matter here, only the
+# table's database.
+#
+# NOTE: Unlike statement-based replication, the database filters
+# are checked for row-based replication.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE dbx; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase galera.tbl.dml.4.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+#
+# galera.tbl.dml cleanup
+#
+--echo #
+--echo # galera.tbl.dml test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = 'dbx1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Account Management (default db allowed, default db not allowed)
+#	Create user
+#	Alter user
+#	Grant
+#	Revoke
+#	Grant all
+#	Revoke all
+#	Drop user
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # galera.acct.mgmt test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE db1;
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Testcases galera.acct.mgmt.1
+#	The default database is allowed.
+#
+
+#
+# Test galera.acct.mgmt.1.1 : CREATE USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.1 : CREATE USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_2"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_3"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.3 : ALTER USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.3 : ALTER USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $assert_text = "User foo is not expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is expired on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.4 : GRANT
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.4 : GRANT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.5 : REVOKE
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.5 : REVOKE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.6 : GRANT ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.6 : GRANT ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.7 : REVOKE ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has no access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--let $assert_debug = SELECT * FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AD USER = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has no access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.8 : DROP USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.8 : DROP USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.acct.mgmt.2
+#	The default database (dbx) is not allowed.
+#
+
+#
+# Test galera.acct.mgmt.2.1 : CREATE USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.1 : CREATE USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_2"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_3"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.3 : ALTER USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.3 : ALTER USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $assert_text = "User foo is not expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is expired on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.4 : GRANT
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.4 : GRANT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.5 : REVOKE
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.5 : REVOKE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.6 : GRANT ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.6 : GRANT ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.7 : REVOKE ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.8 : DROP USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.8 : DROP USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: The account management code will also check the table filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test cleanup
+#
+--echo #
+--echo # galera.acct.mgmt test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP DATABASE db1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+# Reset the database
+#
+--echo #
+--echo # Overall cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db;
+
+--echo # connection node_2
+--connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--echo # connection node_1
+--connection node_1
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_repl_filtersB.cnf
+++ b/mysql-test/suite/galera/t/galera_repl_filtersB.cnf
@@ -1,0 +1,11 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+replicate-wild-do-table=db.%
+
+[mysqld.2]
+replicate-wild-do-table=db1.%
+
+[mysqld.3]
+replicate-wild-do-table=db1.%
+

--- a/mysql-test/suite/galera/t/galera_repl_filtersB.test
+++ b/mysql-test/suite/galera/t/galera_repl_filtersB.test
@@ -1,0 +1,6882 @@
+#
+# Test how replication filters affects Galera replication
+# This test tests the behavior of the repliate-wild-do-table filter.
+#
+# The galera/galera_2node_slave.cnf describes the setup of the nodes
+#
+# async master
+# PXC node 2 and async slave
+# PXC node 3
+#
+# All nodes are configured the same:
+#	[mysqld]
+#	replicate-wild-do-table=db.%
+#	replicate-wild-do-table=db1.%
+#
+# We are testing to see that nodes 2 and 3 (which are PXC nodes),
+# maintain consistency when the async slave node is using replication filters.
+#
+# Database 'db' is allowed by the filters but is meant for tracking the PXC cluster
+# Database 'db1' is allowed by the filter
+# Database 'dbx' is not allowed by the filter
+# Database 'dbx1' is not allowed by the filter
+#
+# db and dbx are meant to be used for allowed/not allowed databases.
+# db also holds some test information and should not be deleted.
+#
+# db1 and dbx1 can be used for TABLE/DATABASE testing.
+#
+
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+--let $test_id = 0
+--let $show_rpl_debug_info = 0
+
+# Cluster setup
+# As node #1 is not a Galera node, we connect to node #2 in order to run
+# include/galera_cluster.inc
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--source include/galera_cluster.inc
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--disable_query_log
+--echo # connection node_2 : starting async slave
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START SLAVE USER='root';
+
+#
+# Create a database called db to hold various test case tracking tables.
+#
+--echo #
+--echo # Test preparation
+--echo #
+
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db;
+USE db; CREATE TABLE db.counter(id INT PRIMARY KEY AUTO_INCREMENT, count INT);
+# Also need to reset the test_id (since we had to drop the db database)
+--let $test_id = 0
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db" AND TABLE_NAME = "counter";
+-- source include/wait_condition.inc
+
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db" AND TABLE_NAME = "counter";
+-- source include/wait_condition.inc
+
+
+#
+# Create a separate database on all nodes, this database is not allowed to replicate
+#
+--connection node_1
+--echo # connection node_1
+CREATE DATABASE dbx;
+
+--connection node_2
+--echo # connection node_2
+CREATE DATABASE dbx;
+
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx";
+--source include/wait_condition.inc
+
+
+#==============================================================
+#
+# ASYNC-GALERA replication testing
+#
+# The tests below involve async replication and galera replication.
+# The intent is to test the affect of replication filters on
+# galera replication (when a PXC node is acting as an async slave).
+#
+#==============================================================
+
+
+
+#
+# Database DDL
+#
+
+
+#
+# Testcases async.db.ddl.1
+#	The default database (db) is allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+#
+# Test async.db.ddl.1.1 : CREATE DATABASE
+#		The default database is allowed.
+#		The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.1.1 : CREATE DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "db1 is on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test async.db.ddl.1.2 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.1.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test async.db.ddl.1.3 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.1.3 : DROP DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DROP database db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'db1';
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'db1';
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.db.ddl.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx, db1, etc...)
+#
+
+#
+# Test async.db.ddl.2.1 : CREATE DATABASE
+#		   The default database is allowed.
+#		   The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.2.1 : CREATE DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+--echo #
+--echo # Test preparation for async.db.ddl.2.2
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+#
+# Test async.db.ddl.2.2 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.2.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE db;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+
+
+#
+# Test async.db.ddl.2.3 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.2.3 : DROP DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; DROP database dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+#
+# Test async.db.ddl.2 cleanup
+#
+--echo # Test async.db.ddl.2 cleanup
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.db.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1)
+#
+
+#
+# Test async.db.ddl.3.1 : CREATE DATABASE
+#		   The default database is not allowed.
+#		   The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.3.1 : CREATE DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test async.db.ddl.3.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.3.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test async.db.ddl.3.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.3.3 : DROP DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 via async replication and
+# replicate to node_3 via galera replication.  The database of the
+# statement (db1) is checked rather than the default database (db).
+# So, since db1 is allowed, this statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; DROP DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.db.ddl.4
+#	The default database (dbx, db1) is not allowed.
+#	All operations are performed on an unallowed database (dbx, db1, db2, ...)
+#
+
+#
+# Test async.db.ddl.4.1 : CREATE DATABASE
+#		   The default database is not allowed.
+#		   The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.4.1 : CREATE DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+# prepare for next test
+--echo # prepare for next tests
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx2 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+#
+# Test async.db.ddl.4.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.4.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; ALTER database dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 1'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was not altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "$default_char_set" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+USE dbx;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test async.db.ddl.4.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.db.ddl.4.3 : DROP DATABASE
+--echo #
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or to node_3.
+# Since the database of the statement (dbx2) is checked rather
+# that the default database (db), the statement will be blocked
+# on node_2 on the async replication thread.
+#
+# NOTE: This statement will never reach node_3 since it gets filtered
+# out on node_2 by the replication filters on the async thread.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DROP DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+--echo #
+--echo # Test async.db.ddl.4 cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+--let $assert_text = 'dbx2 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+
+#
+# Table DDL
+#	CREATE TABLE
+#	DROP TABLE
+#	ALTER TABLE
+#	RENAME TABLE
+#	TRUNCATE TABLE
+#
+
+#
+# Test preparation
+# 	Create db1 and dbx1 on all nodes
+#
+--echo #
+--echo # async.tbl.ddl test preparation
+--echo #
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+CREATE DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = "db1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+#
+# Testcases async.tbl.ddl.1
+#	The default database (db) is allowed.
+#	The database of the table (db1) is allowed.
+#
+
+#
+# Test async.tbl.ddl.1.1 : CREATE TABLE
+#	The default database (db) is allowed.
+#	The database of the table (db1) is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test async.tbl.ddl.1.2 : ALTER TABLE
+#	The default database (db) is allowed.
+#	The database of the table (db1) is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+#
+# Test async.tbl.ddl.1.3 : RENAME TABLE
+#	The default database (db) is allowed.
+#	The database of the table (db1) is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1.t1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 'db1.t2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 'db1.t2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 'db1.t2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.1.4 : TRUNCATE TABLE
+#	The default database (db) is allowed.
+#	The database of the table (db1) is allowed.
+#
+--inc $test_id
+
+# Test preparation
+--echo #
+--echo # async.tbl.ddl.1.4 test preparation
+--echo #
+--echo # connection node_1
+--connection node_1
+USE db; INSERT INTO db1.t2(id) VALUES(1);
+
+--let $assert_text = "db1.t2 has a row on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM db1.t2
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t2 has a row on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = "db1.t2 has a row on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t2
+--source include/assert.inc
+
+
+--echo #
+--echo # Test async.tbl.ddl.1.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; TRUNCATE TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1.t2 is truncated on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.1.5 : DROP TABLE
+#	The default database (db) is allowed.
+#	The database of the table (db1) is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.1.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DROP TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.ddl.2
+#	The default database (db) is allowed.
+#	The database of the table (dbx1) is not allowed.
+#
+
+#
+# Test async.tbl.ddl.2.1 : CREATE TABLE
+#	The default database (db) is allowed.
+#	The database of the table (dbx1) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # async.tbl.dll.2.2 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.2.2 : ALTER TABLE
+#		The default database is allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.2.3 : RENAME TABLE
+#		The default database is allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.2.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+
+#
+# Test async.tbl.ddl.2.4 : TRUNCATE TABLE
+#		The default database is allowed.
+#		The database of the table being truncated is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test async.tbl.ddl.2.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is not truncated on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is not truncated on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.2.5 : DROP TABLE
+#		The default database is allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.2.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; DROP TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is on node_2 (DROP did not replicate)'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is on node_3 (DROP did not replicate)'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test cleanup
+#
+--echo #
+--echo # async.tbl.ddl.2 test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP TABLE dbx1.t2;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+
+
+
+#
+# Testcases async.tbl.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is allowed (db1)
+#
+
+#
+# Test async.tbl.ddl.3.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; CREATE TABLE db1.t1(id INT PRIMARY KEY);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_2 (replicated)'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3 (replicated)'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+
+--source include/assert.inc
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # restore table to original name
+--echo # connection node_1
+--connection node_1
+USE db; RENAME TABLE db1.t2 TO db1.t1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = "t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = "t1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.3.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_1
+--connection node_1
+USE db; INSERT INTO db1.t1(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT MAX(id) = 99 FROM db1.t1
+--source include/wait_condition.inc
+
+--let $assert_text = "Row added to db1.t1 on node_3"
+--let $assert_cond = MAX(id) = 99 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = "Row added to db1.t1 on node_2"
+--let $assert_cond = MAX(id) = 99 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being truncated is allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test async.tbl.ddl.3.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; TRUNCATE TABLE db1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1.t1 is truncated on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.3.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.3.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; DROP TABLE db1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Testcases async.tbl.ddl.4
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is not allowed (dbx)
+#
+
+#
+# Test async.tbl.ddl.4.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Prepare for the rest of the tests by creating this table on all nodes
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.4.2
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_3
+--connection node_3
+# Table dbx1.t1 creation replicates due to galera replication
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = "t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+
+#
+# Test async.tbl.ddl.4.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "dbx1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "dbx1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "dbx1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.ddl.4.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_1'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # restore table to original name
+--echo # connection node_1
+--connection node_1
+# Still use dbx since we don't want this command to replicate
+USE dbx; RENAME TABLE dbx1.t2 TO dbx1.t1;
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for async.tbl.ddl.4.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_1
+--connection node_1
+INSERT INTO dbx1.t1(id) VALUES(99);
+
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t1(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t1(id) VALUES(99);
+
+
+#
+# Test async.tbl.ddl.4.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test async.tbl.ddl.4.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; TRUNCATE TABLE dbx1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t1 is truncated on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t1 is not truncated on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t1 is not truncated on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t1
+--source include/assert.inc
+
+
+
+#
+# Test async.tbl.ddl.4.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.ddl.4.5 : DROP TABLE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DROP TABLE dbx1.t1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_1'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo #
+--echo # Test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP TABLE dbx1.t1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1" AND TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test cleanup
+#
+--echo #
+--echo # async.tbl.ddl test cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+DROP DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = "db1 is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1 is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Table DML (default db allowed, default db not allowed)
+#	Insert
+#	Update
+#	Delete
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # async.tbl.dml test preparation
+--echo #
+
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+CREATE DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = 'dbx1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+--echo # connection node_1
+--connection node_1
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db; CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+USE db; CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = "db1.t1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1.t2 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.dml.1
+#	The default database (db) is allowed.
+#	All table operations are performed on an allowed database (db1).
+#
+
+#
+# Test async.tbl.dml.1.1 : INSERT
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.1.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.1.2 : UPDATE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.1.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.1.3 : DELETE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.1.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE db; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete succeeded on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo #
+--echo # Testcase async.tbl.dml.1 cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+USE db; TRUNCATE TABLE db1.t1;
+
+
+
+#
+# Testcases async.tbl.dml.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test async.tbl.dml.2.1 : INSERT
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.2.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test async.tbl.dml.2 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test async.tbl.dml.2.2 : UPDATE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.2.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.2.3 : DELETE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.2.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase async.tbl.dml.2.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+
+#
+# Testcases async.tbl.dml.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+#
+# Test async.tbl.dml.3.1 : INSERT
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.3.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.3.2 : UPDATE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.3.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.3.3 : DELETE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.3.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will replicate to node_2 and node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_1:yes  node_2:yes  node_3:yes
+#
+USE dbx; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+
+
+#
+# Testcases async.tbl.dml.4
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test async.tbl.dml.4.1 : INSERT
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.4.1 : INSERT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test async.tbl.dml.4 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test async.tbl.dml.4.2 : UPDATE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.4.2 : UPDATE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test async.tbl.dml.4.3 : DELETE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.tbl.dml.4.3 : DELETE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 or node_3 since this
+# will not pass the table filters.
+#
+# NOTE: This statement will be blocked on node_2 and will not reach
+# node_3 at all.
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase async.tbl.dml.4.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+#
+# async.tbl.dml cleanup
+#
+--echo #
+--echo # async.tbl.dml test cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+DROP DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = 'dbx1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Account Management (default db allowed, default db not allowed)
+#	Create user
+#	Alter user
+#	Grant
+#	Revoke
+#	Grant all
+#	Revoke all
+#	Drop user
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # async.acct.mgmt test preparation
+--echo #
+--echo # connection node_1
+--connection node_1
+CREATE DATABASE db1;
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = 'db1.t1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Testcases async.acct.mgmt.1
+#	The default database is allowed.
+#
+
+#
+# Test async.acct.mgmt.1.1 : CREATE USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.1 : CREATE USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_2 (did not replicate)"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3 (did not replicate)"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--let $assert_debug = SELECT USER,HOST FROM mysql.user
+--source include/assert.inc
+
+
+#
+# async.acct.mgmt.1.2 test preparation
+#
+--echo #
+--echo # async.acct.mgmt.1.2 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# This will replicate to node_3 because galera replication does
+# not check replication filters for account management.
+USE db; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--let $assert_debug = SELECT USER,HOST,PASSWORD FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_2"
+--let $assert_cond = password = "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_3"
+--let $assert_cond = password = "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.3 : ALTER USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.3 : ALTER USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $assert_text = "User foo is not expired on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.4 : GRANT
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.4 : GRANT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # async.acct.mgmt.1.5 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.5 : REVOKE
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.5 : REVOKE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+#
+# Test cleanup
+#
+--echo #
+--echo # Test cleanup for async.acct.mgmt.1.5
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.6 : GRANT ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.6 : GRANT ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has NO access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has NO access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # async.acct.mgmt.1.6 test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.7 : REVOKE ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has no access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2 (did not replicate)"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--let $assert_debug = SELECT * FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AD USER = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3 (did not replicate)"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.1.8 : DROP USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.1.8 : DROP USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE db; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is not on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+#
+# Test cleanup async.acct.mgmt.1.7
+#
+--echo #
+--echo # async.acct.mgmt.1.7 test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; DROP USER "foo";
+
+--let $assert_text = 'User foo is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/wait_condition.inc
+
+--let $assert_text = "user foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/assert.inc
+
+
+#
+# Testcases async.acct.mgmt.2
+#	The default database (dbx) is not allowed.
+#
+
+#
+# Test async.acct.mgmt.2.1 : CREATE USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.1 : CREATE USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+#
+# Test prep for the rest of the test cases
+#
+--echo #
+--echo # Test preparation for async.acct.mgmt.2
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--let $assert_debug = SELECT USER,HOST,PASSWORD FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_2"
+--let $assert_cond = password = "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_3"
+--let $assert_cond = password = "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.3 : ALTER USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.3 : ALTER USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+--let $assert_text = "User foo is not expired on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is altered on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not altered on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.4 : GRANT
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.4 : GRANT
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+# Test preparation
+--echo #
+--echo # Test preparation for async.acct.mgmt.2.5
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.5 : REVOKE
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.5 : REVOKE
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+#
+# Test cleanup
+#
+--echo #
+--echo # Test cleanup for async.acct.mgmt.2.5
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.6 : GRANT ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.6 : GRANT ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+# Test preparation
+--echo #
+--echo # Test preparation for async.acct.mgmt.2.7
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.7 : REVOKE ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have access on db1.t1 on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test async.acct.mgmt.2.8 : DROP USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test async.acct.mgmt.2.8 : DROP USER
+--echo #
+
+--echo # connection node_1
+--connection node_1
+
+# EXPECTED: This will not replicate to node_2 because the table filters
+# will not allow the account management operation.
+#
+# NOTE: This statement will not replicate to node_3 (because for
+# account management, galera replication occurs after the replication filter
+# check)
+#
+# SUMMARY: node_1:yes  node_2:no  node_3:no
+#
+USE dbx; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is not on node_1"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+#
+# Test cleanup
+#
+--echo #
+--echo # async.acct.mgmt.2.8 test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; DROP USER "foo";
+--let $assert_text = "user foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/wait_condition.inc
+
+--let $assert_text = "user foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo"
+--source include/assert.inc
+
+
+#
+# Test cleanup
+#
+--echo #
+--echo # async.acct.mgmt test cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#==============================================================
+#
+# GALERA-GALERA replication testing
+# The tests from here down do not involve async replication.
+# The purpose is to test the affect of the replication filters
+# on galera replication.
+#
+# For galera replication, replication filters are not checked
+# for statement-based replication.  However, the filters are
+# checked for row-based replication.
+#
+#==============================================================
+
+
+
+#
+# Database DDL
+#
+
+
+#
+# Testcases galera.db.ddl.1
+#	The default database (db) is allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+
+#
+# Test galera.db.ddl.1.1 : CREATE DATABASE
+#		The default database is allowed.
+#		The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.1.1 : CREATE DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "db1 is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.1.2 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.1.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test galera.db.ddl.1.3 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.1.3 : DROP DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP database db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.db.ddl.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx, db1, etc...)
+#
+
+#
+# Test galera.db.ddl.2.1 : CREATE DATABASE
+#		   The default database is allowed.
+#		   The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.2.1 : CREATE DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+#
+# Test galera.db.ddl.2.2 : DROP DATABASE
+#		The default database is allowed.
+#		The database being dropped is not allowed.
+#
+--inc $test_id
+
+#
+# This setup requires that the database exist on all nodes.
+#
+--echo #
+--echo # galera.db.ddl.2.2 test preparation
+--echo #
+
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+--let $assert_text = "dbx2 is on node_3"
+--let $assert_cond = COUNT(*) FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+--echo #
+--echo # Test galera.db.ddl.2.2 : DROP DATABASE
+--echo #
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP database dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+#
+# Recreate database dbx2 for the next test
+#
+--echo #
+--echo # Test preparation for galera.db.ddl.2.3
+--echo #
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.2.3 : ALTER DATABASE
+#		The default database is allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.2.3 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER DATABASE dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE db;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+#
+# Test galera.db.ddl.2 cleanup
+#
+--echo # Test galera.db.ddl.2 cleanup
+--echo # connection node_2
+--connection node_2
+DROP DATABASE dbx2;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2";
+--source include/wait_condition.inc
+
+
+
+#
+# Testcases galera.db.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1)
+#
+
+#
+# Test galera.db.ddl.3.1 : CREATE DATABASE
+#	The default database is not allowed.
+#	The database being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.3.1 : CREATE DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.3.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.3.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER database db1 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE db1;
+eval ALTER database db1 CHARACTER SET = '$default_char_set';
+
+
+
+#
+# Test galera.db.ddl.3.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.3.3 : DROP DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP DATABASE db1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.db.ddl.4
+#	The default database (dbx, db1) is not allowed.
+#	All operations are performed on an unallowed database (dbx, db1, db2, ...)
+#
+
+#
+# Test galera.db.ddl.4.1 : CREATE DATABASE
+#	The default database is not allowed.
+#	The database being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.4.1 : CREATE DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+#
+# Test galera.db.ddl.4.2 : ALTER DATABASE
+#		The default database is not allowed.
+#		The database being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.4.2 : ALTER DATABASE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+--let $default_char_set = `SELECT DEFAULT_CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER database dbx2 CHARACTER SET = "latin7";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 was altered on node 2'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 was altered on node 3'
+--let $assert_cond = DEFAULT_CHARACTER_SET_NAME = "latin7" FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+USE dbx;
+eval ALTER database dbx2 CHARACTER SET = '$default_char_set';
+
+
+#
+# Test galera.db.ddl.4.3 : DROP DATABASE
+#		   The default database is not allowed.
+#		   The database being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.db.ddl.4.3 : DROP DATABASE
+--echo #
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP DATABASE dbx2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx2"
+--source include/assert.inc
+
+
+
+#
+# Table DDL
+#	CREATE TABLE
+#	DROP TABLE
+#	ALTER TABLE
+#	RENAME TABLE
+#	TRUNCATE TABLE
+#
+
+#
+# Test preparation
+# 	Create db1 and dbx1 on all nodes
+#
+--echo #
+--echo # galera.tbl.ddl test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+#
+# Testcases galera.tbl.ddl.1
+#	The default database (dbx, db1) is allowed.
+#	All operations are performed on a table in an allowed database (db)
+#
+
+#
+# Test galera.tbl.ddl.1.1 : CREATE TABLE
+#		The default database is allowed.
+#		The database of the table being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+#
+# Test galera.tbl.ddl.1.2 : ALTER TABLE
+#		The default database is allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+#
+# Test galera.tbl.ddl.1.3 : RENAME TABLE
+#		The default database is allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.1.4 : TRUNCATE TABLE
+#		The default database is allowed.
+#		The database of the table being truncated is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; TRUNCATE TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.1.5 : DROP TABLE
+#		The default database is allowed.
+#		The database of the table being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.1.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.ddl.2
+#	The default database (db) is allowed.
+#	All operations are performed on a table in a database that is not allowed (dbx1)
+#
+
+#
+# Test galera.tbl.ddl.2.1 : CREATE TABLE
+#		The default database is allowed.
+#		The database of the table being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE TABLE dbx1.t1(id INT PRIMARY KEY);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.2.2 : ALTER TABLE
+#		The default database is allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.2.3 : RENAME TABLE
+#		The default database is allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for galera.tbl.ddl.2.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+
+#
+# Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
+#		The default database is allowed.
+#		The database of the table being truncated is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.2.5 : DROP TABLE
+#		The default database is allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.2.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.ddl.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is allowed (db1)
+#
+
+#
+# Test galera.tbl.ddl.3.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER TABLE db1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; RENAME TABLE db1.t1 TO db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for galera.tbl.ddl.3.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+USE db; INSERT INTO db1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT MAX(id) = 99 FROM db1.t2
+--source include/wait_condition.inc
+
+--let $assert_text = "Row added to db1.t2 on node_3"
+--let $assert_cond = MAX(id) = 99 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being truncated is allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test galera.tbl.ddl.3.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; TRUNCATE TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'db1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM db1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.3.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.3.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP TABLE db1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.ddl.4
+#	The default database (dbx) is not allowed.
+#	All operations are performed on a table in a database that is not allowed (dbx)
+#
+
+#
+# Test galera.tbl.ddl.4.1 : CREATE TABLE
+#		The default database is not allowed.
+#		The database of the table being created is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.1 : CREATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE TABLE dbx1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.4.2 : ALTER TABLE
+#		The default database is not allowed.
+#		The database of the table being altered is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.2 : ALTER TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER TABLE dbx1.t1 ADD COLUMN x3 LONGBLOB;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1.x3 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1.x3 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = "t1" AND COLUMN_NAME="x3"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.4.3 : RENAME TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.3 : RENAME TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; RENAME TABLE dbx1.t1 TO dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't1 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_2'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = 't2 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test preparation for galera.tbl.ddl.4.4
+--echo #
+
+# Add some data to the table to see if the truncate statement is run
+--echo # connection node_2
+--connection node_2
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(99);
+
+
+#
+# Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
+#		The default database is not allowed.
+#		The database of the table being renamed is not allowed.
+#
+--inc $test_id
+
+
+--echo #
+--echo # Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; TRUNCATE TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 'dbx1.t2 is truncated on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 'dbx1.t2 is truncated on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.ddl.4.5 : DROP TABLE
+#		The default database is not allowed.
+#		The database of the table being dropped is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.ddl.4.5 : DROP TABLE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP TABLE dbx1.t2;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = 't2 is not on node_2'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--let $assert_debug = SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "dbx1"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = 't2 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Test cleanup
+#
+--echo #
+--echo # galera.tbl.ddl test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1 is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1 is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Table DML (default db allowed, default db not allowed)
+#	Insert
+#	Update
+#	Delete
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # galera.tbl.dml test preparation
+--echo #
+
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE db1;
+CREATE DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = 'dbx1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+--echo # connection node_2
+--connection node_2
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+USE db; CREATE TABLE dbx1.t2(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/wait_condition.inc
+
+--let $assert_text = "db1.t1 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/assert.inc
+
+--let $assert_text = "dbx1.t2 is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t2"
+--source include/assert.inc
+
+
+#
+# Testcases galera.tbl.dml.1
+#	The default database (db) is allowed.
+#	All table operations are performed on an allowed database (db1).
+#
+
+#
+# Test galera.tbl.dml.1.1 : INSERT
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.1.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.1.2 : UPDATE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.1.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update succeeded on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.1.3 : DELETE
+#		The default database is allowed.
+#		The database of the table being modified is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.1.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete succeeded on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.dml.2
+#	The default database (db) is allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test galera.tbl.dml.2.1 : INSERT
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.2.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 since this
+# will not pass the table filters.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE db; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test galera.tbl.dml.2 test preparation
+--echo #
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test galera.tbl.dml.2.2 : UPDATE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.2.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 since this
+# will not pass the table filters.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.2.3 : DELETE
+#		The default database is allowed.
+#		All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.2.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 since this
+# will not pass the table filters.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE db; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase galera.tbl.dml.2.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+
+#
+# Testcases galera.tbl.dml.3
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+
+#
+# Test galera.tbl.dml.3.1 : INSERT
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.3.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; INSERT INTO db1.t1(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert replicated to node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.3.2 : UPDATE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.3.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; UPDATE db1.t1 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM db1.t1 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.3.3 : DELETE
+#	The default database (dbx) is not allowed.
+#	All operations are performed on an allowed database (db1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.3.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3.
+# Since there are no database filters, and the table filters
+# allow db.% and db1.% the statement will replicate.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DELETE FROM db1.t1 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM db1.t1
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.tbl.dml.4
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+
+#
+# Test galera.tbl.dml.4.1 : INSERT
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.4.1 : INSERT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 since this
+# will not pass the table filters.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Insert succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Insert not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+#
+# Test preparation
+#
+--echo #
+--echo # Test galera.tbl.dml.4 test preparation
+--echo #
+--echo # connection node_3
+--connection node_3
+INSERT INTO dbx1.t2(id) VALUES(1);
+
+
+#
+# Test galera.tbl.dml.4.2 : UPDATE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.4.2 : UPDATE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 since this
+# will not pass the table filters.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Update succeeded on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Update not replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--source include/assert.inc
+
+
+#
+# Test galera.tbl.dml.4.3 : DELETE
+#	The default database (db) is not allowed.
+#	All operations are performed on a database that is not allowed (dbx1).
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.tbl.dml.4.3 : DELETE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will not replicate to node_3 since this
+# will not pass the table filters.
+#
+# SUMMARY: node_2:yes  node_3:no
+#
+USE dbx; DELETE FROM dbx1.t2 WHERE id = 1;
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "Delete succeeded on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "Delete not replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
+
+--echo #
+--echo # Testcase galera.tbl.dml.4.3 cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+USE db; TRUNCATE TABLE dbx1.t2;
+
+--echo # connection node_3
+--connection node_3
+USE db; TRUNCATE TABLE dbx1.t2;
+
+
+#
+# galera.tbl.dml cleanup
+#
+--echo #
+--echo # galera.tbl.dml test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP DATABASE db1;
+DROP DATABASE dbx1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+--let $assert_text = 'dbx1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "dbx1"
+--source include/assert.inc
+
+
+
+#
+# Account Management (default db allowed, default db not allowed)
+#	Create user
+#	Alter user
+#	Grant
+#	Revoke
+#	Grant all
+#	Revoke all
+#	Drop user
+#
+
+#
+# Test preparation
+#
+--echo #
+--echo # galera.acct.mgmt test preparation
+--echo #
+--echo # connection node_2
+--connection node_2
+CREATE DATABASE db1;
+USE db; CREATE TABLE db1.t1(id INT PRIMARY KEY, f2 LONGBLOB);
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1.t1 is on node_3'
+--let $assert_cond = COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = "db1" AND TABLE_NAME = "t1"
+--source include/assert.inc
+
+
+#
+# Testcases galera.acct.mgmt.1
+#	The default database is allowed.
+#
+
+#
+# Test galera.acct.mgmt.1.1 : CREATE USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.1 : CREATE USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_2"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--let $assert_debug = SELECT USER,HOST,PASSWORD FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_3"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.3 : ALTER USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.3 : ALTER USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $assert_text = "User foo is not expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is expired on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.4 : GRANT
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.4 : GRANT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.5 : REVOKE
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.5 : REVOKE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.6 : GRANT ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.6 : GRANT ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.7 : REVOKE ALL
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has no access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--let $assert_debug = SELECT * FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AD USER = "foo"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has no access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.1.8 : DROP USER
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.1.8 : DROP USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE db; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+
+#
+# Testcases galera.acct.mgmt.2
+#	The default database (dbx) is not allowed.
+#
+
+#
+# Test galera.acct.mgmt.2.1 : CREATE USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.1 : CREATE USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; CREATE USER "foo"@"%" IDENTIFIED BY "bar";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.2 : CHANGE PASSWORD
+#	The default database is allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.2 : CHANGE PASSWORD
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $user_password = `SELECT password FROM mysql.user WHERE USER = "foo"`
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; SET PASSWORD FOR "foo"@"%" = PASSWORD("notapassword");
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is altered on node_2"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--let $assert_debug = SELECT USER,HOST,PASSWORD FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is altered on node_3"
+--let $assert_cond = password != "$user_password" FROM mysql.user WHERE user = "foo"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.3 : ALTER USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.3 : ALTER USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+--let $assert_text = "User foo is not expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "N"
+--source include/assert.inc
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; ALTER USER "foo"@"%" PASSWORD EXPIRE;
+
+--let $assert_text = "User foo is expired on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is expired on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE user = "foo" AND password_expired = "Y"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.4 : GRANT
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.4 : GRANT
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; GRANT SELECT ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.5 : REVOKE
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.5 : REVOKE
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; REVOKE SELECT ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have SELECT access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV = "Select"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.6 : GRANT ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.6 : GRANT ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; GRANT ALL ON db1.t1 TO "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo has ALL access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 1 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.7 : REVOKE ALL
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.7 : REVOKE ALL
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; REVOKE ALL ON db1.t1 FROM "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo does not have access on db1.t1 on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo does not have access on db1.t1 on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.tables_priv WHERE TABLE_NAME = "t1" AND USER = "foo" AND TABLE_PRIV LIKE "Select%Insert%Update%Delete%"
+--source include/assert.inc
+
+
+#
+# Test galera.acct.mgmt.2.8 : DROP USER
+#	The default database (dbx) is not allowed.
+#
+--inc $test_id
+
+--echo #
+--echo # Test galera.acct.mgmt.2.8 : DROP USER
+--echo #
+
+--echo # connection node_2
+--connection node_2
+
+# EXPECTED: This will replicate to node_3 via galera replication.
+# For statement-based replication, the galera replication thread
+# will not check with the database filters.
+#
+# NOTE: Since galera replication is not running on the async slave
+# thread, the table filters will not be checked.
+#
+# SUMMARY: node_2:yes  node_3:yes
+#
+USE dbx; DROP USER "foo"@"%";
+
+--eval INSERT INTO db.counter(count) VALUES($test_id)
+
+--let $assert_text = "User foo is not on node_2"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--let $assert_debug = SELECT USER, HOST FROM mysql.user
+--source include/assert.inc
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
+--source include/wait_condition.inc
+
+--let $assert_text = "User foo is not on node_3"
+--let $assert_cond = COUNT(*) = 0 FROM mysql.user WHERE USER = "foo";
+--source include/assert.inc
+
+
+#
+# Test cleanup
+#
+--echo #
+--echo # galera.acct.mgmt test cleanup
+--echo #
+--echo # connection node_2
+--connection node_2
+DROP DATABASE db1;
+
+--echo # connection node_3
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/wait_condition.inc
+
+--let $assert_text = 'db1 is not on node_3'
+--let $assert_cond = COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = "db1"
+--source include/assert.inc
+
+
+
+# Reset the database
+#
+--echo #
+--echo # Overall cleanup
+--echo #
+--echo # connection node_1
+--connection node_1
+DROP DATABASE db;
+
+--echo # connection node_2
+--connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--echo # connection node_1
+--connection node_1
+RESET MASTER;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5030,7 +5030,7 @@ end_with_restore_list:
     if (check_access(thd, INSERT_ACL, "mysql", NULL, NULL, 1, 1) &&
         check_global_access(thd,CREATE_USER_ACL))
       break;
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    /* WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL) called in mysql_create_user */
     /* Conditionally writes to binlog */
     if (!(res= mysql_create_user(thd, lex->users_list)))
       my_ok(thd);
@@ -5042,7 +5042,7 @@ end_with_restore_list:
         check_global_access(thd,CREATE_USER_ACL))
       break;
     /* Conditionally writes to binlog */
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    /* WSREP_TO_ISOLATION_BEGIN() called in mysql_drop_user */
     if (!(res= mysql_drop_user(thd, lex->users_list)))
       my_ok(thd);
     break;
@@ -5053,7 +5053,7 @@ end_with_restore_list:
         check_global_access(thd,CREATE_USER_ACL))
       break;
     /* Conditionally writes to binlog */
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    /* WSREP_TO_ISOLATION_BEGIN() called in mysql_rename_user */
     if (!(res= mysql_rename_user(thd, lex->users_list)))
       my_ok(thd);
     break;
@@ -5068,7 +5068,7 @@ end_with_restore_list:
     thd->binlog_invoker();
 
     /* Conditionally writes to binlog */
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+    /* WSREP_TO_ISOLATION_BEGIN() called in mysql_revoke_all */
     if (!(res = mysql_revoke_all(thd, lex->users_list)))
       my_ok(thd);
     break;
@@ -5135,7 +5135,7 @@ end_with_restore_list:
                                 lex->type == TYPE_ENUM_PROCEDURE, 0))
 	  goto error;
         /* Conditionally writes to binlog */
-        WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+        /* WSREP_TO_ISOLATION_BEGIN() called in mysql_routine_grant */
         res= mysql_routine_grant(thd, all_tables,
                                  lex->type == TYPE_ENUM_PROCEDURE, 
                                  lex->users_list, grants,
@@ -5149,7 +5149,7 @@ end_with_restore_list:
                         all_tables, FALSE, UINT_MAX, FALSE))
 	  goto error;
         /* Conditionally writes to binlog */
-        WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+        /* WSREP_TO_ISOLATION_BEGIN() called in mysql_table_grant */
         res= mysql_table_grant(thd, all_tables, lex->users_list,
 			       lex->columns, lex->grant,
 			       lex->sql_command == SQLCOM_REVOKE);
@@ -5165,7 +5165,7 @@ end_with_restore_list:
       }
       else
       {
-          WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+        /* WSREP_TO_ISOLATION_BEGIN() called in mysql_grant */
         /* Conditionally writes to binlog */
         res = mysql_grant(thd, select_lex->db, lex->users_list, lex->grant,
                           lex->sql_command == SQLCOM_REVOKE,
@@ -6180,9 +6180,7 @@ create_sp_error:
     if (check_access(thd, UPDATE_ACL, "mysql", NULL, NULL, 1, 1) &&
         check_global_access(thd, CREATE_USER_ACL))
       break;
-#ifdef WITH_WSREP
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
-#endif /* WITH_WSREP */
+    /* WSREP_TO_ISOLATION_BEGIN() called inside mysql_user_password_expire */
     /* Conditionally writes to binlog */
     if (!(res= mysql_user_password_expire(thd, lex->users_list)))
       my_ok(thd);


### PR DESCRIPTION
…tements (CREATE USER)

Issue:
There is a different code path for account management statements
(such as CREATE USER, DROP USER, etc..).  For these cases, the replication
filters are checked only for the async slave thread.  The galera applier
threads, therefore, do not check the replication filters.  In addition,
the replication filter check occurs AFTER the statement is replicated
by galera.  This leads to the CREATE USER being galera replicated and
applied on the other galera nodes, but being blocked by the replication
filter on the async slave thread on the async slave node.

Solution
Move the galera replication code to occur AFTER the replication filter
check.  This will apply only to the account management statements to
avoid USER account inconsistency between galera nodes.