### PR TITLE
PXC-2274 : checking for wsrep_node_address in wsrep_sst_common uses t…

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -135,6 +135,9 @@ parse_cnf()
     local var=$2
     local reval=""
 
+    # normalize the variable name by replacing all '_' with '-'
+    var=${var//_/-}
+
     # print the default settings for given group using my_print_default.
     # normalize the variable names specified in cnf file (user can use _ or - for example log-bin or log_bin)
     # then grep for needed variable
@@ -223,12 +226,9 @@ wsrep_auth_not_set()
 }
 
 # For Bug:1200727
-if $MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF sst | grep -q "wsrep_sst_auth"
+if wsrep_auth_not_set
 then
-    if wsrep_auth_not_set
-    then
-        WSREP_SST_OPT_AUTH=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF sst | grep -- "--wsrep_sst_auth" | cut -d= -f2)
-    fi
+    WSREP_SST_OPT_AUTH=$(parse_cnf sst wsrep-sst-auth "")
 fi
 readonly WSREP_SST_OPT_AUTH
 
@@ -250,13 +250,7 @@ else
 fi
 
 
-WSREP_LOG_DEBUG=$(parse_cnf sst wsrep_debug "")
-if [ -z "$WSREP_LOG_DEBUG" ]; then
-    WSREP_LOG_DEBUG=$(parse_cnf sst wsrep-debug "")
-fi
-if [ -z "$WSREP_LOG_DEBUG" ]; then
-    WSREP_LOG_DEBUG=$(parse_cnf mysqld wsrep_debug "")
-fi
+WSREP_LOG_DEBUG=$(parse_cnf sst wsrep-debug "")
 if [ -z "$WSREP_LOG_DEBUG" ]; then
     WSREP_LOG_DEBUG=$(parse_cnf mysqld wsrep-debug "")
 fi
@@ -268,9 +262,6 @@ fi
 
 # Determine the timezone to use for error logging
 LOGGING_TZ=$(parse_cnf mysqld log-timestamps "")
-if [ -z "$LOGGING_TZ" ]; then
-    LOGGING_TZ=$(parse_cnf mysqld log_timestamps "")
-fi
 if [ -z "$LOGGING_TZ" ]; then
     LOGGING_TZ="UTC"
 fi

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -124,13 +124,13 @@ rm -rf "$KEYRING_FILE"
 WSREP_LOG_DIR=${WSREP_LOG_DIR:-""}
 # if WSREP_LOG_DIR env. variable is not set, try to get it from my.cnf
 if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf mysqld-5.6 innodb_log_group_home_dir "")
+    WSREP_LOG_DIR=$(parse_cnf mysqld-5.6 innodb-log-group-home-dir "")
 fi
 if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf mysqld innodb_log_group_home_dir "")
+    WSREP_LOG_DIR=$(parse_cnf mysqld innodb-log-group-home-dir "")
 fi
 if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf server innodb_log_group_home_dir "")
+    WSREP_LOG_DIR=$(parse_cnf server innodb-log-group-home-dir "")
 fi
 
 if [ -n "$WSREP_LOG_DIR" ]; then

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -575,8 +575,8 @@ read_cnf()
     sdecomp=$(parse_cnf sst decompressor "")
 
     # if wsrep_node_address is not set raise a warning
-    wsrep_node_address=$(parse_cnf mysqld wsrep_node_address "")
-    wsrep_sst_receive_address=$(parse_cnf mysqld wsrep_sst_receive_address "")
+    wsrep_node_address=$(parse_cnf mysqld wsrep-node-address "")
+    wsrep_sst_receive_address=$(parse_cnf mysqld wsrep-sst-receive-address "")
     if [[ -z $wsrep_node_address && -z $wsrep_sst_receive_address ]]; then
         wsrep_log_warning "wsrep_node_address or wsrep_sst_receive_address not set." \
                           "Consider setting them if SST fails."
@@ -675,17 +675,11 @@ read_cnf()
 
     # thread options
     encrypt_threads=$(parse_cnf sst encrypt-threads -1)
-    if [[ $encrypt_threads -eq -1 ]]; then
-        encrypt_threads=$(parse_cnf sst encrypt_threads -1)
-    fi
     if [[ $encrypt_threads -le 0 ]]; then
         encrypt_threads=4
     fi
 
     backup_threads=$(parse_cnf sst backup-threads -1)
-    if [[ $backup_threads -eq -1 ]]; then
-        backup_threads=$(parse_cnf sst backup_threads -1)
-    fi
     if [[ $backup_threads -le 0 ]]; then
         backup_threads=4
     fi
@@ -704,9 +698,6 @@ read_cnf()
         bufferpoolsize=$(parse_cnf xtrabackup use-memory "")
         if [[ -z "$bufferpoolsize" ]]; then
             bufferpoolsize=$(parse_cnf mysqld innodb-buffer-pool-size "")
-        fi
-        if [[ -z "$bufferpoolsize" ]]; then
-            bufferpoolsize=$(parse_cnf mysqld innodb_buffer_pool_size "")
         fi
         if [[ -n "$bufferpoolsize" ]]; then
             iapts="$iapts --use-memory=$bufferpoolsize"


### PR DESCRIPTION
…he wrong variable

Issue
The check for wsrep_node_address looks for 'wsrep_node_address' but
parse_cnf() normalizes the names from my_print_defaults by changing
'_' to '-'.  So this means that we will never match these two names.

Solution
Change the calling code to use 'wsrep-node-address' instead of
'wsrep_node_address'.  Also remove some code that searches for
variables using underscores (since the code does nothing).