### PR TITLE
PXC-2368 : PXC 8.0 replication filters

### DIFF
--- a/mysql-test/suite/galera/r/galera_repl_filtersA.result
+++ b/mysql-test/suite/galera/r/galera_repl_filtersA.result
@@ -316,7 +316,6 @@ include/assert.inc ['t2 is on node_3']
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
 #
 # Test async.tbl.ddl.2.4 : TRUNCATE TABLE
 #
@@ -488,7 +487,6 @@ INSERT INTO dbx1.t1(id) VALUES(99);
 # connection node_2
 INSERT INTO dbx1.t1(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t1(id) VALUES(99);
 #
 # Test async.tbl.ddl.4.4 : TRUNCATE TABLE
 #
@@ -609,7 +607,6 @@ include/assert.inc ["Insert not replicated to node_3"]
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(1);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
 #
 # Test async.tbl.dml.2.2 : UPDATE
 #
@@ -691,7 +688,6 @@ include/assert.inc ["Insert not replicated to node_3"]
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(1);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
 #
 # Test async.tbl.dml.4.2 : UPDATE
 #
@@ -1236,7 +1232,6 @@ include/assert.inc ['t2 is on node_3']
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
 #
 # Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
 #
@@ -1355,7 +1350,6 @@ include/assert.inc ['t2 is on node_3']
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
 #
 # Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
 #
@@ -1441,12 +1435,12 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 INSERT INTO db.counter(count) VALUES(96);
 include/assert.inc ["Insert succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Insert not replicated to node_3"]
+include/assert.inc ["Insert replicated to node_3"]
 #
 # Test galera.tbl.dml.2 test preparation
 #
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+include/assert.inc ["Nodes 2 and 3 should be the same"]
 #
 # Test galera.tbl.dml.2.2 : UPDATE
 #
@@ -1456,7 +1450,7 @@ UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(97);
 include/assert.inc ["Update succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Update not replicated to node_3"]
+include/assert.inc ["Update replicated to node_3"]
 #
 # Test galera.tbl.dml.2.3 : DELETE
 #
@@ -1466,7 +1460,7 @@ DELETE FROM dbx1.t2 WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(98);
 include/assert.inc ["Delete succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Delete not replicated to node_3"]
+include/assert.inc ["Delete replicated to node_3"]
 #
 # Testcase galera.tbl.dml.2.3 cleanup
 #
@@ -1515,12 +1509,12 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 INSERT INTO db.counter(count) VALUES(102);
 include/assert.inc ["Insert succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Insert not replicated to node_3"]
+include/assert.inc ["Insert replicated to node_3"]
 #
 # Test galera.tbl.dml.4 test preparation
 #
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+include/assert.inc ["node_2 and node_3 are the same"]
 #
 # Test galera.tbl.dml.4.2 : UPDATE
 #
@@ -1530,7 +1524,7 @@ UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(103);
 include/assert.inc ["Update succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Update not replicated to node_3"]
+include/assert.inc ["Update replicated to node_3"]
 #
 # Test galera.tbl.dml.4.3 : DELETE
 #
@@ -1540,7 +1534,7 @@ DELETE FROM dbx1.t2 WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(104);
 include/assert.inc ["Delete succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Delete not replicated to node_3"]
+include/assert.inc ["Delete replicated to node_3"]
 #
 # Testcase galera.tbl.dml.4.3 cleanup
 #
@@ -1745,6 +1739,22 @@ STOP SLAVE;
 RESET SLAVE ALL;
 # connection node_1
 RESET MASTER;
+CHANGE MASTER TO MASTER_HOST='127.0.0.1' FOR CHANNEL 'wsrep';
+ERROR HY000: CHANGE MASTER with the given parameters cannot be performed on channel 'wsrep'.
+START SLAVE FOR CHANNEL 'wsrep';
+ERROR HY000: START SLAVE FOR CHANNEL cannot be performed on channel 'wsrep'.
+STOP SLAVE FOR CHANNEL 'wsrep';
+ERROR HY000: STOP SLAVE FOR CHANNEL cannot be performed on channel 'wsrep'.
+SHOW RELAYLOG EVENTS FOR CHANNEL 'wsrep';
+ERROR HY000: SHOW RELAYLOG EVENTS cannot be performed on channel 'wsrep'.
+FLUSH RELAY LOGS FOR CHANNEL 'wsrep';
+ERROR HY000: FLUSH RELAY LOGS cannot be performed on channel 'wsrep'.
+SHOW SLAVE STATUS FOR CHANNEL 'wsrep';
+ERROR HY000: SHOW SLAVE STATUS cannot be performed on channel 'wsrep'.
+RESET SLAVE FOR CHANNEL 'wsrep';
+ERROR HY000: RESET SLAVE [ALL] FOR CHANNEL cannot be performed on channel 'wsrep'.
+CHANGE REPLICATION FILTER REPLICATE_DO_DB=(db1) FOR CHANNEL 'wsrep';
+ERROR HY000: CHANGE REPLICATION FILTER cannot be performed on channel 'wsrep'.
 call mtr.add_suppression("WSREP: Pending to replicate MySQL GTID event.*");
 call mtr.add_suppression("WSREP: Pending to replicate MySQL GTID event.*");
 call mtr.add_suppression("WSREP: Pending to replicate MySQL GTID event.*");

--- a/mysql-test/suite/galera/r/galera_repl_filtersB.result
+++ b/mysql-test/suite/galera/r/galera_repl_filtersB.result
@@ -155,7 +155,6 @@ include/assert.inc ['t2 is on node_3']
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
 #
 # Test async.tbl.ddl.2.4 : TRUNCATE TABLE
 #
@@ -327,7 +326,6 @@ INSERT INTO dbx1.t1(id) VALUES(99);
 # connection node_2
 INSERT INTO dbx1.t1(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t1(id) VALUES(99);
 #
 # Test async.tbl.ddl.4.4 : TRUNCATE TABLE
 #
@@ -455,7 +453,6 @@ include/assert.inc ["Insert not replicated to node_3"]
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(1);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
 #
 # Test async.tbl.dml.2.2 : UPDATE
 #
@@ -543,7 +540,6 @@ include/assert.inc ["Insert not replicated to node_3"]
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(1);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
 #
 # Test async.tbl.dml.4.2 : UPDATE
 #
@@ -990,7 +986,6 @@ include/assert.inc ['t2 is on node_3']
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
 #
 # Test galera.tbl.ddl.2.4 : TRUNCATE TABLE
 #
@@ -1109,7 +1104,6 @@ include/assert.inc ['t2 is on node_3']
 # connection node_2
 INSERT INTO dbx1.t2(id) VALUES(99);
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
 #
 # Test galera.tbl.ddl.4.4 : TRUNCATE TABLE
 #
@@ -1195,12 +1189,12 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 INSERT INTO db.counter(count) VALUES(72);
 include/assert.inc ["Insert succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Insert not replicated to node_3"]
+include/assert.inc ["Insert replicated to node_3"]
 #
 # Test galera.tbl.dml.2 test preparation
 #
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+include/assert.inc ["node_2 and node_3 are the same"]
 #
 # Test galera.tbl.dml.2.2 : UPDATE
 #
@@ -1210,7 +1204,7 @@ UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(73);
 include/assert.inc ["Update succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Update not replicated to node_3"]
+include/assert.inc ["Update replicated to node_3"]
 #
 # Test galera.tbl.dml.2.3 : DELETE
 #
@@ -1220,7 +1214,7 @@ DELETE FROM dbx1.t2 WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(74);
 include/assert.inc ["Delete succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Delete not replicated to node_3"]
+include/assert.inc ["Delete replicated to node_3"]
 #
 # Testcase galera.tbl.dml.2.3 cleanup
 #
@@ -1269,12 +1263,12 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 INSERT INTO db.counter(count) VALUES(78);
 include/assert.inc ["Insert succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Insert not replicated to node_3"]
+include/assert.inc ["Insert replicated to node_3"]
 #
 # Test galera.tbl.dml.4 test preparation
 #
 # connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+include/assert.inc ["node_2 and node_3 are the same"]
 #
 # Test galera.tbl.dml.4.2 : UPDATE
 #
@@ -1284,7 +1278,7 @@ UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(79);
 include/assert.inc ["Update succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Update not replicated to node_3"]
+include/assert.inc ["Update replicated to node_3"]
 #
 # Test galera.tbl.dml.4.3 : DELETE
 #
@@ -1294,7 +1288,7 @@ DELETE FROM dbx1.t2 WHERE id = 1;
 INSERT INTO db.counter(count) VALUES(80);
 include/assert.inc ["Delete succeeded on node_2"]
 # connection node_3
-include/assert.inc ["Delete not replicated to node_3"]
+include/assert.inc ["Delete replicated to node_3"]
 #
 # Testcase galera.tbl.dml.4.3 cleanup
 #

--- a/mysql-test/suite/galera/t/galera_repl_filtersA.test
+++ b/mysql-test/suite/galera/t/galera_repl_filtersA.test
@@ -26,6 +26,13 @@
 #
 # db1 and dbx1 can be used for TABLE/DATABASE testing.
 #
+# 8.0 Changes
+# ===========
+# In PXC 5.7, the replication filters would also apply to galera replication,
+# which meant that galera used the global replication
+# In PXC 8.0, this is no longer true.  The galera channel has it's own filters,
+# and no longer uses the global replication filter.
+#
 
 --source include/have_log_bin.inc
 --source include/force_restart.inc
@@ -1291,7 +1298,8 @@ INSERT INTO dbx1.t2(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -1912,7 +1920,8 @@ INSERT INTO dbx1.t1(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t1(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t1
+--source include/wait_condition.inc
 
 
 #
@@ -2348,7 +2357,8 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -2669,7 +2679,8 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -4735,7 +4746,8 @@ INSERT INTO dbx1.t2(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -5189,7 +5201,8 @@ INSERT INTO dbx1.t2(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -5504,16 +5517,10 @@ USE db; DELETE FROM db1.t1 WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
-# is not allowed, so the operation will not replicate.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# NOTE: The default database does not matter here, only the
-# table's database.
-#
-# NOTE: Unlike statement-based replication, the database filters
-# are checked for row-based replication.
-#
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE db; INSERT INTO dbx1.t2(id) VALUES(1);
 
@@ -5528,9 +5535,10 @@ USE db; INSERT INTO dbx1.t2(id) VALUES(1);
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Insert not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
 --source include/assert.inc
+
 
 #
 # Test preparation
@@ -5540,7 +5548,9 @@ USE db; INSERT INTO dbx1.t2(id) VALUES(1);
 --echo #
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $assert_text = "Nodes 2 and 3 should be the same"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
 
 
 #
@@ -5557,16 +5567,10 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
-# is not allowed, so the operation will not replicate.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# NOTE: The default database does not matter here, only the
-# table's database.
-#
-# NOTE: Unlike statement-based replication, the database filters
-# are checked for row-based replication.
-#
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 
@@ -5581,8 +5585,8 @@ USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Update not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
 --source include/assert.inc
 
 
@@ -5600,16 +5604,10 @@ USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
-# is not allowed, so the operation will not replicate.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# NOTE: The default database does not matter here, only the
-# table's database.
-#
-# NOTE: Unlike statement-based replication, the database filters
-# are checked for row-based replication.
-#
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE db; DELETE FROM dbx1.t2 WHERE id = 1;
 
@@ -5624,8 +5622,8 @@ USE db; DELETE FROM dbx1.t2 WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Delete not replicated to node_3"
---let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
 --source include/assert.inc
 
 --echo #
@@ -5797,16 +5795,10 @@ USE dbx; DELETE FROM db1.t1 WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
-# is not allowed, so the operation will not replicate.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# NOTE: The default database does not matter here, only the
-# table's database.
-#
-# NOTE: Unlike statement-based replication, the database filters
-# are checked for row-based replication.
-#
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
 
@@ -5821,8 +5813,8 @@ USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Insert not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
 --source include/assert.inc
 
 #
@@ -5833,7 +5825,9 @@ USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
 --echo #
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $assert_text = "node_2 and node_3 are the same"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
 
 
 #
@@ -5850,14 +5844,8 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
-# is not allowed, so the operation will not replicate.
-#
-# NOTE: The default database does not matter here, only the
-# table's database.
-#
-# NOTE: Unlike statement-based replication, the database filters
-# are checked for row-based replication.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
 # SUMMARY: node_2:yes  node_3:no
 #
@@ -5874,8 +5862,8 @@ USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Update not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
 --source include/assert.inc
 
 
@@ -5893,14 +5881,8 @@ USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 because the table's database, dbx1,
-# is not allowed, so the operation will not replicate.
-#
-# NOTE: The default database does not matter here, only the
-# table's database.
-#
-# NOTE: Unlike statement-based replication, the database filters
-# are checked for row-based replication.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
 # SUMMARY: node_2:yes  node_3:no
 #
@@ -5917,8 +5899,8 @@ USE dbx; DELETE FROM dbx1.t2 WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Delete not replicated to node_3"
---let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
 --source include/assert.inc
 
 --echo #
@@ -6679,6 +6661,36 @@ RESET SLAVE ALL;
 --echo # connection node_1
 --connection node_1
 RESET MASTER;
+
+
+# ==== PXC-2368 test cases ====
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+CHANGE MASTER TO MASTER_HOST='127.0.0.1' FOR CHANNEL 'wsrep';
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+START SLAVE FOR CHANNEL 'wsrep';
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+STOP SLAVE FOR CHANNEL 'wsrep';
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+SHOW RELAYLOG EVENTS FOR CHANNEL 'wsrep';
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+FLUSH RELAY LOGS FOR CHANNEL 'wsrep';
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+SHOW SLAVE STATUS FOR CHANNEL 'wsrep';
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+RESET SLAVE FOR CHANNEL 'wsrep';
+
+--error ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
+CHANGE REPLICATION FILTER REPLICATE_DO_DB=(db1) FOR CHANNEL 'wsrep';
+
+# ==== PXC-2368 test cases end ====
+
 
 --connection node_1
 call mtr.add_suppression("WSREP: Pending to replicate MySQL GTID event.*");

--- a/mysql-test/suite/galera/t/galera_repl_filtersB.test
+++ b/mysql-test/suite/galera/t/galera_repl_filtersB.test
@@ -636,7 +636,8 @@ INSERT INTO dbx1.t2(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -1276,7 +1277,8 @@ INSERT INTO dbx1.t1(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t1(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t1
+--source include/wait_condition.inc
 
 
 #
@@ -1722,7 +1724,8 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -2049,7 +2052,8 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -3689,7 +3693,8 @@ INSERT INTO dbx1.t2(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -4143,7 +4148,8 @@ INSERT INTO dbx1.t2(id) VALUES(99);
 
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(99);
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbx1.t2
+--source include/wait_condition.inc
 
 
 #
@@ -4443,10 +4449,10 @@ USE db; DELETE FROM db1.t1 WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 since this
-# will not pass the table filters.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE db; INSERT INTO dbx1.t2(id) VALUES(1);
 
@@ -4461,8 +4467,8 @@ USE db; INSERT INTO dbx1.t2(id) VALUES(1);
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Insert not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
 --source include/assert.inc
 
 #
@@ -4473,7 +4479,9 @@ USE db; INSERT INTO dbx1.t2(id) VALUES(1);
 --echo #
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $assert_text = "node_2 and node_3 are the same"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
 
 
 #
@@ -4490,10 +4498,10 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 since this
-# will not pass the table filters.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 
@@ -4508,8 +4516,8 @@ USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Update not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
 --source include/assert.inc
 
 
@@ -4527,8 +4535,8 @@ USE db; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 since this
-# will not pass the table filters.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
 # SUMMARY: node_2:yes  node_3:no
 #
@@ -4545,8 +4553,8 @@ USE db; DELETE FROM dbx1.t2 WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Delete not replicated to node_3"
---let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
 --source include/assert.inc
 
 --echo #
@@ -4703,10 +4711,10 @@ USE dbx; DELETE FROM db1.t1 WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 since this
-# will not pass the table filters.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
 
@@ -4721,8 +4729,8 @@ USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Insert not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
+--let $assert_text = "Insert replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
 --source include/assert.inc
 
 #
@@ -4733,7 +4741,9 @@ USE dbx; INSERT INTO dbx1.t2(id) VALUES(1);
 --echo #
 --echo # connection node_3
 --connection node_3
-INSERT INTO dbx1.t2(id) VALUES(1);
+--let $assert_text = "node_2 and node_3 are the same"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--source include/assert.inc
 
 
 #
@@ -4750,10 +4760,10 @@ INSERT INTO dbx1.t2(id) VALUES(1);
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 since this
-# will not pass the table filters.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 
@@ -4768,8 +4778,8 @@ USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Update not replicated to node_3"
---let $assert_cond = COUNT(*) = 0 FROM dbx1.t2 WHERE f2 = "abcde"
+--let $assert_text = "Update replicated to node_3"
+--let $assert_cond = COUNT(*) = 1 FROM dbx1.t2 WHERE f2 = "abcde"
 --source include/assert.inc
 
 
@@ -4787,10 +4797,10 @@ USE dbx; UPDATE dbx1.t2 SET f2 = "abcde" WHERE id = 1;
 --echo # connection node_2
 --connection node_2
 
-# EXPECTED: This will not replicate to node_3 since this
-# will not pass the table filters.
+# EXPECTED: This will replicate to node 3 because the global replication filter
+# does not affect galera replication.
 #
-# SUMMARY: node_2:yes  node_3:no
+# SUMMARY: node_2:yes  node_3:yes
 #
 USE dbx; DELETE FROM dbx1.t2 WHERE id = 1;
 
@@ -4805,8 +4815,8 @@ USE dbx; DELETE FROM dbx1.t2 WHERE id = 1;
 --let $wait_condition = SELECT COUNT(*) = $test_id FROM db.counter;
 --source include/wait_condition.inc
 
---let $assert_text = "Delete not replicated to node_3"
---let $assert_cond = COUNT(*) = 1 FROM dbx1.t2
+--let $assert_text = "Delete replicated to node_3"
+--let $assert_cond = COUNT(*) = 0 FROM dbx1.t2
 --source include/assert.inc
 
 --echo #

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10326,6 +10326,13 @@ bool mysqld_get_one_option(int optid,
             CONFIGURED_BY_STARTUP_OPTIONS);
       } else {
         parse_filter_arg(&channel_name, &filter_val, argument);
+#ifdef WITH_WSREP
+        if (wsrep_is_wsrep_channel_name(channel_name)) {
+          sql_print_error("Configuration of the '%s' channel by replicate-ignore-db is not allowed.",
+            WSREP_CHANNEL_NAME);
+          return 1;
+        }
+#endif /* WITH_WSREP */
         rpl_filter = rpl_channel_filters.get_channel_filter(channel_name);
         rpl_filter->add_ignore_db(filter_val);
         rpl_filter->ignore_db_statistics.set_all(
@@ -10340,6 +10347,13 @@ bool mysqld_get_one_option(int optid,
             CONFIGURED_BY_STARTUP_OPTIONS);
       } else {
         parse_filter_arg(&channel_name, &filter_val, argument);
+#ifdef WITH_WSREP
+        if (wsrep_is_wsrep_channel_name(channel_name)) {
+          sql_print_error("Configuration of the '%s' channel by replicate-do-db is not allowed.",
+            WSREP_CHANNEL_NAME);
+          return 1;
+        }
+#endif /* WITH_WSREP */
         rpl_filter = rpl_channel_filters.get_channel_filter(channel_name);
         rpl_filter->add_do_db(filter_val);
         rpl_filter->do_db_statistics.set_all(
@@ -10356,6 +10370,13 @@ bool mysqld_get_one_option(int optid,
             CONFIGURED_BY_STARTUP_OPTIONS);
       } else {
         parse_filter_arg(&channel_name, &filter_val, argument);
+#ifdef WITH_WSREP
+        if (wsrep_is_wsrep_channel_name(channel_name)) {
+          sql_print_error("Configuration of the '%s' channel by replicate-rewrite-db is not allowed.",
+            WSREP_CHANNEL_NAME);
+          return 1;
+        }
+#endif /* WITH_WSREP */
         rpl_filter = rpl_channel_filters.get_channel_filter(channel_name);
         if (parse_replicate_rewrite_db(&key, &val, filter_val)) return 1;
         rpl_filter->add_db_rewrite(key, val);
@@ -10383,6 +10404,13 @@ bool mysqld_get_one_option(int optid,
             CONFIGURED_BY_STARTUP_OPTIONS);
       } else {
         parse_filter_arg(&channel_name, &filter_val, argument);
+#ifdef WITH_WSREP
+        if (wsrep_is_wsrep_channel_name(channel_name)) {
+          sql_print_error("Configuration of the '%s' channel by replicate-do-table is not allowed.",
+            WSREP_CHANNEL_NAME);
+          return 1;
+        }
+#endif /* WITH_WSREP */
         rpl_filter = rpl_channel_filters.get_channel_filter(channel_name);
         if (rpl_filter->add_do_table_array(filter_val)) {
           LogErr(ERROR_LEVEL, ER_RPL_CANT_ADD_DO_TABLE, argument);
@@ -10403,6 +10431,13 @@ bool mysqld_get_one_option(int optid,
             CONFIGURED_BY_STARTUP_OPTIONS);
       } else {
         parse_filter_arg(&channel_name, &filter_val, argument);
+#ifdef WITH_WSREP
+        if (wsrep_is_wsrep_channel_name(channel_name)) {
+          sql_print_error("Configuration of the '%s' channel by replicate-wild-do-table is not allowed.",
+            WSREP_CHANNEL_NAME);
+          return 1;
+        }
+#endif /* WITH_WSREP */
         rpl_filter = rpl_channel_filters.get_channel_filter(channel_name);
         if (rpl_filter->add_wild_do_table(filter_val)) {
           LogErr(ERROR_LEVEL, ER_RPL_FILTER_ADD_WILD_DO_TABLE_FAILED, argument);
@@ -10424,6 +10459,13 @@ bool mysqld_get_one_option(int optid,
             CONFIGURED_BY_STARTUP_OPTIONS);
       } else {
         parse_filter_arg(&channel_name, &filter_val, argument);
+#ifdef WITH_WSREP
+        if (wsrep_is_wsrep_channel_name(channel_name)) {
+          sql_print_error("Configuration of the '%s' channel by replicate-wild-ignore-table is not allowed.",
+            WSREP_CHANNEL_NAME);
+          return 1;
+        }
+#endif /* WITH_WSREP */
         rpl_filter = rpl_channel_filters.get_channel_filter(channel_name);
         if (rpl_filter->add_wild_ignore_table(filter_val)) {
           LogErr(ERROR_LEVEL, ER_RPL_FILTER_ADD_WILD_IGNORE_TABLE_FAILED,
@@ -10445,6 +10487,13 @@ bool mysqld_get_one_option(int optid,
             CONFIGURED_BY_STARTUP_OPTIONS);
       } else {
         parse_filter_arg(&channel_name, &filter_val, argument);
+#ifdef WITH_WSREP
+        if (wsrep_is_wsrep_channel_name(channel_name)) {
+          sql_print_error("Configuration of the '%s' channel by replicate-ignore-table is not allowed.",
+            WSREP_CHANNEL_NAME);
+          return 1;
+        }
+#endif /* WITH_WSREP */
         rpl_filter = rpl_channel_filters.get_channel_filter(channel_name);
         if (rpl_filter->add_ignore_table_array(filter_val)) {
           LogErr(ERROR_LEVEL, ER_RPL_CANT_ADD_IGNORE_TABLE, argument);

--- a/sql/rpl_filter.cc
+++ b/sql/rpl_filter.cc
@@ -1507,7 +1507,11 @@ bool Sql_cmd_change_repl_filter::change_rpl_filter(THD *thd) {
         mysql_mutex_unlock(&mi->rli->run_lock);
     }
   } else {
-    if (channel_map.is_group_replication_channel_name(lex->mi.channel)) {
+    if (channel_map.is_group_replication_channel_name(lex->mi.channel)
+#ifdef WITH_WSREP
+      || wsrep_is_wsrep_channel_name(lex->mi.channel)
+#endif /* WITH_WSREP */
+      ) {
       /*
         If an explicit FOR CHANNEL clause is provided, the statement
         is disallowed on group replication channels.

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -1432,6 +1432,15 @@ bool mysql_show_relaylog_events(THD *thd) {
     goto err;
   }
 
+#ifdef WITH_WSREP
+  if (thd->lex->mi.channel && wsrep_is_wsrep_channel_name(thd->lex->mi.channel)) {
+    my_error(ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED, MYF(0), "SHOW RELAYLOG EVENTS",
+             thd->lex->mi.channel, "SHOW RELAYLOG EVENTS");
+    res = true;
+    goto err;
+  }
+#endif /* WITH_WSREP */
+
   Log_event::init_show_field_list(&field_list);
   if (thd->send_result_metadata(&field_list,
                                 Protocol::SEND_NUM_ROWS | Protocol::SEND_EOF)) {

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2469,3 +2469,8 @@ const char *wsrep_get_wsrep_status(wsrep_status status) {
 
   return "NULL";
 }
+
+bool wsrep_is_wsrep_channel_name(const char *channel_name)
+{
+  return channel_name && !strcasecmp(channel_name, WSREP_CHANNEL_NAME);
+}

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -425,4 +425,12 @@ bool wsrep_prepare_keys_for_isolation(THD *thd, const char *db,
                                       const TABLE_LIST *table_list,
                                       wsrep_key_arr_t *ka);
 void wsrep_keys_free(wsrep_key_arr_t *key_arr);
+
+
+/* In 8.0, channels now have names
+   Reserve the 'wsrep' name for the WSREP replication channels
+*/
+constexpr char WSREP_CHANNEL_NAME[] = "wsrep";
+bool wsrep_is_wsrep_channel_name(const char *channel_name);
+
 #endif /* WSREP_MYSQLD_H */

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -94,7 +94,7 @@ void wsrep_client_rollback(THD *thd) {
 static Relay_log_info *wsrep_relay_log_init(const char *) {
   uint rli_option = INFO_REPOSITORY_DUMMY;
   Relay_log_info *rli = NULL;
-  rli = Rpl_info_factory::create_rli(rli_option, false, "wsrep", true);
+  rli = Rpl_info_factory::create_rli(rli_option, false, WSREP_CHANNEL_NAME, true);
   if (!rli) {
     WSREP_ERROR("Failed to create Relay-Log for wsrep thread, aborting");
     unireg_abort(MYSQLD_ABORT_EXIT);


### PR DESCRIPTION
Issue
MySQL 8.0 introduces per-channel filters (channels now have names)
as well as the global filter (in 5.7 there was only the global filter).
This causes complications for PXC due to the differences in behavior
between async replication and galera replication.

Solution
Have PXC ignore the global and per-channel filters for galera replication.