### PR TITLE
PXC-3181 Shutdown signal does not shutdown the node used to bootstrap…

### DIFF
--- a/doc/source/manual/bootstrap.rst
+++ b/doc/source/manual/bootstrap.rst
@@ -40,6 +40,11 @@ In case cluster that's being bootstrapped has already been set up before, and to
 
 This way values in :file:`my.cnf` would remain unchanged. Next time node is restarted it won't require updating the configuration file. This can be useful in case cluster has been previously set up and for some reason all nodes went down and the cluster needs to be bootstrapped again. 
 
+.. note::
+
+    A service started with ``mysql@bootstrap`` must be stopped using the same name. For example, the ``systemctl stop mysql`` command
+    does not stop an instance started with the ``mysql@bootstrap`` command.
+    
 Other Reading
 =============
 


### PR DESCRIPTION
… the cluster.

modified file: source/manual/bootstrap
added note to CentOS/RHEL 7 section