### PR TITLE
- PXC#2417: ALTER TABLE .. DISCARD tablespace result in crash as stmt…

### DIFF
--- a/mysql-test/suite/galera/r/galera_non_replicating_ddl.result
+++ b/mysql-test/suite/galera/r/galera_non_replicating_ddl.result
@@ -1,0 +1,44 @@
+#node-1 (issue a non-replicating ddl)
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1), (2), (3), (4);
+select * from t;
+i
+1
+2
+3
+4
+FLUSH TABLE t FOR EXPORT;
+UNLOCK TABLES;
+alter table t discard tablespace;
+select * from t;
+ERROR HY000: Tablespace has been discarded for table 't'
+call mtr.add_suppression("Cannot delete tablespace.*");
+alter table t discard tablespace;
+Warnings:
+Warning	1812	InnoDB: Tablespace is missing for table test/t.
+#node-2 (node-2 is not affected by discard operation on node-1)
+Timeout in wait_condition.inc for SELECT COUNT(*) = 4 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't';
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(11) NOT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+select * from t;
+i
+1
+2
+3
+4
+#node-1 (re-import tablespace on same node and issue drop)
+alter table t import tablespace;
+select * from t;
+i
+1
+2
+3
+4
+drop table t;
+#node-2 (ensure table is now gone from node-2 too)
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist

--- a/mysql-test/suite/galera/t/galera_non_replicating_ddl.test
+++ b/mysql-test/suite/galera/t/galera_non_replicating_ddl.test
@@ -1,0 +1,54 @@
+#
+--source include/galera_cluster.inc
+--source include/force_restart.inc
+
+#-------------------------------------------------------------------------------
+#
+# non-replicating-atomic-ddl: ALTER TABLE <table> DISCARD TABLESPACE
+#
+--connection node_1
+--echo #node-1 (issue a non-replicating ddl)
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1), (2), (3), (4);
+select * from t;
+#
+# non-replicating ddl
+FLUSH TABLE t FOR EXPORT;
+--let $MYSQL_DATA_DIR= `select @@datadir`
+--copy_file $MYSQL_DATA_DIR/test/t.cfg $MYSQL_TMP_DIR/t.cfg
+--copy_file $MYSQL_DATA_DIR/test/t.ibd $MYSQL_TMP_DIR/t.ibd
+UNLOCK TABLES;
+#
+alter table t discard tablespace;
+--error ER_TABLESPACE_DISCARDED
+select * from t;
+#
+call mtr.add_suppression("Cannot delete tablespace.*");
+alter table t discard tablespace;
+
+--connection node_2
+--echo #node-2 (node-2 is not affected by discard operation on node-1)
+#
+--let $wait_condition = SELECT COUNT(*) = 4 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't';
+--source include/wait_condition.inc
+#
+# discard is not replicated so operation on node-2 should work as expected.
+show create table t;
+select * from t;
+
+--connection node_1
+--echo #node-1 (re-import tablespace on same node and issue drop)
+#
+--move_file $MYSQL_TMP_DIR/t.cfg $MYSQL_DATA_DIR/test/t.cfg
+--move_file $MYSQL_TMP_DIR/t.ibd $MYSQL_DATA_DIR/test/t.ibd
+#
+alter table t import tablespace;
+select * from t;
+drop table t;
+
+--connection node_2
+--echo #node-2 (ensure table is now gone from node-2 too)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't';
+--source include/wait_condition.inc
+--error ER_NO_SUCH_TABLE
+select * from t;

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -575,6 +575,11 @@ bool Sql_cmd_alter_table::execute(THD *thd) {
 }
 
 bool Sql_cmd_discard_import_tablespace::execute(THD *thd) {
+
+#ifdef WITH_WSREP
+   thd->wsrep_non_replicating_atomic_ddl = true;
+#endif /* WITH_WSREP */
+
   /* Verify that exactly one of the DISCARD and IMPORT flags are set. */
   DBUG_ASSERT((m_alter_info->flags & Alter_info::ALTER_DISCARD_TABLESPACE) ^
               (m_alter_info->flags & Alter_info::ALTER_IMPORT_TABLESPACE));

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -569,6 +569,7 @@ THD::THD(bool enable_plugins)
       wsrep_applier(is_applier),
       wsrep_applier_closing(false),
       wsrep_client_thread(0),
+      wsrep_non_replicating_atomic_ddl(false),
       wsrep_po_handle(WSREP_PO_INITIALIZER),
       wsrep_po_cnt(0),
       wsrep_po_in_trans(false),
@@ -1008,6 +1009,7 @@ void THD::init(void) {
   wsrep_conflict_state = NO_CONFLICT;
   wsrep_query_state = QUERY_IDLE;
   wsrep_last_query_id = 0;
+  wsrep_non_replicating_atomic_ddl = false;
   wsrep_trx_meta.gtid = WSREP_GTID_UNDEFINED;
   wsrep_trx_meta.depends_on = WSREP_SEQNO_UNDEFINED;
   wsrep_retry_counter = 0;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2851,6 +2851,15 @@ class THD : public MDL_context_owner,
   mysql_cond_t COND_wsrep_thd;
 
   /**
+    set to true when ddl is not marked for replication.
+    example: ALTER TABLE <table> DISCARD TABLESPACE
+    DDL being atomic now may undergo replication (call to wsrep_replicate)
+    and wsrep_replicate is not made to handle DDL related failures.
+    PXC-8.0 continue to replicate DDL using TOI
+  */
+  bool wsrep_non_replicating_atomic_ddl;
+
+  /**
     MySQL flow may replace ha_data (from thd) with temporary ha_data
     for execution of attachable transaction. If brute force abort thread
     is trying to acesss victim ha_data while this replacement is taking


### PR DESCRIPTION
… is not

  tagged for replication

  - ALTER TABLE ... IMPORT/DISCARD tablespace is not replicated as it is local
    operation. Said statement being unsafe to run in cluster mode is also
    blocked under pxc_strict_mode = ENFORCING.

  - Since ALTER is not replicated it doesn't pass through TOI check.

  - ALTER command is not atomic and so wsrep_replicate (dml based binlog
    replication hook) is called called. wsrep_replicate is not equipped to
    handle non-replicating atomic ddl. This causes wsrep_replicate to return
    error when command execute (when it should just ignore this command as
    command is not running in not registered in galera context).