### PR TITLE
- PXC#2128: Duplicate auto_increment values set for concurrent

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -329,6 +329,14 @@ wsrep_view_handler_cb (void*                    app_ctx,
 
   if (wsrep_auto_increment_control)
   {
+    WSREP_INFO("Auto Increment Offset/Increment re-align with cluster"
+                " membership change (Offset: %lu -> %lu)"
+                " (Increment: %lu -> %lu)",
+                global_system_variables.auto_increment_offset,
+                (long unsigned) view->my_idx + 1,
+                global_system_variables.auto_increment_increment,
+                (long unsigned) view->memb_num);
+
     global_system_variables.auto_increment_offset= view->my_idx + 1;
     global_system_variables.auto_increment_increment= view->memb_num;
   }


### PR DESCRIPTION
  sessions on cluster reconfiguration

  Issue:
  -----

  - node leaving cluster can cause dynamic adjustment to auto-increment
    increment and offset based on nodes in primary component.

  - this can affect the auto-inc series and innodb/mysql will need to
    re-calculate auto-inc series based on updated values.

  - with auto-inc re-configuration, auto-inc series is re-calculated.
    for example with off/inc = 3/3 series is say 27, 30, 33, 36, 39,....
    but let's say after 33 off/inc changes to 2/2 then series needs
    to be re-evaluated to adjust to new values.

  - when mysql flow detects decrease in increment it needs to step
    back and re-evaluate the series. for example: 33 is inserted,
    the next value to insert is 36 but if configuration changes
    then standalone server will re-construct 33 (36 - 3 (old off))
    and using 33 as base will project the next number in the series
    to insert.

  - in pxc, with wsrep_auto_increment_control=on, if 33 is inserted
    and off=3/incr=3 (3 node cluster) then next number for the said
    node is 36. pxc can't backtrack old number because it can potentially
    generate number between (34,35) which could conflict with insert
    that is running on node-2,3 that has 34, and 35 reserved.

  - pxc skips back-tracking and instead use the next number in series.
    unfortunately, this part of code though skipped back-tracking or
    readjustment continue to re-calibrate the number.
    while pxc continue to use 36 as base (vs standalone using 33
    so needs re-calibration), pxc flow doesn't need re-calibration
    as pxc retained original number.

  - this re-calibration, caused generation of same value for
    current insert and next value insert.
    (mysql flow identify this use-case and move next-value to
     next legitimate value but only after insert is done on success path).

  - in meantime, if another thread uses this next-value and proceed
    with insert it will end-up inserting next-value (assuming it is next
    value to consume) and current thread that generated curr-value = next-value
    will also insert same value resulting in duplicate-key-error.

  Fix:
  ---

  - Since pxc doesn't re-adjust the autoinc on decrease in incr, pxc
    should avoid re-calibration.