### PR TITLE
PXC-3081: Fix gtid_executed

### DIFF
--- a/sql/rpl_gtid_state.cc
+++ b/sql/rpl_gtid_state.cc
@@ -485,7 +485,7 @@ enum_return_status Gtid_state::generate_automatic_gtid(
 
     if (WSREP(thd) && !seqno_undefined && !thd->wsrep_skip_wsrep_GTID)
       automatic_gtid.sidno = wsrep_sidno;
-    else
+    else if (automatic_gtid.sidno == 0)
       automatic_gtid.sidno = get_server_sidno();
 #else
     if (automatic_gtid.sidno == 0) automatic_gtid.sidno = get_server_sidno();


### PR DESCRIPTION
Issue: rpl_gtid.rpl_transaction_ctx_service was failing because the
provided automatic gtid wasn't in the executed gtid list.

Root cause: a condition in rpl_gtid_state wasn't duplicated in a WITH_WSREP
block.

Fix: duplicated the condition