### PR TITLE
PXC-2038: Update URLs in PXC to use jira not launchpad

### DIFF
--- a/README
+++ b/README
@@ -9,4 +9,5 @@ https://www.percona.com/software/mysql-database/percona-xtradb-cluster
 
 Documentation: https://www.percona.com/doc/percona-xtradb-cluster/5.6/index.html
 
-Launchpad (bugs, milestones, branches): https://bugs.launchpad.net/percona-xtradb-cluster/
+Jira (bugs): https://jira.percona.com/projects/PXC/issues
+

--- a/doc/source/howtos/bugreport.rst
+++ b/doc/source/howtos/bugreport.rst
@@ -3,4 +3,4 @@
 How to Report Bugs
 ==================
 
-All bugs can be reported on `Launchpad <https://bugs.launchpad.net/percona-xtradb-cluster/+filebug>`_. Please note that error.log files from **all** the nodes need to be submitted. 
+All bugs can be reported on `jira.percona.com <https://jira.percona.com/projects/PXC/issues>`_. Please note that error.log files from **all** the nodes need to be submitted. 

--- a/scripts/mysql_install_db.pl.in
+++ b/scripts/mysql_install_db.pl.in
@@ -905,7 +905,7 @@ if ( open(PIPE, "| $mysqld_install_cmd_line") )
              "  cd mysql-test ; perl mysql-test-run.pl");
     }
     report($opt,
-           "Please report any problems with Percona XtraDB Cluster 5.6 at https://bugs.launchpad.net/percona-xtradb-cluster/+filebug",
+           "Please report any problems with Percona XtraDB Cluster 5.6 at https://jira.percona.com/projects/PXC/issues",
            "",
            "The latest information about Percona XtraDB Cluster 5.6 is available on the web at",
            "",
@@ -973,7 +973,7 @@ else
         "Another information source is the MySQL email archive.",
         "",
         "Please check all of the above before submitting a bug report at",
-        "  https://bugs.launchpad.net/percona-xtradb-cluster/+filebug")
+        "  https://jira.percona.com/projects/PXC/issues")
 }
 
 ##############################################################################

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -427,7 +427,7 @@ else
   echo "MySQL email archives available at http://lists.mysql.com/."
   echo
   echo "Please check all of the above before submitting a bug report at"
-  echo "  https://bugs.launchpad.net/percona-xtradb-cluster/+filebug"
+  echo "  https://jira.percona.com/projects/PXC/issues"
   echo
   exit 1
 fi
@@ -479,7 +479,7 @@ then
 
   echo
   echo "Please report any problems at"
-  echo "  https://bugs.launchpad.net/percona-xtradb-cluster/+filebug"
+  echo "  https://jira.percona.com/projects/PXC/issues"
   echo
   echo "Percona recommends that all production deployments be protected with a support"
   echo "contract (http://www.percona.com/mysql-suppport/) to ensure the highest uptime,"

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -111,7 +111,7 @@ extern "C" sig_handler handle_fatal_signal(int sig)
     "diagnose the problem, but since we have already crashed, \n"
     "something is definitely wrong and this may fail.\n"
     "Please help us make Percona XtraDB Cluster better by reporting any\n"
-    "bugs at https://bugs.launchpad.net/percona-xtradb-cluster\n\n");
+    "bugs at https://jira.percona.com/projects/PXC/issues\n\n");
 
   my_safe_printf_stderr("key_buffer_size=%lu\n",
                         (ulong) dflt_key_cache->key_cache_mem_size);


### PR DESCRIPTION
Issue
URLs used in PXC (for bug reporting) use launchpad.

Solution
Change URLs to use point to jira.percona.com not launchpad.