### PR TITLE
PXC-2963: Assertion after implicit commit of empty transaction

### DIFF
--- a/mysql-test/suite/galera/r/pxc_implicit_commit.result
+++ b/mysql-test/suite/galera/r/pxc_implicit_commit.result
@@ -1,0 +1,12 @@
+call mtr.add_suppression(".*The storage engine for the table doesn't support ENCRYPTION.*");
+call mtr.add_suppression(".*The storage engine for the table doesn't support ENCRYPTION.*");
+SET @@session.autocommit=0;
+CREATE TABLE t1(id INT, PRIMARY KEY(id));
+INSERT INTO t1 VALUES (1);
+COMMIT;
+INSERT IGNORE INTO t1 VALUES(1);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
+CREATE TABLE t1(A INT) ENCRYPTION="Y" ENGINE=MEMORY;
+ERROR 42000: The storage engine for the table doesn't support ENCRYPTION
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_implicit_commit.test
+++ b/mysql-test/suite/galera/t/pxc_implicit_commit.test
@@ -1,0 +1,25 @@
+#
+# Test the implicit commit of empty transaction (PXC-2963)
+#
+
+--source include/galera_cluster.inc
+--source include/wait_wsrep_ready.inc
+
+
+--connection node_2
+call mtr.add_suppression(".*The storage engine for the table doesn't support ENCRYPTION.*");
+
+--connection node_1
+call mtr.add_suppression(".*The storage engine for the table doesn't support ENCRYPTION.*");
+
+SET @@session.autocommit=0;
+CREATE TABLE t1(id INT, PRIMARY KEY(id));
+INSERT INTO t1 VALUES (1);
+COMMIT;
+INSERT IGNORE INTO t1 VALUES(1);
+--error 1178
+CREATE TABLE t1(A INT) ENCRYPTION="Y" ENGINE=MEMORY; 
+
+# cleanup
+DROP TABLE t1;
+


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-2963

Fixed implicit commit of the transaction without write sets (empty transaction). When such transaction was implicitly commited, wsrep transaction descriptor was not cleaned up. Then, if next DDL transaction, which caused implicit commit was rolled back because of the failure, because of wrong detection of active thread transaction and entering into before_rollback() with unexpected client state (TOI).