### PR TITLE
- PXC#2199: DROP TRIGGER IF EXISTS increment unexpected GTID

### DIFF
--- a/mysql-test/suite/galera/r/galera_create_trigger.result
+++ b/mysql-test/suite/galera/r/galera_create_trigger.result
@@ -40,3 +40,15 @@ DROP TABLE definer_user;
 DROP TABLE definer_root;
 DROP TABLE definer_default;
 DROP USER 'user1';
+select locate(':1-18', @@global.gtid_executed);
+locate(':1-18', @@global.gtid_executed)
+37
+DROP TRIGGER IF EXISTS non_existing_trigger;
+Warnings:
+Note	1360	Trigger does not exist
+select locate(':1-19', @@global.gtid_executed);
+locate(':1-19', @@global.gtid_executed)
+37
+select locate(':1-19', @@global.gtid_executed);
+locate(':1-19', @@global.gtid_executed)
+37

--- a/mysql-test/suite/galera/t/galera_create_trigger-master.opt
+++ b/mysql-test/suite/galera/t/galera_create_trigger-master.opt
@@ -1,0 +1,2 @@
+--gtid-mode=ON --log-bin --log-slave-updates --enforce-gtid-consistency
+

--- a/mysql-test/suite/galera/t/galera_create_trigger.test
+++ b/mysql-test/suite/galera/t/galera_create_trigger.test
@@ -41,8 +41,10 @@ DROP TABLE definer_default;
 
 DROP USER 'user1';
 
+--connection node_1
+select locate(':1-18', @@global.gtid_executed);
+DROP TRIGGER IF EXISTS non_existing_trigger;
+select locate(':1-19', @@global.gtid_executed);
 
-
-
-
-
+--connection node_2
+select locate(':1-19', @@global.gtid_executed);

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -189,6 +189,11 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
       result= FALSE;
       /* Still, we need to log the query ... */
       stmt_query.append(thd->query().str, thd->query().length);
+#ifdef WITH_WSREP
+      /* Table doesn't exist but query is still being logged
+      so replicate a query with NULL construct. */
+      WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, tables)
+#endif /* WITH_WSREP */
       goto end;
     }
   }


### PR DESCRIPTION
  * MySQL logic would append drop trigger if exists to binlog
    even if there is no trigger present.

  * This early exit path didn't entered GALERA replication world.
    So the said statement got registered only with local gtid.

  * Corrected flow to register said statement early exit flow
    in GALERA replication context.

(cherry picked from commit 2648d0d2f1b164ac9624d677505ec5da7dfa6b24)