### PR TITLE
- PXC-2894: stablizing pquery3 against PXC-8.0

### DIFF
--- a/mysql-test/suite/galera/r/galera_rollback_to_savepoint.result
+++ b/mysql-test/suite/galera/r/galera_rollback_to_savepoint.result
@@ -39,3 +39,62 @@ SELECT * FROM example;
 id	name
 #node-1
 DROP TABLE example;
+#node-1
+use test;
+create table t1 (i int, j int, primary key pk(i));
+create table t3 (i int, primary key pk(i));
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4);
+insert into t3 values (100), (200), (300), (400);
+select * from t1;
+i	j
+1	1
+2	2
+3	3
+4	4
+select * from t3;
+i
+100
+200
+300
+400
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_rollback_to_savepoint SIGNAL entered1 WAIT_FOR continue1";
+begin;
+update t1 set i = i + 10;
+savepoint s1;
+update t3 set i = i + 1000;
+select * from t1;
+i	j
+11	1
+12	2
+13	3
+14	4
+select * from t3;
+i
+1100
+1200
+1300
+1400
+rollback to savepoint s1;;
+#node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+use test;
+alter table t1 add index idx(j);
+SET DEBUG_SYNC = "now SIGNAL continue1";
+#node-1
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+select * from t1;
+i	j
+1	1
+2	2
+3	3
+4	4
+select * from t3;
+i
+100
+200
+300
+400
+SET DEBUG_SYNC = 'RESET';
+drop table t1, t3;

--- a/mysql-test/suite/galera/t/galera_rollback_to_savepoint.test
+++ b/mysql-test/suite/galera/t/galera_rollback_to_savepoint.test
@@ -1,4 +1,5 @@
 --source include/galera_cluster.inc
+--source include/have_debug_sync.inc
 
 #
 # ROLLBACK to savepoint should only rollback the said action.
@@ -53,3 +54,52 @@ SELECT * FROM example;
 --connection node_1
 --echo #node-1
 DROP TABLE example;
+
+
+#-------------------------------------------------------------------------------
+#
+# Background running applier/high priority transaction kills local transaction
+# at ROLLBACK TO SAVEPOINT stage.
+#
+
+--connection node_1
+--echo #node-1
+#
+use test;
+create table t1 (i int, j int, primary key pk(i));
+create table t3 (i int, primary key pk(i));
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4);
+insert into t3 values (100), (200), (300), (400);
+select * from t1;
+select * from t3;
+
+#
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "pxc_rollback_to_savepoint SIGNAL entered1 WAIT_FOR continue1";
+#
+begin;
+update t1 set i = i + 10;
+savepoint s1;
+update t3 set i = i + 1000;
+select * from t1;
+select * from t3;
+--send rollback to savepoint s1;
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+--echo #node-1a
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered1";
+use test;
+alter table t1 add index idx(j);
+SET DEBUG_SYNC = "now SIGNAL continue1";
+
+--connection node_1
+--echo #node-1
+--error ER_LOCK_DEADLOCK
+--reap
+select * from t1;
+select * from t3;
+#
+SET DEBUG_SYNC = 'RESET';
+drop table t1, t3;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2751,7 +2751,12 @@ int MYSQL_BIN_LOG::rollback(THD *thd, bool all) {
       this one
      */
   } else if (thd->lex->sql_command != SQLCOM_ROLLBACK_TO_SAVEPOINT ||
-             thd->wsrep_trx().state() == wsrep::transaction::s_aborting) {
+             thd->wsrep_trx().state() == wsrep::transaction::s_aborting ||
+             (thd->lex->sql_command == SQLCOM_ROLLBACK_TO_SAVEPOINT &&
+              thd->wsrep_trx().state() == wsrep::transaction::s_must_abort)) {
+  /* If transaction has save point and while local transaction is trying to
+  rollback savepoint it is killed by high priority transaction ensure rollback
+  is processed. */
 #else
   } else if (thd->lex->sql_command != SQLCOM_ROLLBACK_TO_SAVEPOINT) {
 #endif /* WITH_WSREP */

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -149,6 +149,17 @@ extern "C" bool wsrep_thd_bf_abort(const THD *bf_thd, THD *victim_thd,
   bool ret = wsrep_bf_abort(bf_thd, victim_thd);
   wsrep_store_threadvars(const_cast<THD*>(bf_thd));
 
+#if 0
+  Normally this code flow is called by background applier thread (bf_thd)
+  but at times when a local thread is force aborted it would also call
+  this flow as part of reschedule_waiter (on release of locks) for other
+  thread handlers. In this use-case avoid restoring thd to bf_thd.
+
+  In theory, we should avoid invoking handle_mdl_conflict if invoking
+  thd is neither bf_thd or victim_thd.
+  wsrep_store_threadvars(const_cast<THD*>(bf_thd));
+#endif
+
   /*
     Send awake signal if victim was BF aborted or does not
     have wsrep on. Note that this should never interrupt RSU

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -804,6 +804,10 @@ bool trans_rollback_to_savepoint(THD *thd, LEX_STRING name) {
   SAVEPOINT *sv = *find_savepoint(thd, name);
   DBUG_TRACE;
 
+#ifdef WITH_WSREP
+  DEBUG_SYNC(thd, "pxc_rollback_to_savepoint");
+#endif /* WITH_WSREP */
+
   if (sv == NULL) {
     my_error(ER_SP_DOES_NOT_EXIST, MYF(0), "SAVEPOINT", name.str);
     return true;


### PR DESCRIPTION
  - If a high priority thread kills a local transaction that is currently
    executing ROLLBACK TO SAVEPOINT statement then transaction is not
    rolled back. This is because of special handling in MySQL rollback
    flow that ignore command code to SQLCOM_ROLLBACK_TO_SAVEPOINT.

  - Given local transaction is forcefully aborted by a background thread
    state of transaction is marked as must_abort. This state could be
    check along with command code == SQLCOM_ROLLBACK_TO_SAVEPOINT to kick-off
    rollback in the case described above.

  (Other fixes were related to accidental merge miss).