### PR TITLE
PXC-2483 : PXC-8.0 upgrade is not initiating mysql_upgrade script wit…

### DIFF
--- a/build-ps/debian/percona-xtradb-cluster-server.install
+++ b/build-ps/debian/percona-xtradb-cluster-server.install
@@ -18,6 +18,7 @@ usr/bin/resolveip
 usr/bin/wsrep_sst_common
 usr/bin/wsrep_sst_xtrabackup-v2
 usr/bin/wsrep_sst_rsync
+usr/bin/wsrep_sst_upgrade
 usr/sbin/mysqld
 usr/share/man/man1/myisamchk.1
 usr/share/man/man1/myisamlog.1

--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -1454,6 +1454,7 @@ fi
 %attr(755, root, root) %{_bindir}/wsrep_sst_common
 %attr(755, root, root) %{_bindir}/wsrep_sst_xtrabackup-v2
 %attr(755, root, root) %{_bindir}/wsrep_sst_rsync
+%attr(755, root, root) %{_bindir}/wsrep_sst_upgrade
 %attr(755, root, root) %{_bindir}/ps_mysqld_helper
 # Explicit %attr() mode not applicaple to symlink
 %{_bindir}/wsrep_sst_rsync_wan

--- a/packaging/deb-in/mysql-packagesource-server-SERIES.install.in
+++ b/packaging/deb-in/mysql-packagesource-server-SERIES.install.in
@@ -42,6 +42,7 @@ usr/bin/wsrep_sst_mysqldump
 usr/bin/wsrep_sst_rsync
 usr/bin/wsrep_sst_xtrabackup
 usr/bin/wsrep_sst_xtrabackup-v2
+usr/bin/wsrep_sst_upgrade
 usr/bin/zlib_decompress usr/lib/mysql/
 # plugins
 usr/lib/mysql/plugin/adt_null.so

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -450,7 +450,7 @@ IF(WIN32)
 
 ELSE()
   IF(WITH_WSREP)
-    SET(WSREP_BINARIES wsrep_sst_common wsrep_sst_rsync wsrep_sst_xtrabackup-v2 clustercheck pyclustercheck)
+    SET(WSREP_BINARIES wsrep_sst_common wsrep_sst_rsync wsrep_sst_xtrabackup-v2 wsrep_sst_upgrade clustercheck pyclustercheck)
   ENDIF()
 
   # Configure this one, for testing, but do not install it.
@@ -484,6 +484,7 @@ ELSE()
       wsrep_sst_common
       wsrep_sst_rsync
       wsrep_sst_xtrabackup-v2
+      wsrep_sst_upgrade
     )
   ENDIF()
 

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -467,7 +467,7 @@ EOF
                 # If donor < local, then this is unsupported, we cannot
                 # have a higher version node donating to a lower version node
                 # (there is no way to downgrade the DB)
-                if compare_versions $MYSQL_VERSION "<" $DONOR_MYSQL_VERSION; then
+                if compare_versions "$MYSQL_VERSION" "<" "$DONOR_MYSQL_VERSION"; then
                     wsrep_log_error "******************* FATAL ERROR ********************** "
                     wsrep_log_error "FATAL: PXC is receiving an SST from a node with a higher version."
                     wsrep_log_error "This node's PXC version is $MYSQL_VERSION.  The donor's PXC version is $DONOR_MYSQL_VERSION."

--- a/scripts/wsrep_sst_upgrade.sh
+++ b/scripts/wsrep_sst_upgrade.sh
@@ -1,0 +1,117 @@
+#!/bin/bash -ue
+
+# Copyright (C) 2019 Percona Inc
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not, write to the
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston
+# MA  02110-1301  USA.
+
+# Documentation: http://www.percona.com/doc/percona-xtradb-cluster/manual/xtrabackup_sst.html
+# Make sure to read that before proceeding!
+
+
+#-------------------------------------------------------------------------------
+#
+# Step-1: Load common code
+#
+. $(dirname $0)/wsrep_sst_common
+
+
+#-------------------------------------------------------------------------------
+#
+# Step-2: Setup default global variable that we plan to use during processing.
+#
+
+declare errcode=0
+declare DATA="${WSREP_SST_OPT_DATA}"
+
+
+#-------------------------------------------------------------------------------
+#
+# Step-3: Helper function to carry-out the main workload.
+#
+function cleanup_upgrade()
+{
+    # Since this is invoked just after exit NNN
+    local estatus=$?
+    if [[ $estatus -ne 0 ]]; then
+        wsrep_log_error "Cleanup after exit with status:$estatus"
+    fi
+
+    if [[ -n ${MYSQL_UPGRADE_TMPDIR} ]]; then
+        rm -rf "${MYSQL_UPGRADE_TMPDIR}"
+    fi
+
+    exit $estatus
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# Step-4: Main workload logic starts here.
+#
+
+# Get our MySQL version
+MYSQL_VERSION=$WSREP_SST_OPT_VERSION
+if [[ -z $MYSQL_VERSION ]]; then
+    wsrep_log_error "******************* FATAL ERROR ********************** "
+    wsrep_log_error "FATAL: Cannot determine the mysqld server version"
+    wsrep_log_error "****************************************************** "
+    exit 2
+fi
+
+auto_upgrade=$(parse_cnf sst auto-upgrade "")
+auto_upgrade=$(normalize_boolean "$auto_upgrade" "on")
+
+# Check the WSREP_SST_OPT_FORCE_UPGRADE environment variable
+force_upgrade=${WSREP_SST_OPT_FORCE_UPGRADE:-""}
+if [[ -z $force_upgrade ]]; then
+    force_upgrade=$(parse_cnf sst force-upgrade "")
+fi
+force_upgrade=$(normalize_boolean "$force_upgrade" "off")
+
+
+read_variables_from_stdin
+[[ $? -ne 0 ]] && exit 2
+
+trap cleanup_upgrade EXIT
+
+# Retrieve the version of the datadir (if possible)
+DATADIR_WSREP_SCHEMA_VERSION="0.0.0"
+if [[ -r "${DATA}/wsrep_state.dat" ]]; then
+    read_variables_from_wsrep_state "${DATA}/wsrep_state.dat"
+    [[ $? -ne 0 ]] && exit 2
+fi
+
+wsrep_log_info "Running upgrade..........."
+set +e
+
+# Pretend that we've done an IST, so that the code:
+# (1) will compare the datadir schema versions (not the server versions)
+# (2) will NOT run the async slave reset
+run_post_processing_steps "$DATA" "${WSREP_SST_OPT_PORT:-4444}" \
+        "$MYSQL_VERSION" "$MYSQL_VERSION" "xtrabackup" "ist" "$force_upgrade" "$auto_upgrade"
+errcode=$?
+
+set -e
+
+if [[ $errcode -ne 0 ]]; then
+    wsrep_log_info "...........upgrade failed.  Exiting"
+    exit $errcode
+else
+    wsrep_log_info "...........upgrade done"
+fi
+
+# Let the server now that we are done with the upgrade
+echo "ready"
+exit 0

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -11953,6 +11953,7 @@ PSI_thread_key key_thread_handle_con_admin_sockets;
 #ifdef WITH_WSREP
 PSI_thread_key key_THREAD_wsrep_sst_joiner;
 PSI_thread_key key_THREAD_wsrep_sst_donor;
+PSI_thread_key key_THREAD_wsrep_sst_upgrade;
 PSI_thread_key key_THREAD_wsrep_applier;
 PSI_thread_key key_THREAD_wsrep_rollbacker;
 #endif /* WITH_WSREP */
@@ -11977,6 +11978,7 @@ static PSI_thread_info all_server_threads[]=
 #ifdef WITH_WSREP
   { &key_THREAD_wsrep_sst_joiner, "THREAD_wsrep_sst_joiner", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_THREAD_wsrep_sst_donor, "THREAD_wsrep_sst_donor", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
+  { &key_THREAD_wsrep_sst_upgrade, "THREAD_wsrep_sst_upgrade", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_THREAD_wsrep_applier, "THREAD_wsrep_applier", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_THREAD_wsrep_rollbacker, "THREAD_wsrep_rollbacker", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME}
 #endif /* WITH_WSREP */

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -656,8 +656,16 @@ static wsrep_cb_status_t wsrep_view_handler_cb(void *, void *recv_ctx,
       unireg_abort(1);
   }
 
-  if (view->state_gap) {
-    WSREP_WARN("Gap in state sequence. Need state transfer.");
+  /* In the case where we do not have a state gap (i.e the node is
+   * up-to-date), then check if the node needs to be upgraded. If we
+   * do need to upgrade then go ahead and call into the SST scripts.
+   */
+  if (view->state_gap || wsp::WSREPState::node_needs_upgrading()) {
+    if (view->state_gap) {
+      WSREP_WARN("Gap in state sequence. Need state transfer.");
+    } else {
+      WSREP_WARN("Out-of-date datadir. Upgrade required");
+    }
 
     /* After that wsrep will call wsrep_sst_prepare. */
     /* keep ready flag 0 until we receive the snapshot */
@@ -674,18 +682,25 @@ static wsrep_cb_status_t wsrep_view_handler_cb(void *, void *recv_ctx,
       wsrep_close_client_connections(true, false);
     }
 
-    ssize_t const req_len = wsrep_sst_prepare(sst_req, thd);
+    ssize_t req_len = 0;
+
+    if (view->state_gap)
+      req_len = wsrep_sst_prepare(sst_req, thd);
+    else
+      req_len = wsrep_sst_upgrade();
 
     if (req_len < 0) {
       WSREP_ERROR("SST preparation failed: %zd (%s)", -req_len,
                   strerror(-req_len));
       new_status = WSREP_MEMBER_UNDEFINED;
-    } else {
+    } else if (view->state_gap) {
       assert(sst_req != NULL);
       *sst_req_len = req_len;
       new_status = WSREP_MEMBER_JOINER;
     }
-  } else {
+  }
+
+  if (!view->state_gap) {
     /*
      *  NOTE: Initialize wsrep_group_uuid here only if it wasn't initialized
      *  before - OR - it was reinitilized on startup (lp:992840)
@@ -1259,23 +1274,6 @@ bool wsrep_start_replication() {
 
   bool const bootstrap(true == wsrep_new_cluster);
   wsrep_new_cluster = false;
-
-  // This is the same check that galera uses
-  if (bootstrap || !strcmp(wsrep_cluster_address, "gcomm://")) {
-    // Check the wsrep schema version in the wsrep_state.dat file
-    // If the version does not match, do not allow wsrep to startup
-
-    wsp::WSREPState  wsrep_state;
-    if (!wsrep_state.load_from(mysql_real_data_home_ptr, WSREP_STATE_FILENAME))
-      return false;
-
-    if (!wsrep_state.wsrep_schema_version_equals(MYSQL_SERVER_VERSION))
-    {
-      WSREP_ERROR("Cluster is not allowed to startup on a datadir that has not been upgraded.");
-      WSREP_ERROR("Current version:%s datadir:%s", MYSQL_SERVER_VERSION, wsrep_state.wsrep_schema_version.c_str());
-      return false;
-    }
-  }
 
   WSREP_INFO("Starting replication");
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -394,6 +394,7 @@ extern PSI_cond_key key_COND_wsrep_sst_thread;
 
 extern PSI_thread_key key_THREAD_wsrep_sst_joiner;
 extern PSI_thread_key key_THREAD_wsrep_sst_donor;
+extern PSI_thread_key key_THREAD_wsrep_sst_upgrade;
 extern PSI_thread_key key_THREAD_wsrep_applier;
 extern PSI_thread_key key_THREAD_wsrep_rollbacker;
 #endif /* HAVE_PSI_INTERFACE */

--- a/sql/wsrep_priv.h
+++ b/sql/wsrep_priv.h
@@ -32,6 +32,7 @@ extern wsrep_seqno_t local_seqno;
 bool wsrep_ready_set(bool x);
 
 ssize_t wsrep_sst_prepare(void **msg, THD *thd);
+ssize_t wsrep_sst_upgrade();
 
 wsrep_cb_status wsrep_sst_donate_cb(void *app_ctx, void *recv_ctx,
                                     const void *msg, size_t msg_len,

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -936,7 +936,7 @@ bool WSREPState::load_from(const char *dir, const char *filename)
   file = mysql_file_fopen(key_file_misc, full_path, O_RDONLY, MYF(0));
   if (!file)
   {
-    WSREP_ERROR("Could not open the wsrep state file : %s", full_path);
+    WSREP_WARN("Could not open the wsrep state file : %s", full_path);
     return false;
   }
 
@@ -1061,6 +1061,23 @@ bool WSREPState::save_to(const char *dir, const char *filename)
     return false;
   }
   return true;
+}
+
+bool WSREPState::node_needs_upgrading()
+{
+    wsp::WSREPState  wsrep_state;
+
+    /* If we can't load the data file, assume the node is out-of-date (i.e. from 5.7) */
+    if (!wsrep_state.load_from(mysql_real_data_home_ptr, WSREP_STATE_FILENAME))
+      return true;
+
+    if (!wsrep_state.wsrep_schema_version_equals(WSREP_SCHEMA_VERSION))
+    {
+      WSREP_WARN("WSREP schema versions  server:%s  datadir:%s", MYSQL_SERVER_VERSION, wsrep_state.wsrep_schema_version.c_str());
+      return true;
+    }
+
+    return false;
 }
 
 }  // namespace wsp

--- a/sql/wsrep_utils.h
+++ b/sql/wsrep_utils.h
@@ -229,6 +229,8 @@ class critical {
 class WSREPState
 {
   public:
+    static bool node_needs_upgrading();
+
     /* Resets all of the data to default values */
     void clear() { wsrep_schema_version.clear(); }
 
@@ -255,6 +257,7 @@ class WSREPState
     */
     void parse_version(const char *str, uint &major, uint &minor, uint &revision);
 };
+
 
 }  // namespace wsp
 

--- a/support-files/wsrep/debian/mysql-server-wsrep.install
+++ b/support-files/wsrep/debian/mysql-server-wsrep.install
@@ -23,6 +23,7 @@ usr/bin/mysqltest
 usr/bin/replace
 usr/bin/resolve_stack_dump
 usr/bin/resolveip
+usr/bin/wsrep_sst_upgrade
 usr/bin/wsrep_sst_xtrabackup-v2
 usr/bin/wsrep_sst_rsync
 usr/bin/wsrep_sst_rsync_wan


### PR DESCRIPTION
…h rsync SST

Issue
When the binaries of a node are upgraded, is restarted and rejoins the cluster.
If no writes have been received, the IST/SST process is skipped
(thus not allowing us to run mysql_upgrade on the node).

Solution
If the IST/SST process is skipped, then check the wsrep_state.dat file.
If the wsrep_schema_version is different, then run wsrep_sst_upgrade.sh