### PR TITLE
- PXC-2898: PXC crashes when concurrent ddl is invoked with instance …

### DIFF
--- a/mysql-test/suite/galera/r/galera_ddl_dml.result
+++ b/mysql-test/suite/galera/r/galera_ddl_dml.result
@@ -153,5 +153,35 @@ mysqlus
 mysqlcroatia
 mysqlindia
 drop table t;
+use test;
+create table t (i int, c1 char(10), c2 char(10), primary key pk(i));
+insert into t values (1, 'newyork', 'us');
+insert into t values (2, 'zagreb', 'croatia');
+insert into t values (3, 'pune', 'india');
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(11) NOT NULL,
+  `c1` char(10) DEFAULT NULL,
+  `c2` char(10) DEFAULT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+#node-1a (obtain backup instance lock)
+lock instance for backup;
+#node-1b (fire alter table that should wait for explicit backup lock)
+alter table t add index idx(c1);;
+#node-1a (release backup instance lock)
+unlock instance;
+#node-1b (check if alter is complete)
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(11) NOT NULL,
+  `c1` char(10) DEFAULT NULL,
+  `c2` char(10) DEFAULT NULL,
+  PRIMARY KEY (`i`),
+  KEY `idx` (`c1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+drop table t;
 set @@wsrep_replicate_myisam = 0;;
 SET DEBUG_SYNC = "reset";

--- a/mysql-test/suite/galera/t/galera_ddl_dml.test
+++ b/mysql-test/suite/galera/t/galera_ddl_dml.test
@@ -356,7 +356,7 @@ drop table t;
 
 #-------------------------------------------------------------------------------
 #
-# 2. virtual column with blob
+# 7. virtual column with blob
 #
 use test;
 create table t (i int, c1 char(10), c2 char(10), c12 char(20) as (CONCAT(c1, c2)), b blob);
@@ -368,6 +368,37 @@ update t set c1 = "mysql";
 select c12 from t;
 drop table t;
 
+
+#-------------------------------------------------------------------------------
+#
+# 8. DDL with BACKUP LOCK
+#
+use test;
+create table t (i int, c1 char(10), c2 char(10), primary key pk(i));
+insert into t values (1, 'newyork', 'us');
+insert into t values (2, 'zagreb', 'croatia');
+insert into t values (3, 'pune', 'india');
+show create table t;
+
+--connection node_1a
+--echo #node-1a (obtain backup instance lock)
+lock instance for backup;
+
+--connection node_1b
+--echo #node-1b (fire alter table that should wait for explicit backup lock)
+--send alter table t add index idx(c1);
+
+--connection node_1a
+--echo #node-1a (release backup instance lock)
+--let wait_condition = select * from information_schema.processlist where state = 'Waiting for backup lock' and Info = 'alter table t add index idx(c1)';
+--source include/wait_condition.inc
+unlock instance;
+
+--connection node_1b
+--echo #node-1b (check if alter is complete)
+--reap
+show create table t;
+drop table t;
 
 #-------------------------------------------------------------------------------
 #

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -147,7 +147,6 @@ extern "C" bool wsrep_thd_bf_abort(const THD *bf_thd, THD *victim_thd,
     wsrep_start_transaction(victim_thd, victim_thd->wsrep_next_trx_id());
   }
   bool ret = wsrep_bf_abort(bf_thd, victim_thd);
-  wsrep_store_threadvars(const_cast<THD*>(bf_thd));
 
 #if 0
   Normally this code flow is called by background applier thread (bf_thd)
@@ -157,6 +156,7 @@ extern "C" bool wsrep_thd_bf_abort(const THD *bf_thd, THD *victim_thd,
 
   In theory, we should avoid invoking handle_mdl_conflict if invoking
   thd is neither bf_thd or victim_thd.
+  This logic was enabled as part of pool-of-thread fix in upstream.
   wsrep_store_threadvars(const_cast<THD*>(bf_thd));
 #endif
 

--- a/sql/sql_backup_lock.cc
+++ b/sql/sql_backup_lock.cc
@@ -97,8 +97,18 @@ static bool acquire_mdl_for_backup(THD *thd, enum_mdl_type mdl_type,
 
   DBUG_ASSERT(mdl_type == MDL_SHARED || mdl_type == MDL_INTENTION_EXCLUSIVE);
 
+#ifdef WITH_WSREP
+  if (mdl_duration == MDL_EXPLICIT) {
+    MDL_EXPLICIT_LOCK_REQUEST_INIT(&mdl_request, MDL_key::BACKUP_LOCK, "", "",
+                                   mdl_type, mdl_duration);
+  } else {
+    MDL_REQUEST_INIT(&mdl_request, MDL_key::BACKUP_LOCK, "", "", mdl_type,
+                     mdl_duration);
+  }
+#else
   MDL_REQUEST_INIT(&mdl_request, MDL_key::BACKUP_LOCK, "", "", mdl_type,
                    mdl_duration);
+#endif /* WITH_WSREP */
 
   return thd->mdl_context.acquire_lock(&mdl_request, lock_wait_timeout);
 }


### PR DESCRIPTION
…locked for backup

  - LOCK INSTANCE FOR BACKUP established backup lock (new in MySQL-8.0).

  - This being explicit lock taken by user, background or high priority transaction
    should not be allowed to preempt this lock. Unfortunately, it was missed
    given the new lock type added in MySQL-8.0.