### PR TITLE
PXC-1017 : LP #1376727: Memcached access to InnoDB is not replicated …

### DIFF
--- a/mysql-test/suite/galera/include/check_for_perl_module.pl
+++ b/mysql-test/suite/galera/include/check_for_perl_module.pl
@@ -1,0 +1,127 @@
+#!/usr/bin/env perl
+
+# Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; version 2
+# of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+#
+# This script is based on checkDBI-DBD-mysql.pl
+#
+# The comments below were taken from checkDBI-DBD-mysql.pl but altered
+# to match the usage of this script.
+#
+
+################################################################################
+#
+# This perl script checks for availability of the Perl module specified.
+# using the "current" perl interpreter.
+#
+# Useful for test environment checking before testing executable perl scripts
+# in the MySQL Server distribution.
+#
+# NOTE: The "shebang" on the first line of this script should always point to
+#       /usr/bin/perl, so that we can use this script to check whether or not we
+#       support running perl scripts with such a shebang without specifying the
+#       perl interpreter on the command line. Such a script is mysqlhotcopy.
+#
+#       When run as "check_for_perl_module.pl" the shebang line will be evaluated
+#       and used. When run as "perl check_for_perl_module.pl" the shebang line is
+#       not used.
+#
+# NOTE: This script will create a temporary file in MTR's tmp dir.
+#       If modules are found, a mysql-test statement which sets a special
+#       variable is written to this file.
+#       A test (or include file) which sources that file can then easily do
+#       an if-check on the special variable to determine success or failure.
+#
+#       Example:
+#
+#	      --let $perlChecker= suite/galera/include/check_for_perl_module.pl
+#         --let $resultFile= $MYSQL_TMP_DIR/mysql-perl-module-check.txt
+#         --chmod 0755 $perlChecker
+#         --exec $perlChecker $resultFile DBI DBD::mysql Cache::Memcached
+#         --source $resultFile
+#         if (!$all_perl_modules_found) {
+#             --skip Test needs Perl modules : $perl_modules_not_found
+#         }
+#
+#         Three variables will be created in the result file:
+#           $perl_modules_found     : string contains names of modules found
+#           $perl_modules_not_found : string contains names of modules not found
+#           $all_perl_modules_found : =1 if all modules found, =0 otherwise
+#
+#       The calling script is also responsible for cleaning up after use:
+#
+#         --remove_file $resultFile
+#
+# Windows notes:
+#   - shebangs may work differently - call this script with "perl " in front.
+#
+# See mysql-test/include/have_dbi_dbd-mysql.inc for example use of this script.
+# This script should be executable for the user running MTR.
+#
+################################################################################
+
+use strict;
+use warnings;
+
+my $result_file = $ARGV[0] or die("result_file not set\n");
+
+my $MODULES_FOUND = "";
+my $MODULES_NOT_FOUND = "";
+
+# By using eval we can suppress warnings and continue after.
+# We need to catch "Can't locate" as well as "Can't load" errors.
+
+# Skip over the first parameter (the result file location)
+for my $i (1 .. $#ARGV) {
+    my $MODULE_NAME=$ARGV[$i];
+    eval{
+        my $FOUND_MODULE = 0;
+        $FOUND_MODULE = 1 if eval "require $MODULE_NAME";
+
+        if ($FOUND_MODULE) {
+            $MODULES_FOUND .= (' '.$MODULE_NAME );
+        }
+        else {
+            $MODULES_NOT_FOUND .= (' '.$MODULE_NAME);
+        };
+    };
+};
+
+# Trim the strings (remove left and right whitespace)
+$MODULES_FOUND =~ s/^\s+|\s+$//g;
+$MODULES_NOT_FOUND =~ s/^\s+|\s+$//g;
+
+# Open a file to be used for transfer of result back to mysql-test.
+# The file must be created whether we write to it or not, otherwise mysql-test
+# will complain if trying to source it.
+open(FILE, ">", $result_file);
+
+print(FILE "let \$perl_modules_found= \"$MODULES_FOUND\";"."\n");
+print(FILE "let \$perl_modules_not_found= \"$MODULES_NOT_FOUND\";"."\n");
+
+if (length($MODULES_NOT_FOUND) == 0) {
+    print(FILE "let \$all_perl_modules_found= 1;"."\n");
+}
+else {
+    print(FILE "let \$all_perl_modules_found= 0;"."\n");
+}
+
+# close the file.
+close(FILE);
+
+1;
+

--- a/mysql-test/suite/galera/include/galera_memcached_run_perl_test.inc
+++ b/mysql-test/suite/galera/include/galera_memcached_run_perl_test.inc
@@ -1,0 +1,103 @@
+#
+# This tries to use the memcached api and returns the
+# results of several operations.  The result of the
+# operations depends on the specific tests.
+#
+# Usage:
+#       --let $MEMCACHED_SERVER_ADDRESS=127.0.0.1:11211
+#       --let $USE_MEMCACHED_BINARY_PROTOCOL=0
+#       --source galera_memcached_run_perl_test.inc
+#       if ($galera_memcached_stat_result != "success")
+#       {
+#           die("Test failure!")
+#       }
+#
+
+--let $perl_test_result_file=$MYSQL_TMP_DIR/galera_memcached_run_perl_test.txt
+
+--let PERL_RESULT_FILE=$perl_test_result_file
+--let USE_MEMCACHED_BINARY_PROTOCOL=$USE_MEMCACHED_BINARY_PROTOCOL
+--let SERVER_ADDRESS=$MEMCACHED_SERVER_ADDRESS
+
+--perl
+    use strict;
+    use warnings;
+
+    my $result_file = $ENV{"PERL_RESULT_FILE"} or die "Missing result_file parameter";
+    my $server_address = $ENV{'SERVER_ADDRESS'} or die "Missing memcached server address parameter";
+    my $use_binary_protocol = $ENV{'USE_MEMCACHED_BINARY_PROTOCOL'} or 0;
+
+    open(FILE, '>', "$result_file") or die("Unable to open $result_file: $!\n");
+
+    my $val;
+    my %versions;
+    my $versions_ref;
+
+    # By using eval we can suppress warnings and continue after.
+    eval {
+        use Cache::Memcached::libmemcached;
+        my $memd = Cache::Memcached::libmemcached->new({
+            'servers' => [ "$server_address" ],
+        });
+
+        if ($use_binary_protocol == 1) {
+            $memd->set_binary_protocol(1);
+            print(FILE "--let \$galera_memcached_binary_protocol=1\n");
+        }
+        else {
+            print(FILE "--let \$galera_memcached_binary_protocol=0\n");
+        }
+
+        #
+        # This will issue the "stat" command
+        # This should always succeed
+        #
+        $versions_ref = $memd->server_versions;
+        if ($versions_ref) {
+            %versions = %{ $versions_ref };
+        }
+        if (%versions) {
+            $val = $versions { $server_address };
+        }
+        if ($val) {
+            print(FILE "--let \$galera_memcached_stat_result=success\n");
+            print(FILE "--let \$galera_memcached_stat_value=\"$val\"\n");
+        }
+        else {
+            print(FILE "--let \$galera_memcached_stat_result=fail\n");
+        }
+
+        #
+        # Try a get(), this should fail if WSREP is enabled
+        # and succeed if WSREP is not enabled
+        #
+        $val = $memd->get("AA");
+        if ($val) {
+            print(FILE "--let \$galera_memcached_get_result=success\n");
+            print(FILE "--let \$galera_memcached_get_value=\"$val\"\n");
+        }
+        else {
+            print(FILE "--let \$galera_memcached_get_result=fail\n");
+        }
+
+        #
+        # Try a set(), this should fail if WSREP is enabled
+        # and succeed if WSREP is not enabled
+        #
+        $val = $memd->set("bb", "A somewhat longer string to use in the set command.");
+        if ($val) {
+            print(FILE "--let \$galera_memcached_set_result=success\n");
+        }
+        else {
+            print(FILE "--let \$galera_memcached_set_result=fail\n");
+        }
+
+        $memd->disconnect_all;
+    };
+
+    close(FILE);
+EOF
+
+--source $perl_test_result_file
+--remove_file $perl_test_result_file
+

--- a/mysql-test/suite/galera/include/have_perl_memcached_module.inc
+++ b/mysql-test/suite/galera/include/have_perl_memcached_module.inc
@@ -1,0 +1,16 @@
+#
+# Checks that the perl Cache::Memcached::libmemcached module is installed.
+# This particular module is needed to test the binary memcached API.
+#
+
+--let $result_file= $MYSQL_TMP_DIR/mysql-perl-module-check.txt
+
+--exec suite/galera/include/check_for_perl_module.pl $result_file Cache::Memcached::libmemcached
+
+--source $result_file
+--remove_file $result_file
+
+if (!$all_perl_modules_found) {
+    --skip Test requires Perl module : Cache::Memcached::libmemcached
+}
+

--- a/mysql-test/suite/galera/r/galera_memcached.result
+++ b/mysql-test/suite/galera/r/galera_memcached.result
@@ -1,0 +1,62 @@
+# Initialize memcached tables
+create database innodb_memcache;
+use innodb_memcache;
+CREATE  TABLE IF NOT EXISTS `cache_policies` (
+`policy_name` VARCHAR(40) PRIMARY KEY,
+`get_policy` ENUM('innodb_only', 'cache_only', 'caching','disabled')
+NOT NULL ,
+`set_policy` ENUM('innodb_only', 'cache_only','caching','disabled')
+NOT NULL ,
+`delete_policy` ENUM('innodb_only', 'cache_only', 'caching','disabled')
+NOT NULL,
+`flush_policy` ENUM('innodb_only', 'cache_only', 'caching','disabled')
+NOT NULL
+) ENGINE = innodb;
+CREATE  TABLE IF NOT EXISTS `containers` (
+`name` varchar(50) not null primary key,
+`db_schema` VARCHAR(250) NOT NULL,
+`db_table` VARCHAR(250) NOT NULL,
+`key_columns` VARCHAR(250) NOT NULL,
+`value_columns` VARCHAR(250),
+`flags` VARCHAR(250) NOT NULL DEFAULT "0",
+`cas_column` VARCHAR(250),
+`expire_time_column` VARCHAR(250),
+`unique_idx_name_on_key` VARCHAR(250) NOT NULL
+) ENGINE = InnoDB;
+CREATE  TABLE IF NOT EXISTS `config_options` (
+`name` varchar(50) not null primary key,
+`value` varchar(50)) ENGINE = InnoDB;
+# Fill in the memcached metadata tables
+use innodb_memcache;
+INSERT INTO cache_policies VALUES("cache_policy", "innodb_only",
+"innodb_only", "innodb_only", "innodb_only");
+INSERT INTO config_options VALUES("separator", "|");
+INSERT INTO containers VALUES ("desc_t1", "test", "t1",
+"c1", "c2", "c3", "c4", "c5", "PRIMARY");
+USE test;
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (c1 VARCHAR(32),
+c2 VARCHAR(1024),
+c3 INT, c4 BIGINT UNSIGNED, c5 INT, primary key(c1))
+ENGINE = INNODB;
+INSERT INTO t1 VALUES ('AA', 'Hello', 0, 0, 0);
+INSERT INTO t1 VALUES ('bb', 'Goodbye', 0, 0, 0);
+# Install and start the memcached plugin
+INSTALL PLUGIN daemon_memcached SONAME 'libmemcached.so';
+# Test that the calls fail when WSREP is enabled (text protocol)
+(text protocol) stat() returned : success
+(text protocol) get() returned : fail
+(text protocol) set() returned : fail
+# Test that the calls fail when WSREP is enabled (binary protocol)
+(binary protocol) stat() returned : success
+(binary protocol) get() returned : fail
+(binary protocol) set() returned : fail
+set global wsrep_provider="none";
+# Test that the calls succeed when WSREP is disabled (text protocol)
+(text protocol) stat() returned : success
+(text protocol) get() returned : success
+(text protocol) set() returned : success
+# Test that the calls succeed when WSREP is disabled (binary protocol)
+(binary protocol) stat() returned : success
+(binary protocol) get() returned : success
+(binary protocol) set() returned : success

--- a/mysql-test/suite/galera/t/galera_memcached.cnf
+++ b/mysql-test/suite/galera/t/galera_memcached.cnf
@@ -1,0 +1,8 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+loose-daemon-memcached-option="-p11017"
+
+[mysqld.2]
+loose-daemon-memcached-option="-p11211"
+

--- a/mysql-test/suite/galera/t/galera_memcached.test
+++ b/mysql-test/suite/galera/t/galera_memcached.test
@@ -1,0 +1,113 @@
+#
+# Checks that the innodb_memcached api is disabled
+# when WSREP is enabled.
+#
+
+--source include/have_innodb.inc
+--source include/have_memcached_plugin.inc
+--source suite/galera/include/have_perl_memcached_module.inc
+--source include/galera_cluster.inc
+--source include/force_restart.inc
+
+#
+# Create the memcached system tables
+#
+--connection node_1
+--echo # Initialize memcached tables
+--source include/memcache_config.inc
+
+
+--echo # Fill in the memcached metadata tables
+use innodb_memcache;
+
+INSERT INTO cache_policies VALUES("cache_policy", "innodb_only",
+                                  "innodb_only", "innodb_only", "innodb_only");
+
+INSERT INTO config_options VALUES("separator", "|");
+
+#
+# describe table for memcache
+#
+INSERT INTO containers VALUES ("desc_t1", "test", "t1",
+                               "c1", "c2", "c3", "c4", "c5", "PRIMARY");
+
+#
+# Tables must exist before plugin can be started!
+#
+USE test;
+
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+CREATE TABLE t1 (c1 VARCHAR(32),
+                 c2 VARCHAR(1024),
+                 c3 INT, c4 BIGINT UNSIGNED, c5 INT, primary key(c1))
+ENGINE = INNODB;
+
+INSERT INTO t1 VALUES ('AA', 'Hello', 0, 0, 0);
+INSERT INTO t1 VALUES ('bb', 'Goodbye', 0, 0, 0);
+
+--echo # Install and start the memcached plugin
+
+#! **** IMPORTANT! ****
+# memcached ports are based on the PXC bug number
+# This way the tests will not interfere with other
+# memcached tests.  Since node_2 is not used, it
+# uses the default port (11211).
+#
+
+INSTALL PLUGIN daemon_memcached SONAME 'libmemcached.so';
+
+--echo # Test that the calls fail when WSREP is enabled (text protocol)
+--let $MEMCACHED_SERVER_ADDRESS=127.0.0.1:11017
+--let $USE_MEMCACHED_BINARY_PROTOCOL=0
+--source suite/galera/include/galera_memcached_run_perl_test.inc
+
+# check the output
+# stat() should succeed, get and set should fail
+--echo (text protocol) stat() returned : $galera_memcached_stat_result
+--echo (text protocol) get() returned : $galera_memcached_get_result
+--echo (text protocol) set() returned : $galera_memcached_set_result
+
+--echo # Test that the calls fail when WSREP is enabled (binary protocol)
+--let $MEMCACHED_SERVER_ADDRESS=127.0.0.1:11017
+--let $USE_MEMCACHED_BINARY_PROTOCOL=1
+--source suite/galera/include/galera_memcached_run_perl_test.inc
+
+# check the output
+# stat() should succeed, get and set should fail
+--echo (binary protocol) stat() returned : $galera_memcached_stat_result
+--echo (binary protocol) get() returned : $galera_memcached_get_result
+--echo (binary protocol) set() returned : $galera_memcached_set_result
+
+#
+# disable WSREP
+#
+set global wsrep_provider="none";
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 0 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--echo # Test that the calls succeed when WSREP is disabled (text protocol)
+--let $MEMCACHED_SERVER_ADDRESS=127.0.0.1:11017
+--let $USE_MEMCACHED_BINARY_PROTOCOL=0
+--source suite/galera/include/galera_memcached_run_perl_test.inc
+
+# check the output
+# all the calls should succeed
+--echo (text protocol) stat() returned : $galera_memcached_stat_result
+--echo (text protocol) get() returned : $galera_memcached_get_result
+--echo (text protocol) set() returned : $galera_memcached_set_result
+
+--echo # Test that the calls succeed when WSREP is disabled (binary protocol)
+--let $MEMCACHED_SERVER_ADDRESS=127.0.0.1:11017
+--let $USE_MEMCACHED_BINARY_PROTOCOL=1
+--source suite/galera/include/galera_memcached_run_perl_test.inc
+
+# check the output
+# all the calls should succeed
+--echo (binary protocol) stat() returned : $galera_memcached_stat_result
+--echo (binary protocol) get() returned : $galera_memcached_get_result
+--echo (binary protocol) set() returned : $galera_memcached_set_result
+
+

--- a/plugin/innodb_memcached/daemon_memcached/daemon/memcached.c
+++ b/plugin/innodb_memcached/daemon_memcached/daemon/memcached.c
@@ -2964,6 +2964,24 @@ static void dispatch_bin_command(conn *c) {
         c->noreply = false;
     }
 
+#ifdef WITH_WSREP
+    if (wsrep_is_wsrep_on() &&
+        c->cmd != PROTOCOL_BINARY_CMD_NOOP &&
+        c->cmd != PROTOCOL_BINARY_CMD_QUIT &&
+        c->cmd != PROTOCOL_BINARY_CMD_STAT &&
+        c->cmd != PROTOCOL_BINARY_CMD_VERSION &&
+        c->cmd != PROTOCOL_BINARY_CMD_VERBOSITY)
+    {
+        if (settings.verbose) {
+            settings.extensions.logger->log(EXTENSION_LOG_WARNING, c,
+                     "The memcached API is disabled because WSREP (Galera replication) is enabled.\n");
+        }
+
+        write_bin_packet(c, PROTOCOL_BINARY_RESPONSE_NOT_SUPPORTED, bodylen);
+        return;
+    }
+#endif /* WITH_WSREP */
+
     switch (c->cmd) {
         case PROTOCOL_BINARY_CMD_VERSION:
             if (extlen == 0 && keylen == 0 && bodylen == 0) {
@@ -4571,6 +4589,21 @@ static char* process_command(conn *c, char *command) {
     }
 
     ntokens = tokenize_command(command, tokens, MAX_TOKENS);
+
+#ifdef WITH_WSREP
+    if (wsrep_is_wsrep_on() &&
+        ntokens >= 1 &&
+        (strcmp(tokens[COMMAND_TOKEN].value, "quit") != 0) &&
+        (strcmp(tokens[COMMAND_TOKEN].value, "stats") != 0) &&
+        (strcmp(tokens[COMMAND_TOKEN].value, "version") != 0) &&
+        (strcmp(tokens[COMMAND_TOKEN].value, "verbosity") != 0)
+        )
+    {
+        out_string(c, "SERVER_ERROR The memcached api is disabled because WSREP (Galera replication) is enabled");
+        return NULL;
+    }
+#endif /* WITH_WSREP */
+
     if (ntokens >= 3 &&
         ((strcmp(tokens[COMMAND_TOKEN].value, "get") == 0) ||
          (strcmp(tokens[COMMAND_TOKEN].value, "bget") == 0))) {

--- a/plugin/innodb_memcached/daemon_memcached/daemon/memcached.h
+++ b/plugin/innodb_memcached/daemon_memcached/daemon/memcached.h
@@ -272,6 +272,11 @@ extern void notify_thread(LIBEVENT_THREAD *thread);
 extern void notify_dispatcher(void);
 extern bool create_notification_pipe(LIBEVENT_THREAD *me);
 
+#ifdef WITH_WSREP
+extern bool wsrep_is_wsrep_on(void);
+#endif /* WITH_WSREP */
+
+
 extern LIBEVENT_THREAD* tap_thread;
 
 typedef struct conn conn;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -242,6 +242,10 @@ extern int  wsrep_check_opts (int argc, char* const* argv);
 extern void wsrep_prepend_PATH (const char* path);
 /* some inline functions are defined in wsrep_mysqld_inl.h */
 
+/* Provide a wrapper of the WSREP_ON macro for plugins to use */
+extern "C" bool wsrep_is_wsrep_on(void);
+
+
 /* Other global variables */
 extern wsrep_seqno_t wsrep_locked_seqno;
 

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -97,6 +97,17 @@ wsrep_prepend_PATH (const char* path)
                  "State snapshot transfer may not be working.");
 }
 
+/**
+ * This is a wrapper around the WSREP_ON macro.  This allows this check
+ * to be called from plugins.
+ */
+extern "C" bool
+wsrep_is_wsrep_on(void)
+{
+  return WSREP_ON;
+}
+
+
 namespace wsp
 {
 


### PR DESCRIPTION
…by Galera

Issue
The memcached API does not replicate changes (via Galera).
The innodb memcache API goes through a different code path than normal
SQL commands, thus it bypasses all the WSREP logic to replicate transactions
(it interacts directly with InnoDB at the binlog level).

Solution
A more thorough solution would involve adding the replication logic to the
memcached event handler.  However, that's a bigger feature change.  For now,
we will disable the memcached API when WSREP is being used on a node.