### PR TITLE
PXC-3154 - Thread pooling hangs on shutdown

### DIFF
--- a/mysql-test/suite/galera/r/thread_pool_shutdown.result
+++ b/mysql-test/suite/galera/r/thread_pool_shutdown.result
@@ -1,0 +1,8 @@
+#node-2a
+SELECT 1;
+1
+1
+#node-2
+SET GLOBAL wsrep_reject_queries=ALL_KILL;
+SET GLOBAL wsrep_reject_queries=NONE;
+# restart

--- a/mysql-test/suite/galera/t/thread_pool_shutdown-master.opt
+++ b/mysql-test/suite/galera/t/thread_pool_shutdown-master.opt
@@ -1,0 +1,1 @@
+--thread_handling=pool-of-threads

--- a/mysql-test/suite/galera/t/thread_pool_shutdown.test
+++ b/mysql-test/suite/galera/t/thread_pool_shutdown.test
@@ -1,0 +1,16 @@
+#
+# PXC-3154 Thread pooling hangs on shutdown
+#
+--source include/galera_cluster.inc
+--source include/force_restart.inc
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+--echo #node-2a
+SELECT 1;
+
+--connection node_2
+--echo #node-2
+SET GLOBAL wsrep_reject_queries=ALL_KILL;
+SET GLOBAL wsrep_reject_queries=NONE;
+--source include/restart_mysqld.inc

--- a/vio/viosocket.cc
+++ b/vio/viosocket.cc
@@ -524,14 +524,6 @@ int vio_shutdown(Vio *vio, int how) {
 
   int r = vio_cancel(vio, how);
 
-#ifdef WITH_WSREP
-  /* with thread pool enabled socket shutdown immediately followed by close
-  fail to deliver the said notification to the pooling worker thread.
-  sleep help ensure that shutdown signal is delivered before the socket is
-  closed. */
-  sleep(1);
-#endif /* WITH_WSREP */
-
   if (!vio->inactive) {
 #ifdef USE_PPOLL_IN_VIO
     if (vio->thread_id != 0 && vio->poll_shutdown_flag.test_and_set()) {


### PR DESCRIPTION
Problem
When wsrep_close_client_connections is called, it closes connections
abruptly. This is ok on shutdown, however, same function is also called
when we set wsrep_cluster_address dynamically and when setting
wsrep_reject_queries=ALL_KILL, which fails to deliver
proper notification to thread_pool threads.

Fix
Adjust wsrep_close_client_connections to first signal the thd as killed
then attempt to close the connection.