### PR TITLE
- PXC#2202: Disconnected Cluster Node should still allow itself to be…

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3148,6 +3148,7 @@ mysql_execute_command(THD *thd, bool first_level)
           (sql_command_flags[lex->sql_command] & CF_CHANGES_DATA) == 0)    &&
         !wsrep_tables_accessible_when_detached(all_tables)                 &&
         lex->sql_command != SQLCOM_SET_OPTION                              &&
+        lex->sql_command != SQLCOM_SHUTDOWN                                &&
         !wsrep_is_show_query(lex->sql_command))
     {
       my_message(ER_UNKNOWN_COM_ERROR,


### PR DESCRIPTION
… shut down

  - MySQL-5.7 introduces SQLCOM_SHUTDOWN command.

  - Once node turns non-primary, PXC allows execution of restricted command.

  - Shutdown command should be allowed but since it was introduced in 5.7
    it got missed (5.6 has different way of handling it and so it worked till 5.6).