### PR TITLE
PXC-761 :  Async slave repository tables copied via SST

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_slave.result
@@ -1,17 +1,29 @@
+# connection node_2
 START SLAVE USER='root';
 Warnings:
 Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+# connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES(1);
+# connection node_2
 INSERT INTO t1 VALUES (2);
+# connection node_3
 SELECT COUNT(*) = 2 FROM t1;
 COUNT(*) = 2
 1
 INSERT INTO t1 VALUES (3);
+# connection node_2
 SELECT COUNT(*) = 3 FROM t1;
 COUNT(*) = 3
 1
+# connection node_1
 DROP TABLE t1;
+# connection node_2
+# connection node_3
+# Restarting node 3 ...
+# restart
+SHOW SLAVE STATUS;
+# connection node_2
 STOP SLAVE;
 RESET SLAVE ALL;
 RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_slave.test
@@ -11,16 +11,19 @@
 --source include/galera_cluster.inc
 
 --connection node_2
+--echo # connection node_2
 --disable_query_log
 --eval CHANGE MASTER TO  MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1;
 --enable_query_log
 START SLAVE USER='root';
 
 --connection node_1
+--echo # connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES(1);
 
 --connection node_2
+--echo # connection node_2
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 
@@ -30,24 +33,52 @@ INSERT INTO t1 VALUES(1);
 INSERT INTO t1 VALUES (2);
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--echo # connection node_3
 --let $wait_condition = SELECT COUNT(*) = 2 FROM t1;
 --source include/wait_condition.inc
 SELECT COUNT(*) = 2 FROM t1;
 INSERT INTO t1 VALUES (3);
 
 --connection node_2
+--echo # connection node_2
 --let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
 --source include/wait_condition.inc
 SELECT COUNT(*) = 3 FROM t1;
 
 --connection node_1
+--echo # connection node_1
 DROP TABLE t1;
 
 --connection node_2
+--echo # connection node_2
 --sleep 1
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 
+#
+# PXC-761
+# Restart node_3, check that it doesn't have any slave info
+#
+--connection node_3
+--echo # connection node_3
+# Remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.3/data/grastate.dat
+--echo # Restarting node 3 ...
+--source include/shutdown_mysqld.inc
+--source include/start_mysqld.inc
+
+--source include/wait_until_connected_again.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+query_vertical SHOW SLAVE STATUS;
+
+# ==== PXC-761 TEST END ====
+
+
+# Test cleanup
+--connection node_2
+--echo # connection node_2
 STOP SLAVE;
 RESET SLAVE ALL;
 


### PR DESCRIPTION
Issue
In the event of an SST, the async slave repository information is
also copied to the JOINER (which can cause problems if multiple nodes
are then copying data from the async master).

Solution
If an SST occurs, remove the async slave repository information.
A "RESET SLAVE ALL" is performed on the JOINER as part of the
mysql_upgrade process.