### PR TITLE
PXC-2345 : Crash triggered with mysqldump single-transaction

### DIFF
--- a/mysql-test/suite/galera/t/galera_mysqldump.test
+++ b/mysql-test/suite/galera/t/galera_mysqldump.test
@@ -1,0 +1,19 @@
+#
+# Tests using mysqldump while PXC is running
+#
+# PXC-2345
+# Ensure that mysqldump with --single-transaction can be called
+# on a running server
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+#
+# PXC-2345
+# Ensure that mysqldump can be called on a running server
+#
+--connection node_1
+exec $MYSQL_DUMP --single-transaction mysql > $MYSQLTEST_VARDIR/log/galera_mysqldump.test.sql;
+--remove_file $MYSQLTEST_VARDIR/log/galera_mysqldump.test.sql

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2041,12 +2041,12 @@ static int binlog_start_consistent_snapshot(handlerton *hton, THD *thd)
   LOG_INFO li;
   DBUG_ENTER("binlog_start_consistent_snapshot");
 
-#if 0
 #ifdef WITH_WSREP
+  /* If operating in emulation binlog mode avoid binlog snapshot as
+     binlog is not open. */
   if (wsrep_emulate_bin_log)
     DBUG_RETURN(0);
 #endif /* WITH_WSREP */
-#endif
 
   if ((err= thd->binlog_setup_trx_data()))
     DBUG_RETURN(err);
@@ -2072,12 +2072,12 @@ static int binlog_clone_consistent_snapshot(handlerton *hton, THD *thd,
 
   DBUG_ENTER("binlog_clone_consistent_snapshot");
 
-#if 0
 #ifdef WITH_WSREP
+  /* If operating in emulation binlog mode avoid binlog snapshot as
+     binlog is not open. */
   if (wsrep_emulate_bin_log)
     DBUG_RETURN(0);
 #endif /* WITH_WSREP */
-#endif
 
   from_cache_mngr= opt_bin_log ?
     (binlog_cache_mngr *) thd_get_cache_mngr(from_thd) : NULL;


### PR DESCRIPTION
Issue
Running 'mysqldump --single-transaction' on a running PXC
server causes a crash.

Solution
If WSREP is enabled, skip over the consistent snapshots.
This was regression from the previous version.