### PR TITLE
PXC-3287: Incorrect link displayed on \help client command

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -3123,7 +3123,7 @@ static int com_help(String *buffer MY_ATTRIBUTE((unused)),
       "\nFor information about Percona products and services, visit:\n"
       "   http://www.percona.com/\n"
       "Percona XtraDB Cluster manual: "
-      "http://www.percona.com/doc/percona-xtradb-cluster/%d.%d\n"
+      "http://www.percona.com/doc/percona-xtradb-cluster/8.0/\n"
       "For the MySQL Reference Manual: http://dev.mysql.com/\n"
       "To buy Percona support, training, or other products, visit:\n"
       "   https://www.percona.com/\n",


### PR DESCRIPTION
Fixed the documentation link.