### PR TITLE
- PXC#2209: compression dictionary is not replicated in PXC

### DIFF
--- a/mysql-test/suite/galera/r/galera_ddl_dml.result
+++ b/mysql-test/suite/galera/r/galera_ddl_dml.result
@@ -9,12 +9,22 @@ set wsrep_replicate_myisam = 1;
 create table t3 (j int) engine=myisam;
 insert into t3 values (100), (200), (300);
 set wsrep_replicate_myisam = 0;
+create compression_dictionary numbers ('percona');
+create table tdict (
+id int,
+a blob column_format compressed,
+b blob column_format compressed with compression_dictionary numbers,
+primary key pk(id)) engine=innodb;
+insert into tdict values (
+1, repeat('percona is great company', 50),
+repeat('percona is great company', 50));
 #node-2
 show tables;
 Tables_in_test
 t1
 t2
 t3
+tdict
 select * from t1;
 i
 1
@@ -27,6 +37,18 @@ j
 100
 200
 300
+show create table tdict;
+Table	Create Table
+tdict	CREATE TABLE `tdict` (
+  `id` int(11) NOT NULL,
+  `a` blob /*!50633 COLUMN_FORMAT COMPRESSED */,
+  `b` blob /*!50633 COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY `numbers` */,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# ensure dictionary is created
+select * from information_schema.xtradb_zip_dict where name like '%number%';
+id	name	zip_dict
+1	numbers	percona
 #node-1
 truncate table t1;
 truncate table t2;
@@ -37,6 +59,7 @@ Tables_in_test
 t1
 t2
 t3
+tdict
 select * from t1;
 i
 select * from t2;
@@ -47,4 +70,10 @@ j
 drop table t1;
 drop table t2;
 drop table t3;
+drop table tdict;
+drop compression_dictionary numbers;
+#node-2
+# ensure dictionary drop is replicated
+select * from information_schema.xtradb_zip_dict where name like '%number%';
+id	name	zip_dict
 set @@wsrep_replicate_myisam = 0;;

--- a/mysql-test/suite/galera/t/galera_ddl_dml.test
+++ b/mysql-test/suite/galera/t/galera_ddl_dml.test
@@ -45,12 +45,26 @@ create table t3 (j int) engine=myisam;
 insert into t3 values (100), (200), (300);
 set wsrep_replicate_myisam = 0;
 
+create compression_dictionary numbers ('percona');
+create table tdict (
+	id int,
+	a blob column_format compressed,
+	b blob column_format compressed with compression_dictionary numbers,
+	primary key pk(id)) engine=innodb;
+insert into tdict values (
+	1, repeat('percona is great company', 50),
+	repeat('percona is great company', 50));
+
+
 --connection node_2
 --echo #node-2
 show tables;
 select * from t1;
 select * from t2;
 select * from t3;
+show create table tdict;
+--echo # ensure dictionary is created
+select * from information_schema.xtradb_zip_dict where name like '%number%';
 
 --connection node_1
 --echo #node-1
@@ -70,6 +84,13 @@ select * from t3;
 drop table t1;
 drop table t2;
 drop table t3;
+drop table tdict;
+drop compression_dictionary numbers;
+
+--connection node_2
+--echo #node-2
+--echo # ensure dictionary drop is replicated
+select * from information_schema.xtradb_zip_dict where name like '%number%';
 
 #-------------------------------------------------------------------------------
 #

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4597,6 +4597,11 @@ end_with_restore_list:
     break;
   case SQLCOM_CREATE_COMPRESSION_DICTIONARY:
   {
+
+#ifdef WITH_WSREP
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+#endif /* WITH_WSREP */
+
     if (lex->default_value->fixed == 0)
       lex->default_value->fix_fields(thd, 0);
     String dict_data;
@@ -4615,6 +4620,11 @@ end_with_restore_list:
   }
   case SQLCOM_DROP_COMPRESSION_DICTIONARY:
   {
+
+#ifdef WITH_WSREP
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+#endif /* WITH_WSREP */
+
     if ((res= mysql_drop_zip_dict(thd, lex->ident.str, lex->ident.length,
                                   lex->drop_if_exists)) == 0)
       my_ok(thd);


### PR DESCRIPTION
  - COMPRESSION_DICTIONARY support is added in PS starting from 5.7.17

  - CREATE and DROP of this object is done through a dedicated set of
    command internally in MySQL. TOI replication was not enabled for these
    commands and so DICTIONARY object was not replicated.

  - Added relevant TOI replication hook.