### PR TITLE
PXC-2935: Assertion `server_state_.rollback_mode() == wsrep::server_s…

### DIFF
--- a/mysql-test/suite/galera/r/pxc_thread_pool_bf_abort.result
+++ b/mysql-test/suite/galera/r/pxc_thread_pool_bf_abort.result
@@ -1,0 +1,14 @@
+CREATE TABLE t1(a int);
+BEGIN;
+SELECT * FROM t1 WHERE a = 0;
+a
+SET DEBUG_SYNC="thread_attach_after_acquire_ownership SIGNAL reached WAIT_FOR continue";
+SELECT * FROM t1 WHERE a = 0;;
+SET DEBUG_SYNC="now WAIT_FOR reached";
+SET DEBUG_SYNC="wsrep_after_bf_abort SIGNAL aborted";
+ALTER TABLE t1 ADD COLUMN b INT;;
+SET DEBUG_SYNC="now WAIT_FOR aborted";
+set DEBUG_SYNC="now SIGNAL continue";
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';

--- a/mysql-test/suite/galera/t/pxc_thread_pool_bf_abort.cnf
+++ b/mysql-test/suite/galera/t/pxc_thread_pool_bf_abort.cnf
@@ -1,0 +1,5 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+thread_handling=pool-of-threads
+

--- a/mysql-test/suite/galera/t/pxc_thread_pool_bf_abort.test
+++ b/mysql-test/suite/galera/t/pxc_thread_pool_bf_abort.test
@@ -1,0 +1,41 @@
+#
+# Brute force abort when using thread pool connection handler
+#
+
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--connection node_1
+CREATE TABLE t1(a int);
+BEGIN;
+SELECT * FROM t1 WHERE a = 0;
+SET DEBUG_SYNC="thread_attach_after_acquire_ownership SIGNAL reached WAIT_FOR continue";
+--send SELECT * FROM t1 WHERE a = 0;
+
+
+--connect node_1a, 127.0.0.1, root,,, $NODE_MYPORT_1
+--connection node_1a
+SET DEBUG_SYNC="now WAIT_FOR reached";
+SET DEBUG_SYNC="wsrep_after_bf_abort SIGNAL aborted";
+--send ALTER TABLE t1 ADD COLUMN b INT;
+
+--connect node_1b, 127.0.0.1, root,,, $NODE_MYPORT_1
+--connection node_1b
+SET DEBUG_SYNC="now WAIT_FOR aborted";
+set DEBUG_SYNC="now SIGNAL continue";
+
+--connection node_1a
+--reap
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+# cleanup
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';
+--disconnect node_1a
+--disconnect node_1b
+--source include/wait_until_count_sessions.inc

--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -110,6 +110,9 @@ static bool thread_attach(THD *thd) {
   /* Wait until possible background rollback has finished before
      attaching the thd. */
   wsrep_wait_rollback_complete_and_acquire_ownership(thd);
+
+  DEBUG_SYNC(thd, "thread_attach_after_acquire_ownership");
+
 #endif /* WITH_WSREP */
 #ifndef DBUG_OFF
   set_my_thread_var_id(thd->thread_id());

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -283,11 +283,9 @@ void Wsrep_client_service::wait_for_replayers(
 
 void Wsrep_client_service::debug_sync(const char *sync_point
                                       __attribute__((unused))) {
-  DBUG_ASSERT(m_thd == current_thd);
-
 #if defined(ENABLED_DEBUG_SYNC)
   if (unlikely(opt_debug_sync_timeout))
-    ::debug_sync(m_thd, sync_point, strlen(sync_point));
+    ::debug_sync(current_thd, sync_point, strlen(sync_point));
     // debug_sync_caller(m_thd, sync_point);
 #endif /* defined(ENABLED_DEBUG_SYNC) */
 }


### PR DESCRIPTION
…tate::rm_async' failed

https://jira.percona.com/browse/PXC-2935

Problem:
This problem occurred only if server was started with option --thread_handling=pool-of-threads.
1. Connection 1: start explicit transaction, execute 1st statement that acquires MDL lock
2. Connection 1: Execute 2nd statement. In threadpool_common.cc thread_attach() we wait for potential transaction that is being rolled back by background_rollbacker to finish. After this we acquire thread ownership and client_state's state is shifted to s_exec.
3. Connection 2: Just after acquiring ownership of the thread and moving state to s_exec by Connection 1 execute another query that conflicts with the MDL lock taken by Connection 1. This causes BF eviction of Connection 1 transaction, but as it is in s_exec state, rollback is not requested to be done by background_rollbacker. Transaction state is shifted to s_must_abort and is expected to be aborted in before_command() call.
4. Connection 1: the flow moves on and gets to before_command(). Transaction is in s_must_abort state and we hit the control path with assert that is wrong.

Solution:
Removed wrong assert.
Added MTR test.
Relaxed assert in client_service::debug_sync() which prevented setting debug_sync from thread another than the one owning client_service object. That prevented setting debug_sync in abort_bf when executing thread is aborter thread.