### PR TITLE
PXC-3204 pxc incorrectly set wsrep_protocol_version when wsrep_auto_i…

### DIFF
--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -184,8 +184,8 @@ void Wsrep_server_service::log_view(
   if (wsrep_auto_increment_control && view.own_index() >= 0) {
     global_system_variables.auto_increment_offset = view.own_index() + 1;
     global_system_variables.auto_increment_increment = view.members().size();
-    wsrep_protocol_version = view.protocol_version();
   }
+  wsrep_protocol_version = view.protocol_version();
   mysql_mutex_unlock(&LOCK_global_system_variables);
 
   /* Update wsrep status variables */


### PR DESCRIPTION
…ncrement_control is disabled

Problem
PXC will instantiate wsrep_protocol_version = wsrep_max_protocol_version
and will adjust the variable when there is a reconfiguration of the
cluster at Wsrep_server_service::log_view. However
wsrep_protocol_version will only change if wsrep_auto_increment_control
is enabled.

Solution
Move wsrep_protocol_version = view.protocol_version() line to outside
the if that checks for wsrep_auto_increment_control, this way the
variable will always have the latest protocol version passed via the
view reconfiguration.