### PR TITLE
[PXC-840] Fix alias for PXC 5.6

### DIFF
--- a/build-ps/rpm/mysql.service
+++ b/build-ps/rpm/mysql.service
@@ -12,7 +12,7 @@ After=network.target syslog.target
 
 [Install]
 WantedBy=multi-user.target
-Alias=mysql.service
+Alias=mysqld.service
 
 [Service]
 # Needed to create system tables etc.


### PR DESCRIPTION
Below issue also affects PXC 5.6. Backported fix to PXC 5.6

systemd configuration for PXC 5.7 has alias typo leading to error when enable called twice
https://jira.percona.com/browse/PXC-840
