### PR TITLE
- PXC#2515: deinit action failed to wait for active commit applier

### DIFF
--- a/mysql-test/suite/galera/r/MW-416.result
+++ b/mysql-test/suite/galera/r/MW-416.result
@@ -112,7 +112,7 @@ test
 wsrep_replicated_after_diff
 1
 #node-1 (create tmp user)
-call mtr.add_suppression("WSREP: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");
 CREATE USER CURRENT_USER();
 ERROR HY000: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function for USER operation while operating in cluster mode
 DROP USER CURRENT_USER();

--- a/mysql-test/suite/galera/t/MW-416.test
+++ b/mysql-test/suite/galera/t/MW-416.test
@@ -139,7 +139,7 @@ SHOW DATABASES;
 #
 --connection node_1
 --echo #node-1 (create tmp user)
-call mtr.add_suppression("WSREP: Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of CURRENT_USER/USER function");
 #
 --error ER_UNKNOWN_ERROR
 CREATE USER CURRENT_USER();

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2066,6 +2066,14 @@ class Find_wsrep_thd : public Find_THD_Impl {
         case COMMITTING:
           return thd->wsrep_query_state == QUERY_COMMITTING;
       }
+    } else if (!WSREP_ON) {
+      /* case when user try to set wsrep_provider = none w/o server shutdown */
+      switch (m_type) {
+        case APPLIER:
+          return thd->wsrep_applier;
+        default:
+          return false;
+      }
     }
     return false;
   }


### PR DESCRIPTION
  - User initiated deinit action by setting wsrep_provider=none
    without shutting down the node failed to wait for active commit
    applier.

  - deinit action made progress and freed memory while applier is active
    applying transaction resulting in the said assert.

  - This is regression introduced during PXC-8.0 refresh.
    Fixed logic to consider active applier even though WSREP_ON = false.