### PR TITLE
PXC-2997 : Remove wsrep_state.dat and supporting code from SST process

### DIFF
--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -1157,8 +1157,19 @@ PREPARE stmt FROM @cmd;
 EXECUTE stmt;
 DROP PREPARE stmt;
 
+#! PXC_SECTION::START
 #
-# SQL commands to create the PXC internal session user and role that is used by the SST process
+# All the commands between PXC_SECTION::START and PXC_SECTION::END will be
+# run whenever PXC starts up.  This is to ensure that the PXC internal session
+# user always exists (this user is also created on upgrade, but in certain
+# upgrade scenarios, such as upgrading from a PS 8.0 node, it will not
+# run the upgrade code).
+#
+# Note: The PXC_SECTION markers must come after an SQL statement.  Due to the
+# way the code is generated, do not place any comments before the markers.
+#
+# SQL commands to create the PXC internal session user and role that is used
+# by the SST process
 #
 # mysql.pxc.internal.session
 #   See the comments in mysql_system_tables.sql
@@ -1214,8 +1225,10 @@ INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mys
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'performance_schema', 'mysql.pxc.sst.role','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N');
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N');
 
+#! PXC_SECTION::END
 # flush privileges at this stage can cause problem with upgrade from 57 -> 80
 # FLUSH PRIVILEGES;
+#--------------------------------
 
 # Move all system tables with InnoDB storage engine to mysql tablespace.
 SET @cmd="ALTER TABLE mysql.db TABLESPACE = mysql";

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -35,7 +35,6 @@ WSREP_LOG_DEBUG=""
 # The NAMEs don't change, however the PATHs may be different (due to packaging)
 readonly MYSQLD_NAME=mysqld
 readonly MYSQLADMIN_NAME=mysqladmin
-readonly MYSQL_UPGRADE_NAME=mysql_upgrade
 readonly MYSQL_CLIENT_NAME=mysql
 
 declare MYSQL_UPGRADE_TMPDIR=""
@@ -526,7 +525,6 @@ EOF
 # Globals
 #   MYSQLD_NAME
 #   MYSQLADMIN_NAME
-#   MYSQL_UPGRADE_NAME
 #   MYSQL_CLIENT_NAME
 #   WSREP_SST_OPT_PARENT
 #   WSREP_SST_OPT_CONF
@@ -690,17 +688,6 @@ function run_post_processing_steps()
     wsrep_log_debug "--$("$mysqld_path" --version | cut -d' ' -f2-)"
 
     # Verify any other needed programs
-    if [[ $run_mysql_upgrade != 'no' ]]; then
-        wsrep_check_program "${MYSQL_UPGRADE_NAME}"
-        if [[ $? -ne 0 ]]; then
-            wsrep_log_error "******************* FATAL ERROR ********************** "
-            wsrep_log_error "Could not locate ${MYSQL_UPGRADE_NAME} (needed for upgrade)"
-            wsrep_log_error "Please ensure that ${MYSQL_UPGRADE_NAME} is in the path"
-            wsrep_log_error "Line $LINENO"
-            wsrep_log_error "******************* FATAL ERROR ********************** "
-            return 2
-        fi
-    fi
     wsrep_check_program "${MYSQLADMIN_NAME}"
     if [[ $? -ne 0 ]]; then
         wsrep_log_error "******************* FATAL ERROR ********************** "

--- a/sql/dd/upgrade/server.h
+++ b/sql/dd/upgrade/server.h
@@ -72,6 +72,11 @@ namespace upgrade {
 bool upgrade_system_schemas(THD *thd);
 
 bool no_server_upgrade_required();
+
+#ifdef WITH_WSREP
+bool upgrade_pxc_only(THD *thd);
+#endif  /* WITH_WSREP */
+
 }  // namespace upgrade
 
 }  // namespace dd

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6503,6 +6503,23 @@ static int init_server_components() {
   }
 #endif
 
+#ifdef WITH_WSREP
+  // PXC-2997: run the PXC portion of the upgrade SQL
+  // This ensures that the mysql.pxc.internal.session user will
+  // always exist.
+  if (!is_help_or_validate_option() && !opt_initialize &&
+      dd::upgrade::no_server_upgrade_required()) {
+    init_optimizer_cost_module(true);
+    if (bootstrap::run_bootstrap_thread(nullptr, nullptr,
+                                        &dd::upgrade::upgrade_pxc_only,
+                                        SYSTEM_THREAD_SERVER_UPGRADE)) {
+        LogErr(ERROR_LEVEL, ER_SERVER_UPGRADE_FAILED);
+        unireg_abort(1);
+    }
+    delete_optimizer_cost_module();
+  }
+#endif  /* WITH_WSREP */
+
   if (!is_help_or_validate_option() && !opt_initialize &&
       !dd::upgrade::no_server_upgrade_required()) {
     if (opt_upgrade_mode == UPGRADE_MINIMAL)

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -275,6 +275,7 @@ extern wsrep_seqno_t wsrep_locked_seqno;
   if (wsrep_debug) WSREP_LOG(INFORMATION_LEVEL, fmt, ##__VA_ARGS__)
 #define WSREP_INFO(fmt, ...) WSREP_LOG(INFORMATION_LEVEL, fmt, ##__VA_ARGS__)
 #define WSREP_WARN(fmt, ...) WSREP_LOG(WARNING_LEVEL, fmt, ##__VA_ARGS__)
+#define WSREP_SYSTEM(fmt, ...) WSREP_LOG(SYSTEM_LEVEL, fmt, ##__VA_ARGS__)
 
 #define WSREP_ERROR(fmt, ...)                                         \
   do {                                                                \

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -609,7 +609,7 @@ static void *sst_joiner_thread(void *a) {
     thd->variables.transaction_isolation = ISO_READ_COMMITTED;
 
     wsrep_sst_complete(thd, -err);
-
+    WSREP_SYSTEM("SST completed");
     delete thd;
     my_thread_end();
   }


### PR DESCRIPTION
Issue
The upgrade from PS (with the same PXC version) was not creating
the mysql.pxc.internal.session user (this is because the upgrade
process is not run since it's the same internal version)

Solution
Have the PXC upgrade code always run on startup if an upgrade is
not required.  This will ensure that the internal session user
is always created.