### PR TITLE
PXC-3087, PXC-3088, PXC-3079: Relax strict mode admin checks

### DIFF
--- a/mysql-test/suite/galera/r/galera_flush_local.result
+++ b/mysql-test/suite/galera/r/galera_flush_local.result
@@ -1,5 +1,9 @@
 OPTIMIZE  /*+ SET_VAR(sort_buffer_size = 0) SET_VAR(myisam_repair_threads=0) */ TABLE t0;
-ERROR 42S02: Table 'test.t0' doesn't exist
+Table	Op	Msg_type	Msg_text
+test.t0	optimize	Warning	Truncated incorrect sort_buffer_size value: '0'
+test.t0	optimize	Warning	Truncated incorrect myisam_repair_threads value: '0'
+test.t0	optimize	Error	Table 'test.t0' doesn't exist
+test.t0	optimize	status	Operation failed
 DROP TABLE IF EXISTS t1, t2, x1, x2;
 CREATE TABLE t1 (f1 INTEGER);
 CREATE TABLE t2 (f1 INT PRIMARY KEY AUTO_INCREMENT, f2 INTEGER);

--- a/mysql-test/suite/galera/r/pxc_non_existent_tables.result
+++ b/mysql-test/suite/galera/r/pxc_non_existent_tables.result
@@ -1,0 +1,30 @@
+ANALYZE TABLE nonexestint1;
+Table	Op	Msg_type	Msg_text
+test.nonexestint1	analyze	Error	Table 'test.nonexestint1' doesn't exist
+test.nonexestint1	analyze	status	Operation failed
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE VIEW v AS SELECT * FROM t1;
+ANALYZE TABLE nonexestint2;
+Table	Op	Msg_type	Msg_text
+test.nonexestint2	analyze	Error	Table 'test.nonexestint2' doesn't exist
+test.nonexestint2	analyze	status	Operation failed
+OPTIMIZE TABLE nonexstent1;
+Table	Op	Msg_type	Msg_text
+test.nonexstent1	optimize	Error	Table 'test.nonexstent1' doesn't exist
+test.nonexstent1	optimize	status	Operation failed
+INSERT INTO t1 VALUES (1);
+ANALYZE TABLE t1, nonexistent3;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+test.nonexistent3	analyze	Error	Table 'test.nonexistent3' doesn't exist
+test.nonexistent3	analyze	status	Operation failed
+ANALYZE TABLE v;
+Table	Op	Msg_type	Msg_text
+test.v	analyze	Error	'test.v' is not BASE TABLE
+test.v	analyze	status	Operation failed
+CHECK TABLE t1, v;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+test.v	check	status	OK
+DROP VIEW v;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_flush_local.test
+++ b/mysql-test/suite/galera/t/galera_flush_local.test
@@ -7,7 +7,6 @@
 #
 # PXC-267
 #
---error ER_NO_SUCH_TABLE
 OPTIMIZE  /*+ SET_VAR(sort_buffer_size = 0) SET_VAR(myisam_repair_threads=0) */ TABLE t0;
 
 --disable_warnings

--- a/mysql-test/suite/galera/t/pxc_non_existent_tables.cnf
+++ b/mysql-test/suite/galera/t/pxc_non_existent_tables.cnf
@@ -1,0 +1,2 @@
+!include ../galera_2nodes.cnf
+

--- a/mysql-test/suite/galera/t/pxc_non_existent_tables.test
+++ b/mysql-test/suite/galera/t/pxc_non_existent_tables.test
@@ -1,0 +1,17 @@
+--source include/have_binlog_format_row.inc
+--source include/galera_cluster.inc
+
+ANALYZE TABLE nonexestint1;
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE VIEW v AS SELECT * FROM t1;
+ANALYZE TABLE nonexestint2;
+OPTIMIZE TABLE nonexstent1;
+
+INSERT INTO t1 VALUES (1);
+ANALYZE TABLE t1, nonexistent3;
+ANALYZE TABLE v;
+CHECK TABLE t1, v;
+
+
+DROP VIEW v;
+DROP TABLE t1;

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1514,9 +1514,8 @@ static bool pxc_strict_mode_admin_check(THD *thd, TABLE_LIST *tables) {
 
       if (table_ref == nullptr ||
           table_ref->hidden() == dd::Abstract_table::HT_HIDDEN_SE) {
-        my_error(ER_NO_SUCH_TABLE, MYF(0), schema_name, table_name);
         thd->mdl_context.release_lock(mdl_request.ticket);
-        return true;
+        continue;
       }
 
       handlerton *hton = nullptr;


### PR DESCRIPTION
Issue: strict mode admin checks reported an error for non existend
tables, even when pxc_strict_mode wasn't enabled. As MySQL normally
allows non existed tables in admin commands, this resulted in many test
failures in various test suites, and also changed how ANALYZE TABLE,
OPTIMIZE TABLE and similar commands handle errors.

Fix: ignore non existent tables in the strict mode checks.