### PR TITLE
PXC-2989 : Rolling 5.7 -> 8.0 node upgrade fails during the SST

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -723,7 +723,7 @@ function run_post_processing_steps()
             if compare_versions "$local_version_str" "!=" "$donor_version_str"; then
                 # Check the sys and wsrep schema versions to determine
                 # if mysql_upgrade is needed
-                wsrep_log_info "Opting mysql_upgrade (sst): local version ($local_version_str) != donor version ($donor_version_str)"
+                wsrep_log_info "Opting for mysql_upgrade (sst): local version ($local_version_str) != donor version ($donor_version_str)"
                 run_mysql_upgrade='yes'
             else
                 wsrep_log_info "Skipping mysql_upgrade (sst): local version ($local_version_str) == donor version ($donor_version_str)"
@@ -833,8 +833,8 @@ function run_post_processing_steps()
         wsrep_check_program "${MYSQL_UPGRADE_NAME}"
         if [[ $? -ne 0 ]]; then
             wsrep_log_error "******************* FATAL ERROR ********************** "
-            wsrep_log_error "Could not locate ${MYSQLD_UPGRADE_NAME} (needed for upgrade)"
-            wsrep_log_error "Please ensure that ${MYSQLD_UPGRADE_NAME} is in the path"
+            wsrep_log_error "Could not locate ${MYSQL_UPGRADE_NAME} (needed for upgrade)"
+            wsrep_log_error "Please ensure that ${MYSQL_UPGRADE_NAME} is in the path"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "******************* FATAL ERROR ********************** "
             return 2


### PR DESCRIPTION
Issue
The SST script is running into an error, but the error output
is using an incorrect variable name.

Solution
Correct the script to use the correct variable.
This is a fix to the error-handling code but does not fix the
underlying problem.