### PR TITLE
Fix Debian init script fails when socket not specified

### DIFF
--- a/build-ps/debian/percona-xtradb-cluster-server-5.7.mysql.init
+++ b/build-ps/debian/percona-xtradb-cluster-server-5.7.mysql.init
@@ -89,6 +89,12 @@ mysql_data_dir=$(mysqld_get_param datadir)
 pid_file=$(mysqld_get_param pid-file)
 
 socket=$(mysqld_get_param socket)
+
+if test -z "$socket"
+then
+    socket="/var/run/mysqld/mysqld.sock"
+fi
+
 if test -z "$pid_file"
 then
     pid_file="$mysql_data_dir/$(hostname).pid"


### PR DESCRIPTION
Set `$socket` to default `/var/run/mysqld/mysqld.sock` when it's not properly detected.

MySQL works fine with `socket` not set in the config file, however, `mysqld --print-defaults` won't print it, therefore `mysqld_get_param()` can not fetch the info properly.

cc #583 
