### PR TITLE
PXC-3128: High priority transactions should work with WSREP

### DIFF
--- a/mysql-test/include/start_transaction_high_prio.inc
+++ b/mysql-test/include/start_transaction_high_prio.inc
@@ -22,14 +22,15 @@
 --let $include_filename= start_transaction_high_prio.inc
 --source include/begin_include_file.inc
 
+let old_debug=`SELECT @@debug`;
 --disable_query_log
-SET GLOBAL DEBUG='+d,dbug_set_high_prio_trx';
+SET GLOBAL DEBUG='d,dbug_set_high_prio_trx';
 --enable_query_log
 
 START TRANSACTION /* HIGH PRIORITY */;
 
 --disable_query_log
-SET GLOBAL DEBUG='-d,dbug_set_high_prio_trx';
+--eval SET GLOBAL DEBUG='$old_debug';
 --enable_query_log
 
 --let $include_filename= start_transaction_high_prio.inc

--- a/mysql-test/suite/galera/r/high_prio_trx_1.result
+++ b/mysql-test/suite/galera/r/high_prio_trx_1.result
@@ -1,0 +1,20 @@
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+# On connection 1
+START TRANSACTION;
+UPDATE t1 SET c1=1 WHERE c1=0;
+
+# On connection 2
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+
+# On connection 1
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+include/assert.inc ['There is a 2 in t1']
+include/assert.inc ['There is no 1 in t1']
+include/assert.inc ['There is no 0 in t1']
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/high_prio_trx_2.result
+++ b/mysql-test/suite/galera/r/high_prio_trx_2.result
@@ -1,0 +1,22 @@
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+# On connection 1
+START TRANSACTION;
+SELECT * FROM t1 WHERE c1=0 FOR UPDATE;
+c1
+0
+
+# On connection 2
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+
+# On connection 1
+UPDATE t1 SET c1=1 WHERE c1=0;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+include/assert.inc ['There is a 2 in t1']
+include/assert.inc ['There is no 1 in t1']
+include/assert.inc ['There is no 0 in t1']
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/high_prio_trx_3.result
+++ b/mysql-test/suite/galera/r/high_prio_trx_3.result
@@ -1,0 +1,27 @@
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY, c2 INT NOT NULL, c3 INT NOT NULL) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0, 0, 0);
+
+# On connection 1
+START TRANSACTION;
+UPDATE t1 SET c1=1, c2=1 WHERE c1=0 AND c2=0;
+
+# On connection 2
+START TRANSACTION;
+UPDATE t1 SET c2=2 WHERE c1=0 AND c2=3;
+
+# On connection 3
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+UPDATE t1 SET c2=3 WHERE c2=0;
+COMMIT;
+
+# On connection 1
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+
+# On connection 2
+COMMIT;
+include/assert.inc ['There is no 3 in t1']
+include/assert.inc ['There is a 2 in t1']
+include/assert.inc ['There is no 1 in t1']
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/high_prio_trx_1.test
+++ b/mysql-test/suite/galera/t/high_prio_trx_1.test
@@ -1,0 +1,59 @@
+--source include/galera_cluster.inc
+
+--disable_query_log
+CALL mtr.add_suppression("InnoDB High Priority being used");
+--enable_query_log
+
+# Scenario:
+#  T1=({R(B), W(B)})
+#  T2=({R(B), W(B), C}, HIGH_PRIORITY).
+#
+# Outcome: T1 must abort, T2 must commit.
+
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+--connect(con1,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con2,localhost,root,,test, $NODE_MYPORT_1)
+
+--echo
+--echo # On connection 1
+--connection con1
+START TRANSACTION;
+UPDATE t1 SET c1=1 WHERE c1=0;
+
+--echo
+--echo # On connection 2
+--connection con2
+--source include/start_transaction_high_prio.inc
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+--disconnect con2
+
+--echo
+--echo # On connection 1
+--connection con1
+# TODO: this should be ER_ERROR_DURING_COMMIT
+--error ER_LOCK_DEADLOCK
+COMMIT;
+--disconnect con1
+
+--connection node_2
+--let $assert_text= 'There is a 2 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 2, count, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'There is no 1 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 1, count, 1] = 0
+--source include/assert.inc
+
+--let $assert_text= 'There is no 0 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0, count, 1] = 0
+--source include/assert.inc
+
+--connection default
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/high_prio_trx_2.test
+++ b/mysql-test/suite/galera/t/high_prio_trx_2.test
@@ -1,0 +1,58 @@
+# Scenario:
+#  T1=({R(B)})
+#  T2=({R(B), W(B), C}, HIGH_PRIORITY).
+#
+# Outcome: T1 must abort, T2 must commit.
+
+--disable_query_log
+CALL mtr.add_suppression("InnoDB High Priority being used");
+--enable_query_log
+
+--source include/galera_cluster.inc
+
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+--connect(con1,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con2,localhost,root,,test, $NODE_MYPORT_1)
+
+--echo
+--echo # On connection 1
+--connection con1
+START TRANSACTION;
+SELECT * FROM t1 WHERE c1=0 FOR UPDATE;
+
+--echo
+--echo # On connection 2
+--connection con2
+--source include/start_transaction_high_prio.inc
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+--disconnect con2
+
+--echo
+--echo # On connection 1
+--connection con1
+# Note: DEADLOCK implies a full ROLLBACK
+--error ER_LOCK_DEADLOCK
+UPDATE t1 SET c1=1 WHERE c1=0;
+--disconnect con1
+
+--connection node_2
+--let $assert_text= 'There is a 2 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 2, count, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'There is no 1 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 1, count, 1] = 0
+--source include/assert.inc
+
+--let $assert_text= 'There is no 0 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0, count, 1] = 0
+--source include/assert.inc
+
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/high_prio_trx_3.test
+++ b/mysql-test/suite/galera/t/high_prio_trx_3.test
@@ -1,0 +1,83 @@
+--source include/galera_cluster.inc
+
+--source include/count_sessions.inc
+
+--disable_query_log
+CALL mtr.add_suppression("InnoDB High Priority being used");
+--enable_query_log
+
+# Scenario:
+#  T1= ({R(Z), R(B), W(Z), W(B)})
+#  T2= ({R(C), R(B), W(B)})
+#  T3= ({R(B), W(B), C}, HIGH_PRIORITY)
+#
+# Outcome: T1 must abort, T3 must commit, T2 must commit
+#          after T3.
+#
+# Lock -> {T1 granted, T2 waiting, T3 waiting};
+# Then T3 jumps the queue:
+# Lock -> {T1 granted, T3 waiting, T2 waiting};
+# T3 Rolls back T1
+# Lock -> {T3 granted, T2 waiting}
+
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY, c2 INT NOT NULL, c3 INT NOT NULL) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0, 0, 0);
+
+--connect(con1,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con2,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con3,localhost,root,,test, $NODE_MYPORT_1)
+
+--echo
+--echo # On connection 1
+--connection con1
+START TRANSACTION;
+UPDATE t1 SET c1=1, c2=1 WHERE c1=0 AND c2=0;
+
+--echo
+--echo # On connection 2
+--connection con2
+START TRANSACTION;
+--send UPDATE t1 SET c2=2 WHERE c1=0 AND c2=3
+
+--echo
+--echo # On connection 3
+--connection con3
+--source include/start_transaction_high_prio.inc
+UPDATE t1 SET c2=3 WHERE c2=0;
+COMMIT;
+--disconnect con3
+
+--echo
+--echo # On connection 1
+--connection con1
+# TODO: should be ER_ERROR_DURING_COMMIT
+--error ER_LOCK_DEADLOCK
+COMMIT;
+--disconnect con1
+
+--echo
+--echo # On connection 2
+--connection con2
+--reap
+COMMIT;
+--disconnect con2
+
+--connection node_2
+--let $assert_text= 'There is no 3 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0 AND t1.c2 = 3 AND t1.c3 = 0, count, 1] = 0
+--source include/assert.inc
+
+--let $assert_text= 'There is a 2 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0 AND t1.c2 = 2 AND t1.c3 = 0, count, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'There is no 1 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 1 AND t1.c2 = 1 AND t1.c3 = 0, count, 1] = 0
+--source include/assert.inc
+
+--connection default
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Issue: when wsrep is running, high priority transactions weren't able to
kill normal priority transactions. This basically broke the scenario
where a PXC node is also part of a normal replication setup.

Root cause: we intentionally broke this feature in 5.7, in commit
5be95d8ff766. The comment/commit message explains that high priority
transactions aren't how galera works, an dshould be disabled.

Compared to that statement codership fixed HPTs also in 5.7, in commit
f2dd26e10785, by translating the HPT kill logic into wsrep functions.

After merging the codership fix in 5.7, we never reverted our
workaround.

For 8.0, we didn't even port f2dd26e10785, we only ported our disabling
"patch".

Fix:

* Reverting 5be95d8ff766
* Porting f2dd26e10785 to 8.0/galera4
* Removed the assert(0)
* Adding some of the high priority tests to the galera suite to ensure
that they don't break in the future
* This commit also improves the start_transactin_high_prio mtr include
so it works when used together with --debug

Remaining issue: as shown by two TODO comments in the tests, we report a
different error message in some cases compared to basic InnoDB behavior.
This doesn't result in any other behavior change however, we can fix it
later when time permits.