### PR TITLE
PXC-2954: DDL to add FK on one node fails but completes on other node s causing inconsistency (8.0)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_alter_table_add_fk.result
+++ b/mysql-test/suite/galera/r/pxc_alter_table_add_fk.result
@@ -1,0 +1,66 @@
+# connection node_1, root
+CREATE DATABASE db1;
+CREATE USER 'testUser' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON db1.* TO 'testUser';
+CREATE USER 'testUser2' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON *.* TO 'testUser2';
+CREATE TABLE db1.t1 ( id INT PRIMARY KEY AUTO_INCREMENT, m INT) ENGINE=innodb;
+CREATE DATABASE db2;
+CREATE TABLE db2.t1 (id INT PRIMARY KEY AUTO_INCREMENT, s INT) ENGINE=innodb;
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_2, testUser - limited privileges
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+ERROR 42000: REFERENCES command denied to user 'testUser'@'localhost' for table 'db2.t1'
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_1, root
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_2, testUser2 - full privileges
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `m` (`m`),
+  CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`m`) REFERENCES `db2`.`t1` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+# connection node_1, root
+SHOW CREATE TABLE db1.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `m` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `m` (`m`),
+  CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`m`) REFERENCES `db2`.`t1` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP USER testUser;
+DROP USER testUser2;

--- a/mysql-test/suite/galera/t/pxc_alter_table_add_fk.test
+++ b/mysql-test/suite/galera/t/pxc_alter_table_add_fk.test
@@ -1,0 +1,67 @@
+#
+# Test that ALTER TABLE ... ADD FOREIGN KEY ... REFERENCES ...
+# is not replicated if the user does not have access to the foreign key.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/wait_wsrep_ready.inc
+
+--connection node_1
+--echo # connection node_1, root
+CREATE DATABASE db1;
+CREATE USER 'testUser' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON db1.* TO 'testUser';
+CREATE USER 'testUser2' IDENTIFIED BY 'secret';
+GRANT ALL PRIVILEGES ON *.* TO 'testUser2';
+
+CREATE TABLE db1.t1 ( id INT PRIMARY KEY AUTO_INCREMENT, m INT) ENGINE=innodb;
+
+CREATE DATABASE db2;
+CREATE TABLE db2.t1 (id INT PRIMARY KEY AUTO_INCREMENT, s INT) ENGINE=innodb;
+
+SHOW CREATE TABLE db1.t1;
+
+# Connect as the user with limited privileges 
+--connect(con_node_2_test_user, 127.0.0.1, testUser, secret,,$NODE_MYPORT_2) 
+--echo # connection node_2, testUser - limited privileges
+
+SHOW CREATE TABLE db1.t1;
+
+--error 1142
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+
+# Ensure that table was not altered locally
+SHOW CREATE TABLE db1.t1;
+
+
+--connection node_1
+--echo # connection node_1, root
+# Ensure that table was not altered by replication
+SHOW CREATE TABLE db1.t1;
+
+
+# Connect as the user with full privileges
+--connect(con_node_2_test_user_2, 127.0.0.1, testUser2, secret,,$NODE_MYPORT_2) 
+--echo # connection node_2, testUser2 - full privileges
+ALTER TABLE db1.t1 ADD FOREIGN KEY (m) REFERENCES db2.t1 (id);
+
+# Ensure that table was altered locally
+SHOW CREATE TABLE db1.t1;
+
+
+--connection node_1
+--echo # connection node_1, root
+
+# Ensure that table was altered by replication
+SHOW CREATE TABLE db1.t1;
+
+
+# Cleanup
+--disconnect con_node_2_test_user
+--disconnect con_node_2_test_user_2
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP USER testUser;
+DROP USER testUser2;
+

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7123,19 +7123,36 @@ bool check_global_access(THD *thd, ulong want_access)
   @retval
    true	  error or access denied. Error is sent to client in this case.
 */
+#ifdef WITH_WSREP
+bool check_fk_parent_table_access(THD *thd,
+                                  const char *child_table_db,
+                                  HA_CREATE_INFO *create_info,
+                                  Alter_info *alter_info,
+                                  bool check_fk_support)
+#else
 bool check_fk_parent_table_access(THD *thd,
                                   const char *child_table_db,
                                   HA_CREATE_INFO *create_info,
                                   Alter_info *alter_info)
+#endif
 {
   Key *key;
   List_iterator<Key> key_iterator(alter_info->key_list);
-  handlerton *db_type= create_info->db_type ? create_info->db_type :
-                                             ha_default_handlerton(thd);
 
-  // Return if engine does not support Foreign key Constraint.
-  if (!ha_check_storage_engine_flag(db_type, HTON_SUPPORTS_FOREIGN_KEYS))
-    return false;
+#ifdef WITH_WSREP
+  if (check_fk_support)
+  {
+#endif
+    handlerton *db_type= create_info->db_type ? create_info->db_type :
+                                                ha_default_handlerton(thd);
+
+    // Return if engine does not support Foreign key Constraint.
+    if (!ha_check_storage_engine_flag(db_type, HTON_SUPPORTS_FOREIGN_KEYS))
+      return false;
+#ifdef WITH_WSREP
+  }
+
+#endif
 
   while ((key= key_iterator++))
   {

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -56,11 +56,18 @@ bool delete_precheck(THD *thd, TABLE_LIST *tables);
 bool insert_precheck(THD *thd, TABLE_LIST *tables);
 bool create_table_precheck(THD *thd, TABLE_LIST *tables,
                            TABLE_LIST *create_table);
+#ifdef WITH_WSREP
+bool check_fk_parent_table_access(THD *thd,
+                                  const char *child_table_db,
+                                  HA_CREATE_INFO *create_info,
+                                  Alter_info *alter_info,
+                                  bool check_fk_support= true);
+#else
 bool check_fk_parent_table_access(THD *thd,
                                   const char *child_table_db,
                                   HA_CREATE_INFO *create_info,
                                   Alter_info *alter_info);
-
+#endif
 bool parse_sql(THD *thd,
                Parser_state *parser_state,
                Object_creation_ctx *creation_ctx);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-2954

TOI transaction is replicated before local transaction is done. Privileges check for FK was done in the middle of actual table altering, but after TOI transactions was replicated. If local transaction detected insufficient privileges, it was rolled back, but already replicated TOI transaction was executed on replicated node in root user context.

Privileges check for foreign keys access was added before replicating TOI transaction.