### PR TITLE
- PXC#2133: Deprecate wsrep-forced-binlog-format and wsrep_sst_method…

### DIFF
--- a/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
@@ -1,5 +1,9 @@
 SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 CREATE TABLE t1 (
 i int(11) NOT NULL AUTO_INCREMENT,
 c char(32) DEFAULT 'dummy_text',
@@ -14,7 +18,11 @@ select sum(i) = SUM from t1;;
 sum(i) = SUM
 1
 SET GLOBAL wsrep_forced_binlog_format='none';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SET GLOBAL wsrep_forced_binlog_format='none';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 drop table t1;
 SET SESSION binlog_format='STATEMENT';
 show variables like 'binlog_format';

--- a/mysql-test/suite/galera/r/galera_ist_mysqldump.result
+++ b/mysql-test/suite/galera/r/galera_ist_mysqldump.result
@@ -4,6 +4,8 @@ GRANT ALL ON *.* TO 'sst'@'localhost';
 FLUSH PRIVILEGES;
 SET GLOBAL wsrep_sst_auth = 'sst:';
 SET GLOBAL wsrep_sst_method = 'mysqldump';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated SST through mysqldump. Percona-XtraDB-Cluster recommends using xtrabackup. Please switch to use xtrabackup or rsync.
 Performing State Transfer on a server that has been shut down cleanly and restarted
 CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
 SET AUTOCOMMIT=OFF;

--- a/mysql-test/suite/galera/r/galera_migrate.result
+++ b/mysql-test/suite/galera/r/galera_migrate.result
@@ -26,6 +26,8 @@ GRANT ALL PRIVILEGES ON *.* TO 'sst';
 SET GLOBAL wsrep_sst_auth = 'sst:';
 CREATE USER 'sst';
 GRANT ALL PRIVILEGES ON *.* TO 'sst';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated SST through mysqldump. Percona-XtraDB-Cluster recommends using xtrabackup. Please switch to use xtrabackup or rsync.
 SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
 VARIABLE_VALUE
 Synced

--- a/mysql-test/suite/galera/r/galera_sst_mysqldump.result
+++ b/mysql-test/suite/galera/r/galera_sst_mysqldump.result
@@ -4,6 +4,8 @@ GRANT ALL ON *.* TO 'sst'@'localhost';
 FLUSH PRIVILEGES;
 SET GLOBAL wsrep_sst_auth = 'sst:';
 SET GLOBAL wsrep_sst_method = 'mysqldump';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated SST through mysqldump. Percona-XtraDB-Cluster recommends using xtrabackup. Please switch to use xtrabackup or rsync.
 Performing State Transfer on a server that has been temporarily disconnected
 CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
 SET AUTOCOMMIT=OFF;

--- a/mysql-test/suite/galera/r/galera_sst_mysqldump_with_key.result
+++ b/mysql-test/suite/galera/r/galera_sst_mysqldump_with_key.result
@@ -4,6 +4,8 @@ GRANT ALL ON *.* TO 'sst'@'localhost';
 FLUSH PRIVILEGES;
 SET GLOBAL wsrep_sst_auth = 'sst:';
 SET GLOBAL wsrep_sst_method = 'mysqldump';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated SST through mysqldump. Percona-XtraDB-Cluster recommends using xtrabackup. Please switch to use xtrabackup or rsync.
 CREATE USER 'sslsst';
 GRANT ALL PRIVILEGES ON *.* TO 'sslsst';
 GRANT USAGE ON *.* TO 'sslsst' REQUIRE SSL;

--- a/mysql-test/suite/galera/r/mysql-wsrep#33.result
+++ b/mysql-test/suite/galera/r/mysql-wsrep#33.result
@@ -4,6 +4,8 @@ GRANT ALL ON *.* TO 'sst'@'localhost';
 FLUSH PRIVILEGES;
 SET GLOBAL wsrep_sst_auth = 'sst:';
 SET GLOBAL wsrep_sst_method = 'mysqldump';
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated SST through mysqldump. Percona-XtraDB-Cluster recommends using xtrabackup. Please switch to use xtrabackup or rsync.
 Performing State Transfer on a server that has been temporarily disconnected
 CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
 SET AUTOCOMMIT=OFF;

--- a/mysql-test/suite/sys_vars/r/wsrep_forced_binlog_format_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_forced_binlog_format_basic.result
@@ -12,28 +12,40 @@ NONE
 SELECT @@session.wsrep_forced_binlog_format;
 ERROR HY000: Variable 'wsrep_forced_binlog_format' is a GLOBAL variable
 SET @@global.wsrep_forced_binlog_format=STATEMENT;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 STATEMENT
 
 # valid values
 SET @@global.wsrep_forced_binlog_format=STATEMENT;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 STATEMENT
 SET @@global.wsrep_forced_binlog_format=ROW;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 ROW
 SET @@global.wsrep_forced_binlog_format=MIXED;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 MIXED
 SET @@global.wsrep_forced_binlog_format=NONE;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 NONE
 SET @@global.wsrep_forced_binlog_format=default;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 NONE
@@ -48,4 +60,6 @@ ERROR 42000: Variable 'wsrep_forced_binlog_format' can't be set to the value of 
 
 # restore the initial value
 SET @@global.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_global_saved;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
 # End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_sst_method_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_sst_method_basic.result
@@ -22,6 +22,8 @@ SELECT @@global.wsrep_sst_method;
 @@global.wsrep_sst_method
 rsync
 SET @@global.wsrep_sst_method=mysqldump;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster has deprecated SST through mysqldump. Percona-XtraDB-Cluster recommends using xtrabackup. Please switch to use xtrabackup or rsync.
 SELECT @@global.wsrep_sst_method;
 @@global.wsrep_sst_method
 mysqldump

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3521,6 +3521,14 @@ int init_common_variables()
                 " (Node is yet not SYNCED with cluster)");
     return 1;
   }
+
+  const char* WSREP_SST_MYSQLDUMP= "mysqldump";
+  if (wsrep_provider_loaded && !strcmp (WSREP_SST_MYSQLDUMP, wsrep_sst_method))
+  {
+    WSREP_WARN("Percona-XtraDB-Cluster has deprecated SST through mysqldump."
+               " Percona-XtraDB-Cluster recommends using xtrabackup."
+               " Please switch to use xtrabackup or rsync.");
+  }
 #endif /* WITH_WSREP */
 
 #ifdef WITH_WSREP

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6443,11 +6443,13 @@ static Sys_var_enum Sys_wsrep_reject_queries(
        ON_UPDATE(wsrep_reject_queries_update));
 
 static Sys_var_enum Sys_wsrep_forced_binlog_format(
-       "wsrep_forced_binlog_format", "binlog format to take effect over user's choice",
+       "wsrep_forced_binlog_format",
+       "binlog format to take effect over user's choice (Deprecated)",
        GLOBAL_VAR(wsrep_forced_binlog_format), 
        CMD_LINE(REQUIRED_ARG, OPT_BINLOG_FORMAT),
        wsrep_binlog_format_names, DEFAULT(BINLOG_FORMAT_UNSPEC),
-       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(wsrep_forced_binlog_format_check),
        ON_UPDATE(0));
 
 static Sys_var_mybool Sys_wsrep_recover_datadir(

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -88,6 +88,18 @@ bool wsrep_sst_method_check (sys_var *self, THD* thd, set_var* var)
     return true;
   }
 
+  if (!strcmp (var->save_result.string_value.str, WSREP_SST_MYSQLDUMP))
+  {
+    WSREP_WARN("Percona-XtraDB-Cluster has deprecated SST through mysqldump."
+               " Percona-XtraDB-Cluster recommends using xtrabackup."
+               " Please switch to use xtrabackup or rsync.");
+    push_warning_printf(
+      thd, Sql_condition::SL_WARNING, ER_UNKNOWN_ERROR,
+      "Percona-XtraDB-Cluster has deprecated SST through mysqldump."
+      " Percona-XtraDB-Cluster recommends using xtrabackup."
+      " Please switch to use xtrabackup or rsync.");
+  }
+
   return false;
 }
 
@@ -1341,6 +1353,9 @@ wsrep_cb_status_t wsrep_sst_donate_cb (void* app_ctx, void* recv_ctx,
 
   if (!strcmp (WSREP_SST_MYSQLDUMP, method))
   {
+    WSREP_WARN("Percona-XtraDB-Cluster has deprecated SST through mysqldump."
+               " Percona-XtraDB-Cluster recommends using xtrabackup."
+               " Please switch to use xtrabackup or rsync.");
     ret = sst_donate_mysqldump(data, &current_gtid->uuid, uuid_str,
                                current_gtid->seqno, bypass, env());
   }

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -678,6 +678,19 @@ bool wsrep_desync_update (sys_var *self, THD* thd, enum_var_type type)
   return false;
 }
 
+bool wsrep_forced_binlog_format_check (sys_var *self, THD* thd, set_var* var)
+{
+  {
+    WSREP_WARN("Percona-XtraDB-Cluster has deprecated"
+               " wsrep_forced_binlog_format");
+    push_warning_printf(
+      thd, Sql_condition::SL_WARNING, ER_UNKNOWN_ERROR,
+      "Percona-XtraDB-Cluster has deprecated"
+      " wsrep_forced_binlog_format");
+  }
+  return false;
+}
+
 bool wsrep_max_ws_size_update (sys_var *self, THD *thd, enum_var_type)
 {
   char max_ws_size_opt[128];

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -86,6 +86,8 @@ extern bool wsrep_slave_threads_update       UPDATE_ARGS;
 extern bool wsrep_desync_check               CHECK_ARGS;
 extern bool wsrep_desync_update              UPDATE_ARGS;
 
+extern bool wsrep_forced_binlog_format_check CHECK_ARGS;
+
 extern bool wsrep_max_ws_size_update         UPDATE_ARGS;
 
 extern bool wsrep_reject_queries_update    UPDATE_ARGS;


### PR DESCRIPTION
…="mysqldump"

  - PXC annouces deprecation of wsrep-forced-binlog-format
    and SST through mysqldump.

  - No change in current behavior but user should avoid using it
    as these features will be removed in next major release.