### PR TITLE
- PXC#2092: RSU failure should be reported and command should be aborted

### DIFF
--- a/mysql-test/suite/galera/r/galera_rsu_error.result
+++ b/mysql-test/suite/galera/r/galera_rsu_error.result
@@ -19,3 +19,27 @@ SELECT COUNT(3) = 4 FROM t1;
 COUNT(3) = 4
 1
 DROP TABLE t1;
+# Node 1
+call mtr.add_suppression("WSREP: RSU failed due to pending transactions");
+call mtr.add_suppression("ALTER TABLE isolation");
+USE test;
+CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
+# Node 1a
+use test;
+SET SESSION wsrep_retry_autocommit = 0;
+SET DEBUG_SYNC = "wsrep_after_replication SIGNAL entered1 WAIT_FOR continue";
+INSERT INTO t1 (f1) VALUES(1);;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+SET wsrep_OSU_method = "RSU";
+ALTER TABLE t2 ADD COLUMN k INT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET SESSION wsrep_OSU_method = "TOI";
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1
+SELECT * FROM t2;
+f1
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/galera_rsu_error.test
+++ b/mysql-test/suite/galera/t/galera_rsu_error.test
@@ -4,6 +4,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_debug_sync.inc
 
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 INSERT INTO t1 VALUES (1), (1);
@@ -29,3 +30,48 @@ INSERT INTO t1 VALUES (1);
 SELECT COUNT(3) = 4 FROM t1;
 
 DROP TABLE t1;
+
+
+#
+# RSU is not allowed if there is active commit transaction.
+#
+--echo # Node 1
+--connection node_1
+call mtr.add_suppression("WSREP: RSU failed due to pending transactions");
+call mtr.add_suppression("ALTER TABLE isolation");
+
+#
+USE test;
+CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
+
+--echo # Node 1a
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+# Make sure autocommit retrying does not kick in as this will mask the error we expect to get
+use test;
+SET SESSION wsrep_retry_autocommit = 0;
+SET DEBUG_SYNC = "wsrep_after_replication SIGNAL entered1 WAIT_FOR continue";
+--send INSERT INTO t1 (f1) VALUES(1);
+
+# Ensure that we have reached the sync points
+--echo # Node 1
+--connection node_1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+
+SET wsrep_OSU_method = "RSU";
+--error ER_LOCK_DEADLOCK
+ALTER TABLE t2 ADD COLUMN k INT;
+SET SESSION wsrep_OSU_method = "TOI";
+
+SET DEBUG_SYNC = "now SIGNAL continue";
+
+# Unblock the sync points
+--echo # Node 1
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+SELECT * FROM t2;
+DROP TABLE t1;
+DROP TABLE t2;

--- a/sql/wsrep_hton.cc
+++ b/sql/wsrep_hton.cc
@@ -516,10 +516,9 @@ wsrep_run_wsrep_commit(THD *thd, handlerton *hton, bool all)
     DBUG_RETURN(WSREP_TRX_ERROR);
   }
 
-  mysql_mutex_lock(&thd->LOCK_wsrep_thd);
-
   DEBUG_SYNC(thd, "wsrep_after_replication");
 
+  mysql_mutex_lock(&thd->LOCK_wsrep_thd);
   switch(rcode) {
   case 0:
     /*

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1469,7 +1469,7 @@ static int wsrep_RSU_begin(THD *thd, char *db_, char *table_)
     WSREP_WARN("RSU desync failed %d for schema: %s, query: %s",
                ret, (thd->db ? thd->db : "(null)"), WSREP_QUERY(thd));
     my_error(ER_LOCK_DEADLOCK, MYF(0));
-    return(ret);
+    return(-1);
   }
 
   mysql_mutex_lock(&LOCK_wsrep_replaying);
@@ -1493,7 +1493,7 @@ static int wsrep_RSU_begin(THD *thd, char *db_, char *table_)
     }
 
     my_error(ER_LOCK_DEADLOCK, MYF(0));
-    return(1);
+    return(-1);
   }
 
   seqno = wsrep->pause(wsrep);
@@ -1505,7 +1505,7 @@ static int wsrep_RSU_begin(THD *thd, char *db_, char *table_)
     /* Pause fail so rollback desync action too. */
     wsrep->resync(wsrep);
 
-    return(1);
+    return(-1);
   }
   thd->global_read_lock.pause_provider(true);
   WSREP_DEBUG("paused at %lld", (long long)seqno);


### PR DESCRIPTION
  - If RSU operation fails (say due to pending transaction or desync failure)
    then attached DDL statement should also fail.

  - RSU executes statement at said node in local fashion
    (not replicated)

  - If RSU fails but attached DDL statement is allowed to execute then
    it is like execution of DDL statement with replication turn-off for
    the given statement and it in turn can cause other replicating
    statement to stall and there-by halting complete cluster.
    [This is not what end-user expect].