### PR TITLE
- PXC#2272: Avoid starting mysqld service (pxc) if one is running

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2041,10 +2041,12 @@ static int binlog_start_consistent_snapshot(handlerton *hton, THD *thd)
   LOG_INFO li;
   DBUG_ENTER("binlog_start_consistent_snapshot");
 
-#ifdef WSREP
+#if 0
+#ifdef WITH_WSREP
   if (wsrep_emulate_bin_log)
     DBUG_RETURN(0);
 #endif /* WITH_WSREP */
+#endif
 
   if ((err= thd->binlog_setup_trx_data()))
     DBUG_RETURN(err);
@@ -2070,10 +2072,12 @@ static int binlog_clone_consistent_snapshot(handlerton *hton, THD *thd,
 
   DBUG_ENTER("binlog_clone_consistent_snapshot");
 
-#ifdef WSREP
+#if 0
+#ifdef WITH_WSREP
   if (wsrep_emulate_bin_log)
     DBUG_RETURN(0);
 #endif /* WITH_WSREP */
+#endif
 
   from_cache_mngr= opt_bin_log ?
     (binlog_cache_mngr *) thd_get_cache_mngr(from_thd) : NULL;
@@ -10292,7 +10296,9 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit)
     DBUG_RETURN(finish_commit(thd));
   }
 
+#ifdef WITH_WSREP
   DEBUG_SYNC(thd, "pxc_in_commit_flush_stage");
+#endif /* WITH_WSREP */
 
   THD *wait_queue= NULL, *final_queue= NULL;
   mysql_mutex_t *leave_mutex_before_commit_stage= NULL;

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -341,7 +341,9 @@ Events::create_event(THD *thd, Event_parse_data *parse_data,
     DBUG_RETURN(TRUE);
   }
 
+#ifdef WITH_WSREP
   WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+#endif /* WITH_WSREP */
 
   if (parse_data->do_not_create)
     DBUG_RETURN(FALSE);
@@ -506,7 +508,9 @@ Events::update_event(THD *thd, Event_parse_data *parse_data,
     }
   }
 
+#ifdef WITH_WSREP
   WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+#endif /* WITH_WSREP */
 
   /* 
     Turn off row binlogging of this statement and use statement-based 
@@ -605,7 +609,10 @@ Events::drop_event(THD *thd, LEX_STRING dbname, LEX_STRING name, bool if_exists)
 
   if (check_access(thd, EVENT_ACL, dbname.str, NULL, NULL, 0, 0))
     DBUG_RETURN(TRUE);
+
+#ifdef WITH_WSREP
   WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
+#endif /* WITH_WSREP */
 
   if (lock_object_name(thd, MDL_key::EVENT,
                        dbname.str, name.str))

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -907,13 +907,16 @@ struct handlerton
                      const char *wild, bool dir, List<LEX_STRING> *files);
    int (*table_exists_in_engine)(handlerton *hton, THD* thd, const char *db,
                                  const char *name);
+   int (*make_pushed_join)(handlerton *hton, THD* thd,
+                           const AQP::Join_plan* plan);
+
+#ifdef WITH_WSREP
    int (*wsrep_abort_transaction)(handlerton *hton, THD *bf_thd, 
 				  THD *victim_thd, my_bool signal);
    int (*wsrep_set_checkpoint)(handlerton *hton, const XID* xid);
    int (*wsrep_get_checkpoint)(handlerton *hton, XID* xid);
    void (*wsrep_fake_trx_id)(handlerton *hton, THD *thd);
-   int (*make_pushed_join)(handlerton *hton, THD* thd, 
-                           const AQP::Join_plan* plan);
+#endif /* WITH_WSREP */
 
   /**
     List of all system tables specific to the SE.

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1483,7 +1483,7 @@ extern "C" void unireg_abort(int exit_code)
     sleep(5); /* so give some time to exit for those which can */
     WSREP_INFO("Some threads may fail to exit.");
   }
-#endif // WITH_WSREP
+#endif /* WITH_WSREP */
   mysql_audit_notify(MYSQL_AUDIT_SERVER_SHUTDOWN_SHUTDOWN,
                      MYSQL_AUDIT_SERVER_SHUTDOWN_REASON_ABORT, exit_code);
 #ifndef _WIN32

--- a/sql/mysqld_thd_manager.cc
+++ b/sql/mysqld_thd_manager.cc
@@ -70,10 +70,12 @@ private:
   Find_THD_Impl *m_impl;
 };
 
+#ifdef WITH_WSREP
 Do_THD_Impl::Do_THD_Impl()
 {
   /* Empty constructor */
 }
+#endif /* WITH_WSREP */
 
 
 #ifdef HAVE_PSI_INTERFACE

--- a/sql/mysqld_thd_manager.h
+++ b/sql/mysqld_thd_manager.h
@@ -41,12 +41,14 @@ void thd_unlock_thread_count(THD *thd);
 class Do_THD_Impl
 {
 public:
+#ifdef WITH_WSREP
   /* We add this empty constructor and defne it in .cc file
   just to avoid gcc-4.4.7 to overoptimize this class in release
   mode that causes gcc to call pure-virtual function for operator()
   instead of derive class function. This is compiler bug observed
   only with Red-Hat shipped compiler and is fixed in gcc-4.8+ for sure. */
   Do_THD_Impl();
+#endif /* WITH_WSREP */
   virtual ~Do_THD_Impl() {}
   virtual void operator()(THD*) = 0;
 #ifdef WITH_WSREP

--- a/sql/rpl_master.cc
+++ b/sql/rpl_master.cc
@@ -599,7 +599,7 @@ bool reset_master(THD* thd)
   if (WSREP(thd) && get_gtid_mode(GTID_MODE_LOCK_NONE) > 0)
   {
     /* RESET MASTER will initialize GTID sequence, and that would happen locally
-       in this node, so better reject it
+       in this node only, so better reject it
     */
     my_message(ER_NOT_ALLOWED_COMMAND,
                "RESET MASTER not allowed when node is in cluster", MYF(0));

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -870,7 +870,9 @@ public:
     if (deferred_events)
     {
       delete deferred_events;
+#ifdef WITH_WSREP
       deferred_events= NULL;
+#endif /* WITH_WSREP */
     }
   };
    

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -26,7 +26,8 @@
 
 #ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
-#endif
+#endif /* WITH_WSREP */
+
 #ifdef HAVE_REPLICATION
 #include "rpl_slave.h"
 
@@ -55,9 +56,6 @@
 #include "tztime.h"                            // Time_zone
 #include "rpl_group_replication.h"
 
-#ifdef WITH_WSREP
-#include "wsrep_mysqld.h"
-#endif
 // Sic: Must be after mysqld.h to get the right ER macro.
 #include "errmsg.h"                            // CR_*
 
@@ -85,7 +83,7 @@ char slave_skip_error_names[SHOW_VAR_FUNC_BUFF_SIZE];
 char* slave_load_tmpdir = 0;
 #ifdef WITH_WSREP
 Master_info *active_mi= 0;
-#endif
+#endif /* WITH_WSREP */
 my_bool replicate_same_server_id;
 ulonglong relay_log_space_limit = 0;
 

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -24,7 +24,7 @@
 
 #ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
-#endif
+#endif /* WITH_WSREP */
 
 #ifdef _WIN32
 #include <crtdbg.h>
@@ -73,7 +73,7 @@ extern "C" void handle_fatal_signal(int sig)
 */
 #ifdef WITH_WSREP
   wsrep_handle_fatal_signal(sig);
-#endif
+#endif /* WITH_WSREP */
 
 #ifdef _WIN32
   SYSTEMTIME utc_time;

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1279,10 +1279,13 @@ bool Sql_cmd_analyze_table::execute(THD *thd)
                          FALSE, UINT_MAX, FALSE))
     goto error;
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_analyze_table::execute()");});
 
   WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, first_table);
+#endif /* WITH_WSREP */
+
   thd->set_slow_log_for_admin_command();
   res= mysql_admin_table(thd, first_table, &thd->lex->check_opt,
                          "analyze", lock_type, 1, 0, 0, 0,
@@ -1319,8 +1322,10 @@ bool Sql_cmd_check_table::execute(THD *thd)
                          TRUE, UINT_MAX, FALSE))
     goto error; /* purecov: inspected */
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_check_table::execute()");});
+#endif /* WITH_WSREP */
 
   thd->enable_slow_log= opt_log_slow_admin_statements;
 
@@ -1351,10 +1356,13 @@ bool Sql_cmd_optimize_table::execute(THD *thd)
                          FALSE, UINT_MAX, FALSE))
     goto error; /* purecov: inspected */
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_optimize_table::execute()");});
 
   WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, first_table);
+#endif /* WITH_WSREP */
+
   thd->set_slow_log_for_admin_command();
   res= (specialflag & SPECIAL_NO_NEW_FUNC) ?
     mysql_recreate_table(thd, first_table, true) :
@@ -1392,10 +1400,13 @@ bool Sql_cmd_repair_table::execute(THD *thd)
                          FALSE, UINT_MAX, FALSE))
     goto error; /* purecov: inspected */
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_repair_table::execute()");});
 
   WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, first_table);
+#endif /* WITH_WSREP */
+
   thd->set_slow_log_for_admin_command();
   res= mysql_admin_table(thd, first_table, &thd->lex->check_opt, "repair",
                          TL_WRITE, 1,

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -543,6 +543,7 @@ bool Sql_cmd_discard_import_tablespace::execute(THD *thd)
   /* first table of first SELECT_LEX */
   TABLE_LIST *table_list= select_lex->get_table_list();
 
+#ifdef WITH_WSREP
   /* Disable DISCARD/IMPORT TABLESPACE as this command
   will execute on single node and can introduce data
   in-consistency in cluster. */
@@ -583,6 +584,7 @@ bool Sql_cmd_discard_import_tablespace::execute(THD *thd)
 
   if (block)
     return true;
+#endif /* WITH_WSREP */
 
   if (check_access(thd, ALTER_ACL, table_list->db,
                    &table_list->grant.privilege,

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6207,11 +6207,12 @@ finish:
     thd->mdl_context.release_statement_locks();
   }
 
+#ifdef WITH_WSREP
+
   /* If DDL has failed then avoid SE checkpoint. */
   thd->wsrep_skip_SE_checkpoint= (res || thd->is_error());
   WSREP_TO_ISOLATION_END;
 
-#ifdef WITH_WSREP
   /*
     Force release of transactional locks if not in active MST and wsrep is on.
   */

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -4391,9 +4391,11 @@ static int test_plugin_options(MEM_ROOT *tmp_root, st_plugin_int *tmp,
       my_strcasecmp(&my_charset_latin1, tmp->name.str, "ndbcluster")))
     plugin_load_option= PLUGIN_OFF;
 
+#ifdef WITH_WSREP
   if (!(my_strcasecmp(&my_charset_latin1, tmp->name.str, "keyring_file") &&
       my_strcasecmp(&my_charset_latin1, tmp->name.str, "keyring_vault")))
     plugin_load_option= PLUGIN_FORCE;
+#endif /* WITH_WSREP */
 
   for (opt= tmp->plugin->system_vars; opt && *opt; opt++)
     count+= 2; /* --{plugin}-{optname} and --plugin-{plugin}-{optname} */

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -4879,7 +4879,7 @@ btr_cur_del_mark_set_clust_rec(
 		/* While cascading delete operations, this becomes possible. */
 #ifdef WITH_WSREP
           // following may assert with wsrep
-#endif
+#endif /* WITH_WSREP */
 		ut_ad(rec_get_trx_id(rec, index) == thr_get_trx(thr)->id);
 		return(DB_SUCCESS);
 	}

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -19779,7 +19779,9 @@ innobase_commit_by_xid(
 
 	if (trx != NULL) {
 		TrxInInnoDB	trx_in_innodb(trx);
+#ifdef WITH_WSREP
 		trx->wsrep_recover_xid = xid;
+#endif /* WITH_WSREP */
 
 		innobase_commit_low(trx);
                 ut_ad(trx->mysql_thd == NULL);

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -54,7 +54,7 @@ Created 5/7/1996 Heikki Tuuri
 extern my_bool wsrep_debug;
 extern my_bool wsrep_log_conflicts;
 #include <wsrep_mysqld.h>
-#endif
+#endif /* WITH_WSREP */
 
 /* Flag to enable/disable deadlock detector. */
 my_bool	innobase_deadlock_detect = TRUE;
@@ -2514,7 +2514,7 @@ RecLock::jump_queue(
 	ut_ad(conflict_lock->trx != m_trx);
 #ifndef WITH_WSREP
 	ut_ad(trx_is_high_priority(m_trx));
-#endif /* WITH_WSREP */
+#endif /* !WITH_WSREP */
 	ut_ad(m_rec_id.m_heap_no != ULINT32_UNDEFINED);
 
 	bool	high_priority = false;

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -54,7 +54,7 @@ Created 12/27/1996 Heikki Tuuri
 #include "buf0lru.h"
 #ifdef WITH_WSREP
 extern my_bool wsrep_debug;
-#endif
+#endif /* WITH_WSREP */
 #include "trx0rec.h"
 #include "fts0fts.h"
 #include "fts0types.h"

--- a/storage/innobase/srv/srv0conc.cc
+++ b/storage/innobase/srv/srv0conc.cc
@@ -43,16 +43,14 @@ Created 2011/04/18 Sunny Bains
 #include "srv0srv.h"
 #include "btr0types.h"
 #include "trx0trx.h"
+
 #ifdef WITH_WSREP
+#include "row0mysql.h"
+#include "dict0dict.h"
+
 extern "C" int wsrep_trx_is_aborting(void *thd_ptr);
 extern my_bool wsrep_debug;
 #endif /* WITH_WSREP */
-#include "row0mysql.h"
-#include "dict0dict.h"
-#ifdef WITH_WSREP
-extern "C" int wsrep_trx_is_aborting(void *thd_ptr);
-extern my_bool wsrep_debug;
-#endif
 
 /** Number of times a thread is allowed to enter InnoDB within the same
 SQL query after it has once got the ticket. */


### PR DESCRIPTION
  - While porting code to 5.7 and eventually during development
    some of the code that was specific to WSREP was left
    without the preprocessing directive WITH_WSREP protection.