### PR TITLE
- PXC-2629: crash during concurrent load.

### DIFF
--- a/mysql-test/suite/galera/r/galera_performance_schema.result
+++ b/mysql-test/suite/galera/r/galera_performance_schema.result
@@ -2,12 +2,12 @@
 use performance_schema;
 select count(*) from setup_instruments where name like '%galera%' or name like '%wsrep%';
 count(*)
-91
+92
 #node-2
 use performance_schema;
 select count(*) from setup_instruments where name like '%galera%' or name like '%wsrep%';
 count(*)
-91
+92
 select count(*) = 5 from performance_schema.threads where name like '%galera%' or name like '%wsrep%';
 count(*) = 5
 1

--- a/mysql-test/suite/galera/r/galera_tablespaces.result
+++ b/mysql-test/suite/galera/r/galera_tablespaces.result
@@ -165,3 +165,40 @@ innodb_undo_002	Undo	active
 SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
 count(*) = 1
 0
+#node-1 (issue dml that would conflict with parallel ALTER TABLESPACE)
+use test;
+create tablespace tab ADD DATAFILE 'tab.ibd';
+create table t1 (i int, primary key pk(i)) tablespace=tab;
+insert into t1 values (1), (2), (3), (4);
+select * from t1;
+i
+1
+2
+3
+4
+select name from information_schema.innodb_tablespaces where name='tab';
+name
+tab
+set session wsrep_retry_autocommit=0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,before_replicate_sync';
+update t1 set i = i + 10 where i = 2;;
+#node-1a (issue ALTER TABLESPACE)
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+alter tablespace tab rename to tab_rename;;
+#node-1b (wait for both to get blocked)
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'signal=before_replicate_sync';
+#node-1
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+select * from t1;
+i
+1
+2
+3
+4
+#node-1a
+#node-1
+drop table t1;
+drop tablespace tab_rename;

--- a/mysql-test/suite/galera/r/pxc_encrypt_rest_gt.result
+++ b/mysql-test/suite/galera/r/pxc_encrypt_rest_gt.result
@@ -210,3 +210,43 @@ DROP TABLESPACE `ts1`;
 #node-2
 select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
 name	flag	encryption
+#node-1 (issue dml that would conflict with parallel ALTER TABLESPACE)
+use test;
+create tablespace tab ADD DATAFILE 'tab.ibd' ENCRYPTION='Y';
+create table t1 (i int, primary key pk(i)) tablespace=tab encryption='y';
+insert into t1 values (1), (2), (3), (4);
+select * from t1;
+i
+1
+2
+3
+4
+select name, encryption from information_schema.innodb_tablespaces where name='tab';
+name	encryption
+tab	Y
+set session wsrep_retry_autocommit=0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,before_replicate_sync';
+update t1 set i = i + 10 where i = 2;;
+#node-1a (issue ALTER TABLESPACE)
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+alter tablespace tab encryption = 'n';
+#node-1b (wait for both to get blocked)
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'signal=before_replicate_sync';
+#node-1
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+select * from t1;
+i
+1
+2
+3
+4
+#node-1a
+select name, encryption from information_schema.innodb_tablespaces where name='tab';
+name	encryption
+tab	N
+#node-1
+drop table t1;
+drop tablespace tab;

--- a/mysql-test/suite/galera/t/galera_tablespaces.test
+++ b/mysql-test/suite/galera/t/galera_tablespaces.test
@@ -13,6 +13,8 @@
 # link though it introduces GTID backlog on failing node.
 #
 
+--source include/have_debug_sync.inc
+
 --source include/galera_cluster.inc
 
 #------------------------------------------------------------------------------
@@ -143,3 +145,55 @@ SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one
 --echo #node-1
 SELECT NAME, SPACE_TYPE, STATE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE SPACE_TYPE = 'Undo' ORDER BY NAME;
 SELECT count(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = 'one_undo' AND STATE = 'empty';
+
+
+
+#------------------------------------------------------------------------------
+#
+# ALTER OF TABLESPACE should add all sub-objects as part of it write-set
+# signature to properly detect conflict with parallel running DML command.
+#
+--connection node_1
+--echo #node-1 (issue dml that would conflict with parallel ALTER TABLESPACE)
+use test;
+create tablespace tab ADD DATAFILE 'tab.ibd';
+create table t1 (i int, primary key pk(i)) tablespace=tab;
+insert into t1 values (1), (2), (3), (4);
+select * from t1;
+select name from information_schema.innodb_tablespaces where name='tab';
+#
+set session wsrep_retry_autocommit=0;
+--let $galera_sync_point = before_replicate_sync
+--source include/galera_set_sync_point.inc
+--send update t1 set i = i + 10 where i = 2;
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--echo #node-1a (issue ALTER TABLESPACE)
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+#
+--send alter tablespace tab rename to tab_rename;
+
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--echo #node-1b (wait for both to get blocked)
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = select count(*) = 1 from information_schema.processlist where State like "innobase_commit_low%" and Info like "alter tablespace tab rename to tab_rename";
+--source include/wait_condition.inc
+--source include/galera_signal_sync_point.inc
+
+--connection node_1
+--echo #node-1
+--error ER_LOCK_DEADLOCK
+--reap
+select * from t1;
+
+--connection node_1a
+--echo #node-1a
+--reap
+--let $wait_condition = select count(*) = 1 from information_schema.innodb_tablespaces where name='tab_rename';
+--source include/wait_condition.inc
+
+--connection node_1
+--echo #node-1
+drop table t1;
+drop tablespace tab_rename;

--- a/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.test
+++ b/mysql-test/suite/galera/t/pxc_encrypt_rest_gt.test
@@ -3,6 +3,7 @@
 #
 --source include/big_test.inc
 --source include/galera_cluster.inc
+--source include/have_debug_sync.inc
 
 # Force a restart at the end of the test
 --source include/force_restart.inc
@@ -207,3 +208,56 @@ DROP TABLESPACE `ts1`;
 --connection node_2
 --echo #node-2
 select name, flag, encryption from information_schema.innodb_tablespaces where name = "ts1" OR name = "test/t1";
+
+
+#------------------------------------------------------------------------------
+#
+# ALTER OF TABLESPACE should add all sub-objects as part of it write-set
+# signature to properly detect conflict with parallel running DML command.
+#
+--connection node_1
+--echo #node-1 (issue dml that would conflict with parallel ALTER TABLESPACE)
+use test;
+create tablespace tab ADD DATAFILE 'tab.ibd' ENCRYPTION='Y';
+create table t1 (i int, primary key pk(i)) tablespace=tab encryption='y';
+insert into t1 values (1), (2), (3), (4);
+select * from t1;
+select name, encryption from information_schema.innodb_tablespaces where name='tab';
+#
+set session wsrep_retry_autocommit=0;
+--let $galera_sync_point = before_replicate_sync
+--source include/galera_set_sync_point.inc
+--send update t1 set i = i + 10 where i = 2;
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--echo #node-1a (issue ALTER TABLESPACE)
+--let $galera_sync_point = before_replicate_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+#
+--send alter tablespace tab encryption = 'n'
+
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--echo #node-1b (wait for both to get blocked)
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = select count(*) = 1 from information_schema.processlist where State like "innobase_commit_low%" and Info like "alter tablespace tab encryption%";
+--source include/wait_condition.inc
+--source include/galera_signal_sync_point.inc
+
+--connection node_1
+--echo #node-1
+--error ER_LOCK_DEADLOCK
+--reap
+select * from t1;
+
+--connection node_1a
+--echo #node-1a
+--reap
+--let $wait_condition = select encryption = 'n' from information_schema.innodb_tablespaces where name='tab';
+--source include/wait_condition.inc
+select name, encryption from information_schema.innodb_tablespaces where name='tab';
+
+--connection node_1
+--echo #node-1
+drop table t1;
+drop tablespace tab;

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -5124,6 +5124,7 @@ void MDL_ticket::wsrep_report(bool debug) {
        	 ((get_type() == MDL_EXCLUSIVE)            ? "exclusive"            :
           "UNKNOWN"))))))))))),
          (m_lock->key.mdl_namespace()  == MDL_key::GLOBAL)    ? "GLOBAL"       :
+         ((m_lock->key.mdl_namespace() == MDL_key::TABLESPACE)? "TABLESPACE"   :
          ((m_lock->key.mdl_namespace() == MDL_key::SCHEMA)    ? "SCHEMA"       :
          ((m_lock->key.mdl_namespace() == MDL_key::TABLE)     ? "TABLE"        :
          ((m_lock->key.mdl_namespace() == MDL_key::FUNCTION)  ? "FUNCTION"     :
@@ -5131,7 +5132,7 @@ void MDL_ticket::wsrep_report(bool debug) {
          ((m_lock->key.mdl_namespace() == MDL_key::TRIGGER)   ? "TRIGGER"      :
          ((m_lock->key.mdl_namespace() == MDL_key::EVENT)     ? "EVENT"        :
          ((m_lock->key.mdl_namespace() == MDL_key::COMMIT)    ? "COMMIT"       :
-         "UNKNOWN"))))))),
+         "UNKNOWN")))))))),
          m_lock->key.db_name(),
          m_lock->key.name());
   }

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -1568,8 +1568,14 @@ class MDL_context {
   inline bool has_locks() const { return !m_ticket_store.is_empty(); }
 
 #ifdef WITH_WSREP
+  inline bool has_stmt_locks() const {
+    return !(m_ticket_store.is_empty(MDL_STATEMENT));
+  }
   inline bool has_transactional_locks() const {
     return !(m_ticket_store.is_empty(MDL_TRANSACTION));
+  }
+  inline bool has_explicit_locks() const {
+    return !(m_ticket_store.is_empty(MDL_EXPLICIT));
   }
 #endif /* WITH_WSREP */
   bool has_locks(MDL_key::enum_mdl_namespace mdl_namespace) const;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1430,6 +1430,7 @@ mysql_mutex_t LOCK_wsrep_group_commit;
 mysql_cond_t COND_wsrep_group_commit;
 mysql_mutex_t LOCK_wsrep_SR_pool;
 mysql_mutex_t LOCK_wsrep_SR_store;
+mysql_mutex_t LOCK_wsrep_alter_tablespace;
 
 // Track replaying thread handler(s).
 int wsrep_replaying = 0;
@@ -2736,6 +2737,7 @@ static void clean_up_mutexes() {
   mysql_cond_destroy(&COND_wsrep_group_commit);
   mysql_mutex_destroy(&LOCK_wsrep_SR_pool);
   mysql_mutex_destroy(&LOCK_wsrep_SR_store);
+  mysql_mutex_destroy(&LOCK_wsrep_alter_tablespace);
 #endif /* WITH_WSREP */
 }
 
@@ -5536,6 +5538,8 @@ static int init_thread_environment() {
                    MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_wsrep_SR_store, &LOCK_wsrep_SR_store,
                    MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(key_LOCK_wsrep_alter_tablespace,
+                   &LOCK_wsrep_alter_tablespace, MY_MUTEX_INIT_FAST);
 #endif /* WITH_WSREP */
   return 0;
 }
@@ -11994,6 +11998,8 @@ PSI_mutex_key key_LOCK_wsrep_thd_attachable_trx;
 PSI_mutex_key key_LOCK_wsrep_sst_thread;
 
 PSI_mutex_key key_LOCK_wsrep_thd_queue;
+
+PSI_mutex_key key_LOCK_wsrep_alter_tablespace;
 #endif /* WITH_WSREP */
 
 /* clang-format off */
@@ -12109,7 +12115,8 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_LOCK_wsrep_thd_attachable_trx, "LOCK_wsrep_thd_attachable_trx", 0, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_wsrep_sst_thread, "LOCK_wsrep_sst_thread", 0, 0, PSI_DOCUMENT_ME},
 
-  { &key_LOCK_wsrep_thd_queue, "LOCK_wsrep_thd_queue", 0, 0, PSI_DOCUMENT_ME}
+  { &key_LOCK_wsrep_thd_queue, "LOCK_wsrep_thd_queue", 0, 0, PSI_DOCUMENT_ME},
+  { &key_LOCK_wsrep_alter_tablespace, "LOCK_wsrep_alter_tablespace", 0, 0, PSI_DOCUMENT_ME}
 #endif /* WITH_WSREP */
 };
 /* clang-format on */

--- a/sql/sql_cmd_ddl_table.cc
+++ b/sql/sql_cmd_ddl_table.cc
@@ -224,6 +224,13 @@ bool Sql_cmd_create_table::execute(THD *thd) {
       }
     }
 
+    /* This could be looked upon as too restrictive given it is taking
+    a global mutex but anyway being TOI if there is alter tablespace
+    operation active in parallel TOI would streamline it. */
+    if (create_info.tablespace) {
+      mysql_mutex_lock(&LOCK_wsrep_alter_tablespace);
+    }
+
     /* Replicate CTAS as TOI.
     Till PXC-5.7, it was being replicated through normal binlog replication.
     After MySQL-8.0, made DDL atomic, it introduces xid in-consistency
@@ -231,7 +238,14 @@ bool Sql_cmd_create_table::execute(THD *thd) {
     if (WSREP(thd) &&
         wsrep_to_isolation_begin(thd, create_table->db,
                                  create_table->table_name, NULL)) {
-        return true;
+      if (create_info.tablespace) {
+        mysql_mutex_unlock(&LOCK_wsrep_alter_tablespace);
+      }
+      return true;
+    }
+
+    if (create_info.tablespace) {
+      mysql_mutex_unlock(&LOCK_wsrep_alter_tablespace);
     }
 #endif /* WITH_WSREP */
 
@@ -377,7 +391,14 @@ bool Sql_cmd_create_table::execute(THD *thd) {
          tables, like mysql replication does
       */
       if (!thd->is_current_stmt_binlog_format_row() ||
-          !(create_info.options & HA_LEX_CREATE_TMP_TABLE))
+          !(create_info.options & HA_LEX_CREATE_TMP_TABLE)) {
+
+        /* This could be looked upon as too restrictive given it is taking
+        a global mutex but anyway being TOI if there is alter tablespace
+        operation active in parallel TOI would streamline it. */
+        if (create_info.tablespace) {
+          mysql_mutex_lock(&LOCK_wsrep_alter_tablespace);
+        }
 
         /* Note we are explictly opening the macro as we need to perform
         cleanup action on TOI failure. */
@@ -386,8 +407,16 @@ bool Sql_cmd_create_table::execute(THD *thd) {
                                      create_table->table_name, NULL)) {
           if (!thd->lex->is_ignore() && thd->is_strict_mode())
             thd->pop_internal_handler();
+          if (create_info.tablespace) {
+            mysql_mutex_unlock(&LOCK_wsrep_alter_tablespace);
+          }
           return true;
         }
+
+        if (create_info.tablespace) {
+          mysql_mutex_unlock(&LOCK_wsrep_alter_tablespace);
+        }
+      }
 #endif /* WITH_WSREP */
 
       /* Regular CREATE TABLE */

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7570,6 +7570,15 @@ static bool wsrep_mysql_parse(THD *thd, const char *rawbuf, uint length,
     thd->wsrep_retry_command = COM_CONNECT;
   }
 
+#if 0
+  /* Keep this code here for easy validation.
+  If there is multi-stmt transaction then transaction locks are present at this
+  point. */
+  DBUG_ASSERT(!thd->mdl_context.has_stmt_locks());
+  DBUG_ASSERT(!thd->mdl_context.has_transactional_locks() || thd->in_multi_stmt_transaction_mode());
+  DBUG_ASSERT(!thd->mdl_context.has_explicit_locks());
+#endif
+
   DBUG_RETURN(false);
 }
 #endif /* WITH_WSREP */

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -25,6 +25,7 @@
 #include "rpl_gtid.h"
 #include <vector>
 #include "wsrep_server_state.h"
+#include "sql/dd/types/tablespace.h"       // dd::fetch_tablespace_table_refs
 
 #define WSREP_UNDEFINED_TRX_ID ULLONG_MAX
 
@@ -362,6 +363,7 @@ extern mysql_mutex_t LOCK_wsrep_group_commit;
 extern mysql_cond_t COND_wsrep_group_commit;
 extern mysql_mutex_t LOCK_wsrep_SR_pool;
 extern mysql_mutex_t LOCK_wsrep_SR_store;
+extern mysql_mutex_t LOCK_wsrep_alter_tablespace;
 
 extern bool wsrep_emulate_bin_log;
 extern int wsrep_to_isolation;
@@ -389,6 +391,8 @@ extern PSI_cond_key key_COND_wsrep_group_commit;
 extern PSI_mutex_key key_LOCK_wsrep_SR_pool;
 extern PSI_mutex_key key_LOCK_wsrep_SR_store;
 
+extern PSI_mutex_key key_LOCK_wsrep_alter_tablespace;
+
 extern PSI_mutex_key key_LOCK_wsrep_global_seqno;
 extern PSI_mutex_key key_LOCK_wsrep_thd_queue;
 extern PSI_cond_key  key_COND_wsrep_thd_queue;
@@ -412,6 +416,7 @@ struct TABLE_LIST;
 class Alter_info;
 int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
                              const TABLE_LIST *table_list,
+                             dd::Tablespace_table_ref_vec* trefs = NULL,
                              Alter_info *alter_info = NULL);
 
 void wsrep_to_isolation_end(THD *thd);


### PR DESCRIPTION
  - Scenario is trying to ALTER TABLESPACE (rename) and fire dml workload
    on table that are part of the same tablespace.

  - This creates a unique problem.
    - ALTER TABLESPACE fails to projects tables that resides in TABLESPACE
      as part of its write-set signature.
    - MySQL system as per agreed semantics take needed MDL lock.
    - ALTER TABLESPACE being a TOI command if it faces problem acquiring lock
      it can bf-abort local running transaction.
    - Local transaction on hitting bf-abort evaluate for replay.
    - REPLAY logic is dependent on certification that in turn depends on
      write-set signature (object that write-set modifies).
    - Given write-set signature for ALTER TABLESPAE is not proper RELAY
      logic feel these 2 transaction don't conflict so allow local transaction
      to REPLAY.
    - Replayed transaction runs with high priority and holds needed lock
      and conflict with local running high prority ALTER TABLESPACE.

    - 2 high priority transaction is not expected scenario so flow on detecting
      it abort the server.

  - Fix:
    - ALTER TABLESPACE now projects tables that reside in tablespace as part
      of its write-set signature.
    - ALTER TABLESPACE needs to obtain this list from DD for which it needs
      a MDL lock on TABLESPACE
    - Too restrictive lock can cause deadlock with parallel running DML thread.
    - Discovery flow take IX locks on tablespace but this opens up possibility
      of new table being added to tablespace in parallel.
    - This is handled by a special mutex that help co-ordinate CREATE/ALTER
      TABLE (to a tablespace) action with ALTER TABLESPACE.
      [Mutex shouldn't affect performance here as anyway TOI will streamline
       the operation].