### PR TITLE
- PXC#2486: Avoid replication of native ddl tables internally as part of

### DIFF
--- a/mysql-test/suite/galera/r/galera_install_object.result
+++ b/mysql-test/suite/galera/r/galera_install_object.result
@@ -1,0 +1,15 @@
+#node-1
+INSTALL COMPONENT "file://component_pfs_example_component_population";
+SELECT * FROM performance_schema.pfs_example_continent;
+NAME
+bar1
+bar2
+#node-2
+SELECT * FROM performance_schema.pfs_example_continent;
+NAME
+bar1
+bar2
+UNINSTALL COMPONENT "file://component_pfs_example_component_population";
+#node-1
+SELECT * FROM performance_schema.pfs_example_continent;
+ERROR 42S02: Table 'performance_schema.pfs_example_continent' doesn't exist

--- a/mysql-test/suite/galera/t/galera_install_object.test
+++ b/mysql-test/suite/galera/t/galera_install_object.test
@@ -1,0 +1,36 @@
+
+#
+# This test exercises multiple scenario that involves testing
+# different DDL + DML statement for innodb and myisam engine
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+
+#-------------------------------------------------------------------------------
+#
+# Test-Scenarios
+#
+# 1. test install of components.
+#
+
+#-------------------------------------------------------------------------------
+#
+# 1. test install of components.
+#
+--connection node_1
+--echo #node-1
+INSTALL COMPONENT "file://component_pfs_example_component_population";
+SELECT * FROM performance_schema.pfs_example_continent;
+
+--connection node_2
+--echo #node-2
+SELECT * FROM performance_schema.pfs_example_continent;
+UNINSTALL COMPONENT "file://component_pfs_example_component_population";
+
+--connection node_1
+--echo #node-1
+--error ER_NO_SUCH_TABLE
+SELECT * FROM performance_schema.pfs_example_continent;


### PR DESCRIPTION
  main DDL statement

  - Some of the DDL statement (like one in the use-case INSTALL COMPONENT)
    can cause creation of native table on the fly.

  - Given the parent DDL statement is replicated using TOI avoid
    replication of such derived/child tables using TOI.

    Parent replication statement will take-care of creation of such child
    tables on replicating/applying node too.