### PR TITLE
PXC-2950 : PXC 8 3 node setup fails to start from backup

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2752,11 +2752,7 @@ int MYSQL_BIN_LOG::rollback(THD *thd, bool all) {
      */
   } else if (thd->lex->sql_command != SQLCOM_ROLLBACK_TO_SAVEPOINT ||
              thd->wsrep_trx().state() == wsrep::transaction::s_aborting ||
-             (thd->lex->sql_command == SQLCOM_ROLLBACK_TO_SAVEPOINT &&
-              thd->wsrep_trx().state() == wsrep::transaction::s_must_abort)) {
-    /* If transaction has save point and while local transaction is trying to
-    rollback savepoint it is killed by high priority transaction ensure rollback
-    is processed. */
+             thd->wsrep_force_savept_rollback) {
 #else
   } else if (thd->lex->sql_command != SQLCOM_ROLLBACK_TO_SAVEPOINT) {
 #endif /* WITH_WSREP */

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6503,6 +6503,28 @@ static int init_server_components() {
   }
 #endif
 
+#ifdef WITH_WSREP
+  /* In the case where no upgrade is required (if we've moved from
+     an 8.0 PS to 8.0 PXC), we will also need to create the
+     wsrep_state.dat.  We do not overwrite any existing wsrep_state.dat
+     file since the database may not have been upgraded. */
+  if (!is_help_or_validate_option() && !opt_initialize &&
+      dd::upgrade::no_server_upgrade_required()) {
+      wsp::WSREPState wsrep_state;
+      wsrep_state.wsrep_schema_version = WSREP_SCHEMA_VERSION;
+      if (!wsrep_state.exists(mysql_real_data_home_ptr, WSREP_STATE_FILENAME)) {
+        if (!wsrep_state.save_to(mysql_real_data_home_ptr, WSREP_STATE_FILENAME)) {
+          WSREP_ERROR("Could not create the wsrep state file : %s",
+                      WSREP_STATE_FILENAME);
+          WSREP_ERROR("Exiting");
+          unireg_abort(1);
+        }
+
+        WSREP_INFO("Created the wsrep_state.dat file (%d)", __LINE__);
+      }
+  }
+#endif /* WITH_WSREP */
+
   if (!is_help_or_validate_option() && !opt_initialize &&
       !dd::upgrade::no_server_upgrade_required()) {
     if (opt_upgrade_mode == UPGRADE_MINIMAL)
@@ -6517,7 +6539,8 @@ static int init_server_components() {
       }
       delete_optimizer_cost_module();
 #ifdef WITH_WSREP
-      /* Create the wsrep state file.
+      /* Create the wsrep state file. This will overwrite any exiting
+         wsrep_state.dat file.  This should be ok since we have run upgrade.
          If user decide to upgrade 5.7 node to 8.0 using offline approach
          then for the first node SST is not invoked and it is auto-upgraded.
          Post successfully upgrade PXC expect wsrep state file to be present. */
@@ -6525,11 +6548,12 @@ static int init_server_components() {
       wsrep_state.wsrep_schema_version = WSREP_SCHEMA_VERSION;
       if (!wsrep_state.save_to(mysql_real_data_home_ptr,
                                WSREP_STATE_FILENAME)) {
-        WSREP_ERROR("Could not create the wsrep state file : %s",
-                    WSREP_STATE_FILENAME);
+        WSREP_ERROR("Could not create the wsrep state file (%d) : %s",
+                    __LINE__, WSREP_STATE_FILENAME);
         WSREP_ERROR("Exiting");
         unireg_abort(1);
       }
+      WSREP_INFO("Created the wsrep_state.dat file (%d)", __LINE__);
 #endif /* WITH_WSREP */
       /*
         When upgrade is finished, we need to initialize the plugins that

--- a/sql/ssl_acceptor_context.cc
+++ b/sql/ssl_acceptor_context.cc
@@ -480,12 +480,12 @@ bool SslAcceptorContext::wsrep_ssl_artifacts_check(bool bootstrapping_node) {
       case SSL_ARTIFACTS_VIA_OPTIONS:
         WSREP_INFO(
             "New joining cluster node configured to use specified SSL "
-            "artificats");
+            "artifacts");
         break;
       case SSL_ARTIFACT_TRACES_FOUND:
       case SSL_ARTIFACTS_NOT_FOUND:
         WSREP_ERROR(
-            "New joining cluster node didn't found %sneeded SSL artifacts",
+            "New joining cluster node didn't find %sneeded SSL artifacts",
             (auto_detection_status == SSL_ARTIFACT_TRACES_FOUND) ? "all " : "");
         return true;
         break;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7817,6 +7817,14 @@ static Sys_var_uint Sys_wsrep_ignore_apply_errors(
     VALID_RANGE(WSREP_IGNORE_ERRORS_NONE, WSREP_IGNORE_ERRORS_MAX), DEFAULT(7),
     BLOCK_SIZE(1));
 
+static Sys_var_uint Sys_wsrep_min_log_verbosity(
+    "wsrep_min_log_verbosity",
+    "Set the minimum logging verbosity "
+    "level of wsrep plugin and Galera",
+    GLOBAL_VAR(wsrep_min_log_verbosity), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(1, 3), DEFAULT(3), BLOCK_SIZE(1), NO_MUTEX_GUARD,
+    NOT_IN_BINLOG);
+
 static const char *pxc_strict_modes[] = {"DISABLED", "PERMISSIVE", "ENFORCING",
                                          "MASTER", NullS};
 static Sys_var_enum Sys_pxc_strict_mode(

--- a/sql/wsrep_utils.h
+++ b/sql/wsrep_utils.h
@@ -387,13 +387,13 @@ class critical {
 };
 #endif
 
-class WSREPState {
+class WSREPState
+{
  public:
-  static bool node_needs_upgrading();
-
   /* Resets all of the data to default values */
   void clear() { wsrep_schema_version.clear(); }
 
+  bool exists(const char *dir, const char *filename);
   bool load_from(const char *dir, const char *filename);
   bool save_to(const char *dir, const char *filename);
 


### PR DESCRIPTION
Issue
The SST can fail if the donor datadir does not have a wsrep_state.dat
file.  This can occur if PXC 8.0 is run on a PS (or MySQL 8.0) datadir.

Solution
If MySQL has determined that an upgrade is not needed, we still
create the wsrep_state.dat file.

also fixed a bad merge (sql/sys_vars.cc)