### PR TITLE
8.0 PXC-3165 - Allow COM_FIELD_LIST to be executed when WSREP is not ready

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_reject_queries.result
+++ b/mysql-test/suite/galera/r/galera_var_reject_queries.result
@@ -19,4 +19,12 @@ SET GLOBAL wsrep_reject_queries = NONE;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
+SET GLOBAL wsrep_reject_queries = ALL;
+Database: test  Table: t1
++-------+---------+-----------+------+-----+---------+-------+---------------------------------+---------+
+| Field | Type    | Collation | Null | Key | Default | Extra | Privileges                      | Comment |
++-------+---------+-----------+------+-----+---------+-------+---------------------------------+---------+
+| f1    | int(11) |           | YES  |     |         |       | select,insert,update,references |         |
++-------+---------+-----------+------+-----+---------+-------+---------------------------------+---------+
+SET GLOBAL wsrep_reject_queries = NONE;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_var_reject_queries.test
+++ b/mysql-test/suite/galera/t/galera_var_reject_queries.test
@@ -43,4 +43,10 @@ SET GLOBAL wsrep_reject_queries = NONE;
 
 SELECT COUNT(*) = 1 FROM t1;
 
+# PXC-3165 - Allow COM_FIELD_LIST to be executed when WSREP is not ready
+--connection node_2
+SET GLOBAL wsrep_reject_queries = ALL;
+--exec $MYSQL_SHOW -P $NODE_MYPORT_1 test t1;
+SET GLOBAL wsrep_reject_queries = NONE;
+
 DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -372,6 +372,7 @@ void init_update_queries(void)
   server_command_flags[COM_TIME]         |= CF_SKIP_WSREP_CHECK;
   server_command_flags[COM_INIT_DB]      |= CF_SKIP_WSREP_CHECK;
   server_command_flags[COM_END]          |= CF_SKIP_WSREP_CHECK;
+  server_command_flags[COM_FIELD_LIST]   |= CF_SKIP_WSREP_CHECK;
  
   /*
     COM_QUERY and COM_SET_OPTION are allowed to pass the early COM_xxx filter,


### PR DESCRIPTION
Problem
Currently we allow users to execute some SHOW and SET commands.
SHOW FIELDS FROM [table] is one of them. However, mysql and mysqlshow
clients currently utilize mysql_list_fields which executes
COM_FIELD_LIST instead of COM_QUERY SHOW FIELDS FROM [table].

Solution
Allow COM_FIELD_LIST to be executed while WSREP is not ready or
wsrep_reject_queries is set to anything rather than NONE.