### PR TITLE
PXC-3019: SESSION_TRACK_GTIDs is broken

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1802,7 +1802,7 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
     WSREP_DEBUG("assigned new next trx id: %" PRIu64, thd->wsrep_next_trx_id());
   }
 
-  bool do_end_of_statement;
+  bool do_end_of_statement = true;
 #endif /* WITH_WSREP */
 
   if (!(server_command_flags[command] & CF_SKIP_QUESTIONS))
@@ -2493,7 +2493,6 @@ dispatch_end:
     WSREP_LOG_THD(thd, "leave");
   }
 
-  do_end_of_statement = true;
   if (WSREP(thd)) {
     /* wsrep BF abort in query exec phase */
     mysql_mutex_lock(&thd->LOCK_wsrep_thd);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3019

The main problem was fixed by commit ee4f6c0bc64b5588c9296f3aaaffdd5fcc45d93e. Mentioned commit cleaned up and fixed the flow in sql_parse.cc dispatch_command() function. The problem was that Session_consistency_gtids_ctx::notify_after_response_packet() method was not called if WSREP provider was not loaded.

Change:
Improved handling of do_end_of_statement variable. It could have happen that variable was not initialized if the flow got to 'done' label in case of error.