### PR TITLE
- PXC#2490: binlog_space_limit crashes PXC to during wsrep_recover mode

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5730,6 +5730,15 @@ a file name for --log-bin-index option", opt_binlog_index_name);
   }
 
 #ifdef HAVE_REPLICATION
+
+#ifdef WITH_WSREP
+  /* In wsrep_recovery mode, PXC avoid creation of new binlog file for
+  the reason mentioned above. In light of the said flow avoid purge
+  action on binlog. */
+  if (!wsrep_recovery)
+  {
+#endif /* WITH_WSREP */
+
   if (opt_bin_log && expire_logs_days)
   {
     time_t purge_time= server_start_time - expire_logs_days*24*60*60;
@@ -5740,6 +5749,11 @@ a file name for --log-bin-index option", opt_binlog_index_name);
   {
     mysql_bin_log.purge_logs_maximum_number(max_binlog_files);
   }
+
+#ifdef WITH_WSREP
+  }
+#endif /* WITH_WSREP */
+
 #endif
 
   if (opt_myisam_log)


### PR DESCRIPTION
  - As part of the "PXC#897: gitd_executed is empty post wsrep_recover"
    fix, PXC skips creation of new binlog file while running in recovery mode.

  - In light of this flow, PXC should also avoud purge action on binlog.

  - Patch adds the check for the same.