### PR TITLE
PXC-3007: Build fails with -DWSREP=OFF

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2082,7 +2082,9 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
       check_secondary_engine_statement(thd, &parser_state, orig_query.str,
                                        orig_query.length);
 
+#ifdef WITH_WSREP
       thd->set_secondary_engine_optimization(saved_secondary_engine);
+#endif /* WITH_WSREP */
 
       DBUG_EXECUTE_IF("parser_stmt_to_error_log", {
         LogErr(INFORMATION_LEVEL, ER_PARSER_TRACE, thd->query().str);
@@ -2187,7 +2189,9 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
         check_secondary_engine_statement(thd, &parser_state,
                                          beginning_of_next_stmt, length);
 
+#ifdef WITH_WSREP
         thd->set_secondary_engine_optimization(saved_secondary_engine);
+#endif /* WITH_WSREP */
       }
 
       /* Need to set error to true for graceful shutdown */

--- a/sql/sql_tablespace.cc
+++ b/sql/sql_tablespace.cc
@@ -1329,7 +1329,9 @@ bool Sql_cmd_alter_tablespace_rename::execute(THD *thd) {
 
   // Lock both tablespace names in one go
   if (lock_tablespace_names(thd, m_tablespace_name, m_new_name)) {
+#ifdef WITH_WSREP
     mysql_mutex_unlock(&LOCK_wsrep_alter_tablespace);
+#endif /* WITH_WSREP */
     return true;
   }
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1654,7 +1654,7 @@ static Sys_var_bool Sys_binlog_order_commits(
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(binlog_order_commits_check),
     ON_UPDATE(0));
 #else
-    GLOBAL_VAR(opt_binlog_order_commits), CMD_LINE(OPT_ARG), DEFAULT(TRUE));
+    GLOBAL_VAR(opt_binlog_order_commits), CMD_LINE(OPT_ARG), DEFAULT(true));
 #endif /* WITH_WSREP */
 
 static Sys_var_ulong Sys_bulk_insert_buff_size(

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2717,10 +2717,12 @@ static void lock_grant_or_update_wait_for_edge(lock_t *lock) {
     /* Grant the lock */
     lock_grant(lock);
   } else {
+#ifdef WITH_WSREP
     WSREP_DEBUG(
         "Failed to grant lock with trx (%lu) due to blocking lock held by trx "
         "(%lu)",
         lock->trx->id, blocking_lock->trx->id);
+#endif /* WITH_WSREP */
     ut_ad(lock->trx != blocking_lock->trx);
     lock_update_wait_for_edge(lock, blocking_lock);
   }

--- a/storage/perfschema/table_pxc_cluster_view.cc
+++ b/storage/perfschema/table_pxc_cluster_view.cc
@@ -18,13 +18,15 @@
   Table PXC_VIEW (implementation).
 */
 
+#ifdef WITH_WSREP
+
 #include "storage/perfschema/table_pxc_cluster_view.h"
 #include "storage/perfschema/pfs_instr.h"
 #include "storage/perfschema/pfs_instr_class.h"
 
-#include "sql/table.h"
 #include "sql/field.h"
 #include "sql/plugin_table.h"
+#include "sql/table.h"
 
 #include "sql/wsrep_mysqld.h"
 #include "sql/wsrep_server_state.h"
@@ -161,3 +163,4 @@ int table_pxc_cluster_view ::read_row_values(TABLE *table, unsigned char *buf,
   return 0;
 }
 
+#endif /* WITH_WSREP */


### PR DESCRIPTION
Issue: some ifdefs were missing, which resulted in wsrep code added to
the normal builds. Some code in the without_wsrep part also failed to
compile.