### PR TITLE
- PXC#2225: Making compilation flag for PXC consistent with PS

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -300,13 +300,6 @@ export CFLAGS=" $COMMON_FLAGS -static-libgcc $MACHINE_SPECS_CFLAGS ${CFLAGS:-}"
 export CXXFLAGS=" $COMMON_FLAGS $MACHINE_SPECS_CFLAGS ${CXXFLAGS:-}"
 export MAKE_JFLAG="${MAKE_JFLAG:--j$PROCESSORS}"
 
-export DEBIAN_VERSION="$(lsb_release -sc)"
-echo $DEBIAN_VERSION
-if [[ "$CMAKE_BUILD_TYPE" == "Debug" ]] && ([[ "$DEBIAN_VERSION" == "yakkety" ]] || [[ "$DEBIAN_VERSION" == "zesty" ]] || [[ "$DEBIAN_VERSION" == "stretch" ]] || [[ "$DEBIAN_VERSION" == "artful" ]] || [[ "$DEBIAN_VERSION" == "bionic" ]]); then
-    export CFLAGS=" $CFLAGS -fno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-error=nonnull-compare -Wno-error=shift-negative-value -Wno-error=misleading-indentation -Wno-error=literal-suffix -Wno-error=virtual-move-assign"
-    export CXXFLAGS=" $CFLAGS -fno-strict-aliasing -Wno-unused-parameter -Wno-sign-compare -Wno-error=deprecated-declarations -Wno-error=nonnull-compare -Wno-error=shift-negative-value -Wno-error=misleading-indentation -Wno-error=literal-suffix -Wno-error=virtual-move-assign"
-fi
-
 #
 # Test jemalloc directory
 if test "x$WITH_JEMALLOC" != "x"

--- a/cmake/build_configurations/compiler_options.cmake
+++ b/cmake/build_configurations/compiler_options.cmake
@@ -24,6 +24,8 @@ ENDIF()
 IF(SIZEOF_VOIDP EQUAL 8)
   SET(64BIT 1)
 ENDIF()
+
+SET(CMAKE_CXX_STANDARD 98)
  
 # Compiler options
 IF(UNIX)  
@@ -67,9 +69,11 @@ IF(UNIX)
     # GCC 6 has C++14 as default, set it explicitly to the old default.
     EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GXX_VERSION)
-    IF(GXX_VERSION VERSION_EQUAL 6.0 OR GXX_VERSION VERSION_GREATER 6.0)
-      SET(COMMON_CXX_FLAGS             "${COMMON_CXX_FLAGS} -std=gnu++03 -std=gnu++11")
-    ENDIF()
+    # Oracle uses gcc version check logic to append gnu++03. PS uses
+    # cmake logic as it works with clang too.
+    #IF(GXX_VERSION VERSION_EQUAL 6.0 OR GXX_VERSION VERSION_GREATER 6.0)
+    #  SET(COMMON_CXX_FLAGS             "${COMMON_CXX_FLAGS} -std=gnu++03 -std=gnu++11")
+    #ENDIF()
     # Disable inline optimizations for valgrind testing to avoid false positives
     IF(WITH_VALGRIND)
       SET(COMMON_CXX_FLAGS             "-fno-inline ${COMMON_CXX_FLAGS}")

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -7456,7 +7456,8 @@ extern "C" void *start_wsrep_THD(void *arg)
   delete thd;
 
   my_thread_end();
-  ERR_remove_state(0);
+  // deprecated in openssl
+  // ERR_remove_state(0);
   my_thread_exit(0);
 
   return(NULL);

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -257,10 +257,10 @@ extern wsrep_seqno_t wsrep_locked_seqno;
 /* use xxxxxx_NNULL macros when thd pointer is guaranteed to be non-null to
  * avoid compiler warnings (GCC 6 and later) */
 #define WSREP_NNULL(thd) \
-  (WSREP_ON && wsrep && thd->variables.wsrep_on)
+  (WSREP_ON && (wsrep != NULL) && thd->variables.wsrep_on)
 
 #define WSREP(thd) \
-  (thd && WSREP_NNULL(thd))
+  ((thd != NULL) && WSREP_NNULL(thd))
 
 #define WSREP_CLIENT(thd) \
   (WSREP(thd) && thd->wsrep_client_thread)


### PR DESCRIPTION
  - MySQL-5.7 code is C++03 compatible.

  - PXC build script started passing C++11 compatibilty
    flags as build failure workaround that eventually
    pollulated lot of build scripts.

  - Patch attempt to remove all these workaround
    and make it compatible with PS/MySQL compilation flags.