### PR TITLE
- PXC#2103: Possible Bug xtrabackup 2.3 with xtradb cluster 5.6

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -6965,8 +6965,47 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all)
       const ulong timeout= thd->variables.lock_wait_timeout;
 
       DBUG_PRINT("debug", ("Acquiring binlog protection lock"));
+
+#ifndef WITH_WSREP
       if (thd->backup_binlog_lock.acquire_protection(thd, MDL_EXPLICIT,
                                                       timeout))
+#else
+      bool lock;
+      while (true)
+      {
+        lock= thd->backup_binlog_lock.acquire_protection(
+                thd, MDL_EXPLICIT, timeout);
+
+        /* A local running thread that is commit state may get killed
+           by background replicating thread.
+
+           kill is null and void as local commit thread is already
+           in commit state and thus has needed locks, certification approval
+           and commit monitor.
+
+           While all locks are taken way before transaction enter commit state
+           backup binlog protection is obtain before the real commit start.
+
+           While waiting for backup binlog lock, if local-commit thread is
+           killed, backup binlog protection flow exits with KILLED
+           return code without acquiring the protection.
+
+           Check for the said state and re-try for protection.
+        */
+        if (lock
+            && thd->wsrep_conflict_state == MUST_ABORT
+            && thd->wsrep_exec_mode == LOCAL_COMMIT)
+        {
+          WSREP_DEBUG("Local Commit backup binlog protection interrupted by"
+                      " a background replicating thread action. Retrying");
+          continue;
+        }
+
+        break;
+      }
+
+      if (lock)
+#endif /* !WITH_WSREP */
       {
         cache_mngr->stmt_cache.reset();
         cache_mngr->trx_cache.reset();


### PR DESCRIPTION
  - XB locks binlog for backup using LOCK BINOG FOR BACKUP.
    This is global non-preemptable lock.

  - Say a local running transaction is in COMMIT state.
    Normally a COMMIT state transaction has all the needed LOCKs
    (or resources) to complete the action but in PS/PXC
    binlog backup protection is taken just before real-commit.

  - If this local running transaction is interrupted by
    a replicated background transaction while it is waiting for
    binlog backup protection then protection fails with error code
    causing COMMIT to fail and eventually assert in GALERA.

    [Galera doesn't expect COMMIT to fail unless it has FATAL
     ir-recoverable error. This is to maintain cluster consistency]

  - But a local running transaction is not suppose to get aborted
    by a background replicated transaction as it has all the needed
    Locks, Commit-Monitor (there-by ensuring ordering).

  - This can still happen if the non-data conflicting transaction
    is replicated but due GAP locking semantics of InnoDB, InnoDB
    project it as conflict. (Also possible with FK GAP lock).
    Given this is as a valid scenario and Galera has protection to handle
    it, we need to re-look at the Global Binlog protection flow path.
    (specific to PS/PXC)

  - If Global Binlog protection flow path is interrupted by
    background transaction then just re-try getting the protection.