### PR TITLE
PXC-3075 : centos8 fails testcase galera_sst_xtrabackup-v2_keyring

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.cnf
@@ -6,8 +6,8 @@ wsrep_debug=1
 
 [sst]
 encrypt=3
-tkey=@ENV.MYSQL_TEST_DIR/std_data/galera-key.pem
-tcert=@ENV.MYSQL_TEST_DIR/std_data/galera-cert.pem
+tkey=@ENV.MYSQL_TEST_DIR/std_data/server-key.pem
+tcert=@ENV.MYSQL_TEST_DIR/std_data/server-cert.pem
 ssl-dhparams=@ENV.MYSQL_TEST_DIR/std_data/dhparams.pem
 
 [mysqld.1]


### PR DESCRIPTION
Issue
The galera-cert.pem and galera-key.pem are causing errors when used
by socat(v1.7.3.2) on Centos8.  The same version of socat on ubuntu
works with no errors.

Solution
Have the test case use the server-cert.pem and server-key.pem intead
of the galera ones.