### PR TITLE
- PXC-2620: Changing mode to RSU should commit the open transaction

### DIFF
--- a/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
+++ b/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
@@ -118,3 +118,33 @@ wsrep_desync	OFF
 Variable_name	Value
 wsrep_desync_count	0
 DROP TABLE t1;
+#node-1
+create table t1 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3), (4);
+select * from t1;
+i
+1
+2
+3
+4
+begin;
+update t1 set i = i + 100;
+select * from t1;
+i
+101
+102
+103
+104
+SET SESSION wsrep_OSU_method=RSU;
+CREATE TEMPORARY TABLE ch3 AS SELECT concat(b1.b, b2.b) AS ch FROM t2 b1, t2 b2;
+ERROR 42S02: Table 'test.t2' doesn't exist
+commit;
+SET SESSION wsrep_OSU_method=TOI;
+select * from t1;
+i
+101
+102
+103
+104
+drop table t1;
+#node-2

--- a/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
+++ b/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
@@ -296,3 +296,32 @@ DROP TABLE t1;
 ##SHOW VARIABLES LIKE 'wsrep_desync';
 ##show status like 'wsrep_desync_count';
 ##--enable_query_log
+
+#-------------------------------------------------------------------------------
+#
+# use-case: if mode is set to RSU in between transaction then ensure that
+#           existing open transaction (if any is committed)
+#
+--connection node_1
+--echo #node-1
+#
+create table t1 (i int, primary key pk(i));
+insert into t1 values (1), (2), (3), (4);
+select * from t1;
+#
+begin;
+update t1 set i = i + 100;
+select * from t1;
+SET SESSION wsrep_OSU_method=RSU;
+--error ER_NO_SUCH_TABLE
+CREATE TEMPORARY TABLE ch3 AS SELECT concat(b1.b, b2.b) AS ch FROM t2 b1, t2 b2;
+commit;
+SET SESSION wsrep_OSU_method=TOI;
+select * from t1;
+drop table t1;
+
+--connection node_2
+--echo #node-2
+#
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc


### PR DESCRIPTION
  - RSU mode is meant to execute DDL only in restricted/isolated mode.
    (per node basis).

  - If RSU mode is changed as part of active multi-statement transaction
    then ensure that such transaction is committed.

  - RSU will execute DDL that will starts it own transaction.