### PR TITLE
- PXC#2162: Assertion failure during crash recovery

### DIFF
--- a/mysql-test/suite/galera/r/galera_trx_lost.result
+++ b/mysql-test/suite/galera/r/galera_trx_lost.result
@@ -15,12 +15,20 @@ ERROR HY000: Lost connection to MySQL server during query
 #node-1
 #waiting to restart node-1
 # restart:
+set session wsrep_on=0;
+set debug="+d,crash_before_trx_commit_in_memory";
+insert into t1 values (40);
+ERROR HY000: Lost connection to MySQL server during query
+#node-1
+#waiting to restart node-1
+# restart:
 select * from t1;
 i
 1
 2
 3
 4
+40
 drop table t1;
 #node-2
 # restart:

--- a/mysql-test/suite/galera/t/galera_trx_lost.test
+++ b/mysql-test/suite/galera/t/galera_trx_lost.test
@@ -50,6 +50,27 @@ insert into t1 values (4);
 --source include/wait_condition.inc
 --source include/galera_wait_ready.inc
 
+#
+# continue with same table but this time insert some rows with wsrep_on=off
+# these transaction will be committed with mysql xid and not wsrep xid.
+set session wsrep_on=0;
+set debug="+d,crash_before_trx_commit_in_memory";
+--error 2013
+insert into t1 values (40);
+
+--connection node_1
+--echo #node-1
+--echo #waiting to restart node-1
+--sleep 3
+
+--let $restart_parameters="restart:"
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--source include/galera_wait_ready.inc
+
 select * from t1;
 drop table t1;
 

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1774,12 +1774,13 @@ trx_write_serialisation_history(
         {
             trx_sys_update_wsrep_checkpoint(trx->xid, sys_header, mtr);
         }
-	else if (trx->wsrep_recover_xid)
+	else if (trx->wsrep_recover_xid
+		 && wsrep_is_wsrep_xid(trx->wsrep_recover_xid))
 	{
 		trx_sys_update_wsrep_checkpoint(
 				trx->wsrep_recover_xid, sys_header, mtr, true);
-		trx->wsrep_recover_xid = NULL;
 	}
+	trx->wsrep_recover_xid = NULL;
 #endif /* WITH_WSREP */
 
 	/* Update the latest MySQL binlog name and offset info


### PR DESCRIPTION
  * Say user is trying to run some workload and decide to run
    part of it with wsrep_on=off.

  * Server/Node hit a crash while running workload in wsrep_on=off
    and some transaction are left out in prepare state that
    could be committed on recovery.

  * Since these transactions got stamped with MySQL XID and not
    wsrep XID, on recovery, avoid updating wsrep co-ordinates
    using these transactions.