### PR TITLE
5.7-pxc-2127 : PXC shutdown hangs when pool-of-threads is set

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2732,7 +2732,7 @@ extern "C" void *signal_hand(void *arg MY_ATTRIBUTE((unused)))
         /* Stop wsrep threads in case they are running. */
         if (wsrep_running_threads > 0)
         {
-          wsrep_stop_replication(NULL);
+          wsrep_stop_replication(NULL, true);
         }
 #endif /* WITH_WSREP */
         close_connections();
@@ -7395,7 +7395,9 @@ extern "C" void *start_wsrep_THD(void *arg)
 
     THD_CHECK_SENTRY(thd);
     if (thd_added)
+    {
       thd_manager->remove_thd(thd);
+    }
   }
   else
   {

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1270,7 +1270,7 @@ void wsrep_recover()
 }
 
 
-void wsrep_stop_replication(THD *thd)
+void wsrep_stop_replication(THD *thd, bool is_server_shutdown)
 {
   WSREP_INFO("Stop replication");
   if (!wsrep)
@@ -1285,7 +1285,12 @@ void wsrep_stop_replication(THD *thd)
 
   wsrep_connected= FALSE;
 
-  wsrep_close_client_connections(TRUE, false);
+  /*
+   * On shutdown, let the normal mysqld shutdown code close the client
+   * connections.  See signal_hand() in mysqld.cc.
+  */
+  if (!is_server_shutdown)
+    wsrep_close_client_connections(TRUE, false);
 
   /* wait until appliers have stopped */
   wsrep_wait_appliers_close(thd);

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -234,7 +234,7 @@ extern void wsrep_close_applier_threads(int count);
 extern void wsrep_kill_mysql(THD *thd);
 
 /* new defines */
-extern void wsrep_stop_replication(THD *thd);
+extern void wsrep_stop_replication(THD *thd, bool is_server_shutdown);
 extern bool wsrep_start_replication();
 extern bool wsrep_must_sync_wait (THD* thd, uint mask = WSREP_SYNC_WAIT_BEFORE_READ);
 extern bool wsrep_sync_wait (THD* thd, uint mask = WSREP_SYNC_WAIT_BEFORE_READ);

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -350,7 +350,7 @@ bool wsrep_provider_update (sys_var *self, THD* thd, enum_var_type type)
      there can be several concurrent clients changing wsrep_provider
   */
   mysql_mutex_unlock(&LOCK_global_system_variables);
-  wsrep_stop_replication(thd);
+  wsrep_stop_replication(thd, false);
 
   /*
     Unlock and lock LOCK_wsrep_slave_threads to maintain lock order & avoid
@@ -492,7 +492,7 @@ bool wsrep_cluster_address_update (sys_var *self, THD* thd, enum_var_type type)
      there can be several concurrent clients changing wsrep_provider
   */
   mysql_mutex_unlock(&LOCK_global_system_variables);
-  wsrep_stop_replication(thd);
+  wsrep_stop_replication(thd, false);
   /*
     Unlock and lock LOCK_wsrep_slave_threads to maintain lock order & avoid
     any potential deadlock.


### PR DESCRIPTION
Issue:
When the threadpool is used, the client connection threads are not
being shutdown correctly by wsrep.  Thus if a client connection is
in use at time of shutdown, the server will hang waiting for the
connection to be killed.

Solution:
On server shutdown, the wsrep code will not attempt to close the
connection, but will rely on the mysql shutdown code to close the
connections.