### PR TITLE
- PXC#2135: If PXC fails to load a keyring plugin then don't server t…

### DIFF
--- a/plugin/keyring/keyring.cc
+++ b/plugin/keyring/keyring.cc
@@ -115,7 +115,11 @@ static int keyring_init(MYSQL_PLUGIN plugin_info)
         " can be created in the specified location. "
         "The keyring_file will stay unusable until correct path to the keyring file "
         "gets provided");
+#ifdef WITH_WSREP
+      return TRUE;
+#else
       return FALSE;
+#endif /* WITH_WSREP */
     }
     is_keys_container_initialized = TRUE;
     return FALSE;

--- a/plugin/keyring_vault/vault_keyring.cc
+++ b/plugin/keyring_vault/vault_keyring.cc
@@ -162,7 +162,11 @@ static int keyring_vault_init(MYSQL_PLUGIN plugin_info)
       if (current_thd != NULL)
         push_warning(current_thd, Sql_condition::SL_WARNING, 42000,
         	     "keyring_vault initialization failure. Please check the server log.");
+#ifdef WITH_WSREP
+      return 1;
+#else
       return 0;
+#endif /* WITH_WSREP */
     }
     is_keys_container_initialized = TRUE;
     return 0;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -4391,6 +4391,10 @@ static int test_plugin_options(MEM_ROOT *tmp_root, st_plugin_int *tmp,
       my_strcasecmp(&my_charset_latin1, tmp->name.str, "ndbcluster")))
     plugin_load_option= PLUGIN_OFF;
 
+  if (!(my_strcasecmp(&my_charset_latin1, tmp->name.str, "keyring_file") &&
+      my_strcasecmp(&my_charset_latin1, tmp->name.str, "keyring_vault")))
+    plugin_load_option= PLUGIN_FORCE;
+
   for (opt= tmp->plugin->system_vars; opt && *opt; opt++)
     count+= 2; /* --{plugin}-{optname} and --plugin-{plugin}-{optname} */
 


### PR DESCRIPTION
…he node/server

  - If some of the nodes of PXC fails to load keyring plugin
    then it could create inconsistency in cluster if the encrypted
    objects are used from the node that has keyring plugin loaded.

  - In ordered to limit the damange, PXC now refuse to start the node
    if keyring plugin params are specified but PXC fails to load them.

  - If user doesn't specify keyring param on some of the node then
    the issue of inconsistency still remains but that's difficult
    to control as it is user induced behavior.
    Also, PXC self protection will shutdown such node on detecting
    inconsistency there-by keeping the data-safe.