### PR TITLE
PXC-2061 : PXC 5.7: wsrep_sync_wait not working

### DIFF
--- a/mysql-test/suite/galera/r/MW-86-wait1.result
+++ b/mysql-test/suite/galera/r/MW-86-wait1.result
@@ -35,6 +35,29 @@ SET GLOBAL debug = "-d,sync.wsrep_apply_cb";
 SET SESSION debug_sync = "now SIGNAL signal.wsrep_apply_cb";
 SET SESSION wsrep_sync_wait = default;
 DROP TABLE t_wait1;
+SET GLOBAL wsrep_provider_options = 'repl.causal_read_timeout=PT0.5S';
+# Node 1
+CREATE TABLE t1(id INT PRIMARY KEY);
+# Node 2 : block at the point right after we have left the commit monitor
+SET GLOBAL wsrep_provider_options = 'dbug=d,sync.applier_interim_commit.after_commit_leave';
+# Node 1 : Perform the insert. This will succeed on node1 but will block on node2
+INSERT INTO t1 VALUES(1);
+# Node 2 : Wait for the commit point
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET SESSION wsrep_sync_wait = 1;
+# Node 2 : try a SELECT, this should timeout
+SELECT COUNT(*) FROM t1;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+# Node 2 : Unblock the commit point
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=sync.applier_interim_commit.after_commit_leave';
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
+SET SESSION wsrep_sync_wait = default;
+DROP TABLE t1;
 SELECT @@debug_sync;
 @@debug_sync
 ON - signals: ''

--- a/mysql-test/suite/galera/t/MW-86-wait1.test
+++ b/mysql-test/suite/galera/t/MW-86-wait1.test
@@ -99,5 +99,58 @@ SET SESSION wsrep_sync_wait = default;
 # from the test.
 DROP TABLE t_wait1;
 
+#----
+# Additional PXC test - See Jira PXC-2061
+# This tests to see if a SELECT (with wsrep_sync_wait=1) waits until
+# the transaction has been applied.
+#----
+--let $show_rpl_debug_info = 0
+
+--connection node_2
+--let $wsrep_provider_options_saved = `SELECT @@wsrep_provider_options`
+SET GLOBAL wsrep_provider_options = 'repl.causal_read_timeout=PT0.5S';
+
+
+--connection node_1
+--echo # Node 1
+CREATE TABLE t1(id INT PRIMARY KEY);
+
+--connection node_2
+--echo # Node 2 : block at the point right after we have left the commit monitor
+--let $galera_sync_point = sync.applier_interim_commit.after_commit_leave
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+--echo # Node 1 : Perform the insert. This will succeed on node1 but will block on node2
+INSERT INTO t1 VALUES(1);
+
+--connection node_2
+--echo # Node 2 : Wait for the commit point
+SET SESSION wsrep_sync_wait = 0;
+--source include/galera_wait_sync_point.inc
+SET SESSION wsrep_sync_wait = 1;
+
+# This should timeout since we are waiting for the apply monitor to clear
+--echo # Node 2 : try a SELECT, this should timeout
+--error ER_LOCK_WAIT_TIMEOUT
+SELECT COUNT(*) FROM t1;
+
+--echo # Node 2 : Unblock the commit point
+--source include/galera_clear_sync_point.inc
+--source include/galera_signal_sync_point.inc
+
+#--echo # Node 2 : run the query
+# This should return after the INSERT has been applied
+SELECT COUNT(*) FROM t1;
+
+--connection node_2
+--disable_query_log
+--eval SET GLOBAL wsrep_provider_options = "$wsrep_provider_options_saved";
+--enable_query_log
+SET SESSION wsrep_sync_wait = default;
+DROP TABLE t1;
+
+
+
 # Make sure no pending signals are leftover to surprise subsequent tests.
 SELECT @@debug_sync;


### PR DESCRIPTION
Issue:
When "wsrep_sync_wait=1", which enforces read causality, we can read
the wrong values, depending on timing. This happens because we are
waiting on the commit monitor to be flushed.

Solution:
We need to wait upon the apply monitor instead of the commit monitor.