### PR TITLE
- PXC#2213: NULL/VOID DDL can commit out-of-order

### DIFF
--- a/mysql-test/suite/galera/r/galera_ddl_dml.result
+++ b/mysql-test/suite/galera/r/galera_ddl_dml.result
@@ -76,4 +76,24 @@ drop compression_dictionary numbers;
 # ensure dictionary drop is replicated
 select * from information_schema.xtradb_zip_dict where name like '%number%';
 id	name	zip_dict
+#node-2
+call mtr.add_suppression("Can't create database");
+#node-1
+set global wsrep_debug=1;
+create table t (i int, primary key pk(i)) engine=innodb;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_in_commit_flush_stage SIGNAL entered1 WAIT_FOR continue1";
+insert into t values (1);;
+#node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+create database test;
+ERROR HY000: Can't create database 'test'; database exists
+SET DEBUG_SYNC = "now SIGNAL continue1";
+#node-1
+select * from t;
+i
+1
+SET GLOBAL wsrep_debug = 0;
+drop table t;
 set @@wsrep_replicate_myisam = 0;;

--- a/mysql-test/suite/galera/t/galera_ddl_dml-master.opt
+++ b/mysql-test/suite/galera/t/galera_ddl_dml-master.opt
@@ -1,0 +1,1 @@
+--log-bin --log-slave-updates

--- a/mysql-test/suite/galera/t/galera_ddl_dml.test
+++ b/mysql-test/suite/galera/t/galera_ddl_dml.test
@@ -6,6 +6,8 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
 
 
 #-------------------------------------------------------------------------------
@@ -91,6 +93,42 @@ drop compression_dictionary numbers;
 --echo #node-2
 --echo # ensure dictionary drop is replicated
 select * from information_schema.xtradb_zip_dict where name like '%number%';
+
+#-------------------------------------------------------------------------------
+#
+# 1. DDL/DML statement and their replication
+#
+--connection node_2
+--echo #node-2
+call mtr.add_suppression("Can't create database");
+
+
+--connection node_1
+--echo #node-1
+#
+--let $wsrep_debug_orig = `SELECT @@wsrep_debug`
+set global wsrep_debug=1;
+#
+create table t (i int, primary key pk(i)) engine=innodb;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_in_commit_flush_stage SIGNAL entered1 WAIT_FOR continue1";
+--send insert into t values (1);
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+--echo #node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+--error ER_DB_CREATE_EXISTS
+create database test;
+SET DEBUG_SYNC = "now SIGNAL continue1";
+
+--connection node_1
+--echo #node-1
+--reap
+select * from t;
+--eval SET GLOBAL wsrep_debug = $wsrep_debug_orig
+drop table t;
 
 #-------------------------------------------------------------------------------
 #

--- a/mysql-test/suite/galera/t/mysql-wsrep#216.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#216.test
@@ -47,7 +47,7 @@ DROP USER u1;
 # Five times for the first node, in the various wsrep_debug messages
 --let $assert_text = 'mysql_native_password' AS '<secret>'
 --let $assert_select = 'mysql_native_password' AS '<secret>'
---let $assert_count = 5
+--let $assert_count = 6
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -10016,6 +10016,8 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit)
     DBUG_RETURN(finish_commit(thd));
   }
 
+  DEBUG_SYNC(thd, "pxc_in_commit_flush_stage");
+
   THD *wait_queue= NULL, *final_queue= NULL;
   mysql_mutex_t *leave_mutex_before_commit_stage= NULL;
   my_off_t flush_end_pos= 0;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1553,6 +1553,7 @@ THD::THD(bool enable_plugins)
   wsrep_skip_wsrep_GTID   = false;
   wsrep_split_trx         = false;
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;
+  wsrep_skip_SE_checkpoint = false;
   wsrep_skip_wsrep_hton   = false;
 #endif /* WITH_WSREP */
   /* Call to init() below requires fully initialized Open_tables_state. */
@@ -1955,6 +1956,7 @@ void THD::init(void)
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;
   wsrep_sst_donor= false;
   wsrep_void_applier_trx  = true;
+  wsrep_skip_SE_checkpoint = false;
   wsrep_skip_wsrep_hton   = false;
 #endif /* WITH_WSREP */
   binlog_row_event_extra_data= 0;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3448,6 +3448,9 @@ public:
   bool                      wsrep_replicate_GTID;
   bool                      wsrep_skip_wsrep_GTID;
 
+  /* DDL statement can fail in which case SE checkpoint shouldn't get updated. */
+  bool                      wsrep_skip_SE_checkpoint;
+
   /* DDL statement. skip registering wsrep_hton handler.
   This is normally blocked by checking wsrep_exec_state != TOTAL_ORDER
   but if sql_log_bin = 0 then the state is not set and DDL should is expected

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6226,6 +6226,9 @@ finish:
   {
     thd->mdl_context.release_statement_locks();
   }
+
+  /* If DDL has failed then avoid SE checkpoint. */
+  thd->wsrep_skip_SE_checkpoint= (res || thd->is_error());
   WSREP_TO_ISOLATION_END;
 
 #ifdef WITH_WSREP

--- a/sql/wsrep_hton.cc
+++ b/sql/wsrep_hton.cc
@@ -50,6 +50,7 @@ void wsrep_cleanup_transaction(THD *thd)
   thd->wsrep_affected_rows= 0;
   thd->wsrep_void_applier_trx= true;
   thd->wsrep_skip_wsrep_GTID= false;
+  thd->wsrep_skip_SE_checkpoint= false;
   return;
 }
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2075,8 +2075,14 @@ static void wsrep_TOI_end(THD *thd)
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
 
-  wsrep_set_SE_checkpoint(thd->wsrep_trx_meta.gtid.uuid,
-                          thd->wsrep_trx_meta.gtid.seqno);
+  if (!thd->wsrep_skip_SE_checkpoint) {
+    wsrep_set_SE_checkpoint(thd->wsrep_trx_meta.gtid.uuid,
+                            thd->wsrep_trx_meta.gtid.seqno);
+  } else {
+    WSREP_DEBUG("Skip SE checkpoint due to TOI statement (%s) failure (%lld)",
+                WSREP_QUERY(thd),
+                (long long)wsrep_thd_trx_seqno(thd));
+  }
   
   if (WSREP_OK == (ret = wsrep->to_execute_end(wsrep, (ulong)thd->thread_id()))) {
     WSREP_DEBUG("Completed query (%s) replication with write-set (%lld) and"


### PR DESCRIPTION
  - With recent performance optimization we expect all
    transaction to pass through ordered_commit.

  - This is true for all transaction including DML and DDL.

  - Unfortunately, if DDL transaction fails in pre-check
    then there is nothing to commit but this DDL statement
    is replicated before execution or pre-check starts
    so it still try to commit.

  - This could cause a race between transaction passing
    through ordered_commit maintaining commit ordering
    vs above short-circuit null/void DDL transaction.

  - Avoid update of wsrep co-ordinate through such
    null/void DDL transaction.