### PR TITLE
PXC-3017 : Remove these SST encryption methods. encrypt=1, encrypt=2,…

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2-options.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2-options.cnf
@@ -11,16 +11,10 @@ close-files
 # compression requires qpress from the Percona repositories
 # compress
 # compress-threads=2
-#encryption=AES256
-#encrypt-key=4FA92C5873672E20FB163A0BCB2BB4A4
 galera-info
 history=backup
 parallel=1
 
 [SST]
-encrypt=1
-encrypt-algo=AES256
-encrypt-key=4FA92C5873672E20FB163A0BCB2BB4A4
-
 # PXC-2602 : test the options processing
 xbstream-opts="--parallel=1"

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_binlog.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_binlog.cnf
@@ -2,6 +2,7 @@
 
 [mysqld]
 wsrep_sst_method=xtrabackup-v2
+wsrep-debug=1
 gtid-mode=ON
 enforce-gtid-consistency=1
 log-slave-updates

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_encrypt_with_key.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_encrypt_with_key.cnf
@@ -5,7 +5,9 @@ wsrep_sst_method=xtrabackup-v2
 wsrep_debug=1
 
 [SST]
-tkey=@ENV.MYSQL_TEST_DIR/std_data/galera-key.pem
-tcert=@ENV.MYSQL_TEST_DIR/std_data/galera-cert.pem
-encrypt=3
+ssl_key=@ENV.MYSQL_TEST_DIR/std_data/server-key.pem
+ssl_cert=@ENV.MYSQL_TEST_DIR/std_data/server-cert.pem
+ssl_ca=@ENV.MYSQL_TEST_DIR/std_data/cacert.pem
+
+encrypt=4
 ssl-dhparams=@ENV.MYSQL_TEST_DIR/std_data/dhparams.pem

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.cnf
@@ -5,9 +5,10 @@ wsrep_sst_method=xtrabackup-v2
 wsrep_debug=1
 
 [sst]
-encrypt=3
-tkey=@ENV.MYSQL_TEST_DIR/std_data/server-key.pem
-tcert=@ENV.MYSQL_TEST_DIR/std_data/server-cert.pem
+encrypt=4
+ssl-key=@ENV.MYSQL_TEST_DIR/std_data/server-key.pem
+ssl-cert=@ENV.MYSQL_TEST_DIR/std_data/server-cert.pem
+ssl-ca=@ENV.MYSQL_TEST_DIR/std_data/cacert.pem
 ssl-dhparams=@ENV.MYSQL_TEST_DIR/std_data/dhparams.pem
 
 [mysqld.1]


### PR DESCRIPTION
… and encrypt=3

Issue
encrypt=1,2,3 has been deprecated.  So this now removes support for these options.

Solution
Remove the code for these options from the SST scripts.  Also, the SST will
fail with a fatal error if these options are still set.