### PR TITLE
PXC-2602 : add support for xbstream options with wsrep_sst_xtrabackup-v2

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2-options.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2-options.cnf
@@ -22,3 +22,6 @@ parallel=2
 encrypt=1
 encrypt-algo=AES256
 encrypt-key=4FA92C5873672E20FB163A0BCB2BB4A4
+
+# PXC-2602 : test the options processing
+xbstream-opts="--parallel=1"

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -250,12 +250,12 @@ parse_cnf()
 
     # look in group+suffix
     if [[ -n $WSREP_SST_OPT_CONF_SUFFIX ]]; then
-        reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF "${group}${WSREP_SST_OPT_CONF_SUFFIX}" | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
+        reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF "${group}${WSREP_SST_OPT_CONF_SUFFIX}" | awk -F= '{st=index($0,"="); cur=$0; if ($1 ~ /_/) { gsub(/_/,"-",$1);} if (st != 0) { print $1"="substr(cur,st+1) } else { print cur }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
     fi
 
     # look in group
     if [[ -z $reval ]]; then
-        reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
+        reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF "${group}" | awk -F= '{st=index($0,"="); cur=$0; if ($1 ~ /_/) { gsub(/_/,"-",$1);} if (st != 0) { print $1"="substr(cur,st+1) } else { print cur }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
     fi
 
     # use default if we haven't found a value

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -27,6 +27,9 @@ ealgo=""
 ekey=""
 ekeyfile=""
 encrypt=0
+
+xbstream_opts=""
+
 nproc=1
 ecode=0
 ssyslog=""
@@ -561,6 +564,7 @@ read_cnf()
         sockopt+=",retry=30"
     fi
 
+    xbstream_opts=$(parse_cnf sst xbstream-opts "")
 }
 
 #
@@ -574,9 +578,9 @@ get_stream()
     if [[ $sfmt == 'xbstream' ]];then 
         wsrep_log_info "Streaming with xbstream"
         if [[ "$WSREP_SST_OPT_ROLE"  == "joiner" ]];then
-            strmcmd="xbstream -x"
+            strmcmd="xbstream -x $xbstream_opts"
         else
-            strmcmd="xbstream -c \${FILE_TO_STREAM}"
+            strmcmd="xbstream -c $xbstream_opts \${FILE_TO_STREAM}"
         fi
     else
         sfmt="tar"


### PR DESCRIPTION
Issue
There is no way to set additional options for xbstream.  For performance
reasons, we would like to set "--parallel=XXX" for xbstream.

Solution
Add the 'xbstream_opts' option to the [sst] section of the config.
Note that on 5.7 and above, there is a separate xbxtream_eopts (encryption
options)

Also fixed a bug in parse_cnf() that would truncate option values that contained
an equals sign ('=')