### PR TITLE
PXC-3109: Shutdown trigger sig 11 assertion : Mysqld_socket_listener::close_listener

### DIFF
--- a/mysql-test/r/admin_interface.result
+++ b/mysql-test/r/admin_interface.result
@@ -187,6 +187,13 @@ SELECT @@admin_address, @@admin_port;
 disconnect admin_tcp_con_ipv6;
 connection default;
 # Stop DB server
+# Test case 18
+# Check that server shuts down gracefully if --create-admin-listener-thread=ON
+# is specified, but without --admin-address parameter
+# Starting up server with --create-admin-listener-thread=ON
+# restart: --create-admin-listener-thread=ON
+connection default;
+# Stop DB server
 #
 # Starting mysqld in the regular mode...
 #

--- a/mysql-test/t/admin_interface.test
+++ b/mysql-test/t/admin_interface.test
@@ -326,6 +326,18 @@ SELECT @@admin_address, @@admin_port;
 
 --enable_result_log
 
+--echo # Test case 18
+--echo # Check that server shuts down gracefully if --create-admin-listener-thread=ON
+--echo # is specified, but without --admin-address parameter
+--echo # Starting up server with --create-admin-listener-thread=ON
+--let $restart_parameters=restart: --create-admin-listener-thread=ON
+--let $wait_for_tcpsocket_status = no_wait
+--source include/start_mysqld.inc
+
+--connection default
+--echo # Stop DB server
+--source include/shutdown_mysqld.inc
+
 --echo #
 --echo # Starting mysqld in the regular mode...
 --echo #

--- a/sql/conn_handler/socket_connection.cc
+++ b/sql/conn_handler/socket_connection.cc
@@ -1471,7 +1471,14 @@ void Mysqld_socket_listener::close_listener() {
     being listened is not included in the m_socket_map. Instead, this socket
     referenced by the data member m_admin_interface_listen_socket.
   */
-  if (m_use_separate_thread_for_admin) {
+
+  /*
+    See the logic in setup_listener()
+    Thread was spawned only if both --admin-address is specified
+    and --create-admin-listener-thread=ON
+   */
+  if (!m_admin_bind_address.address.empty() &&
+      m_use_separate_thread_for_admin) {
 #ifdef _WIN32
     /*
       For Windows, first close the socket referenced by the data member

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -26,6 +26,7 @@
 #include "rpl_msr.h"  // channel_map
 #include "rpl_slave.h"
 #include "sql/sql_lex.h"
+#include "sql/auth/auth_common.h"
 #include "sql_base.h"  // TEMP_PREFIX
 #include "sql_class.h"
 #include "sql_parse.h"
@@ -1127,6 +1128,12 @@ int wsrep_remove_sst_user(bool initialize_thread) {
   int err = 0;
   MYSQL_SESSION session = NULL;
 
+  // Skip the attempt to  mysql.pxc.sst.user in case the server was started with
+  // --skip-grant-tables option. It would fail enyway with error.
+  // This will prevent writing out error to error log.
+  if (skip_grant_tables()) {
+      return ECANCELED;
+  }
   // This array is filled with pairs of entries
   // The first entry is the actual query to be run
   // The second entry is the string to be displayed if the query fails


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3109

Problem:
If --create-admin-listener-thread=ON and --admin-address is not specified, there was still attempt to deinitialize the thread and socket in Mysqld_socket_listener::close_listener(). Thread and socket should be deinitialized only if both were initialized.

Fixed deinitialization of admin listener thread and socket

Additionally fixed admin_interface MTR test by skipping drop attempt of PXC sst user in case when server was started with --skip-grant-tables option. Such drop would fail anyway printing out error message to error log.