### PR TITLE
PXC-3023: DELETE of already deleted records range crashes PXC server

### DIFF
--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -4410,7 +4410,6 @@ static row_to_range_relation_t row_compare_row_to_range(
           row_to_range_relation.row_can_be_in_range = false;
           if (prebuilt->m_stop_tuple_found) {
             ut_ad(stop_len == index_len);
-            ut_ad(direction != 0);
             row_to_range_relation.gap_can_intersect_range = false;
             return (row_to_range_relation);
           }


### PR DESCRIPTION
Removed unnecessary assert preventing row iterator initialization in case when all records in range were deleted, and upper bound of range record was present but also marked as deleted.

This is redo of commit 1aa553074cec9c269bca7f50e1d8656f9ccd0201 from upstream.

No MTR test. Will be added together with next server part merge.