### PR TITLE
PXC-3189 SST fails if super_read_only

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_super_read_only.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_super_read_only.result
@@ -1,0 +1,7 @@
+SELECT 1;
+1
+1
+SET SESSION wsrep_sync_wait = 0;
+# restart
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_super_read_only.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_super_read_only.test
@@ -1,0 +1,26 @@
+#
+# This test checks the pxc-encrypt-cluster-traffic option (auto SSL config).
+# Initial SST happens via xtrabackup, so there is not much to do in the body of the test
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+
+SELECT 1;
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_2
+SET SESSION wsrep_sync_wait = 0;
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+--exec sed -i '/^\[mysqld.2\]/a super_read_only=ON' $MYSQLTEST_VARDIR/my.cnf
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+#cleanup
+--connection node_2
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+--exec sed -i '/^super_read_only=ON/d' $MYSQLTEST_VARDIR/my.cnf

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -791,6 +791,7 @@ function run_post_processing_steps()
         --log-error=${mysqld_err_log} \
         --log_output=NONE \
         --server-id=1 \
+        --super_read_only=OFF \
         --pid-file=${mysql_upgrade_dir_path}/mysqld.pid \
         --socket=$upgrade_socket \
         --datadir=$datadir --wsrep_provider=none"


### PR DESCRIPTION
Problem
If a joiner request an SST, as part of run_post_processing_steps
its required to start a temporary standalone mysqld server. In case
the user has super_read_only set on my.cnf the checks performed on that
routine will fail.

Solution
Always start temporary server with super_read_only=OFF.