### PR TITLE
PXC-2155 : wsrep_sst_xtrabackup-v2 not deleting all folders on cleanup

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -1157,9 +1157,9 @@ initialize_tmpdir()
     fi
 
     if [[ -z "${tmpdir_path}" ]]; then
-        tmpdir_path=$(mktemp -dt pxc_sst_XXXX)
+        tmpdir_path=$(mktemp --tmpdir --directory pxc_sst_XXXX)
     else
-        tmpdir_path=$(mktemp -p "${tmpdir_path}" -dt pxc_sst_XXXX)
+        tmpdir_path=$(mktemp --tmpdir="${tmpdir_path}" --directory pxc_sst_XXXX)
     fi
 
     # This directory (and everything in it), will be removed upon exit
@@ -1387,7 +1387,7 @@ then
     initialize_tmpdir
 
     # main temp directory for SST (non-XB) related files
-    donor_tmpdir=$(mktemp -p "${tmpdirbase}" -dt donor_tmp_XXXX)
+    donor_tmpdir=$(mktemp --tmpdir="${tmpdirbase}" --directory donor_tmp_XXXX)
 
     # raise error if keyring_plugin is enabled but transit encryption is not
     if [[ $keyring_plugin -eq 1 && $encrypt -le 0 ]]; then
@@ -1431,7 +1431,7 @@ then
         fi
 
         # main temp directory for xtrabackup (target-dir)
-        itmpdir=$(mktemp -p "${tmpdirbase}" -dt donor_xb_XXXX)
+        itmpdir=$(mktemp --tmpdir="${tmpdirbase}" --directory donor_xb_XXXX)
 
         if [[ -n "${WSREP_SST_OPT_USER:-}" && "$WSREP_SST_OPT_USER" != "(null)" ]]; then
            INNOEXTRA+=" --user=$WSREP_SST_OPT_USER"
@@ -1589,7 +1589,8 @@ then
     fi
 
     initialize_tmpdir
-    STATDIR=$(mktemp -p "${tmpdirbase}" -dt joiner_XXXX)
+    STATDIR=$(mktemp --tmpdir="${tmpdirbase}" --directory joiner_XXXX)
+
     sst_file_info_path="${STATDIR}/${SST_INFO_FILE}"
 
     recv_data_from_donor_to_joiner $STATDIR "${stagemsg}-sst-info" $stimeout -2


### PR DESCRIPTION
Cherry-pick of commit 733692e06950707788c8c8f1d5acb3a5e7cf5051

Issue
If the TMPDIR environment variable is set, that location was being
used as the root folder (rather than the folder specified by
the "-p" option).  When the sst script exits, it deletes the root
folder, therefore the folders that were created in the TMPDIR were
not getting deleted.

Solution
Use the "--tmpdir" option explicitly instead of "-p" which was
deprecated.  This makes it clearer where the tmp directores are
being created.
