### PR TITLE
PXC-3026: Fix most of WITH_WSREP issues in the 5.6 branch

### DIFF
--- a/check_src/check_file.sh
+++ b/check_src/check_file.sh
@@ -1,0 +1,50 @@
+# Compares a single PS/PXC source file
+# The script will print out an error and a diff if there is any difference 
+# after removing the PXC specific code, not counting whitespace and empty lines
+# The script also allows whitelisting expected differences, such as different
+# product names (Percona Server vs Percona Xtradb Cluster)
+
+# Usage: bash check_src/check_file.sh <file_name> <PS 5.6 source directory>
+# The script should be run from the root directory of the PXC source
+# The PS source should be the currently merged PS tag
+
+# Extending/changing the whitelist:
+# The whitelist directory contains files in a single directory (without
+# subdirectories), each file whitelist a single real source file, with the
+# same name.
+# The whitelist file contains the lines starting with > or < of the expected
+# diff: only the change without the actual line/offset numbers, to prevent
+# unrelated changes from breaking the whitelisted change.
+if [ ! -s $2/$1 ] ; then
+  exit 0
+fi
+F=`mktemp`
+gawk -f check_src/rem.awk $1 > $F
+
+D=`mktemp`
+D2=`mktemp`
+diff -wB $F $2/$1 > $D
+
+if [ -s $D ] ; then
+  WHITELIST_NAME=check_src/whitelist/${1##*/}
+  if [ -f $WHITELIST_NAME ] ; then
+    D3=`mktemp`
+    cat $D | grep "^[<>].*" > $D3
+    diff -wB $WHITELIST_NAME $D3 > $D2
+    rm $D3
+    if [ ! -s $D2 ] ; then
+      echo -n "" > $D
+    fi
+  fi
+fi
+
+if [ -s $D ] ; then
+  echo "============"
+  echo "Error: $1"
+  echo "============"
+  cat $D
+fi
+
+rm $F
+rm $D
+rm $D2

--- a/check_src/rem.awk
+++ b/check_src/rem.awk
@@ -1,0 +1,70 @@
+# AWK script to remove PXC specific code from source files
+# Based on common PXC specific ifdefs/macros
+BEGIN {
+  # We are currently checking a WITH_WSREP ifdef line
+  with_wsrep = 0;
+  # We encountered an if(n)def WITH_WSREP block before,
+  # and it's scope, or the scope of its else clause is still open
+  had_wsrep = 0;
+  # How many ifdefs we have nested?
+  # Used to ensure that we find the correct else/endif
+  nest_level = 0;
+  # We encountered an ifndef WITH_WSREP, or the else clause of 
+  # the ifdef version
+  ifndef_wsrep = 0;
+}
+{
+  skip_this = 0;
+if($0 ~ /WSREP_TO_ISOLATION_BEGIN/) {
+  # Macro defined to nothing without WITH_WSREP
+  skip_this = 1;
+}
+if($0 ~ /WSREP_TO_ISOLATION_END/) {
+  # Macro defined to nothing without WITH_WSREP
+  skip_this = 1;
+}
+if($0 ~ /WSREP_SYNC_WAIT/) {
+  # Macro defined to nothing without WITH_WSREP
+  skip_this = 1;
+}
+if($0 ~ /WAIT_ALLOW_WRITES/) {
+  # Macro defined to nothing without WITH_WSREP
+  skip_this = 1;
+}
+if($0 ~ /#if/) {
+
+  if($0 ~ /WITH_WSREP/ || $0 ~ /WITH_INNODB_DISALLOW_WRITES/) {
+    if($0 ~ /ifndef/) {
+      had_wsrep=1;
+      ifndef_wsrep=1;
+      nest_level=0;
+      skip_this=1;
+    } else {
+      with_wsrep=1;
+      had_wsrep=1;
+      nest_level=0;
+    }
+  } else if(had_wsrep == 1) {
+    nest_level = nest_level + 1;
+  }
+}
+  
+if ($0 ~ /#else/ && (with_wsrep==1 || ifndef_wsrep==1) && nest_level==0) { 
+  if (ifndef_wsrep==1) {
+    with_wsrep=1; 
+    ifndef_wsrep=0;
+  } else {
+    with_wsrep=0; 
+  }
+  skip_this = 1; 
+}
+if ($0 ~ /#endif/ && nest_level==0) {
+  if(had_wsrep==1) { skip_this = 1; }
+  had_wsrep = 0;
+  with_wsrep=0;
+  ifndef_wsrep=0;
+}
+if ($0 ~ /#endif/ && nest_level!=0) { nest_level = nest_level - 1; }
+
+if (with_wsrep==0 && skip_this == 0) print $0;
+}

--- a/check_src/run.sh
+++ b/check_src/run.sh
@@ -1,0 +1,9 @@
+# Compares every source file between PS/PXC for differences without the if WITH_WSREP
+# blocks.
+# Usage:  bash check_src/run.sh <PS_DIRECTORY>
+PS_56_LOCATION=$1
+find . -type f -name '*.h' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+find . -type f -name '*.cc' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+find . -type f -name '*.c' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+find . -type f -name '*.ic' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+

--- a/check_src/whitelist/binlog.cc
+++ b/check_src/whitelist/binlog.cc
@@ -1,0 +1,8 @@
+<     if (WSREP_BINLOG_FORMAT(variables.binlog_format) != BINLOG_FORMAT_ROW && tables)
+>     if (variables.binlog_format != BINLOG_FORMAT_ROW && tables)
+<       else if (WSREP_BINLOG_FORMAT(variables.binlog_format) == BINLOG_FORMAT_ROW &&
+>       else if (variables.binlog_format == BINLOG_FORMAT_ROW &&
+<       if (WSREP_BINLOG_FORMAT(variables.binlog_format) == BINLOG_FORMAT_STMT)
+>       if (variables.binlog_format == BINLOG_FORMAT_STMT)
+<                         WSREP_BINLOG_FORMAT(variables.binlog_format),
+>                         variables.binlog_format,

--- a/check_src/whitelist/log.h
+++ b/check_src/whitelist/log.h
@@ -1,0 +1,1 @@
+< #define WSREP_BINLOG_FORMAT(my_format) my_format

--- a/check_src/whitelist/mysql.cc
+++ b/check_src/whitelist/mysql.cc
@@ -1,0 +1,2 @@
+< 	  "Percona XtraDB Cluster manual: http://www.percona.com/doc/percona-xtradb-cluster/5.6/\n"
+> 	  "Percona Server manual: http://www.percona.com/doc/percona-server/5.6\n"

--- a/check_src/whitelist/signal_handler.cc
+++ b/check_src/whitelist/signal_handler.cc
@@ -1,0 +1,8 @@
+<     "Please help us make Percona XtraDB Cluster better by reporting any\n"
+<     "bugs at https://jira.percona.com/projects/PXC/issues\n\n");
+>     "Please help us make Percona Server better by reporting any\n"
+>     "bugs at https://bugs.percona.com/\n\n");
+<     "You may download the Percona XtraDB Cluster operations manual by visiting\n"
+<     "http://www.percona.com/software/percona-xtradb-cluster/. You may find information\n"
+>     "You may download the Percona Server operations manual by visiting\n"
+>     "http://www.percona.com/software/percona-server/. You may find information\n"

--- a/check_src/whitelist/sql_base.cc
+++ b/check_src/whitelist/sql_base.cc
@@ -1,0 +1,5 @@
+<   ulong binlog_format= thd->variables.binlog_format;
+<   if (log_on == FALSE || 
+<       (WSREP_BINLOG_FORMAT(binlog_format) == BINLOG_FORMAT_ROW))
+>   if (log_on == false ||
+>       thd->variables.binlog_format == BINLOG_FORMAT_ROW)

--- a/check_src/whitelist/sql_class.cc
+++ b/check_src/whitelist/sql_class.cc
@@ -1,0 +1,2 @@
+<     return (int) WSREP_BINLOG_FORMAT(thd->variables.binlog_format);
+>     return (int) thd->variables.binlog_format;

--- a/check_src/whitelist/sql_class.h
+++ b/check_src/whitelist/sql_class.h
@@ -1,0 +1,5 @@
+<     if ((WSREP_BINLOG_FORMAT(variables.binlog_format) == BINLOG_FORMAT_MIXED)&&
+>     if ((variables.binlog_format == BINLOG_FORMAT_MIXED) &&
+<       if (WSREP_BINLOG_FORMAT(variables.binlog_format) == BINLOG_FORMAT_ROW)
+>       if (variables.binlog_format == BINLOG_FORMAT_ROW)
+< #define CF_SKIP_WSREP_CHECK     0

--- a/check_src/whitelist/sql_parse.cc
+++ b/check_src/whitelist/sql_parse.cc
@@ -1,0 +1,2 @@
+<           WSREP_BINLOG_FORMAT(thd->variables.binlog_format) == BINLOG_FORMAT_STMT &&
+>           thd->variables.binlog_format == BINLOG_FORMAT_STMT &&

--- a/mysys/my_thr_init.c
+++ b/mysys/my_thr_init.c
@@ -212,11 +212,9 @@ void my_thread_global_end(void)
         are killed when we enter here.
       */
       if (THR_thread_count)
-      {
         fprintf(stderr,
                 "Error in my_thread_global_end(): %d threads didn't exit\n",
                 THR_thread_count);
-      }
 #endif
       all_threads_killed= 0;
       break;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -1488,7 +1488,7 @@ static int binlog_start_consistent_snapshot(handlerton *hton, THD *thd)
   int err= 0;
   DBUG_ENTER("binlog_start_consistent_snapshot");
 
-#ifdef WSREP
+#ifdef WITH_WSREP
   if (wsrep_emulate_bin_log)
     DBUG_RETURN(0);
 #endif
@@ -1517,7 +1517,7 @@ static int binlog_clone_consistent_snapshot(handlerton *hton, THD *thd,
 
   DBUG_ENTER("binlog_start_consistent_snapshot");
 
-#ifdef WSREP
+#ifdef WITH_WSREP
   if (wsrep_emulate_bin_log)
     DBUG_RETURN(0);
 #endif
@@ -8130,8 +8130,7 @@ int MYSQL_BIN_LOG::recover(IO_CACHE *log, Format_description_log_event *fdle,
   init_alloc_root(&mem_root, TC_LOG_PAGE_SIZE, TC_LOG_PAGE_SIZE);
 
   while ((ev= Log_event::read_log_event(log, 0, fdle, TRUE))
-         && ev->is_valid()
-      )
+         && ev->is_valid())
   {
     if (ev->get_type_code() == QUERY_EVENT &&
         !strcmp(((Query_log_event*)ev)->query, "BEGIN"))

--- a/sql/event_data_objects.cc
+++ b/sql/event_data_objects.cc
@@ -39,7 +39,9 @@
 #include "sp_head.h"
 #include "sql_show.h"                // append_definer, append_identifier
 
+#ifdef WITH_WSREP
 #include "wsrep_thd.h"
+#endif
 
 /**
   @addtogroup Event_Scheduler

--- a/sql/event_scheduler.cc
+++ b/sql/event_scheduler.cc
@@ -30,7 +30,9 @@
 #include "sql_connect.h"         // init_new_connection_handler_thread
 #include "sql_acl.h"             // SUPER_ACL
 #include "global_threads.h"
+#ifdef WITH_WSREP
 #include "debug_sync.h"
+#endif
 
 /**
   @addtogroup Event_Scheduler
@@ -369,9 +371,9 @@ Event_worker_thread::run(THD *thd, Event_queue_element_for_exec *event)
                           job_data.definer.str,
                           job_data.dbname.str, job_data.name.str);
 
+#ifdef WITH_WSREP
   DEBUG_SYNC(thd, "event_worker_thread_end");
 
-#ifdef WITH_WSREP
   if (WSREP(thd))
   {
     mysql_mutex_lock(&thd->LOCK_wsrep_thd);

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -314,7 +314,7 @@ bool
 Events::create_event(THD *thd, Event_parse_data *parse_data,
                      bool if_not_exists)
 {
-  bool ret= TRUE;
+  bool ret;
   bool save_binlog_row_based, event_already_exists;
   ulong save_binlog_format= thd->variables.binlog_format;
   DBUG_ENTER("Events::create_event");
@@ -454,7 +454,7 @@ bool
 Events::update_event(THD *thd, Event_parse_data *parse_data,
                      LEX_STRING *new_dbname, LEX_STRING *new_name)
 {
-  int ret= TRUE;
+  int ret;
   bool save_binlog_row_based;
   ulong save_binlog_format= thd->variables.binlog_format;
   Event_queue_element *new_element;
@@ -583,9 +583,6 @@ err:
   and COMMIT/ROLLBACK is not allowed in stored functions and
   triggers.
 
-  @note Call Events::drop_event_precheck before calling this to
-  perform access checks.
-
   @retval  FALSE  OK
   @retval  TRUE   Error (reported)
 */
@@ -593,7 +590,7 @@ err:
 bool
 Events::drop_event(THD *thd, LEX_STRING dbname, LEX_STRING name, bool if_exists)
 {
-  int ret= TRUE;
+  int ret;
   bool save_binlog_row_based;
   DBUG_ENTER("Events::drop_event");
 

--- a/sql/events.h
+++ b/sql/events.h
@@ -117,8 +117,10 @@ public:
   update_event(THD *thd, Event_parse_data *parse_data,
                LEX_STRING *new_dbname, LEX_STRING *new_name);
 
+#ifdef WITH_WSREP
   static bool
   drop_event_precheck(THD *thd, LEX_STRING dbname);
+#endif
 
   static bool
   drop_event(THD *thd, LEX_STRING dbname, LEX_STRING name, bool if_exists);

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -408,7 +408,9 @@ enum legacy_db_type
   DB_TYPE_MARIA,
   /** Performance schema engine. */
   DB_TYPE_PERFORMANCE_SCHEMA,
+#ifdef WITH_WSREP
   DB_TYPE_WSREP,
+#endif /* WITH_WSREP */
   DB_TYPE_TOKUDB=41,
   DB_TYPE_ROCKSDB=42,
   DB_TYPE_FIRST_DYNAMIC=43,
@@ -935,11 +937,13 @@ struct handlerton
                      const char *wild, bool dir, List<LEX_STRING> *files);
    int (*table_exists_in_engine)(handlerton *hton, THD* thd, const char *db,
                                  const char *name);
+#ifdef WITH_WSREP
    int (*wsrep_abort_transaction)(handlerton *hton, THD *bf_thd, 
 				  THD *victim_thd, my_bool signal);
    int (*wsrep_set_checkpoint)(handlerton *hton, const XID* xid);
    int (*wsrep_get_checkpoint)(handlerton *hton, XID* xid);
    void (*wsrep_fake_trx_id)(handlerton *hton, THD *thd);
+#endif /* WITH_WSREP */
    int (*make_pushed_join)(handlerton *hton, THD* thd, 
                            const AQP::Join_plan* plan);
 
@@ -3748,9 +3752,6 @@ int ha_release_savepoint(THD *thd, SAVEPOINT *sv);
 int ha_wsrep_abort_transaction(THD *bf_thd, THD *victim_thd, my_bool signal);
 void ha_wsrep_fake_trx_id(THD *thd);
 #endif /* WITH_WSREP */
-
-/* Build pushed joins in handlers implementing this feature */
-int ha_make_pushed_joins(THD *thd, const AQP::Join_plan* plan);
 
 /* Build pushed joins in handlers implementing this feature */
 int ha_make_pushed_joins(THD *thd, const AQP::Join_plan* plan);

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2899,13 +2899,12 @@ int TC_LOG_MMAP::open(const char *opt_name)
     mysql_mutex_init(key_PAGE_lock, &pg->lock, MY_MUTEX_INIT_FAST);
     mysql_cond_init(key_PAGE_cond, &pg->cond, 0);
     pg->ptr= pg->start=(my_xid *)(data + i*tc_log_page_size);
-#ifdef WITH_WSREP
-    if (!WSREP_ON) 
-#endif /* WITH_WSREP */
-    pg->end=(my_xid *)(pg->start + tc_log_page_size);
     pg->size=pg->free=tc_log_page_size/sizeof(my_xid);
 #ifdef WITH_WSREP
-    if (WSREP_ON) pg->end=pg->start + pg->size;
+    if (!WSREP_ON) 
+      pg->end=(my_xid *)(pg->start + tc_log_page_size);
+    else
+      pg->end=pg->start + pg->size;
 #else
     pg->end=pg->start + pg->size;
 #endif /* WITH_WSREP */

--- a/sql/log.h
+++ b/sql/log.h
@@ -606,10 +606,12 @@ enum enum_binlog_row_image {
 };
 
 enum enum_binlog_format {
+#ifdef WITH_WSREP
   /*
     statement-based except for cases where only row-based can work (UUID()
     etc):
   */
+#endif /* WITH_WSREP */
   BINLOG_FORMAT_MIXED= 0, ///< statement if safe, otherwise row - autodetected
   BINLOG_FORMAT_STMT=  1, ///< statement-based
   BINLOG_FORMAT_ROW=   2, ///< row-based

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -11535,10 +11535,12 @@ int Rows_log_event::do_apply_event(Relay_log_info const *rli)
         RPL_TABLE_LIST *ptr= static_cast<RPL_TABLE_LIST*>(table_list_ptr);
         DBUG_ASSERT(ptr->m_tabledef_valid);
         TABLE *conv_table;
+#ifdef WITH_WSREP
         /*
           Use special mem_root 'Log_event::m_event_mem_root' while doing
           compatiblity check (i.e., while creating temporary table)
          */
+#endif
         if (!ptr->m_tabledef.compatible_with(thd, const_cast<Relay_log_info*>(rli),
                                              ptr->table, &conv_table))
         {

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1313,9 +1313,7 @@ bool mysqld_embedded=0;
 bool mysqld_embedded=1;
 #endif
 
-#ifndef EMBEDDED_LIBRARY
 static my_bool plugins_are_initialized= FALSE;
-#endif
 
 #ifndef DBUG_OFF
 static const char* default_dbug_option;
@@ -3062,13 +3060,15 @@ void dec_connection_count(THD *thd)
     applier as well as rollbacker threads.
   */
   if (!thd->wsrep_applier)
-#endif /* WITH_WSREP */
   {
+#endif /* WITH_WSREP */
     mysql_mutex_lock(&LOCK_connection_count);
     if (--(*thd->scheduler->connection_count) == 0)
       mysql_cond_signal(&COND_connection_count);
     mysql_mutex_unlock(&LOCK_connection_count);
+#ifdef WITH_WSREP
   }
+#endif /* WITH_WSREP */
 }
 
 
@@ -5505,7 +5505,6 @@ a file name for --log-bin-index option", opt_binlog_index_name);
     unireg_abort(1);
   }
 
-#ifdef WITH_WSREP
   if (plugin_init(&remaining_argc, remaining_argv,
                   (opt_noacl ? PLUGIN_INIT_SKIP_PLUGIN_TABLE : 0) |
                   (opt_help ? PLUGIN_INIT_SKIP_INITIALIZATION : 0)))
@@ -5514,7 +5513,6 @@ a file name for --log-bin-index option", opt_binlog_index_name);
     unireg_abort(1);
   }
   plugins_are_initialized= TRUE;  /* Don't separate from init function */
-#endif /* WITH_WSREP */
   /* we do want to exit if there are any other unknown options */
   if (remaining_argc > 1)
   {

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -73,11 +73,11 @@ extern "C" sig_handler handle_fatal_signal(int sig)
 
   segfaulted = 1;
 
+#ifdef WITH_WSREP
 /*
   The wsrep subsystem has their its own actions
   which need be performed before exiting:
 */
-#ifdef WITH_WSREP
   wsrep_handle_fatal_signal(sig);
 #endif
 

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -2948,7 +2948,7 @@ bool change_password(THD *thd, const char *host, const char *user,
   Acl_table_intact table_intact;
   /* Buffer should be extended when password length is extended. */
   char buff[2048];
-  ulong query_length=0;
+  ulong query_length;
   bool save_binlog_row_based;
   uchar user_key[MAX_KEY_LENGTH];
   char *plugin_temp= NULL;
@@ -10984,12 +10984,14 @@ static bool parse_com_change_user_packet(MPVIO_EXT *mpvio, uint packet_length)
     if (mpvio->charset_adapter->init_client_charset(uint2korr(ptr)))
       DBUG_RETURN(1);
   }
+#ifdef WITH_WSREP
   else
   {
     sql_print_warning("Client failed to provide its character set. "
                       "'%s' will be used as client character set.",
                       mpvio->charset_adapter->charset()->csname);
   }
+#endif
 
   /* Convert database and user names to utf8 */
   db_len= copy_and_convert(db_buff, sizeof(db_buff) - 1, system_charset_info,

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1086,10 +1086,12 @@ bool Sql_cmd_analyze_table::execute(THD *thd)
                          FALSE, UINT_MAX, FALSE))
     goto error;
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_analyze_table::execute()");});
 
   WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, first_table);
+#endif
   thd->set_slow_log_for_admin_command();
   res= mysql_admin_table(thd, first_table, &thd->lex->check_opt,
                          "analyze", lock_type, 1, 0, 0, 0,
@@ -1121,8 +1123,10 @@ bool Sql_cmd_check_table::execute(THD *thd)
                          TRUE, UINT_MAX, FALSE))
     goto error; /* purecov: inspected */
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_check_table::execute()");});
+#endif
 
   thd->enable_slow_log= opt_log_slow_admin_statements;
 
@@ -1148,8 +1152,10 @@ bool Sql_cmd_optimize_table::execute(THD *thd)
                          FALSE, UINT_MAX, FALSE))
     goto error; /* purecov: inspected */
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_optimize_table::execute()");});
+#endif
 
   WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, first_table);
   thd->set_slow_log_for_admin_command();
@@ -1184,8 +1190,10 @@ bool Sql_cmd_repair_table::execute(THD *thd)
                          FALSE, UINT_MAX, FALSE))
     goto error; /* purecov: inspected */
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command",
                   { sql_print_information("In Sql_cmd_repair_table::execute()");});
+#endif
 
   WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, first_table);
   thd->set_slow_log_for_admin_command();

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -26,8 +26,10 @@
 
 /* Classes in mysql */
 
+#ifdef WITH_WSREP
 #include <vector>
 using std::vector;
+#endif
 
 #include "my_global.h"                          /* NO_EMBEDDED_ACCESS_CHECKS */
 #ifdef MYSQL_SERVER
@@ -2206,7 +2208,11 @@ public:
       m_mdl_blocks_commits_lock(NULL)
   {}
 
+#ifdef WITH_WSREP
   bool lock_global_read_lock(THD *thd, bool *own_lock);
+#else
+  bool lock_global_read_lock(THD *thd);
+#endif
   void unlock_global_read_lock(THD *thd);
 
   /**
@@ -2690,8 +2696,12 @@ public:
   int is_current_stmt_binlog_format_row() const {
     DBUG_ASSERT(current_stmt_binlog_format == BINLOG_FORMAT_STMT ||
                 current_stmt_binlog_format == BINLOG_FORMAT_ROW);
+#ifdef WITH_WSREP
     return (WSREP_BINLOG_FORMAT((ulong)current_stmt_binlog_format) ==
             BINLOG_FORMAT_ROW);
+#else
+    return current_stmt_binlog_format == BINLOG_FORMAT_ROW;
+#endif
   }
 
   bool is_current_stmt_binlog_disabled() const;
@@ -3706,7 +3716,9 @@ public:
   void shutdown_active_vio();
 #endif
   void awake(THD::killed_state state_to_set);
+#ifdef WITH_WSREP
   void awake(void);
+#endif
 
   /** Disconnect the associated communication endpoint. */
   void disconnect();
@@ -5842,11 +5854,6 @@ public:
 #else
 #define CF_SKIP_WSREP_CHECK     0
 #endif /* WITH_WSREP */
-
-/**
-  Do not check that wsrep snapshot is ready before allowing this command
-*/
-#define CF_SKIP_WSREP_CHECK     (1U << 2)
 
 void add_to_status(STATUS_VAR *to_var, STATUS_VAR *from_var);
 

--- a/sql/sql_cmd.h
+++ b/sql/sql_cmd.h
@@ -112,11 +112,14 @@ enum enum_sql_command {
   /*
     When a command is added here, be sure it's also added in mysqld.cc
     in "struct show_var_st status_vars[]= {" ...
-
+  */
+#ifdef WITH_WSREP
+  /*
     Also for PXC, if the command is replicated to other nodes as a
     DDL (no-writeset replication), add a testcase to
     galera_wsrep_ddl_access_checking.test
   */
+#endif
   /* This should be the last !!! */
   SQLCOM_END
 };

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -74,11 +74,6 @@ using std::max;
 static int increment_connection_count(THD* thd, bool use_lock);
 #endif
 
-#ifndef EMBEDDED_LIBRARY
-// Increments connection count for user.
-static int increment_connection_count(THD* thd, bool use_lock);
-#endif
-
 HASH global_user_stats;
 HASH global_client_stats;
 HASH global_thread_stats;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1483,10 +1483,8 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
   /* To avoid cross initialization in case of pxc/wsrep due to following jump */
   double start_busy_usecs = 0.0;
   double start_cpu_nsecs = 0.0;
-#endif /* WITH_WSREP */
 
   if (unlikely(opt_userstat))
-#ifdef WITH_WSREP
   if (WSREP(thd)) {
     if (!thd->in_multi_stmt_transaction_mode())
     {
@@ -3360,13 +3358,15 @@ mysql_execute_command(THD *thd)
 
     /* Commit the normal transaction if one is active. */
     if (trans_commit_implicit(thd))
+#ifdef WITH_WSREP
     {
       thd->mdl_context.release_transactional_locks();
-#ifdef WITH_WSREP
       WSREP_DEBUG("implicit commit failed, MDL released: %lu", thd->thread_id);
 #endif /* WITH_WSREP */
       goto error;
+#ifdef WITH_WSREP
     }
+#endif /* WITH_WSREP */
     /* Release metadata locks acquired in this transaction. */
     thd->mdl_context.release_transactional_locks();
   }
@@ -4163,9 +4163,7 @@ end_with_restore_list:
 
     WSREP_TO_ISOLATION_BEGIN(0, 0, first_table)
     if (mysql_rename_tables(thd, first_table, 0))
-    {
       goto error;
-    }
     break;
   }
 #ifndef EMBEDDED_LIBRARY
@@ -4757,8 +4755,10 @@ end_with_restore_list:
   }
 
   case SQLCOM_UNLOCK_TABLES:
+#ifdef WITH_WSREP
   {
     bool table_lock= false;
+#endif
     /*
       It is critical for mysqldump --single-transaction --master-data that
       UNLOCK TABLES does not implicitely commit a connection which has only
@@ -4767,7 +4767,9 @@ end_with_restore_list:
     */
     if (thd->variables.option_bits & OPTION_TABLE_LOCK)
     {
+#ifdef WITH_WSREP
       table_lock= true;
+#endif
       DBUG_ASSERT(!thd->backup_tables_lock.is_acquired());
       /*
         Can we commit safely? If not, return to avoid releasing
@@ -4816,7 +4818,9 @@ end_with_restore_list:
       goto error;
     my_ok(thd);
     break;
+#ifdef WITH_WSREP
   }
+#endif
   case SQLCOM_UNLOCK_BINLOG:
     if (thd->backup_binlog_lock.is_acquired())
       thd->backup_binlog_lock.release(thd);
@@ -5265,6 +5269,7 @@ end_with_restore_list:
       if (check_table_access(thd, LOCK_TABLES_ACL | SELECT_ACL, all_tables,
                              FALSE, UINT_MAX, FALSE))
         goto error;
+#ifdef WITH_WSREP
       /*
         Note:
         We don't check for multiple non-idempotent invocations
@@ -5274,7 +5279,6 @@ end_with_restore_list:
         hence check for provider paused.
         This is to ensure we don't try pause an already paused provider.
        */
-#ifdef WITH_WSREP
       if (WSREP(thd) &&
           !thd->global_read_lock.wsrep_pause_once(&already_paused))
         goto error;
@@ -5308,6 +5312,7 @@ end_with_restore_list:
       if (check_table_access(thd, LOCK_TABLES_ACL | SELECT_ACL, all_tables,
                              FALSE, UINT_MAX, FALSE))
         goto error;
+#ifdef WITH_WSREP
       /*
         Note:
         We don't check for multiple non-idempotent invocations
@@ -5317,7 +5322,6 @@ end_with_restore_list:
         hence check for provider paused.
         This is to ensure we don't try pause an already paused provider.
        */
-#ifdef WITH_WSREP
       if (WSREP(thd) &&
           !thd->global_read_lock.wsrep_pause_once(&already_paused))
         goto error;
@@ -5442,13 +5446,15 @@ end_with_restore_list:
 #endif
   case SQLCOM_BEGIN:
     if (trans_begin(thd, lex->start_transaction_opt))
+#ifdef WITH_WSREP
     {
       thd->mdl_context.release_transactional_locks();
-#ifdef WITH_WSREP
       WSREP_DEBUG("BEGIN failed, MDL released: %lu", thd->thread_id);
 #endif /* WITH_WSREP */
       goto error;
+#ifdef WITH_WSREP
     }
+#endif
     my_ok(thd);
     break;
   case SQLCOM_COMMIT:
@@ -5462,13 +5468,15 @@ end_with_restore_list:
                       (thd->variables.completion_type == 2 &&
                        lex->tx_release != TVL_NO));
     if (trans_commit(thd))
+#ifdef WITH_WSREP
     {
       thd->mdl_context.release_transactional_locks();
-#ifdef WITH_WSREP
       WSREP_DEBUG("COMMIT failed, MDL released: %lu", thd->thread_id);
 #endif /* WITH_WSREP */
       goto error;
+#ifdef WITH_WSREP
     }
+#endif /* WITH_WSREP */
     thd->mdl_context.release_transactional_locks();
     /* Begin transaction with the same isolation level. */
     if (tx_chain)
@@ -5512,13 +5520,15 @@ end_with_restore_list:
                       (thd->variables.completion_type == 2 &&
                        lex->tx_release != TVL_NO));
     if (trans_rollback(thd))
+#ifdef WITH_WSREP
     {
       thd->mdl_context.release_transactional_locks();
-#ifdef WITH_WSREP
       WSREP_DEBUG("rollback failed, MDL released: %lu", thd->thread_id);
 #endif /* WITH_WSREP */
       goto error;
+#ifdef WITH_WSREP
     }
+#endif /* WITH_WSREP */
     thd->mdl_context.release_transactional_locks();
     /* Begin transaction with the same isolation level. */
     if (tx_chain)
@@ -6099,13 +6109,15 @@ create_sp_error:
     break;
   case SQLCOM_XA_COMMIT:
     if (trans_xa_commit(thd))
+#ifdef WITH_WSREP
     {
       thd->mdl_context.release_transactional_locks();
-#ifdef WITH_WSREP
       WSREP_DEBUG("XA commit failed, MDL released: %lu", thd->thread_id);
 #endif /* WITH_WSREP */
       goto error;
+#ifdef WITH_WSREP
     }
+#endif
     thd->mdl_context.release_transactional_locks();
     /*
       We've just done a commit, reset transaction
@@ -6117,13 +6129,15 @@ create_sp_error:
     break;
   case SQLCOM_XA_ROLLBACK:
     if (trans_xa_rollback(thd))
+#ifdef WITH_WSREP
     {
       thd->mdl_context.release_transactional_locks();
-#ifdef WITH_WSREP
       WSREP_DEBUG("XA rollback failed, MDL released: %lu", thd->thread_id);
 #endif /* WITH_WSREP */
       goto error;
+#ifdef WITH_WSREP
     }
+#endif
     thd->mdl_context.release_transactional_locks();
     /*
       We've just done a rollback, reset transaction

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -6921,7 +6921,7 @@ static void downgrade_mdl_if_lock_tables_mode(THD *thd, MDL_ticket *ticket,
   previously prepared.
 
   @param thd                           Thread object
-  @param table                         Original table object with new part_info
+  @param table                         Original table object
   @param alter_info                    ALTER TABLE info
   @param create_info                   Create info for CREATE TABLE
   @param table_list                    List of the table involved

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -786,8 +786,10 @@ static plugin_ref intern_plugin_lock(LEX *lex, plugin_ref rc)
   st_plugin_int *pi= plugin_ref_to_int(rc);
   DBUG_ENTER("intern_plugin_lock");
 
+#ifdef WITH_WSREP
   if (!rc)
     DBUG_RETURN(NULL);
+#endif
 
   mysql_mutex_assert_owner(&LOCK_plugin);
 

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -3462,7 +3462,6 @@ bool Prepared_statement::prepare(const char *packet, uint packet_len)
   error= parse_sql(thd, & parser_state, NULL) ||
     thd->is_error() ||
     init_param_array(this);
-  thd->m_statement_psi= parent_locker;
 
   lex->set_trg_event_type_for_tables();
 
@@ -4149,6 +4148,7 @@ bool Prepared_statement::execute(String *expanded_query, bool open_cursor)
       thd->protocol->send_out_parameters(&this->lex->param_list);
   }
 
+#ifdef WITH_WSREP
   /*
     Log COM_STMT_EXECUTE to the general log. Note, that in case of SQL
     prepared statements this causes two records to be output:
@@ -4167,6 +4167,7 @@ bool Prepared_statement::execute(String *expanded_query, bool open_cursor)
   */
   if (error == 0)
     log_execute_line(thd);
+#endif
 
 error:
   flags&= ~ (uint) IS_IN_USE;

--- a/sql/sql_reload.cc
+++ b/sql/sql_reload.cc
@@ -230,7 +230,6 @@ bool reload_acl_and_cache(THD *thd, unsigned long options,
   {
     if ((options & REFRESH_READ_LOCK) && thd)
     {
-      bool own_lock;
       /*
         On the first hand we need write lock on the tables to be flushed,
         on the other hand we must not try to aspire a global read lock
@@ -247,7 +246,12 @@ bool reload_acl_and_cache(THD *thd, unsigned long options,
 	UNLOCK TABLES
       */
       tmp_write_to_binlog= 0;
+#ifdef WITH_WSREP
+      bool own_lock;
       if (thd->global_read_lock.lock_global_read_lock(thd, &own_lock))
+#else
+      if (thd->global_read_lock.lock_global_read_lock(thd))
+#endif
         return 1; // Killed
       if (close_cached_tables(thd, tables,
                               ((options & REFRESH_FAST) ?  FALSE : TRUE),
@@ -263,10 +267,14 @@ bool reload_acl_and_cache(THD *thd, unsigned long options,
       if (thd->global_read_lock.make_global_read_lock_block_commit(thd)) // Killed
       {
         /* Don't leave things in a half-locked state */
+#ifdef WITH_WSREP
         if (own_lock)
         {
+#endif
           thd->global_read_lock.unlock_global_read_lock(thd);
+#ifdef WITH_WSREP
         }
+#endif
         return 1;
       }
 #ifdef WITH_WSREP

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -69,9 +69,11 @@
 using std::max;
 using std::min;
 
+#ifdef WITH_WSREP
 #if !defined(MYSQL_MAX_VARIABLE_VALUE_LEN)
 #define MYSQL_MAX_VARIABLE_VALUE_LEN 1024
 #endif // !defined(MYSQL_MAX_VARIABLE_VALUE_LEN)
+#endif
 #define STR_OR_NIL(S) ((S) ? (S) : "<nil>")
 
 #ifdef WITH_PARTITION_STORAGE_ENGINE
@@ -8720,8 +8722,12 @@ ST_FIELD_INFO variables_fields_info[]=
 {
   {"VARIABLE_NAME", 64, MYSQL_TYPE_STRING, 0, 0, "Variable_name",
    SKIP_OPEN_TABLE},
+#ifdef WITH_WSREP
   {"VARIABLE_VALUE", MYSQL_MAX_VARIABLE_VALUE_LEN, MYSQL_TYPE_STRING, 0, 1,
    "Value", SKIP_OPEN_TABLE},
+#else
+  {"VARIABLE_VALUE", 1024, MYSQL_TYPE_STRING, 0, 1, "Value", SKIP_OPEN_TABLE},
+#endif
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, SKIP_OPEN_TABLE}
 };
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -2069,6 +2069,7 @@ public:
    */
   char *get_table_name() const { return view != NULL ? view_name.str : table_name; }
 
+#ifdef WITH_WSREP
   /**
      @brief Returns the table alias that this TABLE_LIST represents.
      This is needed to get the real name of the temporary table as the normal
@@ -2078,6 +2079,7 @@ public:
      @details The unqualified table alias
    */
   char *get_table_alias() const { return alias; }
+#endif
 
   int fetch_number_of_rows();
   bool update_derived_keys(Field*, Item**, uint);

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -481,15 +481,13 @@ bool trans_commit_stmt(THD *thd)
 #endif /* WITH_WSREP */
     res= ha_commit_trans(thd, FALSE);
     if (! thd->in_active_multi_stmt_transaction())
-#ifdef WITH_WSREP
     {
-#endif /* WITH_WSREP */
       thd->tx_isolation= (enum_tx_isolation) thd->variables.tx_isolation;
       thd->tx_read_only= thd->variables.tx_read_only;
 #ifdef WITH_WSREP
       wsrep_post_commit(thd, FALSE);
-    }
 #endif /* WITH_WSREP */
+    }
   }
   else if (tc_log)
     tc_log->commit(thd, false);
@@ -731,12 +729,14 @@ bool trans_rollback_to_savepoint(THD *thd, LEX_STRING name)
 
   thd->transaction.savepoints= sv;
 
+#ifdef WITH_WSREP
   /*
     Release metadata locks that were acquired during this savepoint unit
     unless binlogging is on. Releasing locks with binlogging on can break
     replication as it allows other connections to drop these tables before
     rollback to savepoint is written to the binlog.
   */
+#endif
   if (!res && mdl_can_safely_rollback_to_savepoint)
     thd->mdl_context.rollback_to_savepoint(sv->mdl_savepoint);
 

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -2539,7 +2539,9 @@ main(int argc, char **argv)
     return 1;
   }
 
+#ifdef WITH_WSREP
   printf("SET SESSION wsrep_replicate_myisam=ON;\n");
+#endif
   if (argc == 2)
   {
     root_name_end= strmake(fullname, argv[1], FN_REFLEN);

--- a/storage/blackhole/ha_blackhole.cc
+++ b/storage/blackhole/ha_blackhole.cc
@@ -38,7 +38,11 @@ static inline bool is_slave_applier(const THD &thd)
 static inline bool pretend_for_slave(const THD &thd)
 {
   return is_slave_applier(thd) &&
+#ifdef WITH_WSREP
     ((thd.rli_slave && thd.rli_slave->rows_query_ev) || thd.query() == NULL);
+#else
+    (thd.rli_slave->rows_query_ev || thd.query() == NULL);
+#endif
 }
 
 /* Static declarations for handlerton */

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -310,7 +310,6 @@ UNIV_INTERN mysql_pfs_key_t	buf_block_debug_latch_key;
 
 #ifdef UNIV_PFS_MUTEX
 UNIV_INTERN mysql_pfs_key_t	buffer_block_mutex_key;
-UNIV_INTERN mysql_pfs_key_t	buf_pool_mutex_key;
 UNIV_INTERN mysql_pfs_key_t	buf_pool_zip_mutex_key;
 UNIV_INTERN mysql_pfs_key_t	buf_pool_flush_state_mutex_key;
 UNIV_INTERN mysql_pfs_key_t	buf_pool_LRU_list_mutex_key;

--- a/storage/innobase/fts/fts0opt.cc
+++ b/storage/innobase/fts/fts0opt.cc
@@ -2581,7 +2581,9 @@ fts_optimize_add_table(
 		return;
 	}
 
+#ifdef WITH_WSREP
 	ut_ad(table->cached && table->fts != NULL);
+#endif
 
 	/* Make sure table with FTS index cannot be evicted */
 	if (table->can_be_evicted) {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -829,6 +829,14 @@ static MYSQL_THDVAR_ULONG(flush_log_at_trx_commit, PLUGIN_VAR_OPCMDARG,
   " or 2 (write at commit, flush once per second).",
   NULL, NULL, 1, 0, 2, 0);
 
+#ifndef WITH_WSREP
+static MYSQL_THDVAR_BOOL(fake_changes, PLUGIN_VAR_OPCMDARG,
+  "In the transaction after enabled, UPDATE, INSERT and DELETE only move the cursor to the records "
+  "and do nothing other operations (no changes, no ibuf, no undo, no transaction log) in the transaction. "
+  "This is to cause replication prefetch IO. ATTENTION: the transaction started after enabled is affected.",
+  NULL, NULL, FALSE);
+#endif
+
 static MYSQL_THDVAR_STR(tmpdir,
   PLUGIN_VAR_OPCMDARG|PLUGIN_VAR_MEMALLOC,
   "Directory for temporary non-tablespace files.",
@@ -1580,9 +1588,9 @@ innodb_page_size_validate(
 /*======================*/
 	ulong	page_size)		/*!< in: Page Size to evaluate */
 {
+#ifdef WITH_WSREP
 	DBUG_ENTER("innodb_page_size_validate");
 
-#ifdef WITH_WSREP
 	/* With a 4K page_size, Galera triggers an assert upon restart.
 	 * Until that gets resolved, require using the default page size (16K).
 	*/
@@ -1591,6 +1599,7 @@ innodb_page_size_validate(
 	}
 #else
 	ulong		n;
+	DBUG_ENTER("innodb_page_size_validate");
 
 	for (n = UNIV_PAGE_SIZE_SHIFT_MIN;
 	     n <= UNIV_PAGE_SIZE_SHIFT_MAX;
@@ -1811,6 +1820,22 @@ thd_innodb_tmpdir(
 
 	return(tmp_dir);
 }
+
+#ifndef WITH_WSREP
+/******************************************************************//**
+Check the status of fake changes mode (innodb_fake_changes)
+@return	true	if fake change mode is enabled. */
+UNIV_INTERN
+ibool
+thd_fake_changes(
+/*=============*/
+	THD*	thd)	/*!< in: thread handle, or NULL to query
+			the global innodb_supports_xa */
+{
+	return(THDVAR((THD*) thd, fake_changes));
+}
+#endif
+
 /******************************************************************//**
 Returns the lock wait timeout for the current connection.
 @return	the lock wait timeout, in seconds */
@@ -2651,6 +2676,18 @@ innobase_trx_init(
 
 	trx->check_unique_secondary = !thd_test_options(
 		thd, OPTION_RELAXED_UNIQUE_CHECKS);
+
+#ifndef WITH_WSREP
+	/* Transaction on start caches the fake_changes state and uses it for
+	complete transaction lifetime.
+	There are some APIs that doesn't need an active transaction object
+	but transaction object are just use as a cache object/data carrier.
+	Before using transaction object for such APIs refresh the state of
+	fake_changes. */
+	if (trx->state == TRX_STATE_NOT_STARTED) {
+		trx->fake_changes = thd_fake_changes(thd);
+	}
+#endif
 
 #ifdef EXTENDED_SLOWLOG
 	if (thd_log_slow_verbosity(thd) & (1ULL << SLOG_V_INNODB)) {
@@ -3567,7 +3604,6 @@ innobase_init(
 
 	innobase_hton->create_zip_dict = innobase_create_zip_dict;
 	innobase_hton->drop_zip_dict = innobase_drop_zip_dict;
-	innobase_hton->is_reserved_db_name= innobase_check_reserved_file_name;
 
 	ut_a(DATA_MYSQL_TRUE_VARCHAR == (ulint)MYSQL_TYPE_VARCHAR);
 
@@ -4271,6 +4307,12 @@ innobase_create_zip_dict(
 	if (UNIV_UNLIKELY(high_level_read_only)) {
 		DBUG_RETURN(HA_CREATE_ZIP_DICT_READ_ONLY);
 	}
+
+#ifndef WITH_WSREP
+	if (UNIV_UNLIKELY(THDVAR(NULL, fake_changes))) {
+		DBUG_RETURN(HA_CREATE_ZIP_DICT_FAKE_CHANGES);
+	}
+#endif
 	
 	if (UNIV_UNLIKELY(*name_len > ZIP_DICT_MAX_NAME_LENGTH)) {
 		*name_len = ZIP_DICT_MAX_NAME_LENGTH;
@@ -4323,6 +4365,12 @@ innobase_drop_zip_dict(
 	if (UNIV_UNLIKELY(high_level_read_only)) {
 		DBUG_RETURN(HA_DROP_ZIP_DICT_READ_ONLY);
 	}
+
+#ifndef WITH_WSREP
+	if (UNIV_UNLIKELY(THDVAR(NULL, fake_changes))) {
+		DBUG_RETURN(HA_DROP_ZIP_DICT_FAKE_CHANGES);
+	}
+#endif
 
 	switch (dict_drop_zip_dict(name, *name_len)) {
 		case DB_SUCCESS:
@@ -5096,7 +5144,9 @@ innobase_kill_connection(
         handlerton*	hton,	/*!< in:  innobase handlerton */
 	THD*	thd)	/*!< in: handle to the MySQL thread being killed */
 {
+#ifdef WITH_WSREP
         ut_ad(!lock_mutex_own());
+#endif
 	trx_t*	trx;
 
 	DBUG_ENTER("innobase_kill_connection");
@@ -8241,7 +8291,9 @@ ha_innobase::write_row(
 
 	DBUG_ENTER("ha_innobase::write_row");
 
+#ifdef WITH_WSREP
 	DEBUG_SYNC(user_thd, "ha_innobase_write_row");
+#endif
 
 	if (high_level_read_only) {
 		ib_senderrf(ha_thd(), IB_LOG_LEVEL_WARN, ER_READ_ONLY_MODE);
@@ -8429,10 +8481,12 @@ no_commit:
 		build_template(true);
 	}
 
+#ifdef WITH_WSREP
 	/* debug sync point has a special significance given the location
 	where-in auto-inc value is generated but row insert action is not yet
 	started. */
 	DEBUG_SYNC(user_thd, "pxc_autoinc_val_generated");
+#endif
 
 	innobase_srv_conc_enter_innodb(prebuilt->trx);
 
@@ -8654,10 +8708,6 @@ report_error:
 	}
 wsrep_error:
 #endif
-
-	if (error_result == HA_FTS_INVALID_DOCID) {
-		my_error(HA_FTS_INVALID_DOCID, MYF(0));
-	}
 
 	if (error_result == HA_FTS_INVALID_DOCID) {
 		my_error(HA_FTS_INVALID_DOCID, MYF(0));
@@ -9055,7 +9105,9 @@ ha_innobase::update_row(
 
 	DBUG_ENTER("ha_innobase::update_row");
 
+#ifdef WITH_WSREP
 	DEBUG_SYNC(user_thd, "ha_innobase_update_row");
+#endif
 
 	ut_a(prebuilt->trx == trx);
 
@@ -15012,38 +15064,11 @@ ha_innobase::external_lock(
 		    && lock_type == F_WRLCK)
 		|| thd_sql_command(thd) == SQLCOM_CREATE_INDEX
 		|| thd_sql_command(thd) == SQLCOM_DROP_INDEX
-		|| thd_sql_command(thd) == SQLCOM_DELETE)) {
-
-		if (thd_sql_command(thd) == SQLCOM_CREATE_TABLE)
-		{
-			ib_senderrf(thd, IB_LOG_LEVEL_WARN,
-				    ER_INNODB_READ_ONLY);
-			DBUG_RETURN(HA_ERR_INNODB_READ_ONLY);
-		} else {
-			ib_senderrf(thd, IB_LOG_LEVEL_WARN,
-				    ER_READ_ONLY_MODE);
-			DBUG_RETURN(HA_ERR_TABLE_READONLY);
-		}
-
-	}
-
-	/* Check for UPDATEs in read-only mode. */
-	if (srv_read_only_mode
-	    && (thd_sql_command(thd) == SQLCOM_UPDATE
-		|| thd_sql_command(thd) == SQLCOM_INSERT
-		|| thd_sql_command(thd) == SQLCOM_REPLACE
-		|| thd_sql_command(thd) == SQLCOM_DROP_TABLE
-		|| thd_sql_command(thd) == SQLCOM_ALTER_TABLE
-		|| thd_sql_command(thd) == SQLCOM_OPTIMIZE
-		|| (thd_sql_command(thd) == SQLCOM_CREATE_TABLE
-		    && lock_type == F_WRLCK)
-		|| thd_sql_command(thd) == SQLCOM_CREATE_INDEX
-		|| thd_sql_command(thd) == SQLCOM_DROP_INDEX
-		|| thd_sql_command(thd) == SQLCOM_DELETE
-		|| thd_sql_command(thd) ==
-			SQLCOM_CREATE_COMPRESSION_DICTIONARY
-		|| thd_sql_command(thd) ==
-			SQLCOM_DROP_COMPRESSION_DICTIONARY)) {
+ 		|| thd_sql_command(thd) == SQLCOM_DELETE
+ 		|| thd_sql_command(thd) ==
+ 			SQLCOM_CREATE_COMPRESSION_DICTIONARY
+ 		|| thd_sql_command(thd) ==
+ 			SQLCOM_DROP_COMPRESSION_DICTIONARY)) {
 
 		if (thd_sql_command(thd) == SQLCOM_CREATE_TABLE)
 		{
@@ -16161,12 +16186,12 @@ ha_innobase::get_auto_increment(
 
 		current = *first_value > col_max_value ? autoinc : *first_value;
 
+#ifdef WITH_WSREP
 		/* If the increment step of the auto increment column
 		decreases then it is not affecting the immediate
 		next value in the series. */
 		if (prebuilt->autoinc_increment > increment) {
 
-#ifdef WITH_WSREP
 			WSREP_DEBUG("Refresh change in auto-inc configuration"
 				    " from (off: %llu -> %llu)"
 				    " and (inc: %llu -> %llu)."
@@ -16180,8 +16205,6 @@ ha_innobase::get_auto_increment(
 				    current, autoinc);
 			if (!wsrep_on(ha_thd()))
 			{
-#endif /* WITH_WSREP */
-
 			/* MySQL flow will construct last_inserted_id but PXC
 			can't do so because any values in that range are
 			potentially unsafe as they were reserved for other node
@@ -16193,14 +16216,13 @@ ha_innobase::get_auto_increment(
 
 			current = innobase_next_autoinc(
 				current, 1, increment, 1, col_max_value);
-#ifdef WITH_WSREP
 			}
-#endif /* WITH_WSREP */
 
 			dict_table_autoinc_initialize(prebuilt->table, current);
 
 			*first_value = current;
 		}
+#endif /* WITH_WSREP */
 
 		/* Compute the last value in the interval */
 		next_value = innobase_next_autoinc(
@@ -16676,7 +16698,9 @@ innobase_commit_by_xid(
 	DBUG_ASSERT(hton == innodb_hton_ptr);
 
 	trx = trx_get_trx_by_xid(xid);
+#ifdef WITH_WSREP
 	trx->wsrep_recover_xid = xid;
+#endif
 
 	if (trx) {
 		innobase_commit_low(trx);
@@ -20476,6 +20500,15 @@ static	MYSQL_SYSVAR_ENUM(corrupt_table_action, srv_pass_corrupt_table,
   "except for the deletion.",
   NULL, NULL, 0, &corrupt_table_action_typelib);
 
+#ifndef WITH_WSREP
+static MYSQL_SYSVAR_BOOL(locking_fake_changes, srv_fake_changes_locks,
+  PLUGIN_VAR_NOCMDARG,
+  "###EXPERIMENTAL### if enabled, transactions will get S row locks instead "
+  "of X locks for fake changes.  If disabled, fake change transactions will "
+  "not take any locks at all.",
+  NULL, NULL, TRUE);
+#endif
+
 static MYSQL_SYSVAR_UINT(compressed_columns_zip_level,
   srv_compressed_columns_zip_level,
   PLUGIN_VAR_RQCMDARG,
@@ -20688,6 +20721,10 @@ static struct st_mysql_sys_var* innobase_system_variables[]= {
   MYSQL_SYSVAR(saved_page_number_debug),
 #endif /* UNIV_DEBUG */
   MYSQL_SYSVAR(corrupt_table_action),
+#ifndef WITH_WSREP
+  MYSQL_SYSVAR(fake_changes),
+  MYSQL_SYSVAR(locking_fake_changes),
+#endif
   MYSQL_SYSVAR(tmpdir),
   MYSQL_SYSVAR(compressed_columns_zip_level),
   MYSQL_SYSVAR(compressed_columns_threshold),

--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -1268,7 +1268,6 @@ buf_page_hash_get_locked(
 	if (!bpage || buf_pool_watch_is_sentinel(buf_pool, bpage)) {
 		if (!watch) {
 		bpage = NULL;
-		goto unlock_and_exit;
 	}
 		goto unlock_and_exit;
 	}

--- a/storage/innobase/include/sync0sync.ic
+++ b/storage/innobase/include/sync0sync.ic
@@ -261,8 +261,9 @@ mutex_enter_func(
 	ulint		line)		/*!< in: line where locked */
 {
 	ut_ad(mutex_validate(mutex));
-#ifndef WITH_WSREP
+#ifdef WITH_WSREP
 	/* this cannot be be granted when BF trx kills a trx in lock wait state */
+#else
 	ut_ad(!mutex_own(mutex));
 #endif /* WITH_WSREP */
 	/* Note that we do not peek at the value of lock_word before trying

--- a/storage/innobase/include/trx0sys.ic
+++ b/storage/innobase/include/trx0sys.ic
@@ -482,8 +482,9 @@ trx_id_t
 trx_sys_get_new_trx_id(void)
 /*========================*/
 {
-#ifndef WITH_WSREP
+#ifdef WITH_WSREP
 	/* wsrep_fake_trx_id  violates this assert */
+#else
 	ut_ad(mutex_own(&trx_sys->mutex));
 #endif /* WITH_WSREP */
 

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -1832,7 +1832,8 @@ lock_sec_rec_some_has_impl(
 	return(trx_id);
 }
 
-#if defined(UNIV_DEBUG) && !defined(WITH_WSREP)
+#ifndef WITH_WSREP
+#ifdef UNIV_DEBUG
 /*********************************************************************//**
 Checks if some transaction, other than given trx_id, has an explicit
 lock on the given rec, in the given precise_mode.
@@ -1893,7 +1894,8 @@ lock_rec_other_trx_holds_expl(
 
 	return(holds);
 }
-#endif /* UNIV_DEBUG && !WITH_WSREP */
+#endif /* UNIV_DEBUG */
+#endif
 
 /*********************************************************************//**
 Return approximate number or record locks (bits set in the bitmap) for

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -1256,8 +1256,10 @@ os_file_create_simple_func(
 
 #else /* __WIN__ */
 	int		create_flag;
+#ifdef WITH_INNODB_DISALLOW_WRITES
 	if (create_mode != OS_FILE_OPEN && create_mode != OS_FILE_OPEN_RAW)
 		WAIT_ALLOW_WRITES();
+#endif
 
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_SILENT));
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_NO_EXIT));
@@ -1456,8 +1458,10 @@ os_file_create_simple_no_error_handling_func(
 	int		create_flag;
 	const char*	mode_str	= NULL;
 	ut_a(name);
+#ifdef WITH_INNODB_DISALLOW_WRITES
 	if (create_mode != OS_FILE_OPEN && create_mode != OS_FILE_OPEN_RAW)
 		WAIT_ALLOW_WRITES();
+#endif
 
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_SILENT));
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_NO_EXIT));
@@ -1803,8 +1807,10 @@ os_file_create_func(
 #else /* __WIN__ */
 	int		create_flag;
 	const char*	mode_str	= NULL;
+#ifdef WITH_INNODB_DISALLOW_WRITES
 	if (create_mode != OS_FILE_OPEN && create_mode != OS_FILE_OPEN_RAW)
 		WAIT_ALLOW_WRITES();
+#endif
 
 	on_error_no_exit = create_mode & OS_FILE_ON_ERROR_NO_EXIT
 		? TRUE : FALSE;

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -2513,7 +2513,9 @@ row_log_table_apply_ops(
 	const ulint	new_trx_id_col	= dict_col_get_clust_pos(
 		dict_table_get_sys_col(new_table, DATA_TRX_ID), new_index);
 	trx_t*		trx		= thr_get_trx(thr);
+#ifdef WITH_WSREP
         int unused __attribute__((unused));
+#endif
 
 	ut_ad(dict_index_is_clust(index));
 	ut_ad(dict_index_is_online_ddl(index));
@@ -2640,7 +2642,7 @@ all_done:
 		and be ignored when the operation is unsupported. */
 		fallocate(index->online_log->fd,
 			  FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
-			  ofs, srv_sort_buf_size);
+			  ofs, srv_buf_size);
 #endif /* FALLOC_FL_PUNCH_HOLE */
 
 		next_mrec = index->online_log->head.block;
@@ -3361,7 +3363,9 @@ row_log_apply_ops(
 	bool		has_index_lock;
 	const ulint	i	= 1 + REC_OFFS_HEADER_SIZE
 		+ dict_index_get_n_fields(index);
+#ifdef WITH_WSREP
         int unused __attribute__((unused));
+#endif
 
 	ut_ad(dict_index_is_online_ddl(index));
 	ut_ad(*index->name == TEMP_INDEX_PREFIX);
@@ -3476,7 +3480,7 @@ all_done:
 		and be ignored when the operation is unsupported. */
 		fallocate(index->online_log->fd,
 			  FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
-			  ofs, srv_sort_buf_size);
+			  ofs, srv_buf_size);
 #endif /* FALLOC_FL_PUNCH_HOLE */
 
 		next_mrec = index->online_log->head.block;

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -189,10 +189,11 @@ trx_sys_flush_max_trx_id(void)
 	mtr_t		mtr;
 	trx_sysf_t*	sys_header;
 
-#ifndef WITH_WSREP
+#ifdef WITH_WSREP
 	/* wsrep_fake_trx_id  violates this assert
 	 * Copied from trx_sys_get_new_trx_id
 	 */
+#else
 	ut_ad(mutex_own(&trx_sys->mutex));
 #endif /* WITH_WSREP */
 

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1077,6 +1077,14 @@ trx_start_low(
 
 	trx->id = trx_sys_get_new_trx_id();
 
+#ifndef WITH_WSREP
+	/* Cache the state of fake_changes that transaction will use for
+	lifetime. Any change in session/global fake_changes configuration during
+	lifetime of transaction will not be honored by already started
+	transaction. */
+	trx->fake_changes = thd_fake_changes(trx->mysql_thd);
+#endif
+
 	ut_ad(!trx->in_rw_trx_list);
 	ut_ad(!trx->in_ro_trx_list);
 


### PR DESCRIPTION
* Introduces scripts under the check_src directory, which detect
  differences between the pxc WITH_WSREP=OFF source and PS. For the same
  upstream versions, there shouldn't be any changes except for the
  existing whitelists.
  The script also disables WITH_INNODB_DISALLOW_WRITES, as that's
  another 3rd party path not present in PS.
* Whitelisted product name changes, as PXC should be called PXC even
  without WITH_WSREP.
* Whitelisted the use of the WSREP_BINLOG_FORMAT macro, as it defaults
  to a no-op without WITH_WSREP.
* Fixed incorrect naming of the WITH_WSREP macro at a few places
* Added WITH_WSREP if(n)defs everywhere where PXC added/deleted logic
* Removed cosmetic differences compared to PS.