### PR TITLE
PXC-2999 : DML commands are not replicating to PXC-8.0 nodes through …

### DIFF
--- a/mysql-test/suite/galera/r/pxc_mysqlx.result
+++ b/mysql-test/suite/galera/r/pxc_mysqlx.result
@@ -1,0 +1,235 @@
+# Testing CREATE TABLE DDL and INSERT DML (SQL)
+# node 1
+RUN DROP DATABASE IF EXISTS dbtest
+
+0 rows affected
+RUN CREATE DATABASE dbtest
+
+1 rows affected
+RUN USE dbtest
+
+0 rows affected
+RUN CREATE TABLE t1 (
+  id INT PRIMARY KEY,
+  f2 TEXT)
+
+0 rows affected
+RUN INSERT INTO t1 VALUES (1, "foo")
+
+1 rows affected
+RUN INSERT INTO t1 VALUES (2, "bar")
+
+1 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# node 1
+SELECT * FROM dbtest.t1;
+id	f2
+1	foo
+2	bar
+# node 2
+SELECT * FROM dbtest.t1;
+id	f2
+1	foo
+2	bar
+# Testing DELETE DML (SQL)
+RUN DELETE FROM dbtest.t1 WHERE id = 1
+
+1 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# node 1
+SELECT * FROM dbtest.t1;
+id	f2
+2	bar
+# node 2
+SELECT * FROM dbtest.t1;
+id	f2
+2	bar
+# Testing UPDATE DML (SQL)
+RUN UPDATE dbtest.t1 SET f2="baz" WHERE id = 2
+
+1 rows affected
+Rows matched: 1  Changed: 1  Warnings: 0
+RUN INSERT INTO dbtest.t1 VALUES (3, "foobar")
+
+1 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# node 1
+SELECT * FROM dbtest.t1;
+id	f2
+2	baz
+3	foobar
+# node 2
+SELECT * FROM dbtest.t1;
+id	f2
+2	baz
+3	foobar
+# Clearing table for native tests
+# node 1
+DELETE FROM dbtest.t1;
+# Testing INSERT DML (native)
+send Mysqlx.Crud.Insert {
+  collection {
+    name: "t1"
+    schema: "dbtest"
+  }
+  data_model: TABLE
+  projection {
+    name: "id"
+  }
+  projection {
+    name: "f2"
+  }
+  row {
+    field {
+      type: LITERAL
+      literal {
+        type: V_SINT
+        v_signed_int: 1
+      }
+    }
+    field {
+      type: LITERAL
+      literal {
+        type: V_STRING
+        v_string {
+          value: "foo2"
+        }
+      }
+    }
+  }
+}
+
+
+1 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# node 1
+SELECT * FROM dbtest.t1;
+id	f2
+1	foo2
+# node 2
+SELECT * FROM dbtest.t1;
+id	f2
+1	foo2
+# Testing DELETE DML (native)
+send Mysqlx.Crud.Delete {
+  collection {
+    name: "t1"
+    schema: "dbtest"
+  }
+  data_model: TABLE
+  criteria {
+    type: OPERATOR
+    operator {
+      name: "=="
+      param {
+        type: IDENT
+        identifier {
+          name: "id"
+        }
+      }
+      param {
+        type: LITERAL
+        literal {
+          type: V_SINT
+          v_signed_int: 1
+        }
+      }
+    }
+  }
+}
+
+
+1 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# node 1
+SELECT * FROM dbtest.t1;
+id	f2
+# node 2
+SELECT * FROM dbtest.t1;
+id	f2
+# Testing UPDATE DML (native)
+# node 1
+INSERT INTO dbtest.t1 VALUES(1, "foo");
+SELECT * FROM dbtest.t1;
+id	f2
+1	foo
+# node 2
+SELECT * FROM dbtest.t1;
+id	f2
+1	foo
+send Mysqlx.Crud.Update {
+  collection {
+    name: "t1"
+    schema: "dbtest"
+  }
+  data_model: TABLE
+  criteria {
+    type: OPERATOR
+    operator {
+      name: "=="
+      param {
+        type: IDENT
+        identifier {
+          name: "id"
+        }
+      }
+      param {
+        type: LITERAL
+        literal {
+          type: V_SINT
+          v_signed_int: 1
+        }
+      }
+    }
+  }
+  operation {
+    source {
+      name: "f2"
+    }
+    operation: SET
+    value {
+      type: LITERAL
+      literal {
+        type: V_STRING
+        v_string {
+          value: "bar2"
+        }
+      }
+    }
+  }
+}
+
+
+1 rows affected
+Rows matched: 1  Changed: 1  Warnings: 0
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# node 1
+INSERT INTO dbtest.t1 VALUES (2, "baz2");
+SELECT * FROM dbtest.t1;
+id	f2
+1	bar2
+2	baz2
+# node 2
+SELECT * FROM dbtest.t1;
+id	f2
+1	bar2
+2	baz2
+DROP DATABASE dbtest;

--- a/mysql-test/suite/galera/t/pxc_mysqlx.cnf
+++ b/mysql-test/suite/galera/t/pxc_mysqlx.cnf
@@ -1,0 +1,7 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+mysqlx=1
+
+[mysqld.2]
+mysqlx=1

--- a/mysql-test/suite/galera/t/pxc_mysqlx.test
+++ b/mysql-test/suite/galera/t/pxc_mysqlx.test
@@ -1,0 +1,281 @@
+# pxc_mysqlx
+#
+# Simple tests of using the mysqlx plugin with PXC
+#
+--source include/galera_cluster.inc
+--source include/force_restart.inc
+
+--source include/have_mysqlx_plugin.inc
+--source include/xplugin_create_user.inc
+
+# Setup the tables for the test
+# (sql interface) - test basic CRUD scenarios
+# (native interface) - test basic CRUD scenarios
+
+## TEST STARTS HERE
+
+# Setup the test database and test simple CRUD operations
+# and see if they replicate
+--echo # Testing CREATE TABLE DDL and INSERT DML (SQL)
+--connection node_1
+--echo # node 1
+
+--write_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+-->sql
+ DROP DATABASE IF EXISTS dbtest;
+ CREATE DATABASE dbtest;
+ USE dbtest;
+
+ CREATE TABLE t1 (
+  id INT PRIMARY KEY,
+  f2 TEXT);
+
+ INSERT INTO t1 VALUES (1, "foo");
+ INSERT INTO t1 VALUES (2, "bar");
+-->endsql
+EOF
+
+--exec $MYSQLXTEST -u x_root --password='' --file=$MYSQL_TMP_DIR/pxc_mysqlx_script.tmp 2>&1
+--remove_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+
+--connection node_1
+--echo # node 1
+SELECT * FROM dbtest.t1;
+
+--connection node_2
+--echo # node 2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbtest' AND TABLE_NAME = 't1'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 2 FROM dbtest.t1
+--source include/wait_condition.inc
+
+SELECT * FROM dbtest.t1;
+
+
+--echo # Testing DELETE DML (SQL)
+--connection node_1
+--write_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+-->sql
+ DELETE FROM dbtest.t1 WHERE id = 1;
+-->endsql
+EOF
+
+--exec $MYSQLXTEST -u x_root --password='' --file=$MYSQL_TMP_DIR/pxc_mysqlx_script.tmp 2>&1
+--remove_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+
+--connection node_1
+--echo # node 1
+SELECT * FROM dbtest.t1;
+
+--connection node_2
+--echo # node 2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbtest.t1
+--source include/wait_condition.inc
+
+SELECT * FROM dbtest.t1;
+
+
+--echo # Testing UPDATE DML (SQL)
+--connection node_1
+--write_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+-->sql
+ UPDATE dbtest.t1 SET f2="baz" WHERE id = 2;
+ INSERT INTO dbtest.t1 VALUES (3, "foobar");
+-->endsql
+EOF
+
+--exec $MYSQLXTEST -u x_root --password='' --file=$MYSQL_TMP_DIR/pxc_mysqlx_script.tmp 2>&1
+--remove_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+
+--connection node_1
+--echo # node 1
+SELECT * FROM dbtest.t1;
+
+--connection node_2
+--echo # node 2
+--let $wait_condition = SELECT COUNT(*) = 2 FROM dbtest.t1
+--source include/wait_condition.inc
+
+SELECT * FROM dbtest.t1;
+
+
+--echo # Clearing table for native tests
+--connection node_1
+--echo # node 1
+DELETE FROM dbtest.t1;
+
+--echo # Testing INSERT DML (native)
+--write_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+Mysqlx.Crud.Insert {
+  collection {
+                name: "t1"
+                schema: "dbtest"
+             }
+  data_model: TABLE
+        projection {
+        name: "id"
+        }
+        projection {
+        name: "f2"
+        }
+  row {
+    field {
+    type: LITERAL
+    literal {
+      type: V_SINT
+      v_signed_int: 1
+    }}
+    field {
+    type: LITERAL
+    literal {
+      type: V_STRING
+      v_string {
+        value: "foo2"
+      }
+    }}
+  }
+}
+-->recvresult
+EOF
+
+--exec $MYSQLXTEST -u x_root --password='' --file=$MYSQL_TMP_DIR/pxc_mysqlx_script.tmp 2>&1
+--remove_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+
+--connection node_1
+--echo # node 1
+SELECT * FROM dbtest.t1;
+
+--connection node_2
+--echo # node 2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbtest.t1
+--source include/wait_condition.inc
+
+SELECT * FROM dbtest.t1;
+
+
+--echo # Testing DELETE DML (native)
+--write_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+Mysqlx.Crud.Delete {
+  collection {
+    name: "t1"
+    schema: "dbtest"
+  }
+  data_model: TABLE
+  criteria {
+    type: OPERATOR
+    operator {
+      name: "=="
+      param {
+        type: IDENT
+        identifier {
+          name: "id"
+        }
+      }
+      param {
+        type: LITERAL
+        literal {
+          type: V_SINT
+          v_signed_int: 1
+        }
+      }
+    }
+  }
+}
+#-- Mysqlx.Sql.StmtExecuteOk
+-->recvresult
+EOF
+
+--exec $MYSQLXTEST -u x_root --password='' --file=$MYSQL_TMP_DIR/pxc_mysqlx_script.tmp 2>&1
+--remove_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+
+--connection node_1
+--echo # node 1
+SELECT * FROM dbtest.t1;
+
+--connection node_2
+--echo # node 2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM dbtest.t1
+--source include/wait_condition.inc
+
+SELECT * FROM dbtest.t1;
+
+
+--echo # Testing UPDATE DML (native)
+--connection node_1
+--echo # node 1
+INSERT INTO dbtest.t1 VALUES(1, "foo");
+SELECT * FROM dbtest.t1;
+
+--connection node_2
+--echo # node 2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM dbtest.t1
+--source include/wait_condition.inc
+SELECT * FROM dbtest.t1;
+
+--write_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+Mysqlx.Crud.Update {
+  collection {
+    name: "t1"
+    schema: "dbtest"
+  }
+  data_model: TABLE
+  criteria {
+    type: OPERATOR
+    operator {
+      name: "=="
+      param {
+        type: IDENT
+        identifier {
+          name: "id"
+        }
+      }
+      param {
+        type: LITERAL
+        literal {
+             type: V_SINT
+             v_signed_int: 1
+        }
+      }
+    }
+  }
+  operation {
+    source {
+      name: "f2"
+    }
+    operation: SET
+    value {
+      type: LITERAL
+      literal {
+        type: V_STRING
+        v_string {
+          value: "bar2"
+        }
+      }
+    }
+  }
+}
+#-- Mysqlx.Sql.StmtExecuteOk
+-->recvresult
+EOF
+
+--exec $MYSQLXTEST -u x_root --password='' --file=$MYSQL_TMP_DIR/pxc_mysqlx_script.tmp 2>&1
+--remove_file $MYSQL_TMP_DIR/pxc_mysqlx_script.tmp
+
+--connection node_1
+--echo # node 1
+INSERT INTO dbtest.t1 VALUES (2, "baz2");
+SELECT * FROM dbtest.t1;
+
+--connection node_2
+--echo # node 2
+--let $wait_condition = SELECT COUNT(*) = 2 FROM dbtest.t1
+--source include/wait_condition.inc
+
+SELECT * FROM dbtest.t1;
+
+
+# Cleanup
+--connection node_1
+DROP DATABASE dbtest;
+--source include/xplugin_drop_user.inc


### PR DESCRIPTION
…MySQL shell

Issue
DML commands (coming from mysqlsh) are not replicating to the other nodes
This is because the SQL sessions/threads used by the mysqlsh are not
wsrep enabled.

Solution
Setup the threads with wsrep.