### PR TITLE
- PXC#2113: Make PXC depends on PXB-2.4.11+

### DIFF
--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_blog.cnf
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_blog.cnf
@@ -3,11 +3,13 @@
 [mysqld]
 wsrep_sst_method=xtrabackup-v2
 wsrep_sst_auth="root:"
-wsrep_debug=ON
 pxc-encrypt-cluster-traffic=ON
 encrypt_binlog=ON
 master_verify_checksum=ON
 binlog_checksum=CRC32
+
+[xtrabackup]
+xtrabackup-plugin-dir=@ENV.XB_PLUGIN_DIR
 
 [mysqld.1]
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_fpt.cnf
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_fpt.cnf
@@ -3,8 +3,10 @@
 [mysqld]
 wsrep_sst_method=xtrabackup-v2
 wsrep_sst_auth="root:"
-wsrep_debug=ON
 pxc-encrypt-cluster-traffic=ON
+
+[xtrabackup]
+xtrabackup-plugin-dir=@ENV.XB_PLUGIN_DIR
 
 [mysqld.1]
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.cnf
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.cnf
@@ -3,8 +3,10 @@
 [mysqld]
 wsrep_sst_method=xtrabackup-v2
 wsrep_sst_auth="root:"
-wsrep_debug=ON
 pxc-encrypt-cluster-traffic=ON
+
+[xtrabackup]
+xtrabackup-plugin-dir=@ENV.XB_PLUGIN_DIR
 
 [mysqld.1]
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'


### PR DESCRIPTION
  - XB-2.4.11 is now compatible to support data-encryption-at-rest
    and vault-plugin.

  - In order to faciliate this new development, XB added a new param
    xtrabackup-plugin-dir. If this params is not specified during
    SST invocation of PXC it would use the default plugin directory.

    [Normally if XB is installed as package then plugin directory
     could be found but if XB is installed as binary then plugin
     directory is not found in case like this specifying the said
     param help XB to find the needed plugins]

   - With this we also enforce need of XB-2.4.11+ for future PXC releases.

  --------------------

  - XB-2.4.11 also introduced concept of transition-key that can be used
    to re-encrpyt the table/tablespaces/logs while taking backup (in our
    case SST).

  - this transition key help remove dependency on master-key there-by
    allowing different master-key on DONOR and JOINER and also
    probable mix-match of keyring_plugins (file and vault).