### PR TITLE
PXC-3050: Assertion when creating temporary table

### DIFF
--- a/mysql-test/suite/galera/r/galera_create_table_as_select.result
+++ b/mysql-test/suite/galera/r/galera_create_table_as_select.result
@@ -84,3 +84,12 @@ SELECT * FROM t1;
 ERROR 42S02: Table 'test.t1' doesn't exist
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query");
 DROP TABLE t1, t2;
+SET big_tables=ON;
+CREATE TABLE t1 (id INT, a INT, b INT, PRIMARY KEY pkid(id));
+INSERT INTO t1 VALUES (1, 2, 1);
+INSERT INTO t1 VALUES (2, 2, 1);
+CREATE TEMPORARY TABLE t2 AS SELECT a, count(*) c FROM t1 GROUP BY a;
+SHOW TABLES;
+Tables_in_test
+t1
+DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/galera_create_table_as_select.test
+++ b/mysql-test/suite/galera/t/galera_create_table_as_select.test
@@ -161,3 +161,24 @@ CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query");
 
 --connection node_1
 DROP TABLE t1, t2;
+
+#
+# This scenario creates intermediate temporary table to be created
+# as the result of SELECT ... FROM .. GROUP BY
+# SET big_tables=ON causes all temporary tables to be created as InnoDB tables.
+# As we are creating temporary table we are not in TOI mode. However we expect that
+# creation of immediate InnoDB temporary table is still handled correctly 
+# (not attempted to be replicated).
+#  
+
+SET big_tables=ON;
+CREATE TABLE t1 (id INT, a INT, b INT, PRIMARY KEY pkid(id));
+INSERT INTO t1 VALUES (1, 2, 1);
+INSERT INTO t1 VALUES (2, 2, 1);
+CREATE TEMPORARY TABLE t2 AS SELECT a, count(*) c FROM t1 GROUP BY a;
+
+--connection node_2
+SHOW TABLES;
+
+--connection node_1
+DROP TABLE t1, t2;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12509,8 +12509,7 @@ int ha_innobase::wsrep_append_keys(
           table_share->table_name.str, wsrep_thd_query(thd));
 #endif /* WSREP_DEBUG_PRINT */
 
-  if (table_share && table_share->tmp_table != NO_TMP_TABLE &&
-      thd_sql_command(thd) != SQLCOM_CREATE_TABLE) {
+  if (table_share && table_share->tmp_table != NO_TMP_TABLE) {
     WSREP_DEBUG(
         "Skip appending keys to write-set for"
         " temporary-tables DML (THD: %u tmp: %d SQL: %s)",


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3050

Fixed wrong condition which prevented processing of writesets in case of dealing with temporary tables.

The problem was visible in the case when intermediate temporary InnoDB table was created when CREATE TEMPORARY TABLE was executed. That caused client_service to be in local mode, which allowed appending keys related to insertions to the intermediate temporary table.