### PR TITLE
- PXC#2730: force flushing of binlog under pxc binlog emulation mode

### DIFF
--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -685,7 +685,11 @@ private:
   int process_flush_stage_queue(my_off_t *total_bytes_var, bool *rotate_var,
                                 THD **out_queue_var);
   int prepare_ordered_commit(THD *thd, bool all, bool skip_commit= false);
+#ifdef WITH_WSREP
+  int ordered_commit(THD *thd, bool all);
+#else
   int ordered_commit(THD *thd);
+#endif /* WITH_WSREP */
   void handle_binlog_flush_or_sync_error(THD *thd, bool need_lock_log);
 public:
   int open_binlog(const char *opt_name);


### PR DESCRIPTION
  - With recent changes done by upstream (PS) to split ordered_commit into
    2 sub-functions viz. prepare_ordered_commit and ordered_commit,
    optimization for operating PXC commit with emulation binlog got
    mis-placed causing the said bug.

  - Corrected flow to ensure that binlog flushing action is not invoked
    under pxc binlog emulation mode.