### PR TITLE
PXC-2430 : Centos6 : if SST fails in mysql_upgrade, script continues …

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -437,14 +437,23 @@ EOF
     # start mysql-upgrade execution.
     #-----------------------------------------------------------------------
     if [[ $rsync_sst_success -eq 1 ]]; then
-        if [[ "$auto_upgrade" == "on" ]]; then
-            wsrep_log_info "Running mysql-upgrade..........."
-            set +e
-            run_mysql_upgrade "$WSREP_SST_OPT_DATA" "$RSYNC_PORT"
-            set -e
-            wsrep_log_info "...........upgrade done"
+        if [[ $auto_upgrade == "on" ]]; then
+            run_upgrade=1
         else
+            run_upgrade=0
             wsrep_log_info "auto-upgrade disabled by configuration"
+        fi
+
+        wsrep_log_info "Running post-processing ..........."
+        set +e
+        run_post_processing_steps "$WSREP_SST_OPT_DATA" "$RSYNC_PORT" $run_upgrade
+        errcode=$?
+        set -e
+        if [[ $errcode -ne 0 ]]; then
+            wsrep_log_info "...........post-processing failed.  Exiting"
+            exit $errcode
+        else
+            wsrep_log_info "...........post-processing done"
         fi
     fi
 else


### PR DESCRIPTION
…rather than exits

PXC-2433 : PXC-8.0 SST is failing with "use_mysql_upgrade_conf _suffix: unbound variable" error

Issue
In Centos6, a subshell is spawned when running mysql_upgrade.  This causes
the "exit" statement, to exit the subshell and not the script.  Thus the
process continues on after an error has occurred (and we expected to fully exit).

Solution
Change the function to "return" rather than "exit".  In the calling script
handle the return values and exit properly.

Also additional script fixes (PXC-2433)
Also an optimization, do not run mysql_upgrade if donor/joiner have the same mysql version
(major.minor.revision are the same).