### PR TITLE
BLD-1057 : PXC build is failing on Ubuntu Bionic 18.04

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -302,7 +302,7 @@ export MAKE_JFLAG="${MAKE_JFLAG:--j$PROCESSORS}"
 
 export DEBIAN_VERSION="$(lsb_release -sc)"
 echo $DEBIAN_VERSION
-if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]] && ([[ "$DEBIAN_VERSION" == "yakkety" ]] || [[ "$DEBIAN_VERSION" == "zesty" ]] || [[ "$DEBIAN_VERSION" == "stretch" ]] || [[ "$DEBIAN_VERSION" == "artful" ]]); then
+if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]] && ([[ "$DEBIAN_VERSION" == "yakkety" ]] || [[ "$DEBIAN_VERSION" == "zesty" ]] || [[ "$DEBIAN_VERSION" == "stretch" ]] || [[ "$DEBIAN_VERSION" == "artful" ]] || [[ "$DEBIAN_VERSION" == "bionic" ]]); then
     export CFLAGS=" $CFLAGS -fno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-error=nonnull-compare -Wno-error=shift-negative-value -Wno-error=misleading-indentation -Wno-error=literal-suffix -Wno-error=virtual-move-assign"
     export CXXFLAGS=" $CFLAGS -fno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-error=nonnull-compare -Wno-error=shift-negative-value -Wno-error=misleading-indentation -Wno-error=literal-suffix -Wno-error=virtual-move-assign"
 fi


### PR DESCRIPTION
Issue
The build script fails to compile PXC on bionic

Solution
Add "bionic" to the list of ubuntu distros so that we can set the compile flags
correctly.