### PR TITLE
- PXC#2091: LOAD DATA INFILE fails with ERROR 1180 (HY000):

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_load_data_splitting.result
+++ b/mysql-test/suite/galera/r/galera_var_load_data_splitting.result
@@ -37,3 +37,23 @@ SELECT COUNT(*) FROM t1;
 COUNT(*)
 95000
 DROP TABLE t1;
+#node-1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SELECT COUNT(*) = 95000 FROM t1;
+COUNT(*) = 95000
+1
+TRUNCATE TABLE t1;
+set global wsrep_max_ws_rows=100;
+ERROR HY000: wsrep_max_ws_rows exceeded
+set session wsrep_on=0;
+SELECT COUNT(*) = 95000 FROM t1;
+COUNT(*) = 95000
+1
+set session wsrep_on=1;
+#node-2
+SELECT COUNT(*) = 0 FROM t1;
+COUNT(*) = 0
+1
+#node-1
+set global wsrep_max_ws_rows = 0;;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_var_load_data_splitting.test
+++ b/mysql-test/suite/galera/t/galera_var_load_data_splitting.test
@@ -79,3 +79,43 @@ SELECT COUNT(*) FROM t1;
 --echo #node-2
 SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
+
+
+#
+# testing load of data with wsrep-on=off
+#
+--connection node_1
+--echo #node-1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+--disable_query_log
+--eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/galera_var_load_data_splitting.csv' INTO TABLE t1;
+--enable_query_log
+SELECT COUNT(*) = 95000 FROM t1;
+
+#
+TRUNCATE TABLE t1;
+--let $wsrep_max_ws_rows_saved = `SELECT @@wsrep_max_ws_rows`
+set global wsrep_max_ws_rows=100;
+--disable_query_log
+--error ER_ERROR_DURING_COMMIT
+--eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/galera_var_load_data_splitting.csv' INTO TABLE t1;
+--enable_query_log
+
+#
+set session wsrep_on=0;
+--disable_query_log
+--eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/galera_var_load_data_splitting.csv' INTO TABLE t1;
+--enable_query_log
+SELECT COUNT(*) = 95000 FROM t1;
+set session wsrep_on=1;
+
+#
+--connection node_2
+--echo #node-2
+SELECT COUNT(*) = 0 FROM t1;
+
+#
+--connection node_1
+--echo #node-1
+--eval set global wsrep_max_ws_rows = $wsrep_max_ws_rows_saved;
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7872,7 +7872,7 @@ int binlog_log_row(TABLE* table,
   }
 
   /* enforce wsrep_max_ws_rows */
-  if (table->s->tmp_table == NO_TMP_TABLE)
+  if (WSREP(thd) && table->s->tmp_table == NO_TMP_TABLE)
   {
     thd->wsrep_affected_rows++;
     if (wsrep_max_ws_rows &&


### PR DESCRIPTION
  wsrep_max_ws_rows exceeded even when wsrep_on is OFF

  - Galera limits number of rows that can be replicated as part of
    single transaction. This check was accidentlly enforced even
    when wsrep_on=off.