### PR TITLE
PXC-3133 mysqld.cnf: remove log_error_verbosity option

### DIFF
--- a/build-ps/debian/extra/mysqld.cnf
+++ b/build-ps/debian/extra/mysqld.cnf
@@ -9,7 +9,6 @@ datadir=/var/lib/mysql
 socket=/var/run/mysqld/mysqld.sock
 log-error=/var/log/mysql/error.log
 pid-file=/var/run/mysqld/mysqld.pid
-log_error_verbosity=3
 
 # Binary log expiration period is 604800 seconds, which equals 7 days
 binlog_expire_logs_seconds=604800

--- a/build-ps/rpm/mysqld.cnf
+++ b/build-ps/rpm/mysqld.cnf
@@ -9,7 +9,6 @@ datadir=/var/lib/mysql
 socket=/var/lib/mysql/mysql.sock
 log-error=/var/log/mysqld.log
 pid-file=/var/run/mysqld/mysqld.pid
-log_error_verbosity=3
 
 # Binary log expiration period is 604800 seconds, which equals 7 days
 binlog_expire_logs_seconds=604800


### PR DESCRIPTION
In order not to overload logs, remove log_error_verbosity=3 from mysqld.cnf file and use
default value of 2.