### PR TITLE
- PXC#2560: pxc_strict_mode failing intermittently on PXC-5.7.26 branch

### DIFF
--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -159,6 +159,7 @@ alter table tinnodb engine=myisam;
 alter table tinnodb engine=memory;
 alter table tinnodb engine=innodb;
 drop table tinnodb;
+#node-2 (ensure cleanup is done before starting next scenario)
 #node-1
 set global pxc_strict_mode = 'PERMISSIVE';
 select @@pxc_strict_mode;
@@ -302,6 +303,7 @@ Warnings:
 Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of ALTER command on a table (test.tinnodb) that resides in non-transactional storage engine (except switching to transactional engine) with pxc_strict_mode = PERMISSIVE
 alter table tinnodb engine=innodb;
 drop table tinnodb;
+#node-2 (ensure cleanup is done before starting next scenario)
 #node-1
 set global pxc_strict_mode = 'ENFORCING';
 select @@pxc_strict_mode;
@@ -420,6 +422,7 @@ alter table tinnodb engine=memory;
 ERROR HY000: Percona-XtraDB-Cluster prohibits changing storage engine of a table (test.tinnodb) from transactional to non-transactional with pxc_strict_mode = ENFORCING or MASTER
 alter table tinnodb engine=innodb;
 drop table tinnodb;
+#node-2 (ensure cleanup is done before starting next scenario)
 #node-1
 set global pxc_strict_mode = 'DISABLED';
 select @@pxc_strict_mode;

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -196,6 +196,11 @@ alter table tinnodb engine=memory;
 alter table tinnodb engine=innodb;
 drop table tinnodb;
 
+--connection node_2
+--echo #node-2 (ensure cleanup is done before starting next scenario)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'tinnodb';
+--source include/wait_condition.inc
+
 
 #----------------------------
 #
@@ -294,6 +299,10 @@ alter table tinnodb engine=memory;
 alter table tinnodb engine=innodb;
 drop table tinnodb;
 
+--connection node_2
+--echo #node-2 (ensure cleanup is done before starting next scenario)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'tinnodb';
+--source include/wait_condition.inc
 
 #----------------------------
 #
@@ -417,6 +426,12 @@ alter table tinnodb engine=myisam;
 alter table tinnodb engine=memory;
 alter table tinnodb engine=innodb;
 drop table tinnodb;
+
+--connection node_2
+--echo #node-2 (ensure cleanup is done before starting next scenario)
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'tinnodb';
+--source include/wait_condition.inc
+
 
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
  - pxc_strict_mode is failing due to test-case issue that caused
    setting of mode=ENFORCING on n2 even before it execute replicated
    workload from n1 with mode=PERMISSIVE.

    pxc_strict_mode being global setting takes immediate effect.

    n1/n2: mode=PERMISSIVE
    n1: ALTER TABLE ....
    n2: <replicate ALTER and apply with mode=PERMISSIVE>

    n1/n2: mode=ENFORCING
    n2: replicated transaction execution being asynchronous if n2 delays
        execution of above ALTER workload it will now execute it with
        mode=ENFORCING.