### PR TITLE
PXC-3094: SIGSEGV on startup with --daemonize

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2380,8 +2380,9 @@ static void unireg_abort(int exit_code) {
   if (!daemon_launcher_quiet && exit_code) LogErr(ERROR_LEVEL, ER_ABORTING);
 
 #ifdef WITH_WSREP
-  if (WSREP_ON && Wsrep_server_state::instance().state() !=
-                      wsrep::server_state::s_disconnected) {
+  if (WSREP_ON && Wsrep_server_state::initialized() &&
+      Wsrep_server_state::instance().state() !=
+          wsrep::server_state::s_disconnected) {
     WSREP_DEBUG("Initiating abort (unireg_abort)");
 
     wsrep_unireg_abort = true;
@@ -6513,12 +6514,12 @@ static int init_server_components() {
     if (bootstrap::run_bootstrap_thread(nullptr, nullptr,
                                         &dd::upgrade::upgrade_pxc_only,
                                         SYSTEM_THREAD_SERVER_UPGRADE)) {
-        LogErr(ERROR_LEVEL, ER_SERVER_UPGRADE_FAILED);
-        unireg_abort(1);
+      LogErr(ERROR_LEVEL, ER_SERVER_UPGRADE_FAILED);
+      unireg_abort(1);
     }
     delete_optimizer_cost_module();
   }
-#endif  /* WITH_WSREP */
+#endif /* WITH_WSREP */
 
   if (!is_help_or_validate_option() && !opt_initialize &&
       !dd::upgrade::no_server_upgrade_required()) {

--- a/sql/wsrep_server_state.h
+++ b/sql/wsrep_server_state.h
@@ -36,6 +36,8 @@ class Wsrep_server_state : public wsrep::server_state {
   static void destroy();
   static Wsrep_server_state &instance() { return *m_instance; }
 
+  static bool initialized() noexcept { return m_instance != nullptr; }
+
   static wsrep::provider &get_provider() { return instance().provider(); }
 
   static bool has_capability(int capability) {


### PR DESCRIPTION
Issue: daemonize calls unireg_abort, which also includes some WSREP
specific checks in PXC. Daemonize also does this quite early during
startup, when WSREP isn't initialized yet.

Fix: only do WSREP specefic checks in unireg_abort if Wsrep_server_state
is already initialized.