### PR TITLE
PXC-2059 : Create trigger is failing on PXC 5.6.29 node with error th…

### DIFF
--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -438,14 +438,30 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
   if (!trust_function_creators                                && 
       (WSREP_EMULATE_BINLOG(thd) || mysql_bin_log.is_open())  &&
       !(thd->security_ctx->master_access & SUPER_ACL))
+  {
+    /*
+      If WSREP is enabled, then we are ALWAYS doing binlog
+      replication of some sort, and we always require the SUPER
+      privilege (or trust_function_creators).
+      So there is no need to mention anything about the binlog.
+    */
+    if (WSREP(thd))
+      my_message(ER_BINLOG_CREATE_ROUTINE_NEED_SUPER,
+                "You do not have the SUPER privilege"
+                " (you *might* want to use the less safe log_bin_trust_function_creators variable)",
+                MYF(0));
+    else
+      my_error(ER_BINLOG_CREATE_ROUTINE_NEED_SUPER, MYF(0));
+    DBUG_RETURN(TRUE);
+  }
 #else
   if (!trust_function_creators && mysql_bin_log.is_open() &&
       !(thd->security_ctx->master_access & SUPER_ACL))
-#endif /* WITH_WSREP */
   {
     my_error(ER_BINLOG_CREATE_ROUTINE_NEED_SUPER, MYF(0));
     DBUG_RETURN(TRUE);
   }
+#endif /* WITH_WSREP */
 
   if (!create)
   {


### PR DESCRIPTION
…at binary logging is enabled but log_bin is OFF

Issue:
WSREP emulates the binlog when the real binlog is disabled.  Thus the requirement
for CREATE TRIGGER requires the SUPER privilege (or trust_function_creators) all
the time when WSREP is used.

Solution:
Change the error message to reflect the fact that the SUPER privilege is required.