### PR TITLE
- PXC-2683: pquery2 reported failures

### DIFF
--- a/mysql-test/suite/galera/r/galera_ddl_dml.result
+++ b/mysql-test/suite/galera/r/galera_ddl_dml.result
@@ -96,4 +96,21 @@ i
 1
 SET GLOBAL wsrep_debug = 0;
 drop table t;
+use test;
+create table t (i int, c1 char(10), c2 char(10), c12 char(20) as (CONCAT(c1, c2)), b blob);
+insert into t (i, c1, c2, b) values (1, 'newyork', 'us', repeat('a', 1000));
+insert into t (i, c1, c2, b) values (2, 'zagreb', 'croatia', repeat('b', 1000));
+insert into t (i, c1, c2, b) values (3, 'pune', 'india', repeat('c', 1000));
+select c12 from t;
+c12
+newyorkus
+zagrebcroatia
+puneindia
+update t set c1 = "mysql";
+select c12 from t;
+c12
+mysqlus
+mysqlcroatia
+mysqlindia
+drop table t;
 set @@wsrep_replicate_myisam = 0;;

--- a/mysql-test/suite/galera/t/galera_ddl_dml.test
+++ b/mysql-test/suite/galera/t/galera_ddl_dml.test
@@ -132,6 +132,21 @@ drop table t;
 
 #-------------------------------------------------------------------------------
 #
+# 2. virtual column with blob
+#
+use test;
+create table t (i int, c1 char(10), c2 char(10), c12 char(20) as (CONCAT(c1, c2)), b blob);
+insert into t (i, c1, c2, b) values (1, 'newyork', 'us', repeat('a', 1000));
+insert into t (i, c1, c2, b) values (2, 'zagreb', 'croatia', repeat('b', 1000));
+insert into t (i, c1, c2, b) values (3, 'pune', 'india', repeat('c', 1000));
+select c12 from t;
+update t set c1 = "mysql";
+select c12 from t;
+drop table t;
+
+
+#-------------------------------------------------------------------------------
+#
 # remove test-bed
 #
 --eval set @@wsrep_replicate_myisam = $wsrep_replicate_myisam_saved;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9807,7 +9807,10 @@ wsrep_calc_row_hash(
 
 		field_mysql_type = field->type();
 
-		col_type = prebuilt->table->cols[i].mtype;
+		/* Get corresponding InnoDB type */
+		ulint unsigned_flag;
+		col_type =
+		    get_innobase_type_from_mysql_type(&unsigned_flag, field);
 
 		switch (col_type) {
 


### PR DESCRIPTION
  Issue-1:
  -------

  - With invovlement of virtual column, order in which mysql data-dictionary
    and innodb data-dictionary maintains column info could be different.
  - Flow tried using mysql field object ordinal position to look for column
    type in innodb data-dictionary.

  Issue-2:
  --------

  - Race in lock_trx_handle_wait() while checking for trx->wsrep_killed_by_query.
  - Value of the said field is being checked w/o holding trx mutex and decision
    is made to acquire trx mutex. If applier background thread set it after
    trx->wsrep_killed_by_query is checked before acquiring trx mutex it can cause
    trx mutex disorder.

  Issue-3:
  --------

  - Avoid double aborting local thread once through can_grant_lock and then
    through add_ticket as transaction may be already in rollback stage
    and add_ticket will reset variable that rollback stage (trigger through
    can_grant_lock) may have cleared.