### PR TITLE
- PXC#2521: ALTER TABLESPACE is not replicated

### DIFF
--- a/mysql-test/suite/galera/r/galera_tablespaces.result
+++ b/mysql-test/suite/galera/r/galera_tablespaces.result
@@ -73,3 +73,95 @@ drop table t1;
 drop table t2;
 drop tablespace ts1;
 #node-2
+#node-1
+create tablespace ts1 add datafile 'ts1.ibd' engine=innodb;
+create tablespace ts2 add datafile 'ts2.ibd' engine=innodb;
+create table t1 (i int) TABLESPACE ts1 engine=innodb;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) /*!50100 TABLESPACE `ts1` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+name	space_type	state
+ts1	General	normal
+ts2	General	normal
+select name, path from information_schema.innodb_tablespaces_brief where name LIKE 'ts%';
+NAME	PATH
+ts1	ts1.ibd
+ts2	ts2.ibd
+#node-2
+alter tablespace ts1 rename to ts10;
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+name	space_type	state
+ts10	General	normal
+ts2	General	normal
+select name, path from information_schema.innodb_tablespaces_brief where name LIKE 'ts%';
+NAME	PATH
+ts10	ts1.ibd
+ts2	ts2.ibd
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int(11) DEFAULT NULL
+) /*!50100 TABLESPACE `ts10` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+drop tablespace ts2;
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+name	space_type	state
+ts10	General	normal
+#node-1
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+name	space_type	state
+ts10	General	normal
+select name, path from information_schema.innodb_tablespaces_brief where name LIKE 'ts%';
+NAME	PATH
+ts10	ts1.ibd
+drop table t1;
+drop tablespace ts10;
+#node-1
+CREATE UNDO TABLESPACE one_undo ADD DATAFILE 'one_undo.ibu';
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+one_undo	Undo	active
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+count(*) = 1
+0
+#node-2
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+one_undo	Undo	active
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+count(*) = 1
+0
+ALTER UNDO TABLESPACE one_undo SET INACTIVE;
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+one_undo	Undo	inactive
+SELECT SLEEP(5);
+SLEEP(5)
+0
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+count(*) = 1
+1
+DROP UNDO TABLESPACE one_undo;
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+count(*) = 1
+0
+#node-1
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+NAME	SPACE_TYPE	STATE
+innodb_undo_001	Undo	active
+innodb_undo_002	Undo	active
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+count(*) = 1
+0

--- a/mysql-test/suite/galera/r/pxc_encrypt_rest_gt.result
+++ b/mysql-test/suite/galera/r/pxc_encrypt_rest_gt.result
@@ -123,3 +123,25 @@ t2	CREATE TABLE `t2` (
 ) /*!50100 TABLESPACE `foo` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 drop table t1, t2;
 drop tablespace foo;
+#node-1
+CREATE TABLESPACE `ts1` ADD DATAFILE 'ts1.ibd' ENCRYPTION = 'Y' Engine=InnoDB;
+CREATE TABLE t1 (c1 INT) ENCRYPTION = 'Y';
+#node-2
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+name	flag	encryption
+ts1	26624	Y
+test/t1	24609	Y
+alter table t1 tablespace ts1;
+ALTER TABLESPACE ts1 ENCRYPTION = 'N';
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+name	flag	encryption
+ts1	18432	N
+#node-1
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+name	flag	encryption
+ts1	18432	N
+DROP TABLE t1;
+DROP TABLESPACE `ts1`;
+#node-2
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+name	flag	encryption

--- a/mysql-test/suite/galera/t/galera_tablespaces.test
+++ b/mysql-test/suite/galera/t/galera_tablespaces.test
@@ -76,3 +76,70 @@ drop tablespace ts1;
 --echo #node-2
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'ts1';
 --source include/wait_condition.inc
+
+
+#------------------------------------------------------------------------------
+#
+# trying alter and rename of tablespace
+#
+--connection node_1
+--echo #node-1
+create tablespace ts1 add datafile 'ts1.ibd' engine=innodb;
+create tablespace ts2 add datafile 'ts2.ibd' engine=innodb;
+create table t1 (i int) TABLESPACE ts1 engine=innodb;
+show create table t1;
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+select name, path from information_schema.innodb_tablespaces_brief where name LIKE 'ts%';
+
+--connection node_2
+--echo #node-2
+#
+# rename tablespace
+alter tablespace ts1 rename to ts10;
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+select name, path from information_schema.innodb_tablespaces_brief where name LIKE 'ts%';
+show create table t1;
+#
+drop tablespace ts2;
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+
+--connection node_1
+--echo #node-1
+select name, space_type, state from information_schema.innodb_tablespaces where name LIKE 'ts%';
+select name, path from information_schema.innodb_tablespaces_brief where name LIKE 'ts%';
+drop table t1;
+drop tablespace ts10;
+
+#------------------------------------------------------------------------------
+#
+# MySQL-8.0 introduces create/alter/drop of undo tables
+#
+--connection node_1
+--echo #node-1
+CREATE UNDO TABLESPACE one_undo ADD DATAFILE 'one_undo.ibu';
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+
+--connection node_2
+--echo #node-2
+#
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+
+#
+ALTER UNDO TABLESPACE one_undo SET INACTIVE;
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+# -- truncate of undo tablespace after marking inactive may take some time
+SELECT SLEEP(5);
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+
+#
+DROP UNDO TABLESPACE one_undo;
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+
+
+--connection node_1
+--echo #node-1
+SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
+SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.test
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.test
@@ -142,3 +142,30 @@ insert into t2 values (10), (20), (30);
 show create table t2;
 drop table t1, t2;
 drop tablespace foo;
+
+
+#-------------------------------------------------------------------------------
+# alter encrypted general tablespace
+#
+
+--connection node_1
+--echo #node-1
+CREATE TABLESPACE `ts1` ADD DATAFILE 'ts1.ibd' ENCRYPTION = 'Y' Engine=InnoDB;
+CREATE TABLE t1 (c1 INT) ENCRYPTION = 'Y';
+
+--connection node_2
+--echo #node-2
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+alter table t1 tablespace ts1;
+ALTER TABLESPACE ts1 ENCRYPTION = 'N';
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+
+--connection node_1
+--echo #node-1
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+DROP TABLE t1;
+DROP TABLESPACE `ts1`;
+
+--connection node_2
+--echo #node-2
+select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";

--- a/sql/sql_tablespace.cc
+++ b/sql/sql_tablespace.cc
@@ -686,6 +686,11 @@ bool Sql_cmd_alter_tablespace::execute(THD *thd) {
     return true;
   }
 
+#ifdef WITH_WSREP
+  if (WSREP(thd) && wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL))
+    return true;
+#endif /* WITH_WSREP */
+
   if (lock_tablespace_names(thd, m_tablespace_name)) {
     return true;
   }
@@ -1108,6 +1113,12 @@ bool Sql_cmd_create_undo_tablespace::execute(THD *thd) {
     return true;
   }
 
+#ifdef WITH_WSREP
+  if (WSREP(thd) && wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL))
+    return true;
+#endif /* WITH_WSREP */
+
+
   handlerton *hton = nullptr;
   if (get_stmt_hton(thd, m_options->engine_name, m_undo_tablespace_name.str,
                     "CREATE UNDO TABLESPACE", &hton)) {
@@ -1248,6 +1259,11 @@ bool Sql_cmd_alter_undo_tablespace::execute(THD *thd) {
     return true;
   }
 
+#ifdef WITH_WSREP
+  if (WSREP(thd) && wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL))
+    return true;
+#endif /* WITH_WSREP */
+
   handlerton *hton = nullptr;
   if (get_stmt_hton(thd, m_options->engine_name, m_undo_tablespace_name.str,
                     "ALTER UNDO TABLESPACE", &hton)) {
@@ -1336,6 +1352,11 @@ bool Sql_cmd_drop_undo_tablespace::execute(THD *thd) {
   if (check_global_access(thd, CREATE_TABLESPACE_ACL)) {
     return true;
   }
+
+#ifdef WITH_WSREP
+  if (WSREP(thd) && wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL))
+    return true;
+#endif /* WITH_WSREP */
 
   handlerton *hton = nullptr;
   if (get_stmt_hton(thd, m_options->engine_name, m_undo_tablespace_name.str,

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -330,6 +330,9 @@ static void *sst_logger_thread(void *a) {
     enum loglevel level = string_to_loglevel(p);
     if (level != SYSTEM_LEVEL) {
       WSREP_SST_LOG(level, p + 4);
+      if (level == ERROR_LEVEL) {
+        flush_error_log_messages();
+      }
     } else if (strncmp(p, "FIL:", 4) == 0) {
       /* Expect a string with 3 components (separated by semi-colons)
           "FIL" marker


### PR DESCRIPTION
  - ALTER TABLESPACE command failed to replicate using TOI causing
    multiple level assert.

  - Patch fixes replication of alter tablespace and also covers
    other commands that includes CREATE/DROP/ALTER UNDO tablespace.

  (Patch also fixes following issue not related to above fix.
   If WSREP_SST emits error then immediately start flushing error log
   without waiting for log module to initialize)