### PR TITLE
PXC-3151 mysql-systemd: adjust automatic pid creation

### DIFF
--- a/build-ps/debian/extra/mysql-systemd
+++ b/build-ps/debian/extra/mysql-systemd
@@ -210,7 +210,8 @@ fi
 grastate_loc="${datadir}/grastate.dat"
 
 if [[ -z "${pid_path:-}" ]];then
-  pid_path=$datadir/`hostname`.pid
+  hostname=$(hostname)
+  pid_path=$datadir/${hostname%.*}.pid
 else
   case "$pid_path" in
     /* ) ;;

--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -210,7 +210,8 @@ fi
 grastate_loc="${datadir}/grastate.dat"
 
 if [[ -z "${pid_path:-}" ]];then
-  pid_path=$datadir/`hostname`.pid
+  hostname=$(hostname)
+  pid_path=$datadir/${hostname%.*}.pid
 else
   case "$pid_path" in
     /* ) ;;


### PR DESCRIPTION
Adjust mysqld pid finame creation and handling in mysql-systemd script
for the case when "pid-file" parameter is missing from my.cnf file:
 By default pid filename is created based on result of
 "gethostname()" execution where trailing ".whatever" suffix is removed
 and ".pid" extension is added in mysqld.cc:

  strmake(pidfile_name, default_logfile_name, sizeof(pidfile_name) - 5);
  my_stpcpy(fn_ext(pidfile_name), ".pid");  // Add proper extension