### PR TITLE
PXC-3110 Updated current 8.0 documentation.

### DIFF
--- a/doc/source/.res/text/encrypt_binlog.removing.txt
+++ b/doc/source/.res/text/encrypt_binlog.removing.txt
@@ -1,4 +1,4 @@
-Starting from release :rn:`8.0.15-5`, |Percona Server| uses the upstream
+Starting from the release :rn:`8.0.15-5`, |Percona Server| uses the upstream
 implementation of binary log encryption. The variable |encrypt-binlog| is
 removed and the related command line option |opt.encrypt-binlog| is not
 supported. It is important that you remove the |encrypt-binlog| variable from

--- a/doc/source/add-node.rst
+++ b/doc/source/add-node.rst
@@ -46,7 +46,7 @@ proceed to add the next node.
 .. note::
 
    If the state of the node is ``Joiner``, it means that SST hasn't finished.
-   Do not add new nodes until all others are in ``Synced`` state.
+   Do not add new nodes until all others are in a ``Synced`` state.
 
 Starting the Third Node
 =======================
@@ -87,7 +87,7 @@ Next Steps
 
 When you add all nodes to the cluster, you can :ref:`verify replication
 <verify>` by running queries and manipulating data on nodes to see if these
-changes are synchronized accross the cluster.
+changes are synchronized across the cluster.
 
 .. |wsrep_sst_method| replace:: :variable:`wsrep_sst_method`
 .. |wsrep_cluster_address| replace:: :variable:`wsrep_cluster_address`

--- a/doc/source/features/highavailability.rst
+++ b/doc/source/features/highavailability.rst
@@ -1,14 +1,14 @@
 High Availability
 =================
 
-In a basic setup with 3 nodes, |PXC| will continue to function
+In a basic setup with 3 nodes, |PXC| continues to function
 if you take any of the nodes down.
 At any point in time, you can shut down any node to perform maintenance
 or make configuration changes.
 Even in unplanned situations
 (like a node crashing or if it becomes unavailable over the network),
-the |PXC| will continue to work
-and you'll be able to run queries on working nodes.
+the |PXC| continues to work,
+and you are able to run queries on working nodes.
 
 If there were changes to data while a node was down,
 there are two options that the node may use when it joins the cluster again:
@@ -16,8 +16,6 @@ there are two options that the node may use when it joins the cluster again:
 * **State Snapshot Transfer** (SST) is when all data is copied
   from one node to another.
 
-  SST is usually used when a new node joins the cluster
-  and receives all data from an existing node.
   |PXC| uses :program:`xtrabackup` for SST.
 
   SST using ``xtrabackup`` does not require the :command:`READ LOCK` command
@@ -28,15 +26,15 @@ there are two options that the node may use when it joins the cluster again:
   are copied from one node to another.
 
   Even without locking your cluster in read-only state, SST may be intrusive
-  and disrupt normal operation of your services.
+  and disrupt the normal operation of your services.
   IST lets you avoid that.
-  If a node goes down for a short period of time,
+  If a node goes down for a short period,
   it can fetch only those changes that happened while it was down.
-  IST is implemeted using a caching mechanism on nodes.
+  IST is implemented using a caching mechanism on nodes.
   Each node contains a cache, ring-buffer (the size is configurable)
-  of last N changes, and the node is able to transfer part of this cache.
-  Obviously, IST can be done only if the amount of changes needed to transfer
-  is less than N. If it exceeds N, then the joining node has to perform SST.
+  of last N changes, and the node can transfer part of this cache.
+  IST can be done if the amount of changes needed to transfer
+  is less than N. If the amount exceeds N, then the joining node must perform SST.
 
 You can monitor the current state of a node using the following command:
 

--- a/doc/source/features/multimaster-replication.rst
+++ b/doc/source/features/multimaster-replication.rst
@@ -6,10 +6,10 @@ Multi-Master Replication
 
 Multi-master replication means that you can write to any node
 and be sure that the write will be consistent for all nodes in the cluster.
-This is different from regular MySQL replication,
+This type of replication is different from regular MySQL replication,
 where you have to apply writes to master to ensure that it will be synced.
 
-With multi-master replication any write is either committed on all nodes
+With multi-master replication, any write is either committed on all nodes
 or not committed at all.
 The following diagram shows how it works for two nodes,
 but the same logic is applied with any number of nodes in the cluster:
@@ -37,12 +37,12 @@ Response time of ``COMMIT`` includes the following:
 There are two important consequences of this architecture:
 
 * Several appliers can be used in parallel.
-  This enables truely parallel replication.
+  This ability enables parallel replication.
   A slave can have many parallel threads configured
   using the :option:`wsrep_slave_threads` variable.
 
-* There might be a small period of time when a slave is out of sync.
-  This happens because the master may apply events faster than the slave.
+* There might be a small period when a slave is out of sync.
+  This out of sync happens because the master may apply events faster than the slave.
   And if you do read from the slave,
   you may read the data that has not changed yet.
   You can see that from the diagram.
@@ -50,20 +50,20 @@ There are two important consequences of this architecture:
   However, this behavior can be changed
   by setting the :option:`wsrep_causal_reads=ON` variable.
   In this case, the read on the slave will wait until the event is applied
-  (this will obviously increase the response time of the read).
+  (this setting will increase the response time of the read).
   The gap between the slave and the master is the reason
-  why this replication is called *virtually synchronous replication*,
+  why this replication is called *virtually synchronous replication*
   and not *real synchronous replication*.
 
 The described behavior of ``COMMIT`` also has another serious implication.
 If you run write transactions to two different nodes,
-the cluster will use an `optimistic locking model
+the cluster uses an `optimistic locking model
 <http://en.wikipedia.org/wiki/Optimistic_concurrency_control>`_.
-This means a transaction will not check on possible locking conflicts
+This model means a transaction will not check on possible locking conflicts
 during the individual queries, but rather on the ``COMMIT`` stage,
 and you may get ``ERROR`` response on ``COMMIT``.
 
-This is mentioned because it is one of the incompatibilities
+This information is mentioned because it is one of the incompatibilities
 with regular |InnoDB| that you might experience.
 With InnoDB, ``DEADLOCK`` and ``LOCK TIMEOUT`` errors usually happen
 in response to a particular query, but not on ``COMMIT``.

--- a/doc/source/features/pxc-strict-mode.rst
+++ b/doc/source/features/pxc-strict-mode.rst
@@ -4,44 +4,44 @@
 PXC Strict Mode
 ===============
 
-PXC Strict Mode is designed to avoid the use of
+Enabling ``pxc_strict_mode`` avoids the use of
 experimental and unsupported features in |PXC|.
-It performs a number of validations at startup and during runtime.
+It performs several validations at startup and during runtime.
 
 Depending on the actual mode you select,
 upon encountering a failed validation,
 the server will either throw an error
-(halting startup or denying the operation),
+(halting startup or denying the operation)
 or log a warning and continue running as normal.
 The following modes are available:
 
 * ``DISABLED``: Do not perform strict mode validations
   and run as normal.
 
-* ``PERMISSIVE``: If a vaidation fails, log a warning and continue running
+* ``PERMISSIVE``: If validation fails, log a warning and continue running
   as normal.
 
-* ``ENFORCING``: If a validation fails during startup,
+* ``ENFORCING``: If validation fails during startup,
   halt the server and throw an error.
   If a validation fails during runtime,
-  deny the operation and throw an error.
+  deny the operation, and throw an error.
 
 * ``MASTER``: The same as ``ENFORCING`` except that the validation of
   :ref:`explicit table locking <explicit-table-locking>` is not performed.
   This mode can be used with clusters
   in which write operations are isolated to a single node.
 
-By default, PXC Strict Mode is set to ``ENFORCING``,
+By default, ``pxc_strict_mode`` is set to ``ENFORCING``,
 except if the node is acting as a standalone server
-or the node is bootstrapping, then PXC Strict Mode defaults to ``DISABLED``.
+or the node is bootstrapping, then the variable is set to ``DISABLED``.
 
-It is recommended to keep PXC Strict Mode set to ``ENFORCING``,
-because in this case whenever |PXC| encounters an experimental feature
+It is recommended to keep ``pxc_strict_mode`` set to ``ENFORCING``,
+because in this case, whenever |PXC| encounters an experimental feature
 or an unsupported operation, the server will deny it.
-This will force you to re-evaluate your |PXC| configuration
+This setting forces you to re-evaluate your |PXC| configuration
 without risking the consistency of your data.
 
-If you are planning to set PXC Strict Mode to anything else than ``ENFORCING``,
+If you are planning to set the variable to anything else than ``ENFORCING``,
 you should be aware of the limitations and effects
 that this may have on data integrity.
 For more information, see :ref:`validations`.
@@ -55,7 +55,7 @@ or the ``--pxc-strict-mode`` option during ``mysqld`` startup.
    It is better to start the server with the necessary mode
    (the default ``ENFORCING`` is highly recommended).
    However, you can dynamically change it during runtime.
-   For example, to set PXC Strict Mode to ``PERMISSIVE``,
+   For example, to set the variable to ``PERMISSIVE``,
    run the following command::
 
       mysql> SET GLOBAL pxc_strict_mode=PERMISSIVE;
@@ -79,7 +79,7 @@ and do not rely on operations not supported by |PXC|.
 .. warning:: If an unsupported operation is performed on a node
    with ``pxc_strict_mode`` set to ``DISABLED`` or ``PERMISSIVE``,
    it will not be validated on nodes where it is replicated to,
-   even if the destination node has ``pxc_strict_mode`` set to ``ENFORCING``.
+   even if the destination node has the variable set to ``ENFORCING``.
 
 This section describes the purpose and consequences of each validation.
 
@@ -115,7 +115,7 @@ Depending on the selected mode, the following happens:
 
 ``PERMISSIVE``
 
- At startup, no validation is perfromed.
+ At startup, no validation is performed.
 
  At runtime, all operations are permitted,
  but a warning is logged when an undesirable operation
@@ -126,7 +126,7 @@ Depending on the selected mode, the following happens:
  At startup, no validation is performed.
 
  At runtime, any undesirable operation performed on an unsupported table
- is denied and an error is logged.
+ is denied, and an error is logged.
 
 .. note:: Unsupported tables can be converted to use a supported storage engine.
 
@@ -155,7 +155,7 @@ Depending on the selected mode, the following happens:
 ``PERMISSIVE``
 
  At startup, if :variable:`wsrep_replicate_myisam` is set to ``ON``,
- a warning is logged and startup continues.
+ a warning is logged, and startup continues.
 
  At runtime, it is permitted to change :variable:`wsrep_replicate_myisam`
  to any value, but if you set it to ``ON``, a warning is logged.
@@ -166,7 +166,7 @@ Depending on the selected mode, the following happens:
  an error is logged and startup is aborted.
 
  At runtime, any attempt to change :variable:`wsrep_replicate_myisam`
- to ``ON`` fails and an error is logged.
+ to ``ON`` fails, and an error is logged.
 
 .. note:: The :variable:`wsrep_replicate_myisam` variable controls
    *replication* for MyISAM tables,
@@ -191,7 +191,7 @@ Tables without primary keys
 |PXC| cannot properly propagate certain write operations
 to tables that do not have primary keys defined.
 Undesirable operations include data manipulation statements
-that perform writing to table (especially ``DELETE``).
+that perform writing to the table (especially ``DELETE``).
 
 Depending on the selected mode, the following happens:
 
@@ -203,7 +203,7 @@ Depending on the selected mode, the following happens:
 
 ``PERMISSIVE``
 
- At startup, no validation is perfromed.
+ At startup, no validation is performed.
 
  At runtime, all operations are permitted,
  but a warning is logged when an undesirable operation
@@ -215,7 +215,7 @@ Depending on the selected mode, the following happens:
 
  At runtime, any undesirable operation
  performed on a table without an explicit primary key
- is denied and an error is logged.
+ is denied, and an error is logged.
 
 Log output
 ----------
@@ -236,7 +236,7 @@ Depending on the selected mode, the following happens:
 ``PERMISSIVE``
 
  At startup, if ``log_output`` is set only to ``TABLE``,
- a warning is logged and startup continues.
+ a warning is logged, and startup continues.
 
  At runtime, it is permitted to change ``log_output``
  to any value, but if you set it only to ``TABLE``,
@@ -245,9 +245,9 @@ Depending on the selected mode, the following happens:
 ``ENFORCING`` or ``MASTER``
 
  At startup, if ``log_output`` is set only to ``TABLE``,
- an error is logged and startup is aborted.
+ an error is logged, and startup is aborted.
 
- At runtime, any attempt to change ``log_output`` only to ``TABLE`` fails
+ At runtime, any attempt to change ``log_output`` only to ``TABLE`` fails,
  and an error is logged.
 
 .. |log_output| replace:: ``log_output``
@@ -258,7 +258,7 @@ Depending on the selected mode, the following happens:
 Explicit table locking
 ----------------------
 
-|PXC| has only experimental support for explicit table locking operations,
+|PXC| has only experimental support for explicit table locking operations.
 The following undesirable operations lead to explicit table locking
 and are covered by this validation:
 
@@ -286,7 +286,7 @@ Depending on the selected mode, the following happens:
 
  At startup, no validation is performed.
 
- At runtime, any undesirable operation is denied and an error is logged.
+ At runtime, any undesirable operation is denied, and an error is logged.
 
 Auto-increment lock mode
 ------------------------
@@ -308,12 +308,12 @@ the following happens:
 ``PERMISSIVE``
 
  At startup, if ``innodb_autoinc_lock_mode`` is not set to ``2``,
- a warning is logged and startup continues.
+ a warning is logged, and startup continues.
 
 ``ENFORCING`` or ``MASTER``
 
  At startup, if ``innodb_autoinc_lock_mode`` is not set to ``2``,
- an error is logged and startup is aborted.
+ an error is logged, and startup is aborted.
 
 .. note:: This validation is not performed during runtime,
    because the ``innodb_autoinc_lock_mode`` variable
@@ -325,15 +325,15 @@ the following happens:
 Combining schema and data changes in a single statement
 -------------------------------------------------------
 
-With strict mode set to ``ENFORCING``, |PXC| does not support :abbr:`CTAS
+With the variable ``pxc_strict_mode`` set to ``ENFORCING``, |PXC| does not support :abbr:`CTAS
 (CREATE TABLE ... AS SELECT)` statements, because they combine both schema and
 data changes. Note that tables in the SELECT clause should be present on all
 replication nodes.
 
-With strict mode set to ``PERMISSIVE`` or ``DISABLED``, |ctas| statements are
+With the variable set to ``PERMISSIVE`` or ``DISABLED``, |ctas| statements are
 replicated using the :abbr:`TOI (Total Order Isolation)` method to ensure
 consistency. In |PXC| 5.7, |ctas| statements were replicated using DML
-write-sets when strict mode was set to ``PERMISSIVE`` or ``DISABLED``.
+write-sets when the variable was set to ``PERMISSIVE`` or ``DISABLED``.
 
 .. important::
    
@@ -359,7 +359,7 @@ Depending on the strict mode selected, the following happens:
      - At startup, no validation is performed. At runtime, all operations are
        permitted.
    * - PERMISSIVE
-     - At startup, no validation is perfromed. At runtime, all operations are
+     - At startup, no validation is performed. At runtime, all operations are
        permitted, but a warning is logged when a |ctas| operation is performed.
    * - ENFORCING
      - At startup, no validation is performed. At runtime, any CTAS operation is
@@ -367,8 +367,8 @@ Depending on the strict mode selected, the following happens:
 
 .. important::
 
-   Although |ctas| operations for temporary tables are permitted even in
-   ``STRICT`` mode, temporary tables should not be used as *source* tables in
+   Although |ctas| operations for temporary tables are permitted,
+   temporary tables should not be used as *source* tables in
    |ctas| operations due to the fact that temporary tables are not present on
    all nodes.
 
@@ -396,7 +396,7 @@ the following happens:
 
 ``PERMISSIVE``
 
- At startup, no validation is perfromed.
+ At startup, no validation is performed.
 
  At runtime, all operations are permitted,
  but a warning is logged when you discard or import a tablespace.

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -36,9 +36,9 @@
      The Isolation requirement means that no transaction can interfere
      with another.
   
-   InnoDB A
+   InnoDB 
 
-     :term:`Storage Engine` for MySQL and derivatives
+     A :term:`Storage Engine` for MySQL and derivatives
      (:term:`Percona Server`, :term:`MariaDB`) originally written by
      Innobase Oy, since acquired by Oracle. It provides :term:`ACID`
      compliant storage engine with :term:`foreign key` support. InnoDB
@@ -50,20 +50,15 @@
      system that we use to help ensure the continued quality of the
      software we produce. It helps us achieve the aims of:
   
-      * no failed tests in trunk on any platform,
+      * no failed tests in the trunk on any platform,
       * aid developers in ensuring merge requests build and test on all platforms,
       * no known performance regressions (without a damn good explanation).
-  
-   LSN
-
-     Log Serial Number. A term used in relation to the :term:`InnoDB` or
-     :term:`XtraDB` storage engines.
   
    MariaDB
 
      A fork of :term:`MySQL` that is maintained primarily by Monty
-     Program AB. It aims to add features, fix bugs while maintaining 100%
-     backwards compatibility with MySQL.
+     Program AB. MariaDB 
+     aims to add features, fix bugs while maintaining compatibility with MySQL.
   
    MyISAM
 
@@ -118,8 +113,8 @@
   
    LSN
 
-      Each InnoDB page (usually 16kb in size) contains a log sequence number, or
-      LSN. The LSN is the system version number for the entire database. Each
+      Each InnoDB page (usually 16kb in size) contains a log sequence number. 
+      The LSN is the system version number for the entire database. Each
       page's LSN shows how recently it was changed.
   
    InnoDB
@@ -148,7 +143,7 @@
       and HTTP-based applications. It is particularly suited for web sites
       crawling under very high loads while needing persistence or Layer7
       processing. Supporting tens of thousands of connections is clearly
-      realistic with todays hardware. Its mode of operation makes its
+      realistic with today's hardware. Its mode of operation makes its
       integration into existing architectures very easy and riskless, while
       still offering the possibility not to expose fragile web servers to the
       net.
@@ -168,13 +163,13 @@
       purpose.  :program:`xtrabackup` does not require :command:`READ
       LOCK` for the entire syncing process - only for syncing the
       |MySQL| system tables and writing the information about the
-      binlog, galera and slave information (same as the regular
+      binlog, Galera and slave information (same as the regular
       |Percona XtraBackup| backup). The SST method is configured with
       the :variable:`wsrep_sst_method` variable.
   
    UUID
 
-      Universally Unique IDentifier which uniquely identifies the state and the
+      Universally Unique Identifier which uniquely identifies the state and the
       sequence of changes node undergoes. 128-bit UUID is a classic DCE UUID
       Version 1 (based on current time and MAC address). Although in theory this
       UUID could be generated based on the real MAC-address, in the Galera it is
@@ -275,7 +270,7 @@
   
    node
 
-      A cluster node -- a single mysql instance that is in the cluster.
+      A cluster node -- a single MySQL instance that is in the cluster.
   
    primary cluster
 

--- a/doc/source/howtos/proxysql-v2.rst
+++ b/doc/source/howtos/proxysql-v2.rst
@@ -25,7 +25,7 @@ Added Features
   reads. The default value is 100
 - New operation ``--update-cluster`` to update the cluster membership by adding
   server nodes as found. (Note that nodes are added but not removed).  The
-  ``--writer-hg`` option may be used to specify which galera hostgroup to
+  ``--writer-hg`` option may be used to specify which Galera hostgroup to
   update. The ``--remove-all-servers`` option instructs to remove all servers
   from the mysql_servers table before updating the cluster.
 - Hostgroups can be specified on the command-line: ``--writer-hg``,
@@ -66,7 +66,7 @@ Changed Features
 
 - The commands ``--syncusers``, ``--sync-multi-cluster-users``, ``--adduser``,
   and ``--disable`` can use the ``--writer-hg`` option.
-- The command ``--disable`` removes all users associated with the galera cluster
+- The command ``--disable`` removes all users associated with the Galera cluster
   hostgroups. Previously, this command only removed the users with the
   **CLUSTER_APP_USERNAME**.
 - The command ``--disable`` accepts the ``--writer-hg`` option to disable the
@@ -672,7 +672,7 @@ nodes are not removed from the cluster by default.
 If used with ``--remove-all-servers``, then the server list for this configuration
 will be removed before running the update cluster function.
 
-A specific galera cluster can be updated by using the ``--writer-hg`` option
+A specific Galera cluster can be updated by using the ``--writer-hg`` option
 with ``--update-cluster``.  Otherwise the cluster specified in the config file
 will be updated.
 
@@ -712,7 +712,7 @@ the server list and is ONLINE.  This should only be used if the mode is _singlew
 --is-enabled
 --------------------------------------------------------------------------------
 
-This option will check if a galera cluster (specified by the writer hostgroup,
+This option will check if a Galera cluster (specified by the writer hostgroup,
 either from ``--writer-hg`` or from the config file) has any active entries
 in the ``mysql_galera_hostgroups`` table in ProxySQL.
 

--- a/doc/source/howtos/proxysql.rst
+++ b/doc/source/howtos/proxysql.rst
@@ -513,7 +513,7 @@ which is monitored by ProxySQL and can be set to one of the following values:
   changing hardware parts, relocating the server, etc.
 
   When you initiate node shutdown, |PXC| does not send the signal immediately.
-  Intead, it changes the state to ``pxc_maint_mode=SHUTDOWN``
+  Instead, it changes the state to ``pxc_maint_mode=SHUTDOWN``
   and waits for a predefined period (10 seconds by default).
   When ProxySQL detects that the mode is set to ``SHUTDOWN``,
   it changes the status of this node to ``OFFLINE_SOFT``,
@@ -522,7 +522,7 @@ which is monitored by ProxySQL and can be set to one of the following values:
   any long-running transactions that are still active are aborted.
 
 * ``MAINTENANCE``: You can change to this state
-  if you need to perform maintenace on a node without shutting it down.
+  if you need to perform maintenance on a node without shutting it down.
 
   You may need to isolate the node for some time,
   so that it does not receive traffic from ProxySQL
@@ -543,18 +543,17 @@ which is monitored by ProxySQL and can be set to one of the following values:
 
 You can increase the transition period
 using the :variable:`pxc_maint_transition_period` variable
-to accomodate for long-running transactions.
+to accommodate for long-running transactions.
 If the period is long enough for all transactions to finish,
 there should hardly be any disruption in cluster workload.
 
 During the transition period,
 the node continues to receive existing write-set replication traffic,
-ProxySQL avoids openning new connections and starting transactions,
-but the user can still open conenctions to monitor status.
+ProxySQL avoids opening new connections and starting transactions,
+but the user can still open connections to monitor status.
 
 .. note:: If you increase the transition period,
    the packaging script may determine it as a server stall.
-
 
 .. |proxysql| replace:: ProxySQL
 .. |proxysql-admin| replace:: ``proxysql-admin``

--- a/doc/source/howtos/ubuntu_howto.rst
+++ b/doc/source/howtos/ubuntu_howto.rst
@@ -261,7 +261,7 @@ Step 4. Configuring the third node
 Testing replication
 ===================
 
-To test replication, lets create a new database on the second node,
+To test the replication, let's create a new database on the second node,
 create a table for that database on the third node,
 and add some records to the table on the first node.
 

--- a/doc/source/howtos/upgrade_guide.rst
+++ b/doc/source/howtos/upgrade_guide.rst
@@ -269,7 +269,8 @@ cluster:
    size.  Also, during the upgrade, the cluster will operate with an even number
    of nodes - the cluster may run into the split-brain problem.
 
-This upgrade flow auto-detects the presence of the 5.7 data directory and trigger
+This upgrade flow auto-detects the presence of the 5.7 data directory and
+triggers
 the upgrade as part of the node bootup process. The data directory is upgraded
 to be compatible with |pxc| |version|. Then the node joins the cluster and
 enters synced state. The 3-node cluster is restored with 2 nodes running |pxc|

--- a/doc/source/howtos/virt_sandbox.rst
+++ b/doc/source/howtos/virt_sandbox.rst
@@ -199,7 +199,7 @@ with application servers.
    .. note::
 
       ProxySQL uses the concept of *hostgroups* to group cluster nodes.
-      This enables you to balance the load in a cluster by
+      This concept enables you to balance the load in a cluster by
       routing different types of traffic to different groups.
       There are many ways you can configure hostgroups
       (for example master and slaves, read and write load, etc.)
@@ -412,9 +412,9 @@ This example shows how to do it with ``sysbench`` from the EPEL repository.
 
 If you are using |HAProxy| for |MySQL| you can break the privilege system’s
 host part, because |MySQL| will think that the connections are always coming
-from the load balancer. You can work this around using T-Proxy patches and some
+from the load balancer. You can work around this issue by using T-Proxy patches
+and some
 `iptables` magic for the backwards connections. However in the setup described
 in this how-to this is not an issue, since each application server has it's own
 |HAProxy| instance, each application server connects to 127.0.0.1, so MySQL
-will see that connections are coming from the application servers. Just like in
-the normal case.
+will see that connections are coming from the application servers.

--- a/doc/source/install/apt.rst
+++ b/doc/source/install/apt.rst
@@ -85,9 +85,9 @@ Installing from Repository
 
       $ sudo service mysql stop
 
-   .. note:: All Debian-based distributions start services
+   .. note:: All Debian-based distributions start the services
       as soon as the corresponding package is installed.
-      Before starting a |PXC| node, it needs to be properly configured.
+      Before starting a |PXC| node, it must be properly configured.
       For more information, see :ref:`configure`.
 
 Next Steps

--- a/doc/source/install/yum.rst
+++ b/doc/source/install/yum.rst
@@ -77,7 +77,7 @@ Installing from Percona Repository
 
       $ sudo service mysql start
 
-#. Copy the automatically generated temporary password
+#. Copy the automatically- generated, temporary password
    for the superuser account:
 
    .. code-block:: bash

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -9,7 +9,7 @@ integrates |PS|_ and |PXB|_ with the Galera_ library to enable synchronous
 multi-master replication.
 
 A *cluster* consists of *nodes*, where each node contains the same set of data
-synchronized accross nodes.  The recommended configuration is to have at least 3
+synchronized across nodes.  The recommended configuration is to have at least 3
 nodes, but you can have 2 nodes as well.  Each node is a regular MySQL Server
 instance (for example, Percona Server).  You can convert an existing MySQL
 Server instance to a node and run the cluster using this node as a base.  You
@@ -25,7 +25,7 @@ instance.
   All data is available locally, no need for remote access.
 
 * No central management.
-  You can loose any node at any point of time,
+  You can lose any node at any point of time,
   and the cluster will continue to function without any data loss.
 
 * Good solution for scaling a read workload.
@@ -52,4 +52,3 @@ It uses the Galera_ library,
 which is an implementation of the write set replication (wsrep) API
 developed by `Codership Oy <http://www.galeracluster.com/>`_.
 The default and recommended data transfer method is via |PXB|_.
-

--- a/doc/source/limitation.rst
+++ b/doc/source/limitation.rst
@@ -22,7 +22,7 @@ Unsupported queries:
 
    Lock functions, such as ``GET_LOCK()``, ``RELEASE_LOCK()``, and so on
 
-Query log cannot be directed to table.
+Query log cannot be directed to the table.
 
    If you enable query logging, you must forward the log to a file:
 
@@ -37,13 +37,13 @@ Query log cannot be directed to table.
   :variable:`wsrep_max_ws_rows` and :variable:`wsrep_max_ws_size` variables.
   ``LOAD DATA INFILE`` processing will commit every 10 000 rows.
   So large transactions due to ``LOAD DATA``
-  will be split to series of small transactions.
+  will be split to a series of small transactions.
 
 * Due to cluster-level optimistic concurrency control,
   transaction issuing ``COMMIT`` may still be aborted at that stage.
   There can be two transactions writing to the same rows
   and committing in separate |PXC| nodes,
-  and only one of the them can successfully commit.
+  and only one of them can successfully commit.
   The failing one will be aborted.
   For cluster-level aborts, |PXC| gives back deadlock error code: ::
 
@@ -56,7 +56,7 @@ Query log cannot be directed to table.
   for stable high performance, then it should be supported by corresponding
   hardware.
 
-* The minimal recommended size of cluster is 3 nodes.  The 3rd node can be an
+* The minimal recommended size of a cluster is 3 nodes.  The 3rd node can be an
   arbitrator.
 
 * InnoDB fake changes feature is not supported.
@@ -73,6 +73,6 @@ Query log cannot be directed to table.
   tables without a primary key.
 
   .. seealso::
+     `Galera Limitations <https://mariadb.com/kb/en/mariadb-galera-cluster-known-limitations/>`_
 
-     Galera Documentation: Tables without Primary Keys
-        http://galeracluster.com/documentation-webpages/limitations.html#tables-without-primary-keys
+        

--- a/doc/source/management/data_at_rest_encryption.rst
+++ b/doc/source/management/data_at_rest_encryption.rst
@@ -20,7 +20,9 @@ the `encrypt traffic documentation <https://www.percona.com/doc/percona-xtradb-c
 therefore supposed to be safe. Below sections are about securing the
 data-at-rest only. 
 
-|PXC| |version| supports all |data-at-rest| encryption features available from |percona-server| 8.0.
+|PXC| |version| supports all Genrerally Available (GA) |data-at-rest|
+encryption features
+available from |percona-server| 8.0.
 
 .. seealso::
 
@@ -78,8 +80,8 @@ successfully loaded.
 
 .. note:: PXC recommends same configuration on all the nodes of the cluster,
    and that also means all the nodes of the cluster should have keyring
-   configured. Mismatch in keyring configuration will not allow JOINER node to
-   join the cluster.
+   configured. A mismatch in keyring configuration will not allow a JOINER
+   node to join the cluster.
 
 If the user has bootstrapped node with keyring enabled, then upcoming nodes of the
 cluster will inherit the keyring (encrypted key) from the DONOR node
@@ -157,7 +159,8 @@ Also ``keyring_vault_n1.conf`` file contents should be :
 
 Detailed description of these options can be found in the `upstream documentation <https://www.percona.com/doc/percona-server/8.0/management/data_at_rest_encryption.html#keyring-vault-plugin>`_.
 
-Vault-server is an external server so make sure PXC node is able to reach to the said
+Vault-server is an external server so make sure the PXC node is able to reach to
+the said
 server.
 
 .. note:: |PXC| recommends to use same keyring_plugin on all the nodes of the
@@ -191,7 +194,7 @@ consequences are the same, and the corresponding error looks like following:
    ... [ERROR] Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault. ...
 
 In case of accessible vault-server with the wrong mount point, there is no
-error during server boot, but sitll node refuses to start:
+error during server boot, but still node refuses to start:
 
 .. code-block:: text
 
@@ -208,8 +211,8 @@ With |xtrabackup| introducing transition-key logic it is now possible to
 mix-match keyring plugins. For example, user has node-1 configured to use
 ``keyring_file`` plugin and node-2 configured to use ``keyring_vault``.
 
-.. note:: Percona recommends same configuration for all the nodes of the
-   cluster. Mix-match (in keyring plugins) is recommended only during
+.. note:: Percona recommends the same configuration for all nodes of the
+   cluster. A mix-match (in keyring plugins) is recommended only during
    transition from one keying to other.
 
 Upgrade and compatibility issues
@@ -226,8 +229,8 @@ Temporary file encryption
 Percona Server supports the encryption of temporary file storage
 enabled using ``encrypt-tmp-files``. This storage or files are local to the
 node and has no direct effect on |PXC| replication. |PXC| recommends enabling
-it on all the nodes of the cluster, though that is not mandatory. Parameter to
-enable this option is same as in Percona Server:
+it on all the nodes of the cluster, though that is not mandatory. The
+parameter to enable this option is same as in Percona Server:
 
 .. code-block:: text
 
@@ -337,7 +340,7 @@ Migration server options
 * ``--keyring-migration-port``: For TCP/IP connections, the port number to
   connect to on the running server.
 
-* ``--keyring-migration-socket``: For Unix socket file or Windows named pipe
+* ``--keyring-migration-socket``: For a Unix socket file or a Windows named pipe
   connections, the socket file or named pipe to connect to on the running
   server. 
 

--- a/doc/source/manual/certification.rst
+++ b/doc/source/manual/certification.rst
@@ -104,7 +104,7 @@ and only in primary state (skip messages while in state exchange). ::
 
 .. note:: This is an amazing way to solve the problem
    of the id coordination in multi-master systems.
-   Otherwise a node will have to first get an id from central system
+   Otherwise, a node will have to first get an id from central system
    or through a separate agreed protocol,
    and then use it for the packet, thereby doubling the round-trip time.
 
@@ -183,8 +183,9 @@ to reflect reference transaction.
   Using the same case as explained above, Node 1 certification
   also rejects the packet from Node 1.
 
-This suggests that the node doesn't need to wait for certification to complete,
-but just needs to ensure that the packet is written to the channel.
+This action suggests that the node does not need to wait for certification to
+complete,
+but needs to ensure that the packet is written to the channel.
 The applier transaction will always win
 and the local conflicting transaction will be rolled back.
 

--- a/doc/source/manual/gcache_record-set_cache_difference.rst
+++ b/doc/source/manual/gcache_record-set_cache_difference.rst
@@ -29,7 +29,7 @@ then the storage is switched from Heap to Page
 All these limits are non-configurable,
 but having a memory-page size greater than 4MB per transaction
 can cause things to stall due to memory pressure,
-so this limit is reasonable. This is another
+so this limit is reasonable,  another
 limitation to address when Galera supports large transaction.
 
 The same long-running transaction will also generate binlog data

--- a/doc/source/manual/performance_schema_instrumentation.rst
+++ b/doc/source/manual/performance_schema_instrumentation.rst
@@ -39,7 +39,7 @@ Some of the most important are:
   Mutexes, condition variables, and threads related to this are part of
   ``PERFORMANCE_SCHEMA``.
 
-* Galera internally uses monitor mechanism to enforce ordering of
+* Galera internally uses a monitor mechanism to enforce the ordering of
   events. These monitor control events apply and are mainly responsible for
   the wait between different action. All such monitor mutexes and condition
   variables are covered as part of this implementation.

--- a/doc/source/manual/threading_model.rst
+++ b/doc/source/manual/threading_model.rst
@@ -25,7 +25,7 @@ which means at least one wsrep applier thread exists to process the request.
 Applier threads wait for an event, and once it gets the event,
 it applies it using normal slave apply routine path,
 and relays the log info apply path with wsrep-customization.
-These threads are similar to slave worker threads (but not exactly the same).
+These threads are similar to slave worker threads but are not exactly the same.
 
 Coordination is achieved using *Apply and Commit Monitor*.
 A transaction passes through two important states: ``APPLY`` and ``COMMIT``.

--- a/doc/source/manual/xtrabackup_sst.rst
+++ b/doc/source/manual/xtrabackup_sst.rst
@@ -6,10 +6,11 @@ Percona XtraBackup SST Configuration
 
 Percona XtraBackup SST works in two stages:
 
-1. First it identifies the type of data transfer
+1. Identifies the type of data transfer
   based on the presence of :file:`xtrabackup_ist` file on the joiner node.
 
-#. Then it starts data transfer. In case of |SST|, it empties the data directory except for some files
+#. Starts data transfer. In case of |SST|, it empties the data
+directory except for some files
    (:file:`galera.cache`, :file:`sst_in_progress`, :file:`grastate.dat`)
    and then proceeds with SST.
 
@@ -41,7 +42,7 @@ under ``[sst]``.
 Used to specify the Percona XtraBackup streaming format.
 The recommended value is ``streamfmt=xbstream``.
 Certain features are not available with ``tar``, for instance:
-encryption, compression, parallel streaming, streaming incremental backups.
+encryption, compression, parallel streaming, and streaming incremental backups.
 For more information about the ``xbstream`` format, see `The xbstream Binary
 <https://www.percona.com/doc/percona-xtrabackup/2.4/xbstream/xbstream.html>`_.
 
@@ -87,8 +88,8 @@ for ``socat`` encryption based on OpenSSL.
    For testing you can also download certificates from
    `launchpad <https://bazaar.launchpad.net/~percona-core/percona-xtradb-cluster/5.5/files/head:/tests/certs/>`_.
 
-.. note:: Irrespective of what is shown in the example,
-   you can use the same .crt and .pem files on all nodes and it will work,
+.. note:: You can use the same .crt and .pem files on all nodes and it will
+work,
    since there is no server-client paradigm here,
    but rather a cluster with homogeneous nodes.
 
@@ -352,7 +353,7 @@ and should be specified under the ``[sst]`` group.
 XtraBackup SST Dependencies
 ---------------------------
 
-Each suppored version of |PXC| is tested against a specific version of |PXB|:
+Each supported version of |PXC| is tested against a specific version of |PXB|:
 
 * |PXC| 5.6 requires |PXB| 2.3
 * |PXC| 5.7 requires |PXB| 2.4

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -20,7 +20,7 @@ as a common choice for trying out and testing:
 +--------+-----------+---------------+
 
 .. note:: Avoid creating a cluster with two or any even number of nodes,
-   because this can lead to *split brain*.
+   because this can lead to a *split brain*.
    For more information, see :ref:`failover`.
 
 The following procedure provides an overview

--- a/doc/source/security/encrypt-traffic.rst
+++ b/doc/source/security/encrypt-traffic.rst
@@ -48,7 +48,7 @@ to communicate with cluster nodes.
 
 |MySQL| generates default key and certificate
 files and places them in data directory. You can either use them or generate
-new certificates. For generation of new certificate please refer to
+new certificates. For the generation of new certificate please refer to
 :ref:`generate-keys-certs` section.
 
 .. _encrypt-replication-traffic:
@@ -87,7 +87,7 @@ enables automatic configuration of SSL encryption there-by encrypting
 This variable is not dynamic and so cannot be changed on runtime. To
 enable automatic configuration of SSL encryption, set
 ``pxc-encrypt-cluster-traffic=ON`` in the the ``[mysqld]`` section of the
-:file:`my.cnf` file, and restart the cluster (by default it is disabled
+:file:`my.cnf` file, and restart the cluster (by default, it is disabled
 there-by using non-secured channel for replication).
 
 .. note::
@@ -141,7 +141,7 @@ files shoud be specified in the |PXC| configuration. If you do not have the
 necessary files, see :ref:`generate-keys-certs`.
 
 .. note:: Encryption settings are not dynamic.
-   To enable it on a running cluster, you need to restart the entire cluster.
+   To enable it on a running cluster, you must restart the entire cluster.
 
 There are three aspects of |PXC| operation, where you can enable encryption:
 
@@ -361,7 +361,8 @@ If the verification is successful, you should see the following output::
 
 Sometimes, an SSL configuration may fail if the certificate and the CA files contain the same :abbr:`CN (SSL Certificate Common Name)`.
 
-To check if this is the case run ``openssl`` command as follows and verify that the **CN** field differs for the *Subject* and *Issuer* lines.
+To check if this is the case, run ``openssl`` command as follows and verify
+that the **CN** field differs for the *Subject* and *Issuer* lines.
 
 .. code-block:: bash
 

--- a/doc/source/wsrep-files-index.rst
+++ b/doc/source/wsrep-files-index.rst
@@ -7,15 +7,17 @@
 * :file:`GRA_*.log`
    These files contain binlog events in ROW format representing the failed
    transaction. That means that the slave thread was not able to apply one of
-   the transactions. For each of those file, a corresponding warning or error
-   message is present in the mysql error log file. Those error can also be
+   the transactions. For each of those files, a corresponding warning or error
+   message is present in the mysql error log file. Those errors can also be
    false positives like a bad ``DDL`` statement (dropping  a table that doesn't
-   exists for example) and therefore nothing to worry about. However it's
-   always recommended to check these log to understand what's is happening.
+   exists for example) and, therefore, nothing to worry about. However it's
+   always recommended to check these logs.
 
-   To be able to analyze these files binlog header needs to be added to the log
+   To be able to analyze these files the binlog header needs to be added to the
+log
    file. To create the ``GRA_HEADER`` file you need an instance running with
-   :variable:`binlog_checksum` set to ``NONE`` and extract first 120 bytes from
+   :variable:`binlog_checksum` set to ``NONE`` and to extract the first 120
+bytes from
    the binlog file:
 
    .. code-block:: bash
@@ -80,7 +82,7 @@
    This file is used as a main writeset store. It's implemented as a permanent
    ring-buffer file that is preallocated on disk when the node is initialized.
    File size can be controlled with the variable :variable:`gcache.size`. If
-   this value is bigger, more writesets are cached and chances are better that
+   this value is larger, more writesets are cached and chances are better that
    the re-joining node will get |IST| instead of |SST|. Filename can be changed
    with the :variable:`gcache.name` variable.
 
@@ -89,7 +91,7 @@
 
   * ``version`` - grastate version
   * ``uuid`` - a unique identifier for the state and the sequence of changes it
-    undergoes.For more information on how UUID is generated see :term:`UUID`.
+    undergoes. For more information on how UUID is generated see :term:`UUID`.
   * ``seqno`` - Ordinal Sequence Number, a 64-bit signed integer used to denote
     the position of the change in the sequence. ``seqno`` is ``0`` when no
     writesets have been generated or applied on that node, i.e., not
@@ -107,7 +109,7 @@
 
   Examples of this file look like this:
 
-  In case server node has this state when not running it means that that node
+  In case the server node has this state when not running, the node
   crashed during the transaction processing. ::
 
     # GALERA saved state
@@ -116,8 +118,8 @@
     seqno:   -1
     cert_index:
 
-  In case server node has this state when not running it means that the node
-  was gracefully shut down. ::
+  In case the server node has this state when not running, the node was
+  gracefully shut down. ::
 
     # GALERA saved state
     version: 2.1
@@ -125,7 +127,7 @@
     seqno:   5192193423942
     cert_index:
 
-  In case server node has this state when not running it means that the node
+  In case the server node has this state when not running, the node
   crashed during the DDL. ::
 
     # GALERA saved state
@@ -136,13 +138,14 @@
 
 * :file:`gvwstate.dat`
   This file is used for Primary Component recovery feature. This file is
-  created once primary component is formed or changed, so you can get the
-  latest primary component this node was in. And this file is deleted when the
+  created once the primary component is formed or changed, so you can get the
+  latest primary component this node was in. This file is deleted when the
   node is shutdown gracefully.
 
-  First part contains the node :term:`UUID` information. Second part contains
-  the view information. View information is written between ``#vwbeg`` and
-  ``#vwend``. View information consists of:
+  The first part contains the node :term:`UUID` information. The second part
+contains
+  the view information. The view information is written between ``#vwbeg`` and
+  ``#vwend``. The view information consists of the following:
 
  - view_id: [view_type] [view_uuid] [view_seq]. - ``view_type`` is always ``3``
    which means primary view. ``view_uuid`` and ``view_seq`` identifies a unique

--- a/doc/source/wsrep-provider-index.rst
+++ b/doc/source/wsrep-provider-index.rst
@@ -117,10 +117,10 @@ When this variable is set to ``yes``, it will enable debugging.
    :dyn: Yes
    :default: 0
 
-Number of entries allowed on delayed list until auto eviction takes place.
-Setting value to ``0`` disables auto eviction protocol on the node, though node
+Number of entries allowed on delayed list until auto-eviction takes place.
+Setting value to ``0`` disables auto-eviction protocol on the node, though node
 response times will still be monitored. EVS protocol version
-(:variable:`evs.version`) ``1`` is required to enable auto eviction.
+(:variable:`evs.version`) ``1`` is required to enable auto-eviction.
 
 .. variable:: evs.causal_keepalive_period
 
@@ -130,7 +130,7 @@ response times will still be monitored. EVS protocol version
    :dyn: No
    :default: value of :variable:`evs.keepalive_period`
 
-This variable is used for development purposes and shouldn't be used by regular
+This variable is used for development purposes and should not be used by regular
 users.
 
 .. variable:: evs.debug_log_mask
@@ -262,7 +262,7 @@ up (total rounds will be :variable:`evs.max_install_timeouts` + 2).
 
 This variable defines the maximum number of data packets in replication at a
 time. For WAN setups, the variable can be set to a considerably higher value
-than default (for example,512). The value must not be less than
+than default (for example, 512). The value must not be less than
 :variable:`evs.user_send_window`.
 
 .. variable:: evs.stats_report_period
@@ -284,7 +284,8 @@ This variable defines the control period of EVS statistics reporting.
    :default: PT5S
 
 This variable defines the inactivity period after which the node is
-"suspected" to be dead. If all remaining nodes agree on that, the node will be
+"suspected" to be dead. If all of the remaining nodes agree on that, the node
+will be
 dropped out of cluster even before :variable:`evs.inactive_timeout` is reached.
 
 .. variable:: evs.use_aggregate
@@ -431,7 +432,7 @@ cleanup is called on excess overflow pages to delete them.
 
 This variable was used to define how much RAM is available for the system.
 
-.. warning:: This variable has been deprecated and shouldn't be used as it
+.. warning:: This variable has been deprecated and should not be used as it
   could cause a node to crash.
 
 .. variable:: gcache.name
@@ -546,7 +547,7 @@ fragmented.
    :default: 0.25
 
 This variable specifies how much the replication can be throttled during the
-state transfer in order to avoid running out of memory. Value can be set to
+state transfer in order to avoid running out of memory. The value can be set to
 ``0.0`` if stopping replication is acceptable in order to finish state
 transfer.
 
@@ -795,7 +796,7 @@ component.
    :dyn: Yes
    :default: 1
 
-This variable specifies the node weight that's going to be used for Weighted
+This variable specifies the node weight to be used for Weighted
 Quorum calculations.
 
 .. variable::  protonet.backend
@@ -874,7 +875,7 @@ values are available:
    :default: 2147483647
 
 This variable is used to specify the maximum size of a write-set in bytes. This
-is limited to 2 gygabytes.
+is limited to 2 gigabytes.
 
 .. variable::  repl.proto_max
 

--- a/doc/source/wsrep-status-index.rst
+++ b/doc/source/wsrep-status-index.rst
@@ -231,7 +231,7 @@ be sent).
 
 Average length of the send queue since the last status query. When cluster
 experiences network throughput issues or replication throttling, this value
-will be significantly bigger than ``0``.
+will be significantly larger than ``0``.
 
 .. variable:: wsrep_local_state
 

--- a/doc/source/wsrep-system-index.rst
+++ b/doc/source/wsrep-system-index.rst
@@ -178,7 +178,7 @@ STRICT
 
 OPTIMIZED
    Two INSERTs that happen at about the same time on two different nodes in a
-   child table, that insert different (non conflicting rows), but both rows
+   child table, that insert different (non-conflicting rows), but both rows
    point to the same row in the parent table **will not result** in the
    certification failure.
 
@@ -508,7 +508,7 @@ The maximum allowed value is ``1048576``.
    :default: ``2147483647`` (2 GB)
 
 Defines the maximum write-set size (in bytes).
-Anything bigger than the specified value will be rejected.
+Anything larger than the specified value will be rejected.
 
 You can set it to any value between ``1024`` and the default ``2147483647``.
 
@@ -797,9 +797,9 @@ the whole DDL statement is not put under TOI.
 
 Defines whether replication slave should be restarted
 when the node joins back to the cluster.
-Enabling this can be useful because asynchronous replication slave thread
+Enabling this can be useful because the asynchronous replication slave thread
 is stopped when the node tries to apply the next replication event
-while the node is in non-primary state.
+while the node is in a non-primary state.
 
 .. variable:: wsrep_retry_autocommit
 
@@ -833,7 +833,7 @@ autocommit transactions won't be retried.
 Specifies the timeout in microseconds to allow active connection to complete
 COMMIT action before starting RSU.
 
-While running RSU it is expected that user has isolated the node and there is
+While running RSU, it is expected that user has isolated the node and there is
 no active traffic executing on the node. RSU has a check to ensure this, and
 waits for any active connection in ``COMMIT`` state before starting RSU.
 


### PR DESCRIPTION
Updated the following files:
source/.res/text/encrypt_binlog.removing.txt
source/add-node.rst
source/features/highavailability.rst
source/features/multimaster-replication.rst
source/features/pxc-strict-mode.rst
source/glossary.rst
source/howtos/proxysql-v2.rst
source/howtos/proxysql.rst
source/howtos/ubuntu_howto.rst
source/howtos/upgrade_guide.rst
source/howtos/virt_sandbox.rst
source/install/apt.rst
source/install/yum.rst
source/intro.rst
source/limitation.rst
source/management/data_at_rest_encryption.rst
source/manual/certification.rst
source/manual/gcache_record-set_cache_difference.rst
source/manual/performance_schema_instrumentation.rst
source/manual/threading_model.rst
source/manual/xtrabackup_sst.rst
source/overview.rst
source/security/encrypt-traffic.rst
source/wsrep-files-index.rst
source/wsrep-provider-index.rst
source/wsrep-status-index.rst
source/wsrep-system-index.rst