### PR TITLE
PXC-3108: Crash when UNLOCK TABLES called after FTWRL

### DIFF
--- a/mysql-test/suite/galera/r/galera_ftwrl.result
+++ b/mysql-test/suite/galera/r/galera_ftwrl.result
@@ -14,3 +14,41 @@ SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
 DROP TABLE t1;
+SET GLOBAL wsrep_provider_options = "repl.causal_read_timeout=PT1S";
+CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+SET SESSION wsrep_on=OFF;
+FLUSH TABLES WITH READ LOCK;
+SELECT * FROM t1;
+id
+0
+INSERT INTO t1 VALUES (1);
+SELECT * FROM t1;
+id
+0
+1
+SELECT * FROM t1;
+id
+0
+SET SESSION wsrep_on=ON;
+INSERT INTO t1 VALUES (2);
+SELECT * FROM t1;
+id
+0
+1
+2
+SELECT * FROM t1;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+SET SESSION wsrep_causal_reads = OFF;
+SET SESSION wsrep_sync_wait = 0;
+SELECT * FROM t1;
+id
+0
+SET SESSION wsrep_sync_wait = 15;
+UNLOCK TABLES;
+SELECT * FROM t1;
+id
+0
+1
+2
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_ftwrl.test
+++ b/mysql-test/suite/galera/t/galera_ftwrl.test
@@ -36,3 +36,68 @@ SHOW TABLES;
 SELECT COUNT(*) = 1 FROM t1;
 
 DROP TABLE t1;
+
+
+# 
+# Test the scenario when the session on node_1 disables replication and acquires global read lock.
+# Another session on node_2 modifies the table. As the lock is not acquired on node_2 changes are applied
+# and replicated to the cluster.
+# Session on node_1 should still see unmodified table.
+# Then node_1 session enables replication. Should still see not modified table.
+# When node_1 session releases global read lock, rows replicated from node_2 should be visible on node_1
+#
+# The point here is that even if session has disabled replication and acquires global read lock, the replication
+# to this node not take place.
+#
+
+--connection node_1
+--let $wsrep_provider_options_orig = `SELECT @@wsrep_provider_options;`
+
+SET GLOBAL wsrep_provider_options = "repl.causal_read_timeout=PT1S";
+
+CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+SET SESSION wsrep_on=OFF;
+FLUSH TABLES WITH READ LOCK;
+SELECT * FROM t1;
+
+--connection node_2
+INSERT INTO t1 VALUES (1);
+SELECT * FROM t1;
+
+--connection node_1
+# node 1 should still have only one row
+SELECT * FROM t1;
+SET SESSION wsrep_on=ON;
+
+--connection node_2
+INSERT INTO t1 VALUES (2);
+SELECT * FROM t1;
+
+--connection node_1
+
+# As causal reads are enabled by default in MTR and we have read lock on node_1, changes will never be replicated
+--error ER_LOCK_WAIT_TIMEOUT
+SELECT * FROM t1;
+
+--disable_query_log
+--eval SET GLOBAL wsrep_provider_options = "$wsrep_provider_options_orig";
+--enable_query_log
+
+# Disable causality checks
+SET SESSION wsrep_causal_reads = OFF;
+SET SESSION wsrep_sync_wait = 0;
+
+# node_1 is still no synced, but we can select. 1 row expeccted.
+SELECT * FROM t1;
+
+# reenable causality checks
+SET SESSION wsrep_sync_wait = 15;
+
+UNLOCK TABLES;
+
+# now we expect 3 rows
+SELECT * FROM t1;
+
+DROP TABLE t1;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3108

Problem:
When replication was disabled for given session, and session called FTWRL and then enabled replication and executed UNLOCK TABLES, server crashed.

Cause:
When FTWRL is executed, global read lock is acquired. This causes pausing of replicatoion, as we do not want changes done on another nodes to be replicated to this node.
When UNLOCK TABLES is executed, global read lock is released. This causes resynchronization/resuming of replication.
In the given scenario, replication was not paused, but there was attempt to resume it which caused crash.

Additionally I discovered that not pausing replication server if the given session has disabled replication causes changes from another nodes to be replicated to this node even if FTWRL was executed. Replication should be paused/resumed always regardless of replication being enabled or disabled in given session. Note that wsrep_on variable specifies if changes done on this node are replicated to the cluster. Even if its value is 'OFF', changes from cluster are replicated to this node.