### PR TITLE
PXC-3018: SST fails with valgrind

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -668,6 +668,16 @@ function run_post_processing_steps()
         # We don't have readlink, so look for mysqld in the path
         mysqld_path=$(which ${MYSQLD_NAME})
     fi
+    if [[ $mysqld_path == *"memcheck"* ]]; then
+      wsrep_log_debug "Detected valgrind, adjusting mysqld path accordingly"
+      while read -r line
+      do
+        if [[ ${line::1} != "-" ]]; then
+          mysqld_path=$line
+          wsrep_log_debug "Adjusted mysqld to $line"
+        fi
+      done < <(cat /proc/${WSREP_SST_OPT_PARENT}/cmdline | strings -1)
+    fi
     if [[ -z $mysqld_path ]]; then
         wsrep_log_error "******************* FATAL ERROR ********************** "
         wsrep_log_error "Could not locate ${MYSQLD_NAME} (needed for post-processing)"


### PR DESCRIPTION
Issue: the wsrep_sst_common script assumes that the executable of the
parent process is the mysqld executable. This is incorrect when run with
valgrind, in which case it is the memcheck executable.

Solution: if the parent executable is memcheck, locate the mysqld
executabel in its command line. It is the only argument not starting
with a -.