### PR TITLE
- PXC-2964: Node crashes when query is aborted during lock tables for…

### DIFF
--- a/mysql-test/suite/galera/r/galera_lock_table.result
+++ b/mysql-test/suite/galera/r/galera_lock_table.result
@@ -19,3 +19,22 @@ COUNT(*) = 1
 1
 DROP TABLE t1;
 DROP TABLE t2;
+#node-1a
+use mysql;
+start transaction;
+lock tables for backup;
+show create table wsrep_cluster;
+Table	Create Table
+wsrep_cluster	CREATE TABLE `wsrep_cluster` (
+  `cluster_uuid` char(36) NOT NULL,
+  `view_id` bigint(20) NOT NULL,
+  `view_seqno` bigint(20) NOT NULL,
+  `protocol_version` int(11) NOT NULL,
+  `capabilities` int(11) NOT NULL,
+  PRIMARY KEY (`cluster_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+#node-1
+use mysql;
+select count(*) from wsrep_cluster;
+count(*)
+1

--- a/mysql-test/suite/galera/t/galera_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_lock_table.test
@@ -43,3 +43,26 @@ SELECT COUNT(*) = 1 FROM t2;
 
 DROP TABLE t1;
 DROP TABLE t2;
+
+#-------------------------------------------------------------------------------
+#
+# Use-case: Stimulate a case where-in mysqldump invokes LOCK TABLE FOR BACKUP
+#           and start transaction but rely on connection closure for cleanup.
+#
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+--echo #node-1a
+use mysql;
+start transaction;
+lock tables for backup;
+show create table wsrep_cluster;
+
+--connection node_1
+--connection node_1
+--echo #node-1
+#
+--disconnect node_1a
+#
+use mysql;
+select count(*) from wsrep_cluster;

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -323,6 +323,9 @@ int Wsrep_client_service::bf_rollback() {
     m_thd->locked_tables_list.unlock_locked_tables(m_thd);
     m_thd->variables.option_bits &= ~OPTION_TABLE_LOCK;
   }
+  if (m_thd->backup_tables_lock.is_acquired()) {
+    m_thd->backup_tables_lock.release(m_thd);
+  }
   if (m_thd->global_read_lock.is_acquired()) {
     m_thd->global_read_lock.unlock_global_read_lock(m_thd);
   }

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -375,6 +375,8 @@ int Wsrep_high_priority_service::rollback(const wsrep::ws_handle &ws_handle,
   WSREP_DEBUG("%s", m_thd->wsrep_info);
   thd_proc_info(m_thd, m_thd->wsrep_info);
 
+  /* This being a background thread doesn't take a global read
+  lock and backup lock. */
   m_thd->mdl_context.release_transactional_locks();
   mysql_ull_cleanup(m_thd);
   m_thd->mdl_context.release_explicit_locks();


### PR DESCRIPTION
… backup

  Issue:
  ------

  - mysqldump started with lock-for-backup takes backup lock (through
    LOCK TABLE FOR BACKUP) + also starts a transaction.
    START TRANSACTION /*!40100 WITH CONSISTENT SNAPSHOT */

  - On completion it relies on connection closure code to release
    backup lock and close active transaction.

  - PXC logic missed adding release of backup lock before it
    explicilty releases EXPLICIT locks as part of bf_rollback.

  - This created a situation where-in backup-lock variable
    says backup-lock is present but underlying structure
    doesn't have needed lock.
    (underlying structure locks were forcefully released
     as part of EXPLICIT locks release called through bf_rollback).

  Fix:
  ---

  - Ensure backup lock are released before explicilty releasing EXPLICIT locks.