### PR TITLE
PXC-3179: CREATE USER ... RANDOM PASSWORD is not repicating as expected in PXC

### DIFF
--- a/mysql-test/suite/galera/r/pxc_alter_user.result
+++ b/mysql-test/suite/galera/r/pxc_alter_user.result
@@ -44,5 +44,11 @@ ALTER USER 'User1'@'localhost' IDENTIFIED BY '' REPLACE 'root_pass';
 CREATE TABLE test(a int primary key);
 DROP TABLE test;
 # connection node_2, SuperUser1
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of RANDOM PASSWORD for CREATE/ALTER USER operation while operating in cluster mode");
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of RANDOM PASSWORD for CREATE/ALTER USER operation while operating in cluster mode");
+ALTER USER 'User2'@'localhost' IDENTIFIED BY RANDOM PASSWORD;
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of RANDOM PASSWORD for CREATE/ALTER USER operation while operating in cluster mode
+CREATE USER 'User3'@'localhost' IDENTIFIED BY RANDOM PASSWORD;
+ERROR HY000: Percona XtraDB Cluster doesn't allow use of RANDOM PASSWORD for CREATE/ALTER USER operation while operating in cluster mode
 DROP USER User1@localhost;
 DROP USER User2@localhost;

--- a/mysql-test/suite/galera/t/pxc_alter_user.test
+++ b/mysql-test/suite/galera/t/pxc_alter_user.test
@@ -126,7 +126,21 @@ DROP TABLE test;
 --echo # connection node_2, SuperUser1
 --disconnect con_node_2_SuperUser1
 
+
+#
+# CREATE/ALTER USER ... IDENTIFIED BY RANDOM PASSWORD is not allowed in PXC
+#
+--connection node_2
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of RANDOM PASSWORD for CREATE/ALTER USER operation while operating in cluster mode");
 --connection node_1
+call mtr.add_suppression("Percona XtraDB Cluster doesn't allow use of RANDOM PASSWORD for CREATE/ALTER USER operation while operating in cluster mode");
+--error ER_UNKNOWN_ERROR
+ALTER USER 'User2'@'localhost' IDENTIFIED BY RANDOM PASSWORD;
+--error ER_UNKNOWN_ERROR
+CREATE USER 'User3'@'localhost' IDENTIFIED BY RANDOM PASSWORD;
+
+
+# cleanup
 DROP USER User1@localhost;
 DROP USER User2@localhost;
 --source include/wait_until_count_sessions.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3179

Problem:
CREATE/ALTER USER ... IDENTIFIED BY RANDOM PASSWORD creates user on master and slave nodes, but with different passwords. This is because TOI transactions are replicated as statements, so different passwords are generated on different nodes.

Solution:
Forbid using of RANDOM PASSWORD if node replicates to the cluster.