### PR TITLE
PXC-3016: 8.0 set persist binlog_format='STATEMENT' should not succeed

### DIFF
--- a/mysql-test/suite/galera/r/galera_sbr.result
+++ b/mysql-test/suite/galera/r/galera_sbr.result
@@ -1,3 +1,7 @@
+SET PERSIST binlog_format = 'STATEMENT';
+ERROR 42000: Variable 'binlog_format' can't be set to the value of 'STATEMENT'
+SET PERSIST binlog_format = 'MIXED';
+ERROR 42000: Variable 'binlog_format' can't be set to the value of 'MIXED'
 SET GLOBAL binlog_format = 'STATEMENT';
 ERROR 42000: Variable 'binlog_format' can't be set to the value of 'STATEMENT'
 SET SESSION binlog_format = 'STATEMENT';
@@ -12,4 +16,6 @@ COUNT(*) = 2
 1
 DROP TABLE t1;
 SET GLOBAL binlog_format = 'ROW';
+SET PERSIST binlog_format = 'ROW';
+RESET PERSIST binlog_format;
 call mtr.add_suppression("Percona-XtraDB-Cluster prohibits setting binlog_format to STATEMENT or MIXED");

--- a/mysql-test/suite/galera/t/galera_sbr.test
+++ b/mysql-test/suite/galera/t/galera_sbr.test
@@ -9,6 +9,11 @@
 --connection node_1
 # Not allowed in PXC
 --error ER_WRONG_VALUE_FOR_VAR
+SET PERSIST binlog_format = 'STATEMENT';
+--error ER_WRONG_VALUE_FOR_VAR
+SET PERSIST binlog_format = 'MIXED';
+
+--error ER_WRONG_VALUE_FOR_VAR
 SET GLOBAL binlog_format = 'STATEMENT';
 --disable_warnings
 --error ER_WRONG_VALUE_FOR_VAR
@@ -32,5 +37,7 @@ DROP TABLE t1;
 
 --connection node_1
 SET GLOBAL binlog_format = 'ROW';
+SET PERSIST binlog_format = 'ROW';
 
+RESET PERSIST binlog_format;
 call mtr.add_suppression("Percona-XtraDB-Cluster prohibits setting binlog_format to STATEMENT or MIXED");

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1228,7 +1228,8 @@ static bool binlog_format_check(sys_var *self, THD *thd, set_var *var) {
        var->save_result.ulonglong_value == BINLOG_FORMAT_MIXED);
 
   if (WSREP(thd) && stmt_or_mixed &&
-      (var->type == OPT_GLOBAL || var->type == OPT_SESSION)) {
+      (var->type == OPT_GLOBAL || var->type == OPT_SESSION ||
+       var->type == OPT_PERSIST)) {
     /* Setting binlog format to MIXED/STATEMENT is not allowed. */
     WSREP_ERROR(
         "Percona-XtraDB-Cluster prohibits setting"


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3016

Added validation of binlog_format value in case of SET PERSIST statement.

Note: MySQL does not validate parameters values in case of SET PERSIST_ONLY. This is by design. Unfortunately it may lead to server unable to start if the value is set to incorrect one. This is known issue and is system-wide. It is not fixed as the scope of this commit.

Another solution would be disallowing persisting of binlog_format at all (ROW is default for 8.0, PXC allows only ROW), but then the behavior would be inconsistent with upstream, which allows persisting of this value.

Having this fix, the behavior is consistent with upstream (parameter value is validated for session, global, persist and is not validated for persist_only + persisting of values is allowed)