### PR TITLE
Use HTTPS to download boost

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -34,7 +34,7 @@
 SET(BOOST_PACKAGE_NAME "boost_1_59_0")
 SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.gz")
 SET(BOOST_DOWNLOAD_URL
-  "http://jenkins.percona.com/downloads/boost/${BOOST_TARBALL}"
+  "https://jenkins.percona.com/downloads/boost/${BOOST_TARBALL}"
   )
 
 SET(OLD_PACKAGE_NAMES "boost_1_55_0 boost_1_56_0 boost_1_57_0 boost_1_58_0")


### PR DESCRIPTION
Previously, boost was downloaded over HTTP, which risks substitution of malicious code in its place.