### PR TITLE
PXC-2098 : Retry of Store Proc causes assert with next_trx_id

### DIFF
--- a/mysql-test/suite/galera/r/MW-388.result
+++ b/mysql-test/suite/galera/r/MW-388.result
@@ -1,3 +1,6 @@
+#
+# Test LCF handling
+#
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(255)) Engine=InnoDB;
 CREATE PROCEDURE insert_proc ()
 BEGIN
@@ -19,9 +22,9 @@ SET SESSION DEBUG_SYNC = "now WAIT_FOR wsrep_after_replication_reached";
 SET GLOBAL DEBUG = "";
 SET DEBUG_SYNC = "now SIGNAL wsrep_after_replication_continue";
 SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
-SELECT @errno = 1213;
-@errno = 1213
-1
+SELECT @errno;
+@errno
+1213
 SELECT * FROM t1;
 f1	f2
 1	node 2
@@ -30,6 +33,35 @@ SELECT * FROM t1;
 f1	f2
 1	node 2
 3	node 1
+SET DEBUG_SYNC = "reset";
+DROP TABLE t1;
+#
+# Test BFA handling
+#
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(255)) Engine=InnoDB;
+SET GLOBAL wsrep_slave_threads = 2;
+SET GLOBAL DEBUG = "d,sync.wsrep_apply_cb";
+INSERT INTO t1 VALUES (1, 'node 2');;
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION DEBUG_SYNC = 'wsrep_after_replication SIGNAL wsrep_after_replication_reached WAIT_FOR wsrep_after_replication_continue';
+CALL insert_proc ();;
+SET SESSION DEBUG_SYNC = "now WAIT_FOR wsrep_after_replication_reached";
+SET GLOBAL DEBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET DEBUG_SYNC = "now SIGNAL wsrep_after_replication_continue";
+SELECT @errno;
+@errno
+1213
+SELECT * FROM t1;
+f1	f2
+1	node 2
+3	node 1
+SELECT * FROM t1;
+f1	f2
+1	node 2
+3	node 1
+SET DEBUG_SYNC = "reset";
 SET GLOBAL wsrep_slave_threads = DEFAULT;
 DROP TABLE t1;
 DROP PROCEDURE insert_proc;

--- a/mysql-test/suite/galera/t/MW-388.test
+++ b/mysql-test/suite/galera/t/MW-388.test
@@ -3,6 +3,9 @@
 --source include/have_innodb.inc
 --source include/have_debug.inc
 
+--echo #
+--echo # Test LCF handling
+--echo #
 --connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(255)) Engine=InnoDB;
 
@@ -50,6 +53,7 @@ SET SESSION DEBUG_SYNC = "now WAIT_FOR wsrep_after_replication_reached";
 
 SET GLOBAL DEBUG = "";
 SET DEBUG_SYNC = "now SIGNAL wsrep_after_replication_continue";
+--sleep 3
 SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 
 --connection node_2
@@ -58,13 +62,84 @@ SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 --connection node_1
 # We expect no errors here, because the handler in insert_proc() caught the deadlock error
 --reap
-SELECT @errno = 1213;
+SELECT @errno;
+--let $wait_condition = SELECT COUNT(*)=2 FROM t1
+--source include/wait_condition.inc
 SELECT * FROM t1;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*)=2 FROM t1
+--source include/wait_condition.inc
 SELECT * FROM t1;
 
 --connection node_1
+SET DEBUG_SYNC = "reset";
+DROP TABLE t1;
+
+
+
+#
+# Rerun the entire test
+# But change the type of error being forced from LCF to BFA
+#
+--echo #
+--echo # Test BFA handling
+--echo #
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(255)) Engine=InnoDB;
+
+# We need two slave threads here to guarantee progress.
+# If we use only one thread the following could happen
+# in node_1:
+# We block the only slave thread in wsrep_apply_cb and we
+# issue an INSERT (by calling the stored procedure) that will
+# try to acquire galera's local monitor in pre_commit().
+# This usually works fine, except for when a commit cut event
+# sneaks in the slave queue and gets a local seqno smaller than
+# that of the INSERT. Because there is only one slave thread,
+# commit cut is not processed and therefore does not advance
+# local monitor, and our INSERT remains stuck there.
+SET GLOBAL wsrep_slave_threads = 2;
+SET GLOBAL DEBUG = "d,sync.wsrep_apply_cb";
+
+--connection node_2
+--send INSERT INTO t1 VALUES (1, 'node 2');
+
+--connection node_1a
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+
+--connection node_1
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION DEBUG_SYNC = 'wsrep_after_replication SIGNAL wsrep_after_replication_reached WAIT_FOR wsrep_after_replication_continue';
+--send CALL insert_proc ();
+
+--connection node_1a
+SET SESSION DEBUG_SYNC = "now WAIT_FOR wsrep_after_replication_reached";
+
+
+SET GLOBAL DEBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+--sleep 3
+SET DEBUG_SYNC = "now SIGNAL wsrep_after_replication_continue";
+
+--connection node_2
+--reap
+
+--connection node_1
+# We expect no errors here, because the handler in insert_proc() caught the deadlock error
+--reap
+SELECT @errno;
+--let $wait_condition = SELECT COUNT(*)=2 FROM t1
+--source include/wait_condition.inc
+SELECT * FROM t1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*)=2 FROM t1
+--source include/wait_condition.inc
+SELECT * FROM t1;
+
+--connection node_1
+SET DEBUG_SYNC = "reset";
 SET GLOBAL wsrep_slave_threads = DEFAULT;
 DROP TABLE t1;
 DROP PROCEDURE insert_proc;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6254,7 +6254,8 @@ finish:
 #ifdef WITH_WSREP
     else if (thd->sp_runtime_ctx &&
              (thd->wsrep_conflict_state == MUST_ABORT ||
-              thd->wsrep_conflict_state == CERT_FAILURE))
+              thd->wsrep_conflict_state == CERT_FAILURE ||
+              thd->wsrep_conflict_state == ABORTED))
     {
       /*
         The error was cleared, but THD was aborted by wsrep and


### PR DESCRIPTION
Issue:
The assert is 5.7 only.  However, when the stored procedure
fails (due to LCF/BFA), the retry paths are different.
A BFA will cause the sproc to be retried, but not for an LCF.

Solution
Have the LCF and BFA error code paths work the same.  Make sure that
the BFA error case is also handled.