### PR TITLE
PXC-2985 enable mysql service and restart on grastate content

### DIFF
--- a/build-ps/debian/extra/mysql-systemd
+++ b/build-ps/debian/extra/mysql-systemd
@@ -260,6 +260,23 @@ check_running()
     fi
 }
 
+check_grastate_dat() {
+  local seqno=-1
+  local uptime=$(awk '{print int($1/60)}' /proc/uptime)
+  if [ $uptime -lt 5 ]; then
+    if [ -f $grastate_loc ]; then
+      seqno=$(grep 'seqno:' $grastate_loc | cut -d: -f2 | tr -d ' ')
+      if [ $seqno -eq -1 ]; then
+        log_warning_msg "Node has been rebooted, $grastate_loc: seqno = $seqno, mysql service has not been started automatically"
+        exit 1
+      fi
+    else
+      log_failure_msg "$grastate_loc is missing after reboot, mysql service has not been started automatically"
+      exit 1
+    fi
+  fi
+}
+
 # Run mysqld with --wsrep-recover and parse recovered position from log.
 # Position will be stored in wsrep_start_position_opt global.
 wsrep_start_position_opt=""
@@ -335,6 +352,7 @@ ret=0
 case $action in
     "galera-recovery") wsrep_recover_position ;;
     "start-pre") check_running; install_db ;;
+    "check-grastate") check_grastate_dat ;;
     "start-post")
       wait_for_pid created  "$pid_path"; ret=$?
       if [[ $ret -eq 1 ]];then

--- a/build-ps/debian/extra/mysql.service
+++ b/build-ps/debian/extra/mysql.service
@@ -60,6 +60,9 @@ EnvironmentFile=-/etc/default/mysql
 # Needed to create system tables etc.
 ExecStartPre=/usr/bin/mysql-systemd start-pre
 
+# Check grastate.dat file existence and seqno value
+ExecStartPre=/usr/bin/mysql-systemd check-grastate
+
 # Perform automatic wsrep recovery. When server is started without wsrep,
 # mysql-systemd galera_recovery simply returns an empty string.
 # It is always safe to unset _WSREP_START_POSITION environment variable.

--- a/build-ps/debian/percona-xtradb-cluster-server.postinst
+++ b/build-ps/debian/percona-xtradb-cluster-server.postinst
@@ -132,6 +132,23 @@ echo -e "\tmysql -e \"CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmur
 echo -e "\n * See http://www.percona.com/doc/percona-server/8.0/management/udf_percona_toolkit.html for more details\n\n"
 #
 
+# Added by dh_systemd_enable/12.6.1ubuntu2
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+        # This will only remove masks created by d-s-h on package removal.
+        deb-systemd-helper unmask 'mysql.service' >/dev/null || true
+
+        # was-enabled defaults to true, so new installations run enable.
+        if deb-systemd-helper --quiet was-enabled 'mysql.service'; then
+                # Enables the unit on first installation, creates new
+                # symlinks on upgrades if the unit file has changed.
+                deb-systemd-helper enable 'mysql.service' >/dev/null || true
+        else
+                # Update the statefile to add new symlinks (if any), which need to be
+                # cleaned up on purge. Also remove old symlinks.
+                deb-systemd-helper update-state 'mysql.service' >/dev/null || true
+        fi
+fi
+
 # Automatically added by dh_installinit/11.1.6ubuntu2
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
         if [ -x "/etc/init.d/mysql" ]; then


### PR DESCRIPTION
- enable mysql.service after packages installation
- do not restart mysql service within 5 minutes after reboot in case grastate.dat is missing or seqno in it is set to -1