### PR TITLE
PXC-3040: Assertion when ALTER TABLE(SPACE) executed concurrently with another query

### DIFF
--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -401,41 +401,43 @@ bool Sql_cmd_alter_table::execute(THD *thd) {
 
     TABLE_LIST* table = first_table;
 
-    // Acquire lock on the table as it is needed to get the instance from DD
-    MDL_request mdl_request;
-    MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, table->db, table->table_name,
-                     MDL_SHARED, MDL_EXPLICIT);
-    thd->mdl_context.acquire_lock(&mdl_request,
-                                  thd->variables.lock_wait_timeout);
-
+    // mdl_lock scope begin
     {
+      // Acquire lock on the table as it is needed to get the instance from DD
+      MDL_request mdl_request;
+      MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, table->db,
+                       table->table_name, MDL_SHARED, MDL_EXPLICIT);
+      wsrep_scope_guard mdl_lock(
+          [thd, &mdl_request]() {
+            thd->mdl_context.acquire_lock(&mdl_request,
+                                          thd->variables.lock_wait_timeout);
+          },
+          [thd, &mdl_request]() {
+            thd->mdl_context.release_lock(mdl_request.ticket);
+          });
+
       const char *schema_name = table->db;
       const char *table_name = table->table_name;
       dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
       const dd::Table *table_ref = NULL;
 
       if (thd->dd_client()->acquire(schema_name, table_name, &table_ref)) {
-        thd->mdl_context.release_lock(mdl_request.ticket);
         return true;
       }
 
       if (table_ref == nullptr ||
           table_ref->hidden() == dd::Abstract_table::HT_HIDDEN_SE) {
         my_error(ER_NO_SUCH_TABLE, MYF(0), schema_name, table_name);
-        thd->mdl_context.release_lock(mdl_request.ticket);
         return true;
       }
 
       handlerton *hton = nullptr;
       if (dd::table_storage_engine(thd, table_ref, &hton)) {
-        thd->mdl_context.release_lock(mdl_request.ticket);
         return true;
       }
 
       existing_db_type = hton->db_type;
-    }
-
-    thd->mdl_context.release_lock(mdl_request.ticket);
+    }  // mdl_lock scope end
 
     bool is_system_db =
         (first_table && ((strcmp(first_table->db, "mysql") == 0) ||

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -753,28 +753,33 @@ bool Sql_cmd_truncate_table::execute(THD *thd) {
     enum legacy_db_type db_type;
     TABLE_LIST *table = first_table;
 
-    // Acquire lock on the table as it is needed to get the instance from DD
-    MDL_request mdl_request;
-    MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, table->db, table->table_name,
-                     MDL_SHARED, MDL_EXPLICIT);
-    thd->mdl_context.acquire_lock(&mdl_request,
-                                  thd->variables.lock_wait_timeout);
-
+    // mdl_lock scope begin
     {
+      // Acquire lock on the table as it is needed to get the instance from DD
+      MDL_request mdl_request;
+      MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, table->db,
+                       table->table_name, MDL_SHARED, MDL_EXPLICIT);
+      wsrep_scope_guard mdl_lock(
+          [thd, &mdl_request]() {
+            thd->mdl_context.acquire_lock(&mdl_request,
+                                          thd->variables.lock_wait_timeout);
+          },
+          [thd, &mdl_request]() {
+            thd->mdl_context.release_lock(mdl_request.ticket);
+          });
+
       const char *schema_name = table->db;
       const char *table_name = table->table_name;
       dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
       const dd::Table *table_ref = NULL;
 
       if (thd->dd_client()->acquire(schema_name, table_name, &table_ref)) {
-        thd->mdl_context.release_lock(mdl_request.ticket);
         return true;
       }
 
       if (table_ref == nullptr ||
           table_ref->hidden() == dd::Abstract_table::HT_HIDDEN_SE) {
         my_error(ER_NO_SUCH_TABLE, MYF(0), schema_name, table_name);
-        thd->mdl_context.release_lock(mdl_request.ticket);
         return true;
       }
 
@@ -785,9 +790,7 @@ bool Sql_cmd_truncate_table::execute(THD *thd) {
       }
 
       db_type = hton->db_type;
-    }
-
-    thd->mdl_context.release_lock(mdl_request.ticket);
+    }  // mdl_lock scope end
 
     bool is_system_db =
         (table && ((strcmp(table->db, "mysql") == 0) ||

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -514,4 +514,19 @@ enum wsrep::streaming_context::fragment_unit wsrep_fragment_unit(ulong unit);
 constexpr char WSREP_CHANNEL_NAME[] = "wsrep";
 bool wsrep_is_wsrep_channel_name(const char *channel_name);
 
+/* Simple RAII helper */
+class wsrep_scope_guard {
+ public:
+  wsrep_scope_guard(std::function<void()> scope_enter,
+                    std::function<void()> scope_leave)
+      : _scope_leave(scope_leave) {
+    scope_enter();
+  }
+
+  ~wsrep_scope_guard() { _scope_leave(); }
+
+ private:
+  std::function<void()> _scope_leave;
+};
+
 #endif /* WSREP_MYSQLD_H */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3040

Fixed access protection when accessing DD cached objects.
MDL lock was locked, then objects were accessed, their reference count was incremented. Then MDL lock was unlocked before reference count was decreased.

Additional problem was the lack of unlocking of LOCK_wsrep_alter_tablespace if lock_tablespace_names() failed for ALTER TABLESPACE.