### PR TITLE
- PXC#2295: deprecate wsrep_preordered, innodb_disallow_writes,

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
@@ -15,6 +15,8 @@ use test;
 set @@sql_mode = 'NO_AUTO_VALUE_ON_ZERO';
 set @@session.sql_log_bin = 0;
 set @@global.wsrep_drupal_282555_workaround = 1;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 select get_lock("lock-1", 100000);
 get_lock("lock-1", 100000)
 1
@@ -25,6 +27,8 @@ Warning	1366	Incorrect integer value: 'a' for column 'c1' at row 1
 insert into t1 values ('a');
 ERROR 23000: Duplicate entry '0' for key 'c1'
 set @@global.wsrep_drupal_282555_workaround = 0;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 set @@session.sql_log_bin = 1;
 set @@sql_mode = default;
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query");

--- a/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
+++ b/mysql-test/suite/galera/r/galera_binlog_stmt_autoinc.result
@@ -1,9 +1,9 @@
 SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SET GLOBAL wsrep_forced_binlog_format='STATEMENT';
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 CREATE TABLE t1 (
 i int(11) NOT NULL AUTO_INCREMENT,
 c char(32) DEFAULT 'dummy_text',
@@ -19,10 +19,10 @@ sum(i) = SUM
 1
 SET GLOBAL wsrep_forced_binlog_format='none';
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SET GLOBAL wsrep_forced_binlog_format='none';
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 drop table t1;
 SET SESSION binlog_format='STATEMENT';
 show variables like 'binlog_format';

--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -579,6 +579,8 @@ select @@pxc_strict_mode;
 DISABLED
 #node-1
 set session binlog_format = 'STATEMENT';
+Warnings:
+Warning	1287	Setting binlog format to STATEMENT OR MIXED at session level is deprecated and will be removed in future release. While operating in cluster mode use binlog_format=ROW.
 select @@binlog_format;
 @@binlog_format
 STATEMENT
@@ -597,6 +599,8 @@ i
 drop table tinnodb;
 #node-1
 set session binlog_format = 'MIXED';
+Warnings:
+Warning	1287	Setting binlog format to STATEMENT OR MIXED at session level is deprecated and will be removed in future release. While operating in cluster mode use binlog_format=ROW.
 select @@binlog_format;
 @@binlog_format
 MIXED
@@ -641,6 +645,7 @@ PERMISSIVE
 #node-1
 set session binlog_format = 'STATEMENT';
 Warnings:
+Warning	1287	Setting binlog format to STATEMENT OR MIXED at session level is deprecated and will be removed in future release. While operating in cluster mode use binlog_format=ROW.
 Warning	1105	Percona-XtraDB-Cluster doesn't recommend setting binlog_format to STATEMENT or MIXED with pxc_strict_mode = PERMISSIVE
 select @@binlog_format;
 @@binlog_format
@@ -661,6 +666,7 @@ drop table tinnodb;
 #node-1
 set session binlog_format = 'MIXED';
 Warnings:
+Warning	1287	Setting binlog format to STATEMENT OR MIXED at session level is deprecated and will be removed in future release. While operating in cluster mode use binlog_format=ROW.
 Warning	1105	Percona-XtraDB-Cluster doesn't recommend setting binlog_format to STATEMENT or MIXED with pxc_strict_mode = PERMISSIVE
 select @@binlog_format;
 @@binlog_format
@@ -696,6 +702,7 @@ drop table tinnodb;
 #node-1
 set session binlog_format = 'STATEMENT';
 Warnings:
+Warning	1287	Setting binlog format to STATEMENT OR MIXED at session level is deprecated and will be removed in future release. While operating in cluster mode use binlog_format=ROW.
 Warning	1105	Percona-XtraDB-Cluster doesn't recommend setting binlog_format to STATEMENT or MIXED with pxc_strict_mode = PERMISSIVE
 set global pxc_strict_mode = 'ENFORCING';
 ERROR HY000: Can't change pxc_strict_mode to ENFORCING as binlog_format != ROW

--- a/mysql-test/suite/sys_vars/r/wsrep_convert_lock_to_trx_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_convert_lock_to_trx_basic.result
@@ -3,36 +3,60 @@
 #
 # save the initial value
 SET @wsrep_convert_lock_to_trx_global_saved = @@global.wsrep_convert_lock_to_trx;
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 # default
 SELECT @@global.wsrep_convert_lock_to_trx;
 @@global.wsrep_convert_lock_to_trx
 0
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 
 # scope
 SELECT @@session.wsrep_convert_lock_to_trx;
 ERROR HY000: Variable 'wsrep_convert_LOCK_to_trx' is a GLOBAL variable
 SET @@global.wsrep_convert_lock_to_trx=OFF;
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_convert_lock_to_trx;
 @@global.wsrep_convert_lock_to_trx
 0
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SET @@global.wsrep_convert_lock_to_trx=ON;
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_convert_lock_to_trx;
 @@global.wsrep_convert_lock_to_trx
 1
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 
 # valid values
 SET @@global.wsrep_convert_lock_to_trx='OFF';
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_convert_lock_to_trx;
 @@global.wsrep_convert_lock_to_trx
 0
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SET @@global.wsrep_convert_lock_to_trx=ON;
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_convert_lock_to_trx;
 @@global.wsrep_convert_lock_to_trx
 1
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SET @@global.wsrep_convert_lock_to_trx=default;
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_convert_lock_to_trx;
 @@global.wsrep_convert_lock_to_trx
 0
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 
 # invalid values
 SET @@global.wsrep_convert_lock_to_trx=NULL;
@@ -42,4 +66,6 @@ ERROR 42000: Variable 'wsrep_convert_LOCK_to_trx' can't be set to the value of '
 
 # restore the initial value
 SET @@global.wsrep_convert_lock_to_trx = @wsrep_convert_lock_to_trx_global_saved;
+Warnings:
+Warning	1287	'@@wsrep_convert_LOCK_to_trx' is deprecated and will be removed in a future release.
 # End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_drupal_282555_workaround_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_drupal_282555_workaround_basic.result
@@ -3,36 +3,60 @@
 #
 # save the initial value
 SET @wsrep_drupal_282555_workaround_global_saved = @@global.wsrep_drupal_282555_workaround;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 # default
 SELECT @@global.wsrep_drupal_282555_workaround;
 @@global.wsrep_drupal_282555_workaround
 0
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 
 # scope
 SELECT @@session.wsrep_drupal_282555_workaround;
 ERROR HY000: Variable 'wsrep_drupal_282555_workaround' is a GLOBAL variable
 SET @@global.wsrep_drupal_282555_workaround=OFF;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_drupal_282555_workaround;
 @@global.wsrep_drupal_282555_workaround
 0
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SET @@global.wsrep_drupal_282555_workaround=ON;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_drupal_282555_workaround;
 @@global.wsrep_drupal_282555_workaround
 1
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 
 # valid values
 SET @@global.wsrep_drupal_282555_workaround='OFF';
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_drupal_282555_workaround;
 @@global.wsrep_drupal_282555_workaround
 0
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SET @@global.wsrep_drupal_282555_workaround=ON;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_drupal_282555_workaround;
 @@global.wsrep_drupal_282555_workaround
 1
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SET @@global.wsrep_drupal_282555_workaround=default;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_drupal_282555_workaround;
 @@global.wsrep_drupal_282555_workaround
 0
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 
 # invalid values
 SET @@global.wsrep_drupal_282555_workaround=NULL;
@@ -42,4 +66,6 @@ ERROR 42000: Variable 'wsrep_drupal_282555_workaround' can't be set to the value
 
 # restore the initial value
 SET @@global.wsrep_drupal_282555_workaround = @wsrep_drupal_282555_workaround_global_saved;
+Warnings:
+Warning	1287	'@@wsrep_drupal_282555_workaround' is deprecated and will be removed in a future release.
 # End of test

--- a/mysql-test/suite/sys_vars/r/wsrep_forced_binlog_format_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_forced_binlog_format_basic.result
@@ -3,52 +3,68 @@
 #
 # save the initial value
 SET @wsrep_forced_binlog_format_global_saved = @@global.wsrep_forced_binlog_format;
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 # default
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 NONE
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 
 # scope
 SELECT @@session.wsrep_forced_binlog_format;
 ERROR HY000: Variable 'wsrep_forced_binlog_format' is a GLOBAL variable
 SET @@global.wsrep_forced_binlog_format=STATEMENT;
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 STATEMENT
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 
 # valid values
 SET @@global.wsrep_forced_binlog_format=STATEMENT;
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 STATEMENT
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SET @@global.wsrep_forced_binlog_format=ROW;
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 ROW
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SET @@global.wsrep_forced_binlog_format=MIXED;
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 MIXED
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SET @@global.wsrep_forced_binlog_format=NONE;
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 NONE
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SET @@global.wsrep_forced_binlog_format=default;
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 SELECT @@global.wsrep_forced_binlog_format;
 @@global.wsrep_forced_binlog_format
 NONE
+Warnings:
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 
 # invalid values
 SET @@global.wsrep_forced_binlog_format=NULL;
@@ -61,5 +77,5 @@ ERROR 42000: Variable 'wsrep_forced_binlog_format' can't be set to the value of 
 # restore the initial value
 SET @@global.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_global_saved;
 Warnings:
-Warning	1105	Percona-XtraDB-Cluster has deprecated wsrep_forced_binlog_format
+Warning	1287	'@@wsrep_forced_binlog_format' is deprecated and will be removed in a future release.
 # End of test

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3445,6 +3445,42 @@ int init_common_variables()
     pxc_strict_mode= PXC_STRICT_MODE_DISABLED;
   }
 
+  /* wsrep_preordered is not more needed now that performance has been
+  fixed in PXC-5.7. So PXC can immediately replicate the events that it get
+  from async replication queue w/o causing significant increase in
+  replication lag. */
+  if (wsrep_preordered_opt)
+  {
+    WSREP_WARN("wsrep_preordered has been deprecated and will be removed"
+               " in future release");
+  }
+
+  if (wsrep_drupal_282555_workaround)
+  {
+    WSREP_WARN("wsrep_drupal_282555_workaround has been deprecated and will be"
+               " removed in future release");
+  }
+
+  if (wsrep_forced_binlog_format != BINLOG_FORMAT_UNSPEC)
+  {
+    WSREP_WARN("wsrep_forced_binlog_format has been deprecated and will be"
+               " removed in future release");
+  }
+
+  if (wsrep_convert_LOCK_to_trx)
+  {
+    WSREP_WARN("wsrep_convert_LOCK_to_trx has been deprecated and will be"
+               " removed in future release");
+  }
+
+  const char* WSREP_SST_MYSQLDUMP= "mysqldump";
+  if (!strcmp (wsrep_sst_method, WSREP_SST_MYSQLDUMP))
+  {
+    WSREP_WARN("Percona-XtraDB-Cluster has deprecated SST through mysqldump."
+               " Percona-XtraDB-Cluster recommends using xtrabackup."
+               " Please switch to use xtrabackup or rsync.");
+  }
+
   /* Validate if server initial settings are pxc-strict-mode compatible.*/
 
   /* wsrep_replicate_myisam (recommended value = OFF) */
@@ -3526,13 +3562,6 @@ int init_common_variables()
     return 1;
   }
 
-  const char* WSREP_SST_MYSQLDUMP= "mysqldump";
-  if (wsrep_provider_loaded && !strcmp (WSREP_SST_MYSQLDUMP, wsrep_sst_method))
-  {
-    WSREP_WARN("Percona-XtraDB-Cluster has deprecated SST through mysqldump."
-               " Percona-XtraDB-Cluster recommends using xtrabackup."
-               " Please switch to use xtrabackup or rsync.");
-  }
 #endif /* WITH_WSREP */
 
 #ifdef WITH_WSREP

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -949,6 +949,14 @@ static bool binlog_format_check(sys_var *self, THD *thd, set_var *var)
    (var->save_result.ulonglong_value == BINLOG_FORMAT_STMT ||
     var->save_result.ulonglong_value == BINLOG_FORMAT_MIXED);
 
+  if (WSREP(thd) && stmt_or_mixed && var->type == OPT_SESSION)
+  {
+    push_warning(thd, Sql_condition::SL_WARNING, ER_WARN_DEPRECATED_SYNTAX,
+      "Setting binlog format to STATEMENT OR MIXED at session level is"
+      " deprecated and will be removed in future release."
+      " While operating in cluster mode use binlog_format=ROW.");
+  }
+
   if (WSREP(thd) && stmt_or_mixed && var->type == OPT_GLOBAL)
   {
     /* Toggline binlog-format at GLOBAL level to MIXED/STATEMENT
@@ -6261,7 +6269,8 @@ static Sys_var_mybool Sys_wsrep_convert_LOCK_to_trx(
        "wsrep_convert_LOCK_to_trx", "To convert locking sessions (deprecated)"
        "into transactions",
        GLOBAL_VAR(wsrep_convert_LOCK_to_trx), 
-       CMD_LINE(OPT_ARG), DEFAULT(FALSE));
+       CMD_LINE(OPT_ARG), DEFAULT(FALSE), NO_MUTEX_GUARD,
+       NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(0), DEPRECATED(""));
 
 static Sys_var_ulong Sys_wsrep_retry_autocommit(
       "wsrep_retry_autocommit", "Max number of times to retry "
@@ -6322,7 +6331,8 @@ static Sys_var_mybool Sys_wsrep_drupal_282555_workaround(
        "wsrep_drupal_282555_workaround", "To use a workaround for"
        "bad autoincrement value", 
        GLOBAL_VAR(wsrep_drupal_282555_workaround), 
-       CMD_LINE(OPT_ARG), DEFAULT(FALSE));
+       CMD_LINE(OPT_ARG), DEFAULT(FALSE), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(0), ON_UPDATE(0), DEPRECATED(""));
 
 static Sys_var_charptr sys_wsrep_sst_method(
        "wsrep_sst_method", "State snapshot transfer method",
@@ -6466,13 +6476,12 @@ static Sys_var_enum Sys_wsrep_reject_queries(
 
 static Sys_var_enum Sys_wsrep_forced_binlog_format(
        "wsrep_forced_binlog_format",
-       "binlog format to take effect over user's choice (Deprecated)",
+       "binlog format to take effect over user's choice",
        GLOBAL_VAR(wsrep_forced_binlog_format), 
        CMD_LINE(REQUIRED_ARG, OPT_BINLOG_FORMAT),
        wsrep_binlog_format_names, DEFAULT(BINLOG_FORMAT_UNSPEC),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
-       ON_CHECK(wsrep_forced_binlog_format_check),
-       ON_UPDATE(0));
+       ON_CHECK(0), ON_UPDATE(0), DEPRECATED(""));
 
 static Sys_var_mybool Sys_wsrep_recover_datadir(
        "wsrep_recover", "Recover database state after crash and exit",
@@ -6491,7 +6500,9 @@ static Sys_var_mybool Sys_wsrep_log_conflicts(
 
 static Sys_var_mybool Sys_wsrep_preordered(
        "wsrep_preordered", "To enable preordered write set processing",
-       GLOBAL_VAR(wsrep_preordered_opt), CMD_LINE(OPT_ARG), DEFAULT(FALSE));
+       GLOBAL_VAR(wsrep_preordered_opt), CMD_LINE(OPT_ARG), DEFAULT(FALSE),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(0),
+       DEPRECATED(""));
 
 static Sys_var_mybool Sys_wsrep_load_data_splitting(
        "wsrep_load_data_splitting", "To commit LOAD DATA "

--- a/sql/wsrep_sst.h
+++ b/sql/wsrep_sst.h
@@ -25,7 +25,6 @@ typedef struct st_mysql_show_var SHOW_VAR;
 #include "rpl_gtid.h"
 #include "wsrep_api.h"
 
-
 /* system variables */
 extern const char* wsrep_sst_method;
 extern const char* wsrep_sst_receive_address;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -24371,6 +24371,10 @@ innobase_disallow_writes_update(
 						variable */
 	const void*		save)		/* in: temporary storage */
 {
+	ib::warn() << "innodb_disallow_writes has been deprecated and will be"
+                      " removed in future release. Consider using read_only"
+                      " instead.";
+
 	*(my_bool*)var_ptr = *(my_bool*)save;
 	ut_a(srv_allow_writes_event);
 	if (*(my_bool*)var_ptr)
@@ -24384,6 +24388,7 @@ static MYSQL_SYSVAR_BOOL(disallow_writes, innobase_disallow_writes,
   "Tell InnoDB to stop any writes to disk",
   NULL, innobase_disallow_writes_update, FALSE);
 #endif /* WITH_INNODB_DISALLOW_WRITES */
+
 static MYSQL_SYSVAR_BOOL(random_read_ahead, srv_random_read_ahead,
   PLUGIN_VAR_NOCMDARG,
   "Whether to use read ahead for random access within an extent.",

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -208,6 +208,12 @@ mysql_pfs_key_t	srv_worker_thread_key;
 
 #ifdef WITH_WSREP
 extern my_bool wsrep_recovery;
+
+#ifdef WITH_INNODB_DISALLOW_WRITES
+/* Must always init to FALSE. */
+static my_bool	innobase_disallow_writes	= FALSE;
+#endif /* WITH_INNODB_DISALLOW_WRITES */
+
 #endif /* WITH_WSREP */
 
 int unlock_keyrings(THD *thd);
@@ -1866,6 +1872,15 @@ innobase_start_or_create_for_mysql(void)
 			<< " for innodb_flush_method";
 		return(srv_init_abort(DB_ERROR));
 	}
+
+#ifdef WITH_WSREP
+	if (innobase_disallow_writes) {
+		ib::warn() << "innodb_disallow_writes has been deprecated and"
+			      " will be removed in future release."
+			      " Consider using read_only instead.";
+	}
+#endif /* WITH_WSREP */
+
 
 	/* Note that the call srv_boot() also changes the values of
 	some variables to the units used by InnoDB internally */


### PR DESCRIPTION
  wsrep_drupal_282555_workaround, binlog_format=STATEMENT/MIXED

  - wsrep_preordered: deprecated as pxc has fixed inter-node performance
  - innodb_disallow_writes: deprecated. Use read_only instead
  - wsrep_drupal_282555_workaround: auto-inc bug is now fixed (PXC#2128)
  - binlog_format=STATEMENT/MIXED: deprecated to set in session mode.