### PR TITLE
PXC-3170 - Backport to 5.7 - Thread pooling hangs on shutdown

### DIFF
--- a/mysql-test/suite/galera/r/thread_pool_shutdown.result
+++ b/mysql-test/suite/galera/r/thread_pool_shutdown.result
@@ -1,0 +1,8 @@
+#node-2a
+SELECT 1;
+1
+1
+#node-2
+SET GLOBAL wsrep_reject_queries=ALL_KILL;
+SET GLOBAL wsrep_reject_queries=NONE;
+# restart

--- a/mysql-test/suite/galera/t/thread_pool_shutdown-master.opt
+++ b/mysql-test/suite/galera/t/thread_pool_shutdown-master.opt
@@ -1,0 +1,1 @@
+--thread_handling=pool-of-threads

--- a/mysql-test/suite/galera/t/thread_pool_shutdown.test
+++ b/mysql-test/suite/galera/t/thread_pool_shutdown.test
@@ -1,0 +1,16 @@
+#
+# PXC-3154 Thread pooling hangs on shutdown
+#
+--source include/galera_cluster.inc
+--source include/force_restart.inc
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+--echo #node-2a
+SELECT 1;
+
+--connection node_2
+--echo #node-2
+SET GLOBAL wsrep_reject_queries=ALL_KILL;
+SET GLOBAL wsrep_reject_queries=NONE;
+--source include/restart_mysqld.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1124,6 +1124,29 @@ private:
 
 #ifdef WITH_WSREP
 /**
+  This class implements callback function used by
+  wsrep_close_client_connections() to set KILL_CONNECTION
+  flag on all client thds and awake the thread.
+*/
+class Set_wsrep_kill_client_conn : public Do_THD_Impl
+{
+ public:
+  Set_wsrep_kill_client_conn()
+  {}
+
+  virtual void operator()(THD *killing_thd)
+  {
+    if (killing_thd->get_protocol()->connection_alive() &&
+        (WSREP(killing_thd) || killing_thd->wsrep_exec_mode == LOCAL_STATE) &&
+        killing_thd != current_thd)
+    {
+      mysql_mutex_lock(&killing_thd->LOCK_thd_data);
+      killing_thd->awake(THD::KILL_CONNECTION);
+      mysql_mutex_unlock(&killing_thd->LOCK_thd_data);
+    }
+  }
+};
+/**
   This class implements callback function used by close_connections()
   to set KILL_CONNECTION flag on all thds in thd list.
   If m_kill_dump_thread_flag is not set it kills all other threads
@@ -7613,19 +7636,24 @@ void wsrep_close_client_connections(my_bool wait_to_end, bool server_shutdown)
 
   Global_THD_manager *thd_manager= Global_THD_manager::get_instance();
   /*
-    First signal all threads that it's time to die
-    This will give the threads some time to gracefully abort their
-    statements and inform their clients that the server is about to die.
-  */
+   * wsrep_close_client_connections can be used when there is a cluster
+   * reconfiguration or when we set wsrep_reject_queries=ALL_KILL
+   * on those cases if we are using thread pooling,
+   * we cannot close the connections abruptly otherwise the thread pool workers
+   * won't get signaled and will hang forever when we shutdown the server.
+   * Sending a kill signal and awaking the thread.
+   */
 
   sql_print_information("Giving %d client threads a chance to die gracefully",
                         static_cast<int>(thd_manager->get_thd_count()));
+  Set_wsrep_kill_client_conn set_wsrep_kill_client_conn;
+  thd_manager->do_for_all_thd(&set_wsrep_kill_client_conn);
+  if (thd_manager->get_thd_count() > 0)
+    sleep(2);  // Give threads time to die
 
   Call_wsrep_close_client_conn call_wsrep_close_client_conn(server_shutdown);
   thd_manager->do_for_all_thd(&call_wsrep_close_client_conn);
 
-  if (thd_manager->get_thd_count() > 0)
-    sleep(2);         // Give threads time to die
 
 }
 


### PR DESCRIPTION
Problem
When wsrep_close_client_connections is called, it closes connections
abruptly. This is ok on shutdown, however, same function is also called
when we set wsrep_cluster_address dynamically and when setting
wsrep_reject_queries=ALL_KILL, which fails to deliver
proper notification to thread_pool threads.

Fix
Adjust wsrep_close_client_connections to first signal the thd as killed
then attempt to close the connection.