### PR TITLE
- PXC#2072: "flush table <table> for export" should be blocked with m…

### DIFF
--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -5,8 +5,8 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of RELEASE_LOCK");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of GET_LOCK");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of RELEASE_LOCK");
-call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK");
-call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of CREATE TABLE AS SELECT");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of CREATE TABLE AS SELECT");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend setting binlog_format to STATEMENT or MIXED");
@@ -971,6 +971,8 @@ release_lock('a')
 1
 flush table tinnodb with read lock;
 unlock tables;
+flush table tinnodb for export;
+unlock tables;
 set session transaction isolation level serializable;
 flush table with read lock;
 unlock tables;
@@ -1005,6 +1007,8 @@ select release_lock('a');
 release_lock('a')
 1
 flush table tinnodb with read lock;
+unlock tables;
+flush table tinnodb for export;
 unlock tables;
 set session transaction isolation level serializable;
 flush table with read lock;
@@ -1053,6 +1057,10 @@ flush table tinnodb with read lock;
 Warnings:
 Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK with pxc_strict_mode = PERMISSIVE
 unlock tables;
+flush table tinnodb for export;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK with pxc_strict_mode = PERMISSIVE
+unlock tables;
 set session transaction isolation level serializable;
 Warnings:
 Warning	1105	Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = PERMISSIVE
@@ -1084,17 +1092,20 @@ i
 1
 2
 lock table tinnodb read;
-ERROR HY000: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK with pxc_strict_mode = ENFORCING
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT with pxc_strict_mode = ENFORCING
 unlock tables;
 lock table tinnodb write;
-ERROR HY000: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK with pxc_strict_mode = ENFORCING
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT with pxc_strict_mode = ENFORCING
 unlock tables;
 select get_lock('a', 10);
 ERROR HY000: Percona-XtraDB-Cluster prohibits use of GET_LOCK with pxc_strict_mode = ENFORCING
 select release_lock('a');
 ERROR HY000: Percona-XtraDB-Cluster prohibits use of RELEASE_LOCK with pxc_strict_mode = ENFORCING
 flush table tinnodb with read lock;
-ERROR HY000: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK with pxc_strict_mode = ENFORCING
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT with pxc_strict_mode = ENFORCING
+unlock tables;
+flush table tinnodb for export;
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT with pxc_strict_mode = ENFORCING
 unlock tables;
 set session transaction isolation level serializable;
 ERROR HY000: Percona-XtraDB-Cluster doesn't recommend using SERIALIZABLE isolation with pxc_strict_mode = ENFORCING

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -32,8 +32,8 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of GET_LOCK");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of RELEASE_LOCK");
 
-call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK");
-call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT");
+call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of LOCK TABLE/FLUSH TABLE <table> WITH READ LOCK/FOR EXPORT");
 
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of CREATE TABLE AS SELECT");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of CREATE TABLE AS SELECT");
@@ -1042,6 +1042,8 @@ select get_lock('a', 10);
 select release_lock('a');
 flush table tinnodb with read lock;
 unlock tables;
+flush table tinnodb for export;
+unlock tables;
 set session transaction isolation level serializable;
 #
 # they should continue to work ir-respective of mode.
@@ -1077,6 +1079,8 @@ unlock tables;
 select get_lock('a', 10);
 select release_lock('a');
 flush table tinnodb with read lock;
+unlock tables;
+flush table tinnodb for export;
 unlock tables;
 set session transaction isolation level serializable;
 #
@@ -1115,6 +1119,8 @@ unlock tables;
 select get_lock('a', 10);
 select release_lock('a');
 flush table tinnodb with read lock;
+unlock tables;
+flush table tinnodb for export;
 unlock tables;
 set session transaction isolation level serializable;
 #
@@ -1161,6 +1167,9 @@ select get_lock('a', 10);
 select release_lock('a');
 --error ER_UNKNOWN_ERROR
 flush table tinnodb with read lock;
+unlock tables;
+--error ER_UNKNOWN_ERROR
+flush table tinnodb for export;
 unlock tables;
 --error ER_UNKNOWN_ERROR
 set session transaction isolation level serializable;


### PR DESCRIPTION
…ode=ENFORCING

  - FLUSH TABLE FOR EXPORT is meant to lock table and flush all related
    logs to prepare table for export.

  - This command is local to the node and is not replicated.

  - Just like FLUSH TABLE <table> for READ LOCK this command too causes
    table to get locked locally and this lock is non-preemptable.

  With that background is make sense to block this command with
  pxc-strict-mode=ENFORCING.