### PR TITLE
PXC-2692: Disable keyring encryption

### DIFF
--- a/mysql-test/suite/sys_vars/r/default_table_encryption_basic.result
+++ b/mysql-test/suite/sys_vars/r/default_table_encryption_basic.result
@@ -110,17 +110,20 @@ SELECT @@global.default_table_encryption = false;
 Warnings:
 Warning	1292	Truncated incorrect DOUBLE value: 'OFF'
 SET SESSION default_table_encryption=KEYRING_ON;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@session.default_table_encryption;
 @@session.default_table_encryption
-KEYRING_ON
+OFF
 SET SESSION default_table_encryption=ONLINE_TO_KEYRING;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@session.default_table_encryption;
 @@session.default_table_encryption
-ONLINE_TO_KEYRING
+OFF
 SET SESSION default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@session.default_table_encryption;
 @@session.default_table_encryption
-ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+OFF
 SET GLOBAL default_table_encryption=OFF;
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
@@ -130,17 +133,20 @@ SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
 ON
 SET PERSIST default_table_encryption=KEYRING_ON;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-KEYRING_ON
+ON
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_TO_KEYRING
+ON
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+ON
 SET PERSIST default_table_encryption=ON;
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
@@ -172,17 +178,20 @@ SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
 OFF
 SET PERSIST default_table_encryption=KEYRING_ON;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-KEYRING_ON
+OFF
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_TO_KEYRING
+OFF
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+ERROR 42000: Keyring encryption is not supported in Percona XtraDB Cluster.
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+OFF
 SET PERSIST default_table_encryption=ON;
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption

--- a/mysql-test/suite/sys_vars/t/default_table_encryption_basic.test
+++ b/mysql-test/suite/sys_vars/t/default_table_encryption_basic.test
@@ -118,12 +118,15 @@ SELECT @@session.default_table_encryption = false;
 SET GLOBAL default_table_encryption=false;
 SELECT @@global.default_table_encryption = false;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET SESSION default_table_encryption=KEYRING_ON;
 SELECT @@session.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET SESSION default_table_encryption=ONLINE_TO_KEYRING;
 SELECT @@session.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET SESSION default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SELECT @@session.default_table_encryption;
 
@@ -133,12 +136,15 @@ SELECT @@global.default_table_encryption;
 SET PERSIST default_table_encryption=ON;
 SELECT @@global.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET PERSIST default_table_encryption=KEYRING_ON;
 SELECT @@global.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
 SELECT @@global.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SELECT @@global.default_table_encryption;
 
@@ -169,12 +175,15 @@ SELECT @@session.default_table_encryption;
 SET GLOBAL default_table_encryption=OFF;
 SELECT @@global.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET PERSIST default_table_encryption=KEYRING_ON;
 SELECT @@global.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
 SELECT @@global.default_table_encryption;
 
+--Error ER_WRONG_VALUE_FOR_VAR
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SELECT @@global.default_table_encryption;
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7350,6 +7350,16 @@ static bool check_set_default_table_encryption_access(
   // the value is unchanged.
   longlong previous_val = thd->variables.default_table_encryption;
   longlong val = (longlong)var->save_result.ulonglong_value;
+
+#ifdef WITH_WSREP
+  if (val > 1) {
+    my_message(ER_WRONG_VALUE_FOR_VAR,
+               "Keyring encryption is not supported in Percona XtraDB Cluster.",
+               MYF(0));
+    return true;
+  }
+#endif
+
   if ((!var->is_global_persist() && val == previous_val) ||
       thd->security_context()->check_access(SUPER_ACL) ||
       (thd->security_context()

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2827,7 +2827,11 @@ dberr_t Encryption::set_algorithm(const char *option, Encryption *encryption) {
     encryption->m_type = AES;
 
   } else if (innobase_strcasecmp(option, "KEYRING") == 0) {
+#ifdef WITH_WSREP
+    return (DB_UNSUPPORTED);
+#else
     encryption->m_type = KEYRING;
+#endif
   } else {
     return (DB_UNSUPPORTED);
   }


### PR DESCRIPTION
PXC currently doesn't support keyring encryption, and this feature is
also experimental in PS, and not supported by PXB.
This change makes this explicit, preventing later replication failures.