### PR TITLE
PXC-3153: SQL failure in SST donor thread leaves the server hanging

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -25,8 +25,8 @@
 #include "mysqld.h"
 #include "rpl_msr.h"  // channel_map
 #include "rpl_slave.h"
-#include "sql/sql_lex.h"
 #include "sql/auth/auth_common.h"
+#include "sql/sql_lex.h"
 #include "sql_base.h"  // TEMP_PREFIX
 #include "sql_class.h"
 #include "sql_parse.h"
@@ -529,8 +529,7 @@ static void *sst_joiner_thread(void *a) {
     mysql_cond_signal(&arg->COND_wsrep_sst_thread);
     mysql_mutex_unlock(&arg->LOCK_wsrep_sst_thread);
 
-    if (err)
-    {
+    if (err) {
       // The process has exited, so the logger thread should
       // also have exited
       if (logger_thd) pthread_join(logger_thd, NULL);
@@ -1132,7 +1131,7 @@ int wsrep_remove_sst_user(bool initialize_thread) {
   // --skip-grant-tables option. It would fail enyway with error.
   // This will prevent writing out error to error log.
   if (skip_grant_tables()) {
-      return ECANCELED;
+    return ECANCELED;
   }
   // This array is filled with pairs of entries
   // The first entry is the actual query to be run
@@ -1194,6 +1193,14 @@ static void *sst_donor_thread(void *a) {
 #ifdef HAVE_PSI_INTERFACE
     wsrep_pfs_delete_thread();
 #endif /* HAVE_PSI_INTERFACE */
+
+    /* Inform server about SST script startup and release TO isolation */
+    mysql_mutex_lock(&arg->LOCK_wsrep_sst_thread);
+    arg->err = -err;
+    mysql_cond_signal(&arg->COND_wsrep_sst_thread);
+    mysql_mutex_unlock(
+        &arg->LOCK_wsrep_sst_thread);  //! @note arg is unusable after that.
+
     return NULL;
   }
 


### PR DESCRIPTION
Issue: if the donor thread exits with an error before the SST process
was started, it leaves the spawning thread waiting for a signal forever.
This results in the entire server hanging.

Fix: also send this signal if donor bootstrap sql statements fail.