### PR TITLE
- PXC#2390: Non-atomic SE parallel DDL can race with atomic SE DML while

### DIFF
--- a/mysql-test/suite/galera/r/galera_ddl_dml.result
+++ b/mysql-test/suite/galera/r/galera_ddl_dml.result
@@ -132,5 +132,51 @@ i
 SET GLOBAL wsrep_debug = 0;
 SET DEBUG_SYNC = 'RESET';
 drop table t;
+#node-1
+create table t (i int, primary key pk(i)) engine=innodb;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_in_commit_flush_stage SIGNAL entered1 WAIT_FOR continue1";
+insert into t values (1);;
+#node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+create table t2 (i int, primary key pk(i)) engine=memory;;
+#node-1c (check if ddl is waiting for final commit that suggest intermediate commit done)
+SET DEBUG_SYNC = "now SIGNAL continue1";
+#node-1
+select * from t;
+i
+1
+#node-1a
+select * from t2;
+i
+#node-1
+SET GLOBAL wsrep_debug = 0;
+SET DEBUG_SYNC = 'RESET';
+drop table t;
+drop table t2;
+#node-1
+create table t (i int, primary key pk(i)) engine=innodb;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_in_commit_flush_stage SIGNAL entered1 WAIT_FOR continue1";
+insert into t values (1);;
+#node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+create table t2 (i int, primary key pk(i)) engine=innodb;;
+#node-1c (check if ddl is waiting for final commit that suggest intermediate commit done)
+SET DEBUG_SYNC = "now SIGNAL continue1";
+#node-1
+select * from t;
+i
+1
+#node-1a
+select * from t2;
+i
+#node-1
+SET GLOBAL wsrep_debug = 0;
+SET DEBUG_SYNC = 'RESET';
+drop table t;
+drop table t2;
 set @@wsrep_replicate_myisam = 0;;
 SET DEBUG_SYNC = "reset";

--- a/mysql-test/suite/galera/t/galera_ddl_dml.test
+++ b/mysql-test/suite/galera/t/galera_ddl_dml.test
@@ -213,6 +213,91 @@ drop table t;
 
 #-------------------------------------------------------------------------------
 #
+# 3. Test-case exercise a use-case where-in atomic engine DML is waiting to get
+#    get committed and at same time DDL from non-atomic engine initiate.
+#    This non-atomic engine DDL can cause intermediate commit that can cause
+#    update of wsrep co-ordinates before DML that has smaller seqno is done with
+#    commit.
+#
+--connection node_1
+--echo #node-1
+create table t (i int, primary key pk(i)) engine=innodb;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_in_commit_flush_stage SIGNAL entered1 WAIT_FOR continue1";
+--send insert into t values (1);
+
+--connection node_1a
+--echo #node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+# fire non-atomic storage engine ddl that will cause intemediate commit
+--send create table t2 (i int, primary key pk(i)) engine=memory;
+
+--connection node_1c
+--echo #node-1c (check if ddl is waiting for final commit that suggest intermediate commit done)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'innobase_commit_low%' and INFO = 'create table t2 (i int, primary key pk(i)) engine=memory';
+--source include/wait_condition.inc
+SET DEBUG_SYNC = "now SIGNAL continue1";
+
+--connection node_1
+--echo #node-1
+--reap
+select * from t;
+
+--connection node_1a
+--echo #node-1a
+--reap
+select * from t2;
+
+--connection node_1
+--echo #node-1
+--eval SET GLOBAL wsrep_debug = $wsrep_debug_orig
+SET DEBUG_SYNC = 'RESET';
+drop table t;
+drop table t2;
+
+#-------------------------------------------------------------------------------
+#
+# 4. Same as Case-3 but this time DDL is also from atomic storage engine
+#
+--connection node_1
+--echo #node-1
+create table t (i int, primary key pk(i)) engine=innodb;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_in_commit_flush_stage SIGNAL entered1 WAIT_FOR continue1";
+--send insert into t values (1);
+
+--connection node_1a
+--echo #node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+# fire non-atomic storage engine ddl that will cause intemediate commit
+--send create table t2 (i int, primary key pk(i)) engine=innodb;
+
+--connection node_1c
+--echo #node-1c (check if ddl is waiting for final commit that suggest intermediate commit done)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'waiting for handler commit' and INFO = 'create table t2 (i int, primary key pk(i)) engine=innodb';
+--source include/wait_condition.inc
+SET DEBUG_SYNC = "now SIGNAL continue1";
+
+--connection node_1
+--echo #node-1
+--reap
+select * from t;
+
+--connection node_1a
+--echo #node-1a
+--reap
+select * from t2;
+
+--connection node_1
+--echo #node-1
+--eval SET GLOBAL wsrep_debug = $wsrep_debug_orig
+SET DEBUG_SYNC = 'RESET';
+drop table t;
+drop table t2;
+#-------------------------------------------------------------------------------
+#
 # remove test-bed
 #
 --eval set @@wsrep_replicate_myisam = $wsrep_replicate_myisam_saved;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -705,6 +705,7 @@ THD::THD(bool enable_plugins)
   wsrep_replicate_GTID = false;
   wsrep_skip_wsrep_GTID = false;
   wsrep_split_trx = false;
+  wsrep_intermediate_commit = false;
   m_wsrep_next_trx_id = WSREP_UNDEFINED_TRX_ID;
   wsrep_skip_SE_checkpoint = false;
   wsrep_skip_wsrep_hton = false;
@@ -1025,6 +1026,7 @@ void THD::init(void) {
   wsrep_replicate_GTID = false;
   wsrep_skip_wsrep_GTID = false;
   wsrep_split_trx = false;
+  wsrep_intermediate_commit = false;
   wsrep_gtid_event_buf = NULL;
   wsrep_gtid_event_buf_len = 0;
   m_wsrep_next_trx_id = WSREP_UNDEFINED_TRX_ID;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2936,6 +2936,10 @@ class THD : public MDL_context_owner,
      then commit the said transaction as part of external_lock(UNLOCK). */
   bool wsrep_split_trx;
 
+  /* Set to true if intermediate commit is active. Use to skip
+  update of wsrep co-ordinates for intermediate commit. */
+  bool wsrep_intermediate_commit;
+
   /*
     Transaction id:
     * m_next_wsrep_trx_id is assigned on the first query after

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -745,7 +745,12 @@ extern "C" void wsrep_thd_auto_increment_variables(
 }
 
 bool wsrep_safe_to_persist_xid(THD *thd) {
-  /* transaction rollback too too also invokes persist of XID.
+  /* Avoid persist of XID during intermediate commit. Wait for final commit. */
+  if (thd->wsrep_intermediate_commit) {
+    return (false);
+  }
+
+  /* transaction rollback also invokes persist of XID.
   Avoid persisting XID in this use-case. */
   bool safe_to_persist_xid = false;
   if (thd->wsrep_conflict_state == NO_CONFLICT ||

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -280,9 +280,12 @@ void trx_sys_update_wsrep_checkpoint(
         else
           return;
       } else {
-        /* DDL transaction are committed twice now.
-        Once through trans_commit_stmt and then through galera checkpoint.
-        But not all DDL are atomic so we continue to have both persist point */
+        /* DDL transaction are executed as TOI.
+        With 8.0, DDL are atomic and will cause commit of transaction
+        in InnoDB world that will cause xid to persist.
+        Same xid is re-persisted when TOI ends.
+        Latter call is still needed for DDL transaction that non-atomic.
+        So condition check is now >= and not just > */
         ut_ad(xid_seqno >= trx_sys_cur_xid_seqno);
         trx_sys_cur_xid_seqno = xid_seqno;
       }


### PR DESCRIPTION
  updating wsrep co-ordinates

  - MySQL-8.0, executes DDL commit for non-atomic storage engine objects
    at 2 level: intermediate commit and final commit.
    [Reason for intermediate commit is not clear from code].

  - This non-atomic storage engine DDL is also replicated by PXC using TOI.

  - This causes double persistence of the same wsrep co-ordinates

  - Patch works a solution to avoid persistence of wsrep co-ordinates
    during intermediate commit.