### PR TITLE
PXC-2555 : SST initialization delay

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -767,7 +767,7 @@ wait_for_listen()
 
             # Now get the processtree for this pid
             # If the parentpid is NOT in the process tree, then ignore
-            if ! echo $(get_parent_pids $pid) | grep -q " $parentpid "; then
+            if ! echo "$(get_parent_pids $pid)" | grep -qw "$parentpid"; then
                 continue
             fi
 


### PR DESCRIPTION
Issue
In certain cases (most notably, running the PXC docker images for
kubernetes), the SST logic to find the parent pid would fail (due
to the pid being at the end of the list of pids).

Solution
Change the grep to look for the pids correctly.