### PR TITLE
- PXC#2523: Incase of SST erorr ensure log messages are flushed befor…

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -105,6 +105,10 @@ ulong pxc_maint_transition_period = 30;
 /* enables PXC SSL auto-config */
 bool pxc_encrypt_cluster_traffic = 0;
 
+/* force flush of error message if error is detected at early stage
+   during SST or other initialization. */
+bool pxc_force_flush_error_message = false;
+
 /* End configuration options */
 
 static wsrep_uuid_t cluster_uuid = WSREP_UUID_UNDEFINED;
@@ -544,6 +548,10 @@ static void wsrep_log_cb(wsrep_log_level_t level, const char *msg) {
       break;
     case WSREP_LOG_ERROR:
     case WSREP_LOG_FATAL:
+      if (!wsrep_is_SE_initialized()) {
+        pxc_force_flush_error_message = true;
+        flush_error_log_messages();
+      }
       WSREP_GALERA_LOG(ERROR_LEVEL, msg);
       break;
     case WSREP_LOG_DEBUG:

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -332,6 +332,7 @@ static void *sst_logger_thread(void *a) {
       WSREP_SST_LOG(level, p + 4);
       if (level == ERROR_LEVEL) {
         flush_error_log_messages();
+        pxc_force_flush_error_message = true;
       }
     } else if (strncmp(p, "FIL:", 4) == 0) {
       /* Expect a string with 3 components (separated by semi-colons)


### PR DESCRIPTION
…e aborting

  - With new MySQL logging framework, log messages are buffered and not flushed
    till log module is not initialized.

  - log-module is initialized after SST so if there is error during SST then
    it is possible that log messages are never flushed leaving now clue for
    end-user to understand SST failure reason.

  - Patch fix this scenario by forcing flush of messages if error is detected
    from sst/galera/wsrep module before SST is initialized.