### PR TITLE
- PXC#2396: handler operation is being brute force aborted

### DIFF
--- a/mysql-test/suite/galera/r/MW-329.result
+++ b/mysql-test/suite/galera/r/MW-329.result
@@ -13,9 +13,6 @@ INSERT INTO t1 (f1) VALUES (FLOOR( 1 + RAND( ) * 65535 ));
 END WHILE;
 END|
 CALL proc_insert();;
-SELECT VARIABLE_VALUE > 0 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays';
-VARIABLE_VALUE > 0
-1
 DROP PROCEDURE proc_insert;
 DROP TABLE t1;
 CALL mtr.add_suppression("conflict state 3 after post commit");

--- a/mysql-test/suite/galera/r/galera_ddl_dml.result
+++ b/mysql-test/suite/galera/r/galera_ddl_dml.result
@@ -178,5 +178,37 @@ SET GLOBAL wsrep_debug = 0;
 SET DEBUG_SYNC = 'RESET';
 drop table t;
 drop table t2;
+call mtr.add_suppression("Slave SQL: Error \'Table \'t\' already exists\' on query.*");
+call mtr.add_suppression("Slave SQL: Error \'Table \'t\' already exists\' on query.*");
+#node-1 (this connection will take handler lock)
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1);
+handler t open h1;
+#node-2 (this connection will issue a conflicting ddl)
+alter table t engine=innodb;
+#node-1a
+#node-1 (now close handler)
+handler h1 close;
+create table t (i int, primary key pk(i)) engine=innodb;
+ERROR 42S01: Table 't' already exists
+drop table t;
+#node-1 (this connection will take user level lock)
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1);
+select get_lock('a', 10);
+get_lock('a', 10)
+1
+#node-2 (this connection will issue a conflicting ddl)
+alter table t engine=innodb;
+select sleep(5);
+sleep(5)
+0
+#node-1 (now release user level lock)
+select release_lock('a');
+release_lock('a')
+1
+create table t (i int, primary key pk(i)) engine=innodb;
+ERROR 42S01: Table 't' already exists
+drop table t;
 set @@wsrep_replicate_myisam = 0;;
 SET DEBUG_SYNC = "reset";

--- a/mysql-test/suite/galera/r/galera_performance_schema.result
+++ b/mysql-test/suite/galera/r/galera_performance_schema.result
@@ -36,7 +36,4 @@ insert into t values (3);
 #node-1
 commit;
 ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
-select count(*) > 0 from performance_schema.events_waits_current where event_name like '%COND_wsrep_rollback%';;
-count(*) > 0
-1
 drop table t;

--- a/mysql-test/suite/galera/t/MW-329.test
+++ b/mysql-test/suite/galera/t/MW-329.test
@@ -62,7 +62,8 @@ while ($count)
 # Confirm that some transaction replays occurred
 #
 
-SELECT VARIABLE_VALUE > 0 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays';
+--let $wait_condition = SELECT VARIABLE_VALUE > 0 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays';
+--source include/wait_condition.inc
 
 #
 # Terminate the stored procedure

--- a/mysql-test/suite/galera/t/galera_ddl_dml.test
+++ b/mysql-test/suite/galera/t/galera_ddl_dml.test
@@ -296,6 +296,60 @@ select * from t2;
 SET DEBUG_SYNC = 'RESET';
 drop table t;
 drop table t2;
+
+#-------------------------------------------------------------------------------
+#
+# 5. Explicit lock in form of HANDLER locks.
+#
+--connection node_1
+call mtr.add_suppression("Slave SQL: Error \'Table \'t\' already exists\' on query.*");
+--connection node_2
+call mtr.add_suppression("Slave SQL: Error \'Table \'t\' already exists\' on query.*");
+
+--connection node_1
+--echo #node-1 (this connection will take handler lock)
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1);
+handler t open h1;
+
+--connection node_2
+--echo #node-2 (this connection will issue a conflicting ddl)
+alter table t engine=innodb;
+
+--connection node_1a
+--echo #node-1a
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for table metadata lock' and INFO = 'alter table t engine=innodb'
+--source include/wait_condition.inc
+
+--connection node_1
+--echo #node-1 (now close handler)
+handler h1 close;
+--error ER_TABLE_EXISTS_ERROR
+create table t (i int, primary key pk(i)) engine=innodb;
+drop table t;
+
+#-------------------------------------------------------------------------------
+#
+# 6. Explicit lock in form of get_lock locks.
+#
+--connection node_1
+--echo #node-1 (this connection will take user level lock)
+create table t (i int, primary key pk(i)) engine=innodb;
+insert into t values (1);
+select get_lock('a', 10);
+
+--connection node_2
+--echo #node-2 (this connection will issue a conflicting ddl)
+alter table t engine=innodb;
+select sleep(5);
+
+--connection node_1
+--echo #node-1 (now release user level lock)
+select release_lock('a');
+--error ER_TABLE_EXISTS_ERROR
+create table t (i int, primary key pk(i)) engine=innodb;
+drop table t;
+
 #-------------------------------------------------------------------------------
 #
 # remove test-bed

--- a/mysql-test/suite/galera/t/galera_performance_schema.test
+++ b/mysql-test/suite/galera/t/galera_performance_schema.test
@@ -60,6 +60,9 @@ insert into t values (3);
 --sleep 2
 --error ER_LOCK_DEADLOCK
 commit;
+#
 --replace_regex /[1-9][0-9]+/PREVIOUS_COUNT/
---eval select count(*) > $condvar from performance_schema.events_waits_current where event_name like '%COND_wsrep_rollback%';
+--let $wait_condition = select count(*) > $condvar from performance_schema.events_waits_current where event_name like '%COND_wsrep_rollback%';
+--source include/wait_condition.inc
+#
 drop table t;

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -4764,6 +4764,13 @@ void MDL_context::set_lock_duration(MDL_ticket *mdl_ticket,
   DBUG_ASSERT(mdl_ticket->m_duration == MDL_TRANSACTION &&
               duration != MDL_TRANSACTION);
   m_ticket_store.remove(MDL_TRANSACTION, mdl_ticket);
+#ifdef WITH_WSREP
+  /* This will take care of HANDLER <table> OPEN <handler-name> lock
+  construct and other such construct that exercise use of explicit lock. */
+  if (duration == MDL_EXPLICIT) {
+    mdl_ticket->set_wsrep_non_preemptable_status(true);
+  }
+#endif /* WITH_WSREP */
   m_ticket_store.push_front(duration, mdl_ticket);
 
 #ifndef DBUG_OFF


### PR DESCRIPTION
  - handler operation (HANDLER <table> open <handle>)
    will take explicit lock.

  - This explicit lock check was not being detected
    as part of brute-force abort flow that caused
    the said thread with handler lock to get forcefully aborted.

  - Patch now marks lock with explicit duration as non-preemptable.

Also fixed some timing issues mainly waiting for event to appear
as they are applied in async fashion.