### PR TITLE
- PXC#2411: mysqlx plugin is not loaded if joiner is busy with SST or…

### DIFF
--- a/sql/srv_session_service.cc
+++ b/sql/srv_session_service.cc
@@ -29,6 +29,10 @@
 #include <stddef.h>
 #include <new>
 
+#ifdef WITH_WSREP
+#include "wsrep_mysqld.h"
+#endif /* WITH_WSREP */
+
 #include "my_dbug.h"
 /*
  service_srv_session.h should not be first to be included as it will include
@@ -183,7 +187,15 @@ int srv_session_close(Srv_session *session) {
     1  available
 */
 int srv_session_server_is_available() {
+#ifdef WITH_WSREP
+  if (WSREP_ON) {
+    return (get_server_state() == SERVER_OPERATING && wsrep_node_is_synced());
+  } else {
+    return get_server_state() == SERVER_OPERATING;
+  }
+#else
   return get_server_state() == SERVER_OPERATING;
+#endif /* WITH_WSREP */
 }
 
 /**

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2308,7 +2308,8 @@ bool wsrep_node_is_donor() {
 }
 
 bool wsrep_node_is_synced() {
-  return (WSREP_ON) ? (local_status.get() == WSREP_MEMBER_SYNCED) : false;
+  /* If node is not running in cluster mode then node is always in sync state */
+  return (WSREP_ON) ? (local_status.get() == WSREP_MEMBER_SYNCED) : true;
 }
 
 const char *wsrep_get_exec_mode(wsrep_exec_mode state) {


### PR DESCRIPTION
… IST

  - mysqlx is loaded as plugin. As part of the plugin initialize action,
    mysqlx needs to query mysql.user table to findout some details.

  - As per original flow of mysql, mysqlx plugin will wait for
    server to start accepting connection before it fires this query.

  - In PXC, even though node open socket for accepting queries,
    it may not be able to process queries till the state of the node
    is turned to SYNCED. Normally this would happen instantly but
    if node is receiving IST then moving to SYNCED state may take time.
    (if node has received SST and there are write-sets pending in gcache
     to apply, node may take time to move to SYNCED state).

  - This condition was missing that caused mysqlx query to failed
    and so mysqlx plugin was never activiated.

  - mysqlx waits for server to start accepting connection.
    This condition is modified to now ensure that server is also ready
    to accept query and not just connection.