### PR TITLE
PXC-3202 fix postun scriplet error

### DIFF
--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -1796,7 +1796,7 @@ done
 
 %if 0%{?systemd}
 if [ $1 -eq 0 ];then
-    %systemd_postun
+    /usr/bin/systemctl daemon-reload >/dev/null 2>&1 || :
 else
     serv=$(/usr/bin/systemctl list-units | grep 'mysql@.*.service' | grep 'active running' | head -1 | awk '{ print $1 }')
     numint=0
@@ -1819,7 +1819,7 @@ else
             else
                 echo "Not bootstrapping with $(( numint-1 )) nodes already in cluster PC"
                 echo "Restarting with mysql.service in its stead"
-                %systemd_postun
+                /usr/bin/systemctl daemon-reload >/dev/null 2>&1 || :
                 /usr/bin/systemctl stop mysql@bootstrap.service
                 /usr/bin/systemctl start mysql.service
             fi


### PR DESCRIPTION
Replace %systemd_postun scriplet invocation with its value due to the fact, that
%systemd_postun scriplet has been changed in recent systemd packages,
shipped with centos8, in the way, so that it expands into "empty string" and causes the issue.