### PR TITLE
Remove systemd timeout during sst

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -133,7 +133,11 @@ wait_for_pid () {
         fi
     fi
 
-    i=$(( i+1 ))
+# incrementing sleep to 10x if we're doing an SST is just random.
+# instead, we're just not going to timeout if we doing an SST
+if [[ $startup_sleep -ne 10 ]];then
+  i=$(( i+1 ))
+fi
     sleep $startup_sleep
 
     if [[ $verb = 'created' ]];then 

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -730,6 +730,10 @@ read_cnf()
         done
     fi
 
+    if [[ ! -z "$(parse_cnf mysqld ignore-db-dir '')" ]]; then
+        cpat+="\|.*/$(echo "$(parse_cnf mysqld ignore-db-dir '' '|')"| sed -e 's/|/$\\|.*\//g')$"
+    fi
+
     # Retry the connection 30 times (at 1-second intervals)
     if [[ ! "$sockopt" =~ retry= ]]; then
         sockopt+=",retry=30"


### PR DESCRIPTION
Currently the RHEL mysql-systemd startup script checks if SST is needed, and if so it increases the startup_sleep timeout 10x (it does this by increasing each iteration sleep interval from 1 second to 10 seconds between loop iteration checks).  10x is just random.  We have a 5TB DB and SST takes much longer than any reasonable timeout when an SST is not being performed * 10.  This patch works within the current logic to bypass the timeout if an SST is being performed.  Removing the 10x logic could be more complete, but this was the least intrusive patch.

Without this patch mysqld never starts on our system if an SST is needed because the SST data transfer and restore takes > 5 hours, and the script, as it exists before this patch, kills the process after about an hour.  This is adjustable, but again, it would adjust the NORMAL TIMEOUT of the service startup without the SST because the SST timeout is currently tied to the NORMAL TIMEOUT * 10.  This patch simply waits if an SST is being performed and never times out.