### PR TITLE
PXC-3171: Fix PXC 5.7 -> 8.0 upgrade

### DIFF
--- a/sql/dd/impl/upgrade/server.cc
+++ b/sql/dd/impl/upgrade/server.cc
@@ -512,6 +512,12 @@ bool upgrade_pxc_only(THD *thd) {
     return false;
   }
 
+  if (opt_initialize || !dd::upgrade::no_server_upgrade_required()) {
+    // These SQL statements assume an initialized/upgraded server, will fail
+    // wit older versions. Not an issue, skip them.
+    return false;
+  }
+
   Disable_autocommit_guard autocommit_guard(thd);
   Bootstrap_error_handler bootstrap_error_handler;
 


### PR DESCRIPTION
Issue: PXC upgrade failed because the server executed sql statements on
the mysql db before it was updated to the 8.0 schema

Fix: only run those statements on an upgraded schema