### PR TITLE
Added sst rm exclusion for any ignore_db_dir

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -730,6 +730,10 @@ read_cnf()
         done
     fi
 
+    if [[ ! -z "$(parse_cnf mysqld ignore-db-dir '')" ]]; then
+        cpat+="\|.*/$(echo "$(parse_cnf mysqld ignore-db-dir '' '|')"| sed -e 's/|/$\\|.*\//g')$"
+    fi
+
     # Retry the connection 30 times (at 1-second intervals)
     if [[ ! "$sockopt" =~ retry= ]]; then
         sockopt+=",retry=30"


### PR DESCRIPTION
Currently an SST with wsrep_sst_xtrabackup-v2 removes all folders in datadir, assuming they are all databases.  MySQL allows exclusion of folders in datadir with a repeating key: ignore_db_dir.  An SST should not delete these folders.  They are commonly things like /var/lib/mysql/tmp or /var/lib/mysql/binlogs or other mysql system folders which have been relocated to /var/lib/mysql commonly for disk partitioning reasons.  In summary, MySQL provides for an exclusion configuration key: ignore_db_dir, and xtrabackup's SST should honor this.