### PR TITLE
PXC-3222 Review and Revise (if necessary) references to Galera 2.x in…

### DIFF
--- a/doc/source/wsrep-provider-index.rst
+++ b/doc/source/wsrep-provider-index.rst
@@ -895,12 +895,18 @@ accept in the cluster. Used only for debugging.
    :dyn: No
    :default: 2
 
-This variable is used to choose the checksum algorithm for network packets. The
-following values are available:
+This variable is used to choose the checksum algorithm for network packets.
+The ``CRC32-C`` option is optimized and may be hardware accelerated on Intel CPUs. The following values are available:
 
  * ``0`` - disable checksum
- * ``1`` - plain ``CRC32`` (used in Galera 2.x)
- * ``2`` - hardware accelerated ``CRC32-C``
+ * ``1`` - ``CRC32``
+ * ``2`` - ``CRC32-C``
+ 
+ The following is an example of the variable use:
+ 
+ .. code-block:: bash
+ 
+     wsrep_provider_options="socket.checksum=2"
 
 .. variable::  socket.ssl
 


### PR DESCRIPTION
… PXC 8.0 User Manual

modified wsrep-provider-index
modified socket.checksum description
added example
The reference to Galera 2.x was removed and the description was rewritten.  The reference was to backward compatibility with option 1
https://mariadb.com/kb/en/wsrep_provider_options/#socketchecksum