### PR TITLE
- PXC#2165: Failing to set wsrep_node_address or wsrep_sst_receive_ad…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -574,6 +574,14 @@ read_cnf()
     scomp=$(parse_cnf sst compressor "")
     sdecomp=$(parse_cnf sst decompressor "")
 
+    # if wsrep_node_address is not set raise a warning
+    wsrep_node_address=$(parse_cnf mysqld wsrep_node_address "")
+    wsrep_sst_recieve_address=$(parse_cnf mysqld wsrep_sst_recieve_address "")
+    if [[ -z $wsrep_node_address && -z $wsrep_sst_recieve_address ]]; then
+        wsrep_log_warning "wsrep_node_address or wsrep_sst_recieve_address not set." \
+                          "Consider setting them if SST fails."
+    fi
+
     # If pv is not in the PATH, then disable the 'progress'
     # and 'rlimit' options
     progress=$(parse_cnf sst progress "")


### PR DESCRIPTION
…dress

  can cause SST to fail

  - If user fail to set wsrep_node_address or wsrep_sst_receive_address
    SST could fail without any hint towards the missing configuration.

  - Of-course it doesn't fail always but in restricted cases
    as listed in documentation.

  - Post this fix, script would emit a warning to help user get an hint
    of what may be missing.