### PR TITLE
- PXC-2896: Stablize PXC-8.0 mtr

### DIFF
--- a/mysql-test/include/check-testcase.test
+++ b/mysql-test/include/check-testcase.test
@@ -12,6 +12,7 @@
 
 # ---- WITH_WSREP
 --source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
 # ---- WITH_WSREP
 --disable_query_log
 


### PR DESCRIPTION
  - Issue: check test-case fails to connect to node-2.
    Solution: added extra check in check test-case to wait for node to get ready.

- PXC-2652: wait_for_mysqld_startup fails during SST due to protocol=tcp in .my.cnf

  - Issue: mysqladmin fails to consider my.cnf params used for booting server.
  - Solution: Corrected mysqladmin invocation.