### PR TITLE
PXC-2918 configuration options adjustment for pxc-80

### DIFF
--- a/build-ps/debian/extra/my.cnf
+++ b/build-ps/debian/extra/my.cnf
@@ -11,7 +11,6 @@ log-error=/var/log/mysqld.log
 pid-file=/var/run/mysqld/mysqld.pid
 log-bin
 log_slave_updates
-expire_logs_days=7
 
-# Disabling symbolic-links is recommended to prevent assorted security risks
-symbolic-links=0
+# Binary log expiration period is 604800 seconds, which equals 7 days
+binlog_expire_logs_seconds=604800

--- a/build-ps/debian/extra/mysqld.cnf
+++ b/build-ps/debian/extra/mysqld.cnf
@@ -9,11 +9,10 @@ datadir=/var/lib/mysql
 socket=/var/run/mysqld/mysqld.sock
 log-error=/var/log/mysql/error.log
 pid-file=/var/run/mysqld/mysqld.pid
-expire_logs_days=7
 log_error_verbosity=3
 
-# Disabling symbolic-links is recommended to prevent assorted security risks
-symbolic-links=0
+# Binary log expiration period is 604800 seconds, which equals 7 days
+binlog_expire_logs_seconds=604800
 
 ######## wsrep ###############
 # Path to Galera library
@@ -28,7 +27,7 @@ wsrep_cluster_address=gcomm://
 binlog_format=ROW
 
 # Slave thread to use
-wsrep_slave_threads= 8
+wsrep_slave_threads=8
 
 wsrep_log_conflicts
 
@@ -48,10 +47,3 @@ pxc_strict_mode=ENFORCING
 
 # SST method
 wsrep_sst_method=xtrabackup-v2
-
-###########################################
-
-[mysqld_safe]
-pid-file = /var/run/mysqld/mysqld.pid
-socket   = /var/run/mysqld/mysqld.sock
-nice     = 0

--- a/build-ps/debian/extra/percona-xtradb-cluster.conf.d/mysqld.cnf
+++ b/build-ps/debian/extra/percona-xtradb-cluster.conf.d/mysqld.cnf
@@ -8,7 +8,6 @@ log-error=/var/log/mysqld.log
 pid-file=/var/run/mysqld/mysqld.pid
 log-bin
 log_slave_updates
-expire_logs_days=7
 
-# Disabling symbolic-links is recommended to prevent assorted security risks
-symbolic-links=0
+# Binary log expiration period is 604800 seconds, which equals 7 days
+binlog_expire_logs_seconds=604800

--- a/build-ps/debian/extra/percona-xtradb-cluster.conf.d/wsrep.cnf
+++ b/build-ps/debian/extra/percona-xtradb-cluster.conf.d/wsrep.cnf
@@ -14,7 +14,7 @@ binlog_format=ROW
 default_storage_engine=InnoDB
 
 # Slave thread to use
-wsrep_slave_threads= 8
+wsrep_slave_threads=8
 
 wsrep_log_conflicts
 

--- a/build-ps/debian/extra/wsrep.cnf
+++ b/build-ps/debian/extra/wsrep.cnf
@@ -14,7 +14,7 @@ binlog_format=ROW
 default_storage_engine=InnoDB
 
 # Slave thread to use
-wsrep_slave_threads= 8
+wsrep_slave_threads=8
 
 wsrep_log_conflicts
 

--- a/build-ps/rpm/mysqld.cnf
+++ b/build-ps/rpm/mysqld.cnf
@@ -9,11 +9,10 @@ datadir=/var/lib/mysql
 socket=/var/lib/mysql/mysql.sock
 log-error=/var/log/mysqld.log
 pid-file=/var/run/mysqld/mysqld.pid
-expire_logs_days=7
 log_error_verbosity=3
 
-# Disabling symbolic-links is recommended to prevent assorted security risks
-symbolic-links=0
+# Binary log expiration period is 604800 seconds, which equals 7 days
+binlog_expire_logs_seconds=604800
 
 ######## wsrep ###############
 # Path to Galera library
@@ -28,7 +27,7 @@ wsrep_cluster_address=gcomm://
 binlog_format=ROW
 
 # Slave thread to use
-wsrep_slave_threads= 8
+wsrep_slave_threads=8
 
 wsrep_log_conflicts
 
@@ -48,10 +47,3 @@ pxc_strict_mode=ENFORCING
 
 # SST method
 wsrep_sst_method=xtrabackup-v2
-
-###########################################
-
-[mysqld_safe]
-pid-file = /var/run/mysqld/mysqld.pid
-socket   = /var/run/mysqld/mysqld.sock
-nice     = 0

--- a/build-ps/rpm/wsrep.cnf
+++ b/build-ps/rpm/wsrep.cnf
@@ -14,7 +14,7 @@ binlog_format=ROW
 default_storage_engine=InnoDB
 
 # Slave thread to use
-wsrep_slave_threads= 8
+wsrep_slave_threads=8
 
 wsrep_log_conflicts
 


### PR DESCRIPTION
1. Remove deprecated "symbolic-links=0" option
2. Change deprecated "expire_logs_days=7" to "binlog_expire_logs_seconds"
3. Remove "[mysqld_safe]" section from sonfigs since mysqld_safe script
is not used anymore
4. "wsrep_slave_threads" option definition prettifying