### PR TITLE
- PXC-2480: Failed to replicate CURRENT_USER() involved ALTER TABLE

### DIFF
--- a/mysql-test/suite/galera/r/MW-416.result
+++ b/mysql-test/suite/galera/r/MW-416.result
@@ -108,3 +108,25 @@ performance_schema
 test
 wsrep_replicated_after_diff
 1
+#node-1 (create tmp user)
+call mtr.add_suppression("WSREP: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");
+CREATE USER CURRENT_USER();
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+DROP USER CURRENT_USER();
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+ALTER USER CURRENT_USER() PASSWORD EXPIRE;
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+RENAME USER CURRENT_USER() to 'root2'@'localhost';
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+RENAME USER 'root2'@'localhost' to CURRENT_USER();
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+GRANT ALL PRIVILEGES ON *.* TO CURRENT_USER();
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+GRANT DROP ON *.* TO CURRENT_USER();
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+REVOKE CREATE ON *.* FROM CURRENT_USER();
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+REVOKE ALL ON *.* FROM CURRENT_USER();
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
+#node-2
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");

--- a/mysql-test/suite/galera/t/MW-416.test
+++ b/mysql-test/suite/galera/t/MW-416.test
@@ -1,3 +1,4 @@
+#
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
@@ -128,3 +129,40 @@ SHOW DATABASES;
 --disable_query_log
 --eval SELECT $wsrep_replicated_after - $wsrep_replicated_before AS wsrep_replicated_after_diff
 --enable_query_log
+
+#-------------------------------------------------------------------------------
+# cover scenario involving user of CURRENT_USER()
+#
+--connection node_1
+--echo #node-1 (create tmp user)
+call mtr.add_suppression("WSREP: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");
+#
+--error ER_UNKNOWN_ERROR
+CREATE USER CURRENT_USER();
+#
+--error ER_UNKNOWN_ERROR
+DROP USER CURRENT_USER();
+#
+--error ER_UNKNOWN_ERROR
+ALTER USER CURRENT_USER() PASSWORD EXPIRE;
+#
+--error ER_UNKNOWN_ERROR
+RENAME USER CURRENT_USER() to 'root2'@'localhost';
+--error ER_UNKNOWN_ERROR
+RENAME USER 'root2'@'localhost' to CURRENT_USER();
+#
+--error ER_UNKNOWN_ERROR
+GRANT ALL PRIVILEGES ON *.* TO CURRENT_USER();
+#
+--error ER_UNKNOWN_ERROR
+GRANT DROP ON *.* TO CURRENT_USER();
+#
+--error ER_UNKNOWN_ERROR
+REVOKE CREATE ON *.* FROM CURRENT_USER();
+#
+--error ER_UNKNOWN_ERROR
+REVOKE ALL ON *.* FROM CURRENT_USER();
+
+--connection node_2
+--echo #node-2
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -8899,12 +8899,28 @@ bool mysql_rename_user(THD *thd, List <LEX_USER> &list)
     if (!(user_from= get_current_user(thd, tmp_user_from)))
     {
       result= TRUE;
+#ifdef WITH_WSREP
+      /* if operation to get current_user fails there is no point
+      in continuing further to scan for rename-to user.
+      Also, the while logic will cause rename-to user to appear NULL.*/
+      mysql_mutex_unlock(&acl_cache->lock);
+      mysql_rwlock_unlock(&LOCK_grant);
+      DBUG_RETURN(result);
+#endif /* WITH_WSREP */
       continue;
     }  
     tmp_user_to= user_list++;
     if (!(user_to= get_current_user(thd, tmp_user_to)))
     {
       result= TRUE;
+#ifdef WITH_WSREP
+      /* if operation to get current_user fails there is no point
+      in continuing further to scan for rename-to user.
+      Also, the while logic will cause rename-to user to appear NULL.*/
+      mysql_mutex_unlock(&acl_cache->lock);
+      mysql_rwlock_unlock(&LOCK_grant);
+      DBUG_RETURN(result);
+#endif /* WITH_WSREP */
       continue;
     }  
     DBUG_ASSERT(user_to != 0); /* Syntax enforces pairs of users. */


### PR DESCRIPTION
  - CURRENT_USER refers to current running active user.

  - When the said statement is replicated through TOI and is executed
    using applier thread then CURRENT_USER() context is not valid.
    (as applier thread is running in background).

  - This can cause error/assert (starting 5.7). While we wait for
    proper fix from upstream we should block ALTER operation involving
    CURRENT_USER().