### PR TITLE
PXC-2934: Assertion `owning_thread_id_ == wsrep::this_thread::get_id()' failed.

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-21677.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-21677.result
@@ -1,0 +1,28 @@
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+SET SESSION wsrep_trx_fragment_size = 1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (4);
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+3
+SET GLOBAL DEBUG = "d,sync.wsrep_apply_toi_cb";
+SET GLOBAL DEBUG = "d,sync.wsrep_bf_abort";
+TRUNCATE TABLE t1;
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_bf_abort_reached";
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_cb_reached";
+SET GLOBAL DEBUG = "d,sync.wsrep_rollback_cb";
+INSERT INTO t1 VALUES (5);
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = DEFAULT;
+SET GLOBAL DEBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi_cb";
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_rollback_cb_reached";
+SET GLOBAL DEBUG = "d,sync.wsrep_bf_abort_failed";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_bf_abort WAIT_FOR sync.wsrep_bf_abort_failed_reached";
+SET GLOBAL DEBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_rollback_cb";
+SET DEBUG_SYNC = "RESET";
+SET DEBUG_SYNC = "RESET";
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/MDEV-21677.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-21677.test
@@ -1,0 +1,116 @@
+#
+# MDEV-21677 Assertion `owning_thread_id_ == wsrep::this_thread::get_id()'
+#
+# This test exposes a race condition between rollbacker thread and rollback
+# fragment processing.
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+
+#
+# On node_2 we start a SR transaction, it going to
+# be BF aborted later on
+#
+--connection node_2
+SET SESSION wsrep_trx_fragment_size = 1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (4);
+
+--connection node_1
+SELECT COUNT(*) FROM t1; # Sync wait
+
+
+#
+# Issue a conflicting TRUNCATE statement on node_1:
+# - on node_2, block it before it is going to apply
+# - on node_1, block it before BF aborts the INSERT
+#
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+SET GLOBAL DEBUG = "d,sync.wsrep_apply_toi_cb";
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+SET GLOBAL DEBUG = "d,sync.wsrep_bf_abort";
+
+--connection node_1
+--send TRUNCATE TABLE t1
+
+--connection node_1a
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_bf_abort_reached";
+
+--connection node_2a
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_toi_cb_reached";
+
+
+#
+# Generate one more fragment on the SR transaction.
+# This is going to fail certification and results
+# in a rollback fragment.
+#
+--connection node_1a
+SET GLOBAL DEBUG = "d,sync.wsrep_rollback_cb";
+
+--connection node_2
+--let $expected_cert_failures = `SELECT VARIABLE_VALUE + 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'`
+
+--send INSERT INTO t1 VALUES (5)
+
+#
+# Wait until after certify and observe the certification
+# failure. Let both continue and we are done on node_2.
+#
+--connection node_2a
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_cert_failures FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'
+--source include/wait_condition.inc
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+SET GLOBAL DEBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_toi_cb";
+
+--connection node_2
+--error ER_LOCK_DEADLOCK
+--reap
+
+
+#
+# Wait for the transaction to fail certification on node_1.
+# We expect a rollback fragment to be delivered
+#
+--connection node_1a
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_rollback_cb_reached";
+
+
+#
+# This is the crucial part of the test:
+# If both rollbacker and rollback fragment are allowed to
+# process the same thd concurrently, then we expect the
+# assertion to trigger on applier thread processing the
+# rollback fragment.
+# First signal the TRUNCATE, and expect it fails to
+# BF abort the INSERT.
+#
+--connection node_1a
+SET GLOBAL DEBUG = "d,sync.wsrep_bf_abort_failed";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_bf_abort WAIT_FOR sync.wsrep_bf_abort_failed_reached";
+SET GLOBAL DEBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_rollback_cb";
+
+--connection node_1
+--reap
+
+#
+# Cleanup
+#
+--connection node_2
+SET DEBUG_SYNC = "RESET";
+
+--connection node_1
+SET DEBUG_SYNC = "RESET";
+DROP TABLE t1;


### PR DESCRIPTION
This is cherrypicked from Codership.
MDEV-21677 Assertion `owning_thread_id_ == wsrep::this_thread::get_id()'

Update wsrep-lib to include fixes in rollback processing for streaming
transactions. Avoid the case where both rollbacker and rollback
fragment attempt to rollback the same transaction
concurrently (leading to the assert in title).
The patch includes a new MTR test that reproduces the issue
deterministically.

(cherry picked from `https://github.com/codership/mariadb-server/pull/139`)

Note to reviewers:
1. In multi-threaded environments, the assertion `owning_thread_id_ == wsrep::this_thread::get_id()` can be hit from various code paths and this patch fixes one such path that happens during the rollback of a high priority transaction caused by Streaming Replication.

2. The commit message and the test case comments have been retained to be in sync with the upstream.

Jenkins link: https://pxc.cd.percona.com/job/pxc-8.0-param/54/console