### PR TITLE
- PXC#2062: PXC support for data encryption

### DIFF
--- a/mysql-test/suite/galera/r/pxc_data_at_rest_encrypt.result
+++ b/mysql-test/suite/galera/r/pxc_data_at_rest_encrypt.result
@@ -1,0 +1,75 @@
+#node-1
+use test;
+create table t (i int, primary key pk(i)) encryption='y';
+insert into t values (1), (2), (3);
+select * from t;
+i
+1
+2
+3
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+#node-2
+select * from t;
+i
+1
+2
+3
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+drop table t;
+#node-2 being killed
+Killing server ...
+#node-1
+CREATE TABLE e1 (
+id INT NOT NULL AUTO_INCREMENT,
+text VARCHAR(10) DEFAULT NULL,
+PRIMARY KEY (id)
+) ENCRYPTION='Y';
+INSERT INTO e1(text) VALUES('aaaaa');
+INSERT INTO e1(text) VALUES('bbbbb');
+#node-2 restarted (should get encrypted table through SST)
+# restart
+select * from e1;
+id	text
+1	aaaaa
+2	bbbbb
+show create table e1;
+Table	Create Table
+e1	CREATE TABLE `e1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `text` varchar(10) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+drop table e1;
+#node-2 being killed
+#node-1
+CREATE TABLE e1 (
+id INT NOT NULL AUTO_INCREMENT,
+text VARCHAR(10) DEFAULT NULL,
+PRIMARY KEY (id)
+) ENCRYPTION='Y';
+INSERT INTO e1(text) VALUES('aaaaa');
+INSERT INTO e1(text) VALUES('bbbbb');
+#node-2 restarted (should get encrypted table through IST)
+# restart
+select * from e1;
+id	text
+1	aaaaa
+2	bbbbb
+show create table e1;
+Table	Create Table
+e1	CREATE TABLE `e1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `text` varchar(10) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+drop table e1;

--- a/mysql-test/suite/galera/r/pxc_encrypt_rest_blog.result
+++ b/mysql-test/suite/galera/r/pxc_encrypt_rest_blog.result
@@ -1,0 +1,155 @@
+#node-1
+use test;
+create table t1 (i int, primary key pk(i)) encryption='y';
+create table t2 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3);
+insert into t1 values (10), (20), (30);
+select * from t1;
+i
+1
+2
+3
+10
+20
+30
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Start_encryption	1	163	
+#node-2
+select * from t1;
+i
+1
+2
+3
+10
+20
+30
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+select * from t2;
+i
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table t1, t2;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Start_encryption	2	163	
+#node-2 being killed
+Killing server ...
+#node-1
+use test;
+create table t1 (i int, primary key pk(i)) encryption='y';
+create table t2 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3);
+insert into t1 values (10), (20), (30);
+select * from t1;
+i
+1
+2
+3
+10
+20
+30
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Start_encryption	1	163	
+#node-2 restarted (should get encrypted table through SST)
+# restart
+select * from t1;
+i
+1
+2
+3
+10
+20
+30
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+select * from t2;
+i
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table t1, t2;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Start_encryption	2	163	
+#node-2 being shutdown
+#node-1
+use test;
+create table t1 (i int, primary key pk(i)) encryption='y';
+create table t2 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3);
+insert into t1 values (10), (20), (30);
+select * from t1;
+i
+1
+2
+3
+10
+20
+30
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Start_encryption	1	163	
+#node-2 restarted (should get encrypted table through IST)
+# restart
+select * from t1;
+i
+1
+2
+3
+10
+20
+30
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+select * from t2;
+i
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table t1, t2;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Start_encryption	2	163	

--- a/mysql-test/suite/galera/r/pxc_encrypt_rest_fpt.result
+++ b/mysql-test/suite/galera/r/pxc_encrypt_rest_fpt.result
@@ -1,0 +1,75 @@
+#node-1
+use test;
+create table t (i int, primary key pk(i)) encryption='y';
+insert into t values (1), (2), (3);
+select * from t;
+i
+1
+2
+3
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+#node-2
+select * from t;
+i
+1
+2
+3
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+drop table t;
+#node-2 being killed
+Killing server ...
+#node-1
+CREATE TABLE e1 (
+id INT NOT NULL,
+text VARCHAR(10) DEFAULT NULL,
+PRIMARY KEY (id)
+) ENCRYPTION='Y';
+INSERT INTO e1 VALUES(1, 'aaaaa');
+INSERT INTO e1 VALUES(2, 'bbbbb');
+#node-2 restarted (should get encrypted table through SST)
+# restart
+select * from e1;
+id	text
+1	aaaaa
+2	bbbbb
+show create table e1;
+Table	Create Table
+e1	CREATE TABLE `e1` (
+  `id` int(11) NOT NULL,
+  `text` varchar(10) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+drop table e1;
+#node-2 being shutdown 
+#node-1
+CREATE TABLE e1 (
+id INT NOT NULL,
+text VARCHAR(10) DEFAULT NULL,
+PRIMARY KEY (id)
+) ENCRYPTION='Y';
+INSERT INTO e1 VALUES(1, 'aaaaa');
+INSERT INTO e1 VALUES(2, 'bbbbb');
+#node-2 restarted (should get encrypted table through IST)
+# restart
+select * from e1;
+id	text
+1	aaaaa
+2	bbbbb
+show create table e1;
+Table	Create Table
+e1	CREATE TABLE `e1` (
+  `id` int(11) NOT NULL,
+  `text` varchar(10) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+drop table e1;

--- a/mysql-test/suite/galera/r/pxc_encrypt_rest_gt.result
+++ b/mysql-test/suite/galera/r/pxc_encrypt_rest_gt.result
@@ -1,0 +1,126 @@
+#node-1
+use test;
+CREATE TABLESPACE foo ADD DATAFILE 'foo.ibd' ENCRYPTION='Y';
+create table t1 (i int, primary key pk(i)) tablespace foo encryption='y';
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='n';
+ERROR HY000: InnoDB: Tablespace `foo` can contain only an ENCRYPTED tables.
+insert into t1 values (1), (2), (3);
+select * from t1;
+i
+1
+2
+3
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+#node-2
+select * from t1;
+i
+1
+2
+3
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='y';
+insert into t2 values (10), (20), (30);
+#node-1
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+drop table t1, t2;
+drop tablespace foo;
+#node-2 being killed
+Killing server ...
+#node-1
+use test;
+CREATE TABLESPACE foo ADD DATAFILE 'foo.ibd' ENCRYPTION='Y';
+create table t1 (i int, primary key pk(i)) tablespace foo encryption='y';
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='n';
+ERROR HY000: InnoDB: Tablespace `foo` can contain only an ENCRYPTED tables.
+insert into t1 values (1), (2), (3);
+select * from t1;
+i
+1
+2
+3
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+#node-2 restarted (should get encrypted table through SST)
+# restart
+call mtr.add_suppression(".*can contain only an ENCRYPTED tables.*");
+select * from t1;
+i
+1
+2
+3
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='y';
+insert into t2 values (10), (20), (30);
+#node-1
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+drop table t1, t2;
+drop tablespace foo;
+#node-2 being shutdown
+#node-1
+use test;
+CREATE TABLESPACE foo ADD DATAFILE 'foo.ibd' ENCRYPTION='Y';
+create table t1 (i int, primary key pk(i)) tablespace foo encryption='y';
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='n';
+ERROR HY000: InnoDB: Tablespace `foo` can contain only an ENCRYPTED tables.
+insert into t1 values (1);
+select * from t1;
+i
+1
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+#node-2 restarted (should get encrypted table through IST)
+# restart
+call mtr.add_suppression(".*can contain only an ENCRYPTED tables.*");
+select * from t1;
+i
+1
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='y';
+insert into t2 values (10), (20), (30);
+#node-1
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='y'
+drop table t1, t2;
+drop tablespace foo;

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_blog.cnf
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_blog.cnf
@@ -1,0 +1,22 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_sst_auth="root:"
+wsrep_debug=ON
+pxc-encrypt-cluster-traffic=ON
+encrypt_binlog=ON
+master_verify_checksum=ON
+binlog_checksum=CRC32
+
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.1/keyring.1
+server_id=1
+
+[mysqld.2]
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.2/keyring.2
+server_id=2

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_blog.test
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_blog.test
@@ -1,0 +1,131 @@
+
+#
+#
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+# Force a restart at the end of the test
+--source include/force_restart.inc
+
+#
+# This test-case will cover data-at-rest encryption scenarios.
+# MySQL-5.7 introduced
+# - file-per-tablespace encryption.
+# PS start with 5.7.21-21 extended this to support encryption of
+# - general tablespace
+# - temporary tablespace
+# - binlog encryption
+
+
+#===============================================================================
+# binlog encryption encryption support
+# galera uses binlog for replication and if binlog is encrypted before galera
+# replicate then replication will break.
+
+#-------------------------------------------------------------------------------
+# direct repliction of encrypted tablespace
+#
+--connection node_1
+--echo #node-1
+use test;
+#
+create table t1 (i int, primary key pk(i)) encryption='y';
+create table t2 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3);
+insert into t1 values (10), (20), (30);
+select * from t1;
+show create table t1;
+
+--connection node_1
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+
+--connection node_2
+--echo #node-2
+select * from t1;
+show create table t1;
+select * from t2;
+show create table t2;
+drop table t1, t2;
+
+--connection node_2
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+
+#-------------------------------------------------------------------------------
+# sst of the encrypted table
+#
+--connection node_2
+--echo #node-2 being killed
+--source include/kill_galera.inc
+
+--connection node_1
+--echo #node-1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+use test;
+#
+create table t1 (i int, primary key pk(i)) encryption='y';
+create table t2 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3);
+insert into t1 values (10), (20), (30);
+select * from t1;
+show create table t1;
+
+--connection node_1
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+
+--connection node_2
+--echo #node-2 restarted (should get encrypted table through SST)
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from t1;
+show create table t1;
+select * from t2;
+show create table t2;
+drop table t1, t2;
+
+--connection node_2
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+
+#-------------------------------------------------------------------------------
+# ist of the encrypted table
+#
+--connection node_2
+--echo #node-2 being shutdown
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--echo #node-1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+use test;
+#
+create table t1 (i int, primary key pk(i)) encryption='y';
+create table t2 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3);
+insert into t1 values (10), (20), (30);
+select * from t1;
+show create table t1;
+
+--connection node_1
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+
+--connection node_2
+--echo #node-2 restarted (should get encrypted table through IST)
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from t1;
+show create table t1;
+select * from t2;
+show create table t2;
+drop table t1, t2;
+
+--connection node_2
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123 LIMIT 1;
+

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_fpt.cnf
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_fpt.cnf
@@ -1,0 +1,19 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_sst_auth="root:"
+wsrep_debug=ON
+pxc-encrypt-cluster-traffic=ON
+
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.1/keyring.1
+server_id=1
+
+[mysqld.2]
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.2/keyring.2
+server_id=2

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_fpt.test
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_fpt.test
@@ -1,0 +1,101 @@
+
+#
+#
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+# Force a restart at the end of the test
+--source include/force_restart.inc
+
+#
+# This test-case will cover data-at-rest encryption scenarios.
+# MySQL-5.7 introduced
+# - file-per-tablespace encryption.
+# PS start with 5.7.21-21 extended this to support encryption of
+# - general tablespace
+# - temporary tablespace
+# - binlog encryption
+
+
+#===============================================================================
+# file-per-tablespace encryption support
+
+#-------------------------------------------------------------------------------
+# direct repliction of encrypted tablespace
+#
+--connection node_1
+--echo #node-1
+use test;
+create table t (i int, primary key pk(i)) encryption='y';
+insert into t values (1), (2), (3);
+select * from t;
+show create table t;
+
+--connection node_2
+--echo #node-2
+select * from t;
+show create table t;
+drop table t;
+
+#-------------------------------------------------------------------------------
+# sst of the encrypted table
+#
+--connection node_2
+--echo #node-2 being killed
+--source include/kill_galera.inc
+
+--connection node_1
+--echo #node-1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+#
+CREATE TABLE e1 (
+  id INT NOT NULL,
+  text VARCHAR(10) DEFAULT NULL,
+  PRIMARY KEY (id)
+) ENCRYPTION='Y';
+INSERT INTO e1 VALUES(1, 'aaaaa');
+INSERT INTO e1 VALUES(2, 'bbbbb');
+
+--connection node_2
+--echo #node-2 restarted (should get encrypted table through SST)
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from e1;
+show create table e1;
+drop table e1;
+
+#-------------------------------------------------------------------------------
+# ist of the encrypted table
+#
+--connection node_2
+--echo #node-2 being shutdown 
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--echo #node-1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+#
+CREATE TABLE e1 (
+  id INT NOT NULL,
+  text VARCHAR(10) DEFAULT NULL,
+  PRIMARY KEY (id)
+) ENCRYPTION='Y';
+INSERT INTO e1 VALUES(1, 'aaaaa');
+INSERT INTO e1 VALUES(2, 'bbbbb');
+
+--connection node_2
+--echo #node-2 restarted (should get encrypted table through IST)
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from e1;
+show create table e1;
+drop table e1;

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.cnf
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.cnf
@@ -1,0 +1,19 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_sst_auth="root:"
+wsrep_debug=ON
+pxc-encrypt-cluster-traffic=ON
+
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.1/keyring.1
+server_id=1
+
+[mysqld.2]
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;pc.ignore_sb=true'
+early_plugin_load=@ENV.KEYRING_PLUGIN
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.2/keyring.2
+server_id=2

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.test
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.test
@@ -1,0 +1,140 @@
+
+#
+#
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+# Force a restart at the end of the test
+--source include/force_restart.inc
+
+#
+# This test-case will cover data-at-rest encryption scenarios.
+# MySQL-5.7 introduced
+# - file-per-tablespace encryption.
+# PS start with 5.7.21-21 extended this to support encryption of
+# - general tablespace
+# - temporary tablespace
+# - binlog encryption
+
+
+#===============================================================================
+# general tablespace encryption support
+
+#-------------------------------------------------------------------------------
+# direct repliction of encrypted tablespace
+#
+--connection node_1
+--echo #node-1
+use test;
+CREATE TABLESPACE foo ADD DATAFILE 'foo.ibd' ENCRYPTION='Y';
+#
+create table t1 (i int, primary key pk(i)) tablespace foo encryption='y';
+--error ER_ILLEGAL_HA_CREATE_OPTION
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='n';
+#
+insert into t1 values (1), (2), (3);
+select * from t1;
+show create table t1;
+
+--connection node_2
+--echo #node-2
+select * from t1;
+show create table t1;
+#
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='y';
+insert into t2 values (10), (20), (30);
+
+--connection node_1
+--echo #node-1
+show create table t2;
+drop table t1, t2;
+drop tablespace foo;
+
+#-------------------------------------------------------------------------------
+# sst of the encrypted table
+#
+--connection node_2
+--echo #node-2 being killed
+--source include/kill_galera.inc
+
+--connection node_1
+--echo #node-1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+#
+use test;
+CREATE TABLESPACE foo ADD DATAFILE 'foo.ibd' ENCRYPTION='Y';
+#
+create table t1 (i int, primary key pk(i)) tablespace foo encryption='y';
+--error ER_ILLEGAL_HA_CREATE_OPTION
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='n';
+#
+insert into t1 values (1), (2), (3);
+select * from t1;
+show create table t1;
+
+--connection node_2
+--echo #node-2 restarted (should get encrypted table through SST)
+--source include/start_mysqld.inc
+call mtr.add_suppression(".*can contain only an ENCRYPTED tables.*");
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from t1;
+show create table t1;
+#
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='y';
+insert into t2 values (10), (20), (30);
+
+--connection node_1
+--echo #node-1
+show create table t2;
+drop table t1, t2;
+drop tablespace foo;
+
+
+#-------------------------------------------------------------------------------
+# ist of the encrypted table
+#
+--connection node_2
+--echo #node-2 being shutdown
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--echo #node-1
+# this is to ensure IST happens with smaller data-set
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+#
+use test;
+CREATE TABLESPACE foo ADD DATAFILE 'foo.ibd' ENCRYPTION='Y';
+#
+create table t1 (i int, primary key pk(i)) tablespace foo encryption='y';
+--error ER_ILLEGAL_HA_CREATE_OPTION
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='n';
+#
+insert into t1 values (1);
+select * from t1;
+show create table t1;
+
+--connection node_2
+--echo #node-2 restarted (should get encrypted table through IST)
+--source include/start_mysqld.inc
+call mtr.add_suppression(".*can contain only an ENCRYPTED tables.*");
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+select * from t1;
+show create table t1;
+#
+create table t2 (i int, primary key pk(i)) tablespace foo encryption='y';
+insert into t2 values (10), (20), (30);
+
+--connection node_1
+--echo #node-1
+show create table t2;
+drop table t1, t2;
+drop tablespace foo;


### PR DESCRIPTION
  - Percona Server, starting from 5.7.21-21 expanded support for
    for data-encryption to include general tablespace and binary logs.

  - PXC inheritted this functionality and enabled the support for
    the same.