### PR TITLE
- PXC#2066: PXC multiple transaction recovery hits debug assert

### DIFF
--- a/storage/innobase/include/trx0sys.h
+++ b/storage/innobase/include/trx0sys.h
@@ -293,7 +293,9 @@ void
 trx_sys_update_wsrep_checkpoint(
         const XID*      xid,         /*!< in: WSREP XID */
         trx_sysf_t*     sys_header,  /*!< in: sys_header */
-        mtr_t*          mtr);        /*!< in: mtr       */
+        mtr_t*          mtr,         /*!< in: mtr       */
+        bool            recovery = false);
+                                     /*!< in: running recovery */
 
 void
 /** Read WSREP checkpoint XID from sys header. */

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1777,7 +1777,7 @@ trx_write_serialisation_history(
 	else if (trx->wsrep_recover_xid)
 	{
 		trx_sys_update_wsrep_checkpoint(
-				trx->wsrep_recover_xid, sys_header, mtr);
+				trx->wsrep_recover_xid, sys_header, mtr, true);
 		trx->wsrep_recover_xid = NULL;
 	}
 #endif /* WITH_WSREP */


### PR DESCRIPTION
  xid_seqno > trx_sys_cur_xid_seqno

  Problem:
  -------
  - When recovery happens prepare transactions are revived based on
    undo-log entries in InnoDB. This order may not match with the
    commit order logged to binlog.
  - Sequence matching is not needed for MySQL as standalone.
    Aim is to just ensure that all prepare stage transaction are marked
    as committed.

  - But in PXC the commit order of recover transaction should be same as
    it would be if transaction are running normally or we need to ensure
    that only the latest seen xid is updated and persisted as wsrep recover
    position co-ordinates.

  Patch takes latter approach and ensure only the latest seen xid is updated.