### PR TITLE
PXC-3182 - disallow write on 8.0 while 5.7 nodes are still on the clu…

### DIFF
--- a/mysql-test/suite/galera/r/pxc_block_write_while_in_rolling_upgrade.result
+++ b/mysql-test/suite/galera/r/pxc_block_write_while_in_rolling_upgrade.result
@@ -1,0 +1,30 @@
+#node-2
+CALL mtr.add_suppression("Percona-XtraDB-Cluster doesn't recommend use of multiple major versions while accepting write workload with pxc_strict_mode = PERMISSIVE");
+CALL mtr.add_suppression("pxc_maint_mode cannot be changed while using of multiple major versions");
+CALL mtr.add_suppression("Percona-XtraDB-Cluster prohibits use of multiple major versions while accepting write workload with pxc_strict_mode = ENFORCING");
+SET @global_saved_strict_tmp = @@global.pxc_strict_mode;
+SET GLOBAL pxc_strict_mode = ENFORCING;
+CREATE TABLE tb1 (ID INT PRIMARY KEY);
+INSERT INTO tb1 VALUES (1),(2),(3);
+SET GLOBAL debug="+d,simulate_wsrep_multiple_major_versions";
+SET GLOBAL pxc_maint_mode = DISABLED;
+ERROR HY000: pxc_maint_mode cannot be changed while using of multiple major versions
+include/assert_grep.inc [Assert that the expected entry is in the error log when pxc_strict_mode = ENFORCING]
+INSERT INTO tb1 VALUES (4);
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of multiple major versions while accepting write workload with pxc_strict_mode = ENFORCING or MASTER
+UPDATE tb1 SET ID = 5 WHERE ID = 3;
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of multiple major versions while accepting write workload with pxc_strict_mode = ENFORCING or MASTER
+DELETE FROM tb1 WHERE ID = 2;
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of multiple major versions while accepting write workload with pxc_strict_mode = ENFORCING or MASTER
+include/assert_grep.inc [Assert that the expected entry is in the error log when pxc_strict_mode = ENFORCING]
+SET GLOBAL pxc_strict_mode = PERMISSIVE;
+INSERT INTO tb1 VALUES (4);
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of multiple major versions while accepting write workload with pxc_strict_mode = PERMISSIVE
+UPDATE tb1 SET ID = 5 WHERE ID = 3;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of multiple major versions while accepting write workload with pxc_strict_mode = PERMISSIVE
+DELETE FROM tb1 WHERE ID = 2;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of multiple major versions while accepting write workload with pxc_strict_mode = PERMISSIVE
+include/assert_grep.inc [Assert that the expected entry is in the error log when pxc_strict_mode = ENFORCING]

--- a/mysql-test/suite/galera/t/pxc_block_write_while_in_rolling_upgrade.test
+++ b/mysql-test/suite/galera/t/pxc_block_write_while_in_rolling_upgrade.test
@@ -1,0 +1,80 @@
+#
+# PXC-3182 - disallow write on 8.0 while 5.7 nodes are still on the cluster
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug.inc
+
+--connection node_2
+--echo #node-2
+CALL mtr.add_suppression("Percona-XtraDB-Cluster doesn't recommend use of multiple major versions while accepting write workload with pxc_strict_mode = PERMISSIVE");
+CALL mtr.add_suppression("pxc_maint_mode cannot be changed while using of multiple major versions");
+CALL mtr.add_suppression("Percona-XtraDB-Cluster prohibits use of multiple major versions while accepting write workload with pxc_strict_mode = ENFORCING");
+SET @global_saved_strict_tmp = @@global.pxc_strict_mode;
+SET GLOBAL pxc_strict_mode = ENFORCING;
+CREATE TABLE tb1 (ID INT PRIMARY KEY);
+INSERT INTO tb1 VALUES (1),(2),(3);
+
+# provoke reconfiguration 
+SET GLOBAL debug="+d,simulate_wsrep_multiple_major_versions";
+--disable_query_log
+SET GLOBAL wsrep_cluster_address=@@wsrep_cluster_address;
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment'
+--source include/wait_condition.inc
+SET SESSION wsrep_sync_wait = DEFAULT;
+--enable_query_log
+
+# Test Error trying to change pxc_maint_mode
+--error ER_UNKNOWN_ERROR
+SET GLOBAL pxc_maint_mode = DISABLED;
+--let $assert_text= Assert that the expected entry is in the error log when pxc_strict_mode = ENFORCING
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = Synchronized with group, ready for connections
+--let $assert_select= .* \[ERROR\] .* pxc_maint_mode cannot be changed while using of multiple major versions
+--let $assert_count= 1
+--source include/assert_grep.inc
+
+# Test Error while writing data
+--error ER_UNKNOWN_ERROR
+INSERT INTO tb1 VALUES (4);
+--error ER_UNKNOWN_ERROR
+UPDATE tb1 SET ID = 5 WHERE ID = 3;
+--error ER_UNKNOWN_ERROR
+DELETE FROM tb1 WHERE ID = 2;
+
+--let $assert_text= Assert that the expected entry is in the error log when pxc_strict_mode = ENFORCING
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = Synchronized with group, ready for connections
+--let $assert_select= .* \[ERROR\] .* Percona-XtraDB-Cluster prohibits use of multiple major versions while accepting write workload with pxc_strict_mode = ENFORCING or MASTER
+--let $assert_count= 3
+--source include/assert_grep.inc
+
+# Test warning while writing data
+SET GLOBAL pxc_strict_mode = PERMISSIVE;
+INSERT INTO tb1 VALUES (4);
+UPDATE tb1 SET ID = 5 WHERE ID = 3;
+DELETE FROM tb1 WHERE ID = 2;
+--let $assert_text= Assert that the expected entry is in the error log when pxc_strict_mode = ENFORCING
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = Synchronized with group, ready for connections
+--let $assert_select= .* \[Warning\] .* Percona-XtraDB-Cluster doesn't recommend use of multiple major versions while accepting write workload with pxc_strict_mode = PERMISSIVE
+--let $assert_count= 3
+--source include/assert_grep.inc
+
+# Cleanup 
+--disable_query_log
+SET GLOBAL pxc_strict_mode = @global_saved_strict_tmp;
+SET GLOBAL debug="-d,simulate_wsrep_multiple_major_versions";
+SET GLOBAL wsrep_cluster_address=@@wsrep_cluster_address;
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment'
+--source include/wait_condition.inc
+SET SESSION wsrep_sync_wait = DEFAULT;
+DROP TABLE tb1;
+--enable_query_log
+

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1605,6 +1605,54 @@ static bool pxc_strict_mode_lock_check(THD *thd) {
 
   return block;
 }
+/*
+ * This function should be called to determine if cluster still has nodes
+ * with lower versions of wsrep_protocol_version (eg.: version 3).
+ * Writing on a new node can crash nodes with lower version 8.0->5.7
+ */
+static bool block_write_while_in_rolling_upgrade(THD *thd) {
+  /* Ignore check while server is not ready or for background wsrep applier too
+   * (like slave thread) */
+  if (!wsrep_node_is_synced() || (WSREP(thd) && thd->wsrep_applier))
+    return false;
+
+  bool block = false;
+  LEX *lex = thd->lex;
+  if (sql_command_flags[lex->sql_command] & CF_CHANGES_DATA) {
+    bool multi_version_cluster = wsrep_protocol_version < 4;
+    if (multi_version_cluster ||
+        DBUG_EVALUATE_IF("simulate_wsrep_multiple_major_versions", true,
+                         false)) {
+      const char *msg;
+      switch (pxc_strict_mode) {
+        case PXC_STRICT_MODE_DISABLED:
+          /* Do nothing */
+          break;
+        case PXC_STRICT_MODE_PERMISSIVE:
+          msg =
+              "Percona-XtraDB-Cluster doesn't recommend use of multiple major"
+              " versions while accepting write workload"
+              " with pxc_strict_mode = PERMISSIVE";
+          WSREP_WARN("%s", msg);
+          push_warning_printf(thd, Sql_condition::SL_WARNING, ER_UNKNOWN_ERROR,
+                              "%s", msg);
+          break;
+        case PXC_STRICT_MODE_MASTER:
+        case PXC_STRICT_MODE_ENFORCING:
+        default:
+          block = true;
+          msg =
+              "Percona-XtraDB-Cluster prohibits use of multiple major versions"
+              " while accepting write workload with pxc_strict_mode = "
+              "ENFORCING or MASTER";
+          WSREP_ERROR("%s", msg);
+          my_message(ER_UNKNOWN_ERROR, msg, MYF(0));
+          break;
+      }
+    }
+  }
+  return block;
+}
 #endif /* WITH_WSREP */
 
 /**
@@ -3329,6 +3377,9 @@ int mysql_execute_command(THD *thd, bool first_level) {
         !wsrep_is_show_query(lex->sql_command)) {
       my_message(ER_UNKNOWN_COM_ERROR,
                  "WSREP has not yet prepared node for application use", MYF(0));
+      return -1;
+    }
+    if (block_write_while_in_rolling_upgrade(thd)) {
       return -1;
     }
   }

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -122,6 +122,12 @@ ulong pxc_strict_mode = PXC_STRICT_MODE_ENFORCING;
 can stop diverting queries to this node. */
 ulong pxc_maint_mode = PXC_MAINT_MODE_DISABLED;
 
+/* wsrep-pxc-maint-mode controls whenever maintenance mode has been set by
+ * Wsrep_server_service::log_view.
+ * This blocks users from changing pxc_maint_mode
+ */
+bool wsrep_pxc_maint_mode_forced = false;
+
 /* sleep for this period before delivering shutdown signal. */
 ulong pxc_maint_transition_period = 30;
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -149,6 +149,7 @@ enum enum_pxc_maint_modes {
   PXC_MAINT_MODE_MAINTENANCE,
 };
 extern ulong pxc_maint_mode;
+extern bool wsrep_pxc_maint_mode_forced;
 extern ulong pxc_maint_transition_period;
 extern bool pxc_encrypt_cluster_traffic;
 

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -186,6 +186,33 @@ void Wsrep_server_service::log_view(
     global_system_variables.auto_increment_increment = view.members().size();
   }
   wsrep_protocol_version = view.protocol_version();
+  bool not_shutdown = (pxc_maint_mode != PXC_MAINT_MODE_SHUTDOWN);
+  bool multi_version_cluster = wsrep_protocol_version < 4;
+  if (not_shutdown &&
+      ((multi_version_cluster &&
+        (pxc_strict_mode > PXC_STRICT_MODE_PERMISSIVE)) ||
+       DBUG_EVALUATE_IF("simulate_wsrep_multiple_major_versions", true,
+                        false))) {
+    std::ostringstream os;
+    os << "Detected Protocol version: " << wsrep_protocol_version
+       << " Changing pxc_maint_mode to "
+          "MAINTENANCE.";
+    WSREP_INFO("%s", os.str().c_str());
+    pxc_maint_mode = PXC_MAINT_MODE_MAINTENANCE;
+    wsrep_pxc_maint_mode_forced = true;
+  } else {
+    /* if pxc_maint_mode was previously set by wsrep, we should reset */
+    if (wsrep_pxc_maint_mode_forced &&
+        pxc_maint_mode != PXC_MAINT_MODE_SHUTDOWN) {
+      std::ostringstream os;
+      os << "Detected Protocol version: " << wsrep_protocol_version
+         << " Changing pxc_maint_mode to "
+            "DISABLED.";
+      WSREP_INFO("%s", os.str().c_str());
+      pxc_maint_mode = PXC_MAINT_MODE_DISABLED;
+      wsrep_pxc_maint_mode_forced = false;
+    }
+  }
   mysql_mutex_unlock(&LOCK_global_system_variables);
 
   /* Update wsrep status variables */

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -1003,6 +1003,18 @@ bool pxc_maint_mode_check(sys_var *, THD *, set_var *var) {
     my_message(ER_UNKNOWN_ERROR, message, MYF(0));
     return true;
   }
+  /* pxc-maint-mode cannot be changed if operating with multiple major versions
+   * and pxc_strict_mode set to ENFORCING or MASTER.
+   * check Wsrep_server_service::log_view() */
+  if (wsrep_pxc_maint_mode_forced &&
+      pxc_strict_mode >= PXC_STRICT_MODE_ENFORCING) {
+    const char *msg =
+        "pxc_maint_mode cannot be changed while using of multiple major "
+        "versions";
+    WSREP_ERROR("%s", msg);
+    my_message(ER_UNKNOWN_ERROR, msg, MYF(0));
+    return true;
+  }
 
   /* Following transitions are allowed.
   DISABLED -> MAINTENANCE


### PR DESCRIPTION
…ster

This commit introduces the control of blocking queries that will modify
any data while cluster is operating with protocol lower than 4 and
pxc_strict_mode set to ENFORCING or MASTER.
It also sets pxc_maint_mode to MAINTENANCE so proxies won't redirect
traffic to this node while operating in multi major version mode.

Attempting to disable pxc_maint_mode while still on pxc_strict_mode
is not allowed.

Caveats:
Async replication is also blocked (this can cause the same issue on 5.7 nodes)
Disabling pxc_strict_mode, allow users to set pxc_maint_mode to DISABLED. Re-enabling pxc_strict_mode again doesn't automatically SET pxc_maint_mode to MAINTENANCE again, unless there is a reconfiguration of cluster view.