### PR TITLE
PXC-3184: Node crashes on startup if socat isn't found and SST fails

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2413,7 +2413,12 @@ static void unireg_abort(int exit_code) {
      * wsrep threads here, we can only diconnect from service */
     wsrep_close_client_connections(false, true);
     wsrep_close_threads(NULL);
-    Wsrep_server_state::instance().disconnect();
+
+    auto state = Wsrep_server_state::instance().state();
+    if (state != wsrep::server_state::s_disconnected &&
+        state != wsrep::server_state::s_disconnecting) {
+      Wsrep_server_state::instance().disconnect();
+    }
 
     THD *thd = current_thd;
     if (thd) {

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -476,10 +476,8 @@ static void *sst_joiner_thread(void *a) {
       // Close the pipe, so that the other side gets an EOF
       proc.close_write_pipe();
     }
-
     if (!err && proc.pipe() && !proc.error()) {
       const char *tmp = my_fgets(out, out_len, proc.pipe());
-
       if (!tmp || strlen(tmp) < (magic_len + 2) ||
           strncasecmp(tmp, magic, magic_len)) {
         if (mysql_mutex_lock(&LOCK_wsrep_sst)) abort();
@@ -758,7 +756,7 @@ std::string wsrep_sst_prepare() {
   if (addr_len < 0) {
     WSREP_ERROR("Failed to prepare for '%s' SST. Unrecoverable.",
                 wsrep_sst_method);
-    unireg_abort(1);
+    throw wsrep::runtime_error("Failed to prepare for SST. Unrecoverable");
   }
 
   std::string ret;


### PR DESCRIPTION
Problem:
When socat is not found (or any other error occurs when sst script prepares SST request) server exits with crash.

Cause:
When we start mysqld wsrep_init_startup() initializes wsrep provider part and waits for node to be in 'initializing' or 'joiner' state. This wait can throw the exception, if we shift to 'disconnected' state. Exception is not caught.

While waiting sst_request_cb is called from context of wsrep_replication_process() (Galera). If socat is not present, creation of SST request string fails and we call unireg_abort() from this context. This causes wsrep provider to disconnect.

As the result we end up with unhandled exception in wsrep_init_startup() and server crash.

Several problems here:
1. unireg_abort() causes node disconnection from the group. As we are in context of wsrep_replication_process() this request cannot be fully processed (message waits in the queue for its turn to be picked up by wsrep_replication_process(), so we are waiting in sst_request_cb()
2. Fortunately the above causes shifting of server state to 'disconnecting', which causes exception to be generated when waiting in wsrep_init_startup(). Unfortunately there is no way to go from this point, as wsrep_replication_process() is blocked, so we cannot call unireg_abort() again (it will block in the same way as sst_request_cb()). The only thing we could do here is hard abort.

Solution:
When preparation of SST request fails in sst_request_cb(), instead of calling unireg_abort() we throw the exception (this is the original approach). Exception is caught gracefully in wsrep_provider_26 and translated into WSREP_CB_FAILURE error returned to Galera's replicator object. When error is detected, Galera shuts down its internals and causes server abort.

Additional improvements:
1. Prevent disconnecting of server in unireg_abort() if already disconnected.
2. Catch exception in wsrep_init_startup() and abort the server.