### PR TITLE
PXC-2952: wsrep_incoming_addresses does not contain proper values if wsrep_node_incoming_address set to AUTO

### DIFF
--- a/mysql-test/suite/sys_vars/r/wsrep_incoming_addresses_basic.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_incoming_addresses_basic.result
@@ -1,0 +1,29 @@
+#
+# wsrep_incoming_addresses
+#
+SHOW VARIABLES LIKE 'wsrep_node_incoming_address';
+Variable_name	Value
+wsrep_node_incoming_address	AUTO
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+Variable_name	Value
+wsrep_incoming_addresses	IP_ADDR:PORT
+
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+Variable_name	Value
+wsrep_incoming_addresses	4.3.2.1:98765
+call mtr.add_suppression("Could not parse wsrep_node_incoming_address : 4.3.2.1:123456789123456789123456789123456789");
+
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+Variable_name	Value
+wsrep_incoming_addresses	
+Pattern "Could not parse wsrep_node_incoming_address : 4.3.2.1:123456789123456789123456789123456789" found
+
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+Variable_name	Value
+wsrep_incoming_addresses	[2001:db8::1:0:0:1]:98765
+call mtr.add_suppression("Could not parse wsrep_node_incoming_address : .2001:db8::1:0:0:1.:123456789123456789123456789123456789");
+
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+Variable_name	Value
+wsrep_incoming_addresses	
+Pattern "Could not parse wsrep_node_incoming_address : \[2001:db8::1:0:0:1\]:123456789123456789123456789123456789" found

--- a/mysql-test/suite/sys_vars/t/wsrep_incoming_addresses_basic-master.opt
+++ b/mysql-test/suite/sys_vars/t/wsrep_incoming_addresses_basic-master.opt
@@ -1,0 +1,1 @@
+--wsrep_provider=$WSREP_PROVIDER --wsrep_cluster_address='gcomm://' --wsrep_new_cluster

--- a/mysql-test/suite/sys_vars/t/wsrep_incoming_addresses_basic.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_incoming_addresses_basic.test
@@ -1,0 +1,58 @@
+--source include/have_wsrep_provider.inc
+--source include/have_wsrep.inc
+
+--echo #
+--echo # wsrep_incoming_addresses
+--echo #
+
+# the default value of wsrep_node_incoming_address should be AUTO
+SHOW VARIABLES LIKE 'wsrep_node_incoming_address';
+
+# wsrep_incoming_addresses should contain ip like ipv4:port or [ipv6]:port of current server 
+# (value should not be AUTO).
+# Simple replacement for ipv4, ipv6, but not AUTO
+--replace_regex /[0-9.]+:[0-9]+$/IP_ADDR:PORT/ /[0-9,a-f,A-F\[\]:]+:[0-9]+$/IP_ADDR:PORT/
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+
+# IPv4
+# Now restart the server with specified wsrep_node_incoming_address
+# wsrep_incoming_addresses should point to specified address 
+--let $restart_parameters = "restart:--wsrep_node_incoming_address=4.3.2.1:98765"
+--replace_regex /# restart:.*//
+--source include/restart_mysqld.inc
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+
+# Invalid address. 
+# Unfortunately validation of provided IP inside wsrep_server_incoming_address() wsrep_mysql.cc
+# is weak and deals only with port strtol overflow (values like a.b:wrong are considered as valid ones)
+call mtr.add_suppression("Could not parse wsrep_node_incoming_address : 4.3.2.1:123456789123456789123456789123456789");
+--let $restart_parameters = "restart:--wsrep_node_incoming_address=4.3.2.1:123456789123456789123456789123456789"
+--replace_regex /# restart:.*//
+--source include/restart_mysqld.inc
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+
+# Ensure that invalid value for wsrep_node_incoming_address was logged
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN = Could not parse wsrep_node_incoming_address : 4.3.2.1:123456789123456789123456789123456789
+--source include/search_pattern.inc
+
+
+# IPv6
+--let $restart_parameters = "restart:--wsrep_node_incoming_address=[2001:db8::1:0:0:1]:98765"
+--replace_regex /# restart:.*//
+--source include/restart_mysqld.inc
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+
+# Invalid address. 
+call mtr.add_suppression("Could not parse wsrep_node_incoming_address : .2001:db8::1:0:0:1.:123456789123456789123456789123456789");
+--let $restart_parameters = "restart:--wsrep_node_incoming_address=[2001:db8::1:0:0:1]:123456789123456789123456789123456789"
+--replace_regex /# restart:.*//
+--source include/restart_mysqld.inc
+SHOW STATUS LIKE 'wsrep_incoming_addresses';
+
+# Ensure that invalid value for wsrep_node_incoming_address was logged
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN = Could not parse wsrep_node_incoming_address : \[2001:db8::1:0:0:1\]:123456789123456789123456789123456789
+--source include/search_pattern.inc
+
+

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -812,7 +812,6 @@ static std::string wsrep_server_incoming_address() {
           WSREP_WARN(
               "Guessing address for incoming client connections: "
               "address too long.");
-          inc_addr[0] = '\0';
         }
       }
 
@@ -843,7 +842,9 @@ static std::string wsrep_server_incoming_address() {
   }
 
 done:
-  ret = wsrep_node_incoming_address;
+
+  // inc_addr contains proper address, or is empty string
+  ret = inc_addr;
   return ret;
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-2952

Autodetected server address that is internally passed as the parameter to the Galera library was unconditionally overridden by wsrep_node_incoming_address value.