### PR TITLE
- PXC#2508: crash while reloading user table for user w/o hostname

### DIFF
--- a/sql/auth/sql_user_table.cc
+++ b/sql/auth/sql_user_table.cc
@@ -681,6 +681,15 @@ bool log_and_commit_acl_ddl(THD *thd, bool transactional_tables,
   if (!result) {
     User_params user_params(extra_users);
     mysql_rewrite_acl_query(thd, Consumer_type::BINLOG, &user_params);
+#ifdef WITH_WSREP
+    /* If operating in cluster mode + binlog is enabled + sql_log_bin = 0
+    dis-allow write_to_binlog routine to execute. */
+    write_to_binlog =
+        (WSREP(thd) && (mysql_bin_log.is_open() &&
+                        !(thd->variables.option_bits & OPTION_BIN_LOG)))
+            ? false
+            : write_to_binlog;
+#endif /* WITH_WSREP */
     if (write_to_binlog) {
       LEX_CSTRING query;
       enum_sql_command command;


### PR DESCRIPTION
  (Note: fix is not for the bug mentioned above but as part of the investigation
   we found another sub-issue. this fix will address it keeping original bug open)

  - If user has turned sql_log_bin = off then write_to_binlog action shouldn't
    execute. MySQL flow will generate all needed binlog events before finally
    blocking it at write-stage. This means all work spend in generating binlog
    events is of no use. (Of-course there is no harm in generating these events
    and discarding them w/o using them).

  - Fix identifies the said condition and block generation of such events
    if running in cluster mode.