### PR TITLE
PXC-2992: Assertion when SQL_LOG_BIN=0 and table is created COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY

### DIFF
--- a/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
+++ b/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
@@ -3,6 +3,9 @@ SET SESSION sql_log_bin = 0;
 CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 CREATE USER 'demo'@'localhost' IDENTIFIED BY 's3kr3t';
+CREATE COMPRESSION_DICTIONARY numbers('');
+CREATE TABLE t3(id INT,a BLOB COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY numbers);
+INSERT INTO t3 VALUES(1, "abc");
 SET SESSION sql_log_bin = 1;
 INSERT INTO t1 VALUES (2);
 SELECT @@global.gtid_executed;
@@ -10,6 +13,10 @@ SELECT @@global.gtid_executed;
 
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
 call mtr.add_suppression("Ignoring error 'Unknown table 'test.t2'' on query");
+CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t3'' on query");
+call mtr.add_suppression("Ignoring error 'Unknown table 'test.t3'' on query");
+CALL mtr.add_suppression("Slave SQL: Error 'Compression dictionary 'numbers' does not exist'");
+call mtr.add_suppression("Ignoring error 'Compression dictionary 'numbers' does not exist'");
 call mtr.add_suppression("Query apply failed.*");
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
@@ -24,6 +31,8 @@ DROP USER 'demo'@'localhost';
 ERROR HY000: Operation DROP USER failed for 'demo'@'localhost'
 DROP TABLE t1;
 DROP TABLE t2;
+DROP TABLE t3;
+DROP COMPRESSION_DICTIONARY numbers;
 use test;
 create table t (i int, primary key pk(i)) engine=innodb;
 insert into t values (1);

--- a/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
+++ b/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
@@ -15,6 +15,11 @@ INSERT INTO t1 VALUES (1);
 
 CREATE USER 'demo'@'localhost' IDENTIFIED BY 's3kr3t';
 
+# PXC-2992
+CREATE COMPRESSION_DICTIONARY numbers('');
+CREATE TABLE t3(id INT,a BLOB COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY numbers);
+INSERT INTO t3 VALUES(1, "abc");
+
 SET SESSION sql_log_bin = 1;
 
 INSERT INTO t1 VALUES (2);
@@ -24,7 +29,12 @@ SELECT @@global.gtid_executed;
 --connection node_2
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
 call mtr.add_suppression("Ignoring error 'Unknown table 'test.t2'' on query");
+CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t3'' on query");
+call mtr.add_suppression("Ignoring error 'Unknown table 'test.t3'' on query");
+CALL mtr.add_suppression("Slave SQL: Error 'Compression dictionary 'numbers' does not exist'");
+call mtr.add_suppression("Ignoring error 'Compression dictionary 'numbers' does not exist'");
 call mtr.add_suppression("Query apply failed.*");
+
 SELECT COUNT(*) = 1 FROM t1;
 SELECT COUNT(*) = 0 FROM t1 WHERE f1 = 1;
 SHOW TABLES;
@@ -34,6 +44,8 @@ DROP USER 'demo'@'localhost';
 --connection node_1
 DROP TABLE t1;
 DROP TABLE t2;
+DROP TABLE t3;
+DROP COMPRESSION_DICTIONARY numbers;
 
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-2992

When binlog is disabled, replication is disabled as well, but action is not blocked locally. When table with compressed column that uses compression dictionary was created, replication of creation was skipped, but then, when local table was created. That caused insertion of foreign key from compression_dictionary table into compression_dictionary_cols (2 tables from compression dictionary). There was missing check if statement should be replicated in wsrep_append_foreign_key() which caused attempt to replicate insertion of foreign key and assertion because no active wsrep transaction was detected (which is OK).

The fix is to detect that binlog is disabled and skip replication of foreign key insertion.

Additionally common conditions for transaction replication have been extracted to wsrep_do_replication() function and condition for db_type == DB_TYPE_PARTITION_DB has been removed as DB_TYPE_PARTITION_DB is obsolete, not used type.