### PR TITLE
PXC-2954: DDL to add FK on one node fails but completes on other node s causing inconsistency (5.7)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_alter_table_add_fk.result
+++ b/mysql-test/suite/galera/r/pxc_alter_table_add_fk.result
@@ -1,0 +1,66 @@
+# connection node_1, root
+CREATE DATABASE db1;
+CREATE USER 'testUser' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON db1.* TO 'testUser';
+CREATE USER 'testUser2' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON *.* TO 'testUser2';
+CREATE TABLE db1.t1 ( id INT PRIMARY KEY AUTO_INCREMENT, m INT) ENGINE=innodb;
+CREATE DATABASE db2;
+CREATE TABLE db2.t1 (id INT PRIMARY KEY AUTO_INCREMENT, s INT) ENGINE=innodb;
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_2, testUser - limited privileges
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+ERROR 42000: REFERENCES command denied to user 'testUser'@'localhost' for table 'db2.t1'
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_1, root
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_2, testUser2 - full privileges
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `m` (`m`),
+  CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`m`) REFERENCES `db2`.`t1` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_1, root
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `m` (`m`),
+  CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`m`) REFERENCES `db2`.`t1` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP USER testUser;
+DROP USER testUser2;

--- a/mysql-test/suite/galera/t/pxc_alter_table_add_fk.test
+++ b/mysql-test/suite/galera/t/pxc_alter_table_add_fk.test
@@ -1,0 +1,66 @@
+#
+# Test that ALTER TABLE ... ADD FOREIGN KEY ... REFERENCES ...
+# is not replicated if the user does not have access to the foreign key.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connection node_1
+--echo # connection node_1, root
+CREATE DATABASE db1;
+CREATE USER 'testUser' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON db1.* TO 'testUser';
+CREATE USER 'testUser2' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON *.* TO 'testUser2';
+
+CREATE TABLE db1.t1 ( id INT PRIMARY KEY AUTO_INCREMENT, m INT) ENGINE=innodb;
+
+CREATE DATABASE db2;
+CREATE TABLE db2.t1 (id INT PRIMARY KEY AUTO_INCREMENT, s INT) ENGINE=innodb;
+
+SHOW CREATE TABLE db1.t1;
+
+# Connect as the user with limited privileges 
+--connect(con_node_2_test_user, localhost, testUser, secret,) 
+--echo # connection node_2, testUser - limited privileges
+
+SHOW CREATE TABLE db1.t1;
+
+--error 1142
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+
+# Ensure that table was not altered by replication
+SHOW CREATE TABLE db1.t1;
+
+
+--connection node_1
+--echo # connection node_1, root
+# Ensure that table was not altered by replication
+SHOW CREATE TABLE db1.t1;
+
+
+# Connect as the user with full privileges
+--connect(con_node_2_test_user_2, localhost, testUser2, secret,) 
+--echo # connection node_2, testUser2 - full privileges
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+
+# Ensure that table was altered by replication
+SHOW CREATE TABLE db1.t1;
+
+
+--connection node_1
+--echo # connection node_1, root
+
+# Ensure that table was altered by replication
+SHOW CREATE TABLE db1.t1;
+
+
+# Cleanup
+--disconnect con_node_2_test_user
+--disconnect con_node_2_test_user_2
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP USER testUser;
+DROP USER testUser2;
+

--- a/sql/auth/auth_common.h
+++ b/sql/auth/auth_common.h
@@ -714,10 +714,18 @@ bool delete_precheck(THD *thd, TABLE_LIST *tables);
 bool lock_tables_precheck(THD *thd, TABLE_LIST *tables);
 bool create_table_precheck(THD *thd, TABLE_LIST *tables,
                            TABLE_LIST *create_table);
+#if WITH_WSREP
+bool check_fk_parent_table_access(THD *thd,
+                                  const char *child_table_db,
+                                  HA_CREATE_INFO *create_info,
+                                  Alter_info *alter_info,
+                                  bool check_fk_support = true);
+#else
 bool check_fk_parent_table_access(THD *thd,
                                   const char *child_table_db,
                                   HA_CREATE_INFO *create_info,
                                   Alter_info *alter_info);
+#endif
 bool check_readonly(THD *thd, bool err_if_readonly);
 void err_readonly(THD *thd);
 

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -4419,19 +4419,36 @@ bool check_global_access(THD *thd, ulong want_access)
   @retval
    true	  error or access denied. Error is sent to client in this case.
 */
+#ifdef WITH_WSREP
+bool check_fk_parent_table_access(THD *thd,
+                                  const char *child_table_db,
+                                  HA_CREATE_INFO *create_info,
+                                  Alter_info *alter_info,
+                                  bool check_fk_support)
+#else
+
 bool check_fk_parent_table_access(THD *thd,
                                   const char *child_table_db,
                                   HA_CREATE_INFO *create_info,
                                   Alter_info *alter_info)
+#endif
 {
   Key *key;
   List_iterator<Key> key_iterator(alter_info->key_list);
-  handlerton *db_type= create_info->db_type ? create_info->db_type :
-                                             ha_default_handlerton(thd);
 
-  // Return if engine does not support Foreign key Constraint.
-  if (!ha_check_storage_engine_flag(db_type, HTON_SUPPORTS_FOREIGN_KEYS))
-    return false;
+#ifdef WITH_WSREP
+  if (check_fk_support)
+  {
+#endif
+    handlerton *db_type= create_info->db_type ? create_info->db_type :
+                                                ha_default_handlerton(thd);
+
+	  // Return if engine does not support Foreign key Constraint.
+    if (!ha_check_storage_engine_flag(db_type, HTON_SUPPORTS_FOREIGN_KEYS))
+      return false;
+#ifdef WITH_WSREP
+  }
+#endif
 
   while ((key= key_iterator++))
   {

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -355,6 +355,26 @@ bool Sql_cmd_alter_table::execute(THD *thd)
 
 
 #ifdef WITH_WSREP
+  /* Check if foreign keys are accessible.
+  1. Transaction is replicated first, then is done locally.
+  2. Replicated node applies write sets in context
+  of root user.
+  Above two conditions may cause that even if we have no access to FKs,
+  transactions will replicate with success, but fail locally.
+
+  Here we check only for FK access, not if the engine supports FKs.
+  That's enough, because right now we need only to know if transaction
+  should be rolled back because of lack of access and not replicated,
+  or we can replicate it and let replicated node do the rest of the job. */
+  if (alter_info.flags & Alter_info::ADD_FOREIGN_KEY)
+  {
+    if (check_fk_parent_table_access(thd, select_lex->db,
+                                     &create_info, &alter_info, false))
+    {
+      DBUG_RETURN(TRUE);
+    }
+  }
+
   /* PXC doesn't recommend/allow ALTER operation on table created using
   non-transactional storage engine (like MyISAM, HEAP/MEMORY, etc....)
   except ALTER operation to change storage engine to transactional storage


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-2954

TOI transaction is replicated before local transaction is done. Privileges check for FK was done in the middle of actual table altering, but after TOI transactions was replicated. If local transaction detected insufficient privileges, it was rolled back, but already replicated TOI transaction was executed on replicated node in root user context.

Privileges check for foreign keys access was added before replicating TOI transaction.