### PR TITLE
PXC-2453 : block PXC-8.0 upgrade from PXC-5.6 or lower

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -949,7 +949,7 @@ SET(SYSTEM_LIBRARIES
   LZ4
 # LZMA     use bundled by default here
   PROTOBUF
-  READLINE
+#  READLINE use EDITLINE=bundled
   RAPIDJSON
   RE2
   SSL

--- a/plugin/keyring/keyring.cc
+++ b/plugin/keyring/keyring.cc
@@ -124,7 +124,15 @@ static int keyring_init(MYSQL_PLUGIN plugin_info MY_ATTRIBUTE((unused))) {
     logger.reset(new Logger());
     if (create_keyring_dir_if_does_not_exist(keyring_file_data_value)) {
       logger->log(ERROR_LEVEL, ER_KEYRING_FAILED_TO_CREATE_KEYRING_DIR);
+#ifdef WITH_WSREP
+      /* If running in cluster mode, keyring initialization failure is treated
+      as fatal error to avoid inconsistency in cluster enviornment where-in
+      some node of the cluster are running with keyring enabled and other
+      in keyring disabled mode, despite of same user provided configuration. */
+      return true;
+#else
       return false;
+#endif
     }
     keys.reset(new Keys_container(logger.get()));
     std::vector<std::string> allowedFileVersionsToInit;

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -1066,7 +1066,7 @@ INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.session', 'localhost', 'SE
 FLUSH PRIVILEGES;
 
 #
-# SQL commands to create the PXC SST root and role that is used by the SST process
+# SQL commands to create the PXC internal session user and role that is used by the SST process
 #
 # mysql.pxc.internal.session
 #   See the comments in mysql_system_tables.sql
@@ -1076,13 +1076,15 @@ FLUSH PRIVILEGES;
 #  GRANT SUPER ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
 #  GRANT RELOAD ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
 #
-#INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.internal.session','N','N','N','N','N','N','Y','N','N','N','Y','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','Y','N','N','N','','','','',0,0,0,0,'caching_sha2_password','$A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED','N',CURRENT_TIMESTAMP,  NULL,'Y','N','N',NULL,NULL,NULL);
+#INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.internal.session','N','N','N','N','N','N','Y','N','N','N','Y','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','Y','N','N','N','','','','',0,0,0,0,'caching_sha2_password','$A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED','N',CURRENT_TIMESTAMP, NULL,'Y','N','N',NULL,NULL,NULL,NULL);
 
+# (Use this since the CREATE DATABASE doesn't work when the grant is in a role)
+# So we assign the mysql.pxc.internal.session root privileges with grant option
 # These are the values for
 #  GRANT ALL PRIVILEGES ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
 #  GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
 #
-INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.internal.session','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','','','','',0,0,0,0,'caching_sha2_password','$A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED','N',CURRENT_TIMESTAMP,  NULL,'Y','Y','Y',NULL,NULL,NULL);
+INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.internal.session','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','Y','','','','',0,0,0,0,'caching_sha2_password','$A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED','N',CURRENT_TIMESTAMP,NULL,'Y','Y','Y',NULL,NULL,NULL,NULL);
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'localhost', 'BACKUP_ADMIN', 'Y');
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'localhost', 'BINLOG_ADMIN', 'Y');
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'localhost', 'CONNECTION_ADMIN', 'Y');
@@ -1097,6 +1099,7 @@ INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'lo
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'localhost', 'SYSTEM_VARIABLES_ADMIN', 'Y');
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'localhost', 'XA_RECOVER_ADMIN', 'Y');
 
+
 #
 # mysql.pxc.sst.role
 #   See the comments in mysql_system_tables.sql
@@ -1106,7 +1109,7 @@ INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'lo
 #  GRANT CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT SELECT ON performance_schema.* TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT CREATE ON PERCONA_SCHEMA.* to 'mysql.pxc.sst.role'@localhost;
-INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.sst.role','N','N','N','N','N','N','Y','N','Y','N','N','N','N','N','N','Y','N','Y','N','N','Y','N','N','N','N','N','N','N','N','','','','',0,0,0,0,'caching_sha2_password','','Y',CURRENT_TIMESTAMP,NULL,'Y','N','N',NULL,NULL,NULL);
+INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.sst.role','N','N','N','N','N','N','Y','N','Y','N','N','N','N','N','N','Y','N','Y','N','N','Y','N','N','N','N','N','N','N','N','','','','',0,0,0,0,'caching_sha2_password','','Y',CURRENT_TIMESTAMP,NULL,'Y','N','N',NULL,NULL,NULL,NULL);
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'BACKUP_ADMIN', 'N');
 INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Select,Insert,Create', '');
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'performance_schema', 'mysql.pxc.sst.role','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N');

--- a/scripts/mysql_system_users.sql
+++ b/scripts/mysql_system_users.sql
@@ -45,8 +45,9 @@ CREATE USER 'mysql.infoschema'@localhost IDENTIFIED WITH caching_sha2_password
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql.infoschema'@localhost;
 GRANT SELECT ON *.* TO 'mysql.infoschema'@localhost;
 
--- Create the PXC SST root
--- This user is used by the SST process to create the SST user and
+-- Create the PXC internal session user
+-- This user is used by PXC to run commands needed by PXC.
+-- Specifically, this user is used by the SST process to create the SST user and
 -- run other commands needed before/after the SST.
 -- If the privileges are changed, the mysql_system_tables_fix.sql script
 -- will also need to be modified to match.
@@ -60,6 +61,7 @@ CREATE USER 'mysql.pxc.internal.session'@localhost IDENTIFIED WITH caching_sha2_
  AS '$A$005$THISISACOMBINATIONOFINVALIDSALTANDPASSWORDTHATMUSTNEVERBRBEUSED'
  ACCOUNT LOCK;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql.pxc.internal.session'@localhost;
+
 -- Due to bugs with roles, we need to grant superuser access here
 GRANT ALL PRIVILEGES ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
 GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
@@ -67,8 +69,9 @@ GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *
 --GRANT SUPER ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
 --GRANT RELOAD ON *.* TO 'mysql.pxc.internal.session'@localhost WITH GRANT OPTION;
 
+
 -- Create the PXC SST role
--- This role is used during PXC SST (on the donor)
+-- This role is used by the SST user during an SST (on the donor)
 -- These are the permissions needed to backup the database (using Percona XtraBackup)
 -- See https://www.percona.com/doc/percona-xtrabackup/8.0/using_xtrabackup/privileges.html
 CREATE ROLE 'mysql.pxc.sst.role'@localhost;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -745,6 +745,7 @@ The documentation is based on the source files such as:
 #include "wsrep_mysqld.h"
 #include "wsrep_sst.h"
 #include "wsrep_thd.h"
+#include "wsrep_utils.h"
 #include "wsrep_var.h"
 #endif /* WITH_WSREP */
 
@@ -7539,7 +7540,15 @@ int mysqld_main(int argc, char **argv)
 
 #ifdef WITH_WSREP /* WSREP AFTER SE */
   if (opt_initialize) {
-    /*! bootstrap wsrep init was taken care of above */
+    /* Create the wsrep state file */
+    wsp::WSREPState  wsrep_state;
+    wsrep_state.wsrep_schema_version = WSREP_SCHEMA_VERSION;
+    if (!wsrep_state.save_to(mysql_real_data_home_ptr, WSREP_STATE_FILENAME))
+    {
+      WSREP_ERROR("Could not create the wsrep state file : %s", WSREP_STATE_FILENAME);
+      WSREP_ERROR("Exiting");
+      unireg_abort(MYSQLD_ABORT_EXIT);
+    }
   } else {
     wsrep_SE_initialized();
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -20,6 +20,7 @@
 #include "query_options.h"
 #include "rpl_gtid.h"
 #include "wsrep/src/wsrep_api.h"
+#include "mysql_version.h"
 // #include "sql/log.h"
 
 #define WSREP_UNDEFINED_TRX_ID ULLONG_MAX
@@ -433,5 +434,26 @@ void wsrep_keys_free(wsrep_key_arr_t *key_arr);
 */
 constexpr char WSREP_CHANNEL_NAME[] = "wsrep";
 bool wsrep_is_wsrep_channel_name(const char *channel_name);
+
+
+/* In 8.0, a WSREP state file was added to keep track of information
+   about WSREP that could be accessed by other processes (e.g. SST)
+
+   This file is named 'wsrep_state.dat'
+ */
+
+/* Name of the file that holds metadata about the WSREP state.
+ */
+constexpr char WSREP_STATE_FILENAME[] = "wsrep_state.dat";
+
+/* Version number for the state file format
+ */
+constexpr char WSREP_STATE_FILE_VERSION_NAME[] = "version";
+constexpr char WSREP_STATE_FILE_VERSION[] = "1.0";
+
+/* This identifies the PXC version of the datadir/schema.
+ */
+constexpr char WSREP_SCHEMA_VERSION_NAME[] = "wsrep_schema_version";
+constexpr char WSREP_SCHEMA_VERSION[] = MYSQL_SERVER_VERSION;
 
 #endif /* WSREP_MYSQLD_H */

--- a/sql/wsrep_utils.h
+++ b/sql/wsrep_utils.h
@@ -225,6 +225,37 @@ class critical {
 };
 #endif
 
+
+class WSREPState
+{
+  public:
+    /* Resets all of the data to default values */
+    void clear() { wsrep_schema_version.clear(); }
+
+    bool load_from(const char *dir, const char *filename);
+    bool save_to(const char *dir, const char *filename);
+
+    /* Compare the server version with the wsrep version
+       Returns true if the wsrep version matches the server version EXACTLY
+       (to the major.minor.revision values).
+    */
+    bool wsrep_schema_version_equals(const char *server_version);
+
+    /* Before saving and after loading, the version string
+       may be modified/truncated to conform to "x.y.z"
+       e.g. "8.0.15-5" would be shortened to "8.0.15"
+       and "8.0" would be lengthened to "8.0.0"
+    */
+    std::string wsrep_schema_version;
+
+  private:
+    /* Parses a "a.b.c" version string into it's three component
+       parts.  If a compoenent is missing, it will be assinged
+       a value of 0.
+    */
+    void parse_version(const char *str, uint &major, uint &minor, uint &revision);
+};
+
 }  // namespace wsp
 
 #endif /* WSREP_UTILS_H */


### PR DESCRIPTION
PXC-2465 : Error while starting intermediate server for upgrade and post-processing
PXC-2462 : Cryptic error message if PXB binaries are not found
PXC-2468 : Unable to find plugin dir during intermediate server start

Issue
Various issues. Main issue is determining when to run mysql_upgrade
(especially for an IST)

Solution
Also added code for PXC-2453 (to check that versions < 5.7.19 are blocked from SST)
Added checks to see if xbstream/xbcrypt are properly installed
Added checks for schema version when running IST (if not the same, run upgrade)
Also clean up the server session properly on error
Also check the wsrep schema version on cluster bootstrap (disallow if not the current version)