### PR TITLE
PXC-3030: Sql_string::c_str can't be used on empty strings

### DIFF
--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -441,7 +441,7 @@ static int scan(TABLE *table, uint field, INTTYPE &val) {
 static int scan(TABLE *table, uint field, char *strbuf, uint strbuf_len) {
   String str;
   (void)table->field[field]->val_str(&str);
-  strncpy(strbuf, str.c_ptr(), std::min(str.length(), (size_t)strbuf_len));
+  strncpy(strbuf, str.ptr(), std::min(str.length(), (size_t)strbuf_len));
   strbuf[strbuf_len - 1] = '\0';
   return 0;
 }


### PR DESCRIPTION
Issue: condition depends on uninitialized memory, reported by valgrind.

Fix: use .ptr() instead, as described in the comment for .c_str()