### PR TITLE
PXC-3051: ACL cache transaction conflict causes assertion

### DIFF
--- a/mysql-test/suite/galera/r/galera_events3.result
+++ b/mysql-test/suite/galera/r/galera_events3.result
@@ -1,0 +1,13 @@
+call mtr.add_suppression("Operation DROP USER failed");
+call mtr.add_suppression("Operation DROP USER failed");
+CREATE TABLE t1(a INT AUTO_INCREMENT, b INT, PRIMARY KEY pka(a));
+SET DEBUG_SYNC = 'now WAIT_FOR has_global_grant.got_lock'; ;
+SET @@global.debug = '+d,has_global_grant_hold_lock';
+CREATE EVENT ev2 ON SCHEDULE EVERY 60 SECOND DO INSERT INTO t1(b) VALUES (1);
+SET @@global.debug = '-d,has_global_grant_hold_lock';
+DROP USER 'testuser'@'%';
+ERROR HY000: Operation DROP USER failed for 'testuser'@'%'
+SET DEBUG_SYNC = 'now signal has_global_grant.release_lock';
+SET DEBUG_SYNC = 'RESET';
+DROP EVENT ev2;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_events3.test
+++ b/mysql-test/suite/galera/t/galera_events3.test
@@ -1,0 +1,41 @@
+#
+# Test ACL cache access conflict between event and user thread
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--connection node_2
+call mtr.add_suppression("Operation DROP USER failed");
+
+--connection node_1
+call mtr.add_suppression("Operation DROP USER failed");
+CREATE TABLE t1(a INT AUTO_INCREMENT, b INT, PRIMARY KEY pka(a));
+--send SET DEBUG_SYNC = 'now WAIT_FOR has_global_grant.got_lock'; 
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+
+SET @@global.debug = '+d,has_global_grant_hold_lock';
+CREATE EVENT ev2 ON SCHEDULE EVERY 60 SECOND DO INSERT INTO t1(b) VALUES (1);
+
+# wait for event to get the lock
+--connection node_1
+--reap
+SET @@global.debug = '-d,has_global_grant_hold_lock';
+
+# at this point event execution thread owns the lock and waits on debug_sync point
+
+--error ER_CANNOT_USER
+DROP USER 'testuser'@'%';
+
+# allow event execution to continue
+SET DEBUG_SYNC = 'now signal has_global_grant.release_lock';
+
+# cleanup
+SET DEBUG_SYNC = 'RESET';
+DROP EVENT ev2;
+DROP TABLE t1;
+--disconnect node_1a
+--source include/wait_until_count_sessions.inc

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -141,10 +141,8 @@ extern "C" bool wsrep_thd_bf_abort(const THD *bf_thd, THD *victim_thd,
                                    bool signal) {
   /* Note: do not store/reset globals before wsrep_bf_abort() call
      to avoid losing BF thd context. */
-  if (WSREP(victim_thd) && !victim_thd->wsrep_trx().active()) {
-    WSREP_DEBUG("BF abort for non active transaction");
-    wsrep_start_transaction(victim_thd, victim_thd->wsrep_next_trx_id());
-  }
+
+  /* Transaction will be started inside wsrep_bf_abort if not started yet */
   bool ret = wsrep_bf_abort(bf_thd, victim_thd);
 
 #if 0


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3051

Fixed the problem of brute force aborting event transaction at the stage of accessing ACL cache (MDL conflict). There were several problems:
1. In such case event transaction (victim thread) is not started yet, so BF thread attempted to start it twice, but providing -1 as transaction ID. -1 is special identifier for uninitialized transaction. Such start causes transaction to be in inconsistent state (-1 as id, but flagged as flag::start_transaction). Such start was done twice (in wsrep_thd_bf_abort() and wsrep_bf_abort()). The 2nd call detected inconsistent state and raised assert. Unnecessary call to wsrep_start_transaction() was removed.
2. After fixing above problem, transaction was still in inconsistent state, and was aborted. It caused another assert at the later stage when actual event execution was done. There was attempt to start transaction again (as its id was still -1), but still in inconsistent state with flags equal flag::start_transaction. As the transaction was BF aborted, it should not execute. => Added initialization of wsrep_next_trx_id, which allowed detection of transaction BF abortion after ACL cache access. Additionally improved handling transaction result at the end of event thread execution.