### PR TITLE
- PXC-2655: Setting pxc-encrypt-cluster-traffic=ON by default

### DIFF
--- a/mysql-test/include/default_mysqld.cnf
+++ b/mysql-test/include/default_mysqld.cnf
@@ -26,6 +26,7 @@ innodb-log-file-size=5M
 # galera.cnf file for this setting
 pxc_strict_mode=DISABLED
 pxc_maint_transition_period=0
+pxc_encrypt_cluster_traffic=OFF
 log_error_verbosity=3
 
 # MAINTAINER:

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7601,6 +7601,6 @@ static Sys_var_ulong Sys_pxc_maint_transition_period(
 static Sys_var_bool Sys_pxc_encrypt_cluster_traffic(
     "pxc_encrypt_cluster_traffic", "PXC cluster traffic SSL auto-configuration",
     READ_ONLY GLOBAL_VAR(pxc_encrypt_cluster_traffic), CMD_LINE(OPT_ARG),
-    DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG);
+    DEFAULT(true), NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
 #endif /* WITH_WSREP */


### PR DESCRIPTION
  Issue:
  -----

  * PXC Cluster is exposed to risk of un-authorized data access (by default)
    as joining node doesn't need to handshake any credentials.

  * By turning pxc-encrypt-cluster-traffic=ON by default joining nodes
    will need approved SSL certificates. User can set it to OFF if user
    trust the network enviornment.