### PR TITLE
PXC-2684 : Cluster node hangs after Stored Procedure is BF-aborted

### DIFF
--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4706,6 +4706,15 @@ longlong Item_func_sleep::val_int()
       break;
     error= 0;
   }
+
+#ifdef WITH_WSREP
+  // PXC-2684 : If the sleep() is interrupted, return an error
+  if (thd->killed == THD::KILL_QUERY)
+  {
+    my_error(ER_QUERY_INTERRUPTED, MYF(0));
+  }
+#endif /* WITH_WSREP */
+
   thd_wait_end(thd);
   mysql_mutex_unlock(&LOCK_item_func_sleep);
   mysql_mutex_lock(&thd->mysys_var->mutex);


### PR DESCRIPTION
Issue
When a "SELECT SLEEP(10);" is used in a stored procedure, and the
stored proc is BF-aborted, the sleep would be interrupted, but an error
was not returned.  So the sproc would continue on and try to COMMIT.
However the higher priority transaction (which BF-aborted) the SLEEP,
assumed that the SLEEP thread released its locks (which it hadn't).

Solution
Have the SLEEP() set an error if interrupted, thus allowing the sproc
to cleanup and release its locks.