### PR TITLE
PXC-3295: [5.7] [MTR] Make high priority transactions work with PXC

### DIFF
--- a/mysql-test/include/start_transaction_high_prio.inc
+++ b/mysql-test/include/start_transaction_high_prio.inc
@@ -22,14 +22,15 @@
 --let $include_filename= start_transaction_high_prio.inc
 --source include/begin_include_file.inc
 
+let old_debug=`SELECT @@debug`;
 --disable_query_log
-SET GLOBAL DEBUG='+d,dbug_set_high_prio_trx';
+SET GLOBAL DEBUG='d,dbug_set_high_prio_trx';
 --enable_query_log
 
 START TRANSACTION /* HIGH PRIORITY */;
 
 --disable_query_log
-SET GLOBAL DEBUG='-d,dbug_set_high_prio_trx';
+--eval SET GLOBAL DEBUG='$old_debug';
 --enable_query_log
 
 --let $include_filename= start_transaction_high_prio.inc

--- a/mysql-test/suite/galera/r/high_prio_trx_1.result
+++ b/mysql-test/suite/galera/r/high_prio_trx_1.result
@@ -1,0 +1,20 @@
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+# On connection 1
+START TRANSACTION;
+UPDATE t1 SET c1=1 WHERE c1=0;
+
+# On connection 2
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+
+# On connection 1
+COMMIT;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+include/assert.inc ['There is a 2 in t1']
+include/assert.inc ['There is no 1 in t1']
+include/assert.inc ['There is no 0 in t1']
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/high_prio_trx_2.result
+++ b/mysql-test/suite/galera/r/high_prio_trx_2.result
@@ -1,0 +1,22 @@
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+# On connection 1
+START TRANSACTION;
+SELECT * FROM t1 WHERE c1=0 FOR UPDATE;
+c1
+0
+
+# On connection 2
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+
+# On connection 1
+UPDATE t1 SET c1=1 WHERE c1=0;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+include/assert.inc ['There is a 2 in t1']
+include/assert.inc ['There is no 1 in t1']
+include/assert.inc ['There is no 0 in t1']
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/high_prio_trx_3.result
+++ b/mysql-test/suite/galera/r/high_prio_trx_3.result
@@ -1,0 +1,27 @@
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY, c2 INT NOT NULL, c3 INT NOT NULL) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0, 0, 0);
+
+# On connection 1
+START TRANSACTION;
+UPDATE t1 SET c1=1, c2=1 WHERE c1=0 AND c2=0;
+
+# On connection 2
+START TRANSACTION;
+UPDATE t1 SET c2=2 WHERE c1=0 AND c2=3;
+
+# On connection 3
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+UPDATE t1 SET c2=3 WHERE c2=0;
+COMMIT;
+
+# On connection 1
+COMMIT;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+
+# On connection 2
+COMMIT;
+include/assert.inc ['There is no 3 in t1']
+include/assert.inc ['There is a 2 in t1']
+include/assert.inc ['There is no 1 in t1']
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/high_prio_trx_1.test
+++ b/mysql-test/suite/galera/t/high_prio_trx_1.test
@@ -1,0 +1,59 @@
+--source include/galera_cluster.inc
+
+--disable_query_log
+CALL mtr.add_suppression("InnoDB High Priority being used");
+--enable_query_log
+
+# Scenario:
+#  T1=({R(B), W(B)})
+#  T2=({R(B), W(B), C}, HIGH_PRIORITY).
+#
+# Outcome: T1 must abort, T2 must commit.
+
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+--connect(con1,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con2,localhost,root,,test, $NODE_MYPORT_1)
+
+--echo
+--echo # On connection 1
+--connection con1
+START TRANSACTION;
+UPDATE t1 SET c1=1 WHERE c1=0;
+
+--echo
+--echo # On connection 2
+--connection con2
+--source include/start_transaction_high_prio.inc
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+--disconnect con2
+
+--echo
+--echo # On connection 1
+--connection con1
+# TODO: this should be ER_ERROR_DURING_COMMIT
+--error ER_LOCK_DEADLOCK
+COMMIT;
+--disconnect con1
+
+--connection node_2
+--let $assert_text= 'There is a 2 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 2, count, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'There is no 1 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 1, count, 1] = 0
+--source include/assert.inc
+
+--let $assert_text= 'There is no 0 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0, count, 1] = 0
+--source include/assert.inc
+
+--connection default
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/high_prio_trx_2.test
+++ b/mysql-test/suite/galera/t/high_prio_trx_2.test
@@ -1,0 +1,58 @@
+# Scenario:
+#  T1=({R(B)})
+#  T2=({R(B), W(B), C}, HIGH_PRIORITY).
+#
+# Outcome: T1 must abort, T2 must commit.
+
+--disable_query_log
+CALL mtr.add_suppression("InnoDB High Priority being used");
+--enable_query_log
+
+--source include/galera_cluster.inc
+
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0);
+
+--connect(con1,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con2,localhost,root,,test, $NODE_MYPORT_1)
+
+--echo
+--echo # On connection 1
+--connection con1
+START TRANSACTION;
+SELECT * FROM t1 WHERE c1=0 FOR UPDATE;
+
+--echo
+--echo # On connection 2
+--connection con2
+--source include/start_transaction_high_prio.inc
+UPDATE t1 SET c1=2 WHERE c1=0;
+COMMIT;
+--disconnect con2
+
+--echo
+--echo # On connection 1
+--connection con1
+# Note: DEADLOCK implies a full ROLLBACK
+--error ER_LOCK_DEADLOCK
+UPDATE t1 SET c1=1 WHERE c1=0;
+--disconnect con1
+
+--connection node_2
+--let $assert_text= 'There is a 2 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 2, count, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'There is no 1 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 1, count, 1] = 0
+--source include/assert.inc
+
+--let $assert_text= 'There is no 0 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0, count, 1] = 0
+--source include/assert.inc
+
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/high_prio_trx_3.test
+++ b/mysql-test/suite/galera/t/high_prio_trx_3.test
@@ -1,0 +1,83 @@
+--source include/galera_cluster.inc
+
+--source include/count_sessions.inc
+
+--disable_query_log
+CALL mtr.add_suppression("InnoDB High Priority being used");
+--enable_query_log
+
+# Scenario:
+#  T1= ({R(Z), R(B), W(Z), W(B)})
+#  T2= ({R(C), R(B), W(B)})
+#  T3= ({R(B), W(B), C}, HIGH_PRIORITY)
+#
+# Outcome: T1 must abort, T3 must commit, T2 must commit
+#          after T3.
+#
+# Lock -> {T1 granted, T2 waiting, T3 waiting};
+# Then T3 jumps the queue:
+# Lock -> {T1 granted, T3 waiting, T2 waiting};
+# T3 Rolls back T1
+# Lock -> {T3 granted, T2 waiting}
+
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (c1 INT NOT NULL PRIMARY KEY, c2 INT NOT NULL, c3 INT NOT NULL) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (0, 0, 0);
+
+--connect(con1,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con2,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con3,localhost,root,,test, $NODE_MYPORT_1)
+
+--echo
+--echo # On connection 1
+--connection con1
+START TRANSACTION;
+UPDATE t1 SET c1=1, c2=1 WHERE c1=0 AND c2=0;
+
+--echo
+--echo # On connection 2
+--connection con2
+START TRANSACTION;
+--send UPDATE t1 SET c2=2 WHERE c1=0 AND c2=3
+
+--echo
+--echo # On connection 3
+--connection con3
+--source include/start_transaction_high_prio.inc
+UPDATE t1 SET c2=3 WHERE c2=0;
+COMMIT;
+--disconnect con3
+
+--echo
+--echo # On connection 1
+--connection con1
+# TODO: should be ER_ERROR_DURING_COMMIT
+--error ER_LOCK_DEADLOCK
+COMMIT;
+--disconnect con1
+
+--echo
+--echo # On connection 2
+--connection con2
+--reap
+COMMIT;
+--disconnect con2
+
+--connection node_2
+--let $assert_text= 'There is no 3 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0 AND t1.c2 = 3 AND t1.c3 = 0, count, 1] = 0
+--source include/assert.inc
+
+--let $assert_text= 'There is a 2 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 0 AND t1.c2 = 2 AND t1.c3 = 0, count, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'There is no 1 in t1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM t1 WHERE t1.c1 = 1 AND t1.c2 = 1 AND t1.c3 = 0, count, 1] = 0
+--source include/assert.inc
+
+--connection default
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3246,42 +3246,8 @@ check_trx_exists(
 		/* User trx can be forced to rollback,
 		so we unset the disable flag. */
 		ut_ad(trx->in_innodb & TRX_FORCE_ROLLBACK_DISABLE);
-
-#ifdef WITH_WSREP
-		/* With 5.7 InnoDB introduce a mechanism for force rollback.
-		If a conflict is detected then high priority transaction can
-		cause low priority transaction to force rollback.
-		Rollback action is executed as part of high priority transaction
-		thread hogging it till it is done.
-		Galera uses different logic. It has a dedicated rollback thread
-		that does this on request. Also, not each transaction is
-		rollback by rollback thread. For example: if statement is in
-		advance mode with query_state = QUERY_EXEC then rollback is
-		done as part of do_command/dispatch_command flow.
-		For PXC we will disable InnoDB logic and opt for original Galera
-		logic. */
-		if (!wsrep_on(thd)) {
-			trx->in_innodb &= TRX_FORCE_ROLLBACK_MASK;
-		}
-#else
 		trx->in_innodb &= TRX_FORCE_ROLLBACK_MASK;
-#endif /* WITH_WSREP */
-
 	} else {
-
-#ifdef WITH_WSREP
-		/* Check comment above.
-		Why we need to re-set DISABLE for every call ?
-		* trx_init() resets the complete mask masking DISABLE bit
-		too without caring what was the original state of this bit.
-		If this bit is set and then trx_init so continue to keep it
-		and not mask it. This is InnoDB error we are will correct it
-		in PXC here. */
-		if (wsrep_on(thd)) {
-			trx->in_innodb |= TRX_FORCE_ROLLBACK_DISABLE;
-		}
-#endif /* WITH_WSREP */
-
 		ut_a(trx->magic_n == TRX_MAGIC_N);
 
 		innobase_trx_init(thd, trx);

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -70,10 +70,6 @@ Created 3/26/1996 Heikki Tuuri
 #endif /* WITH_WSREP */
 static const ulint MAX_DETAILED_ERROR_LEN = 256;
 
-#ifdef WITH_WSREP
-#include <wsrep_mysqld.h>
-#endif /* WITH_WSREP */
-
 /** Set of table_id */
 typedef std::set<
 	table_id_t,
@@ -3585,8 +3581,9 @@ Kill all transactions that are blocking this transaction from acquiring locks.
 void
 trx_kill_blocking(trx_t* trx)
 {
+	DBUG_ENTER("trx_kill_blocking");
 	if (trx->hit_list.empty()) {
-		return;
+		DBUG_VOID_RETURN;
 	}
 
 	DEBUG_SYNC_C("trx_kill_blocking_enter");
@@ -3746,5 +3743,5 @@ trx_kill_blocking(trx_t* trx)
 
 		row_mysql_freeze_data_dictionary(trx);
 	}
-
+	DBUG_VOID_RETURN;
 }


### PR DESCRIPTION
This is a backport of PXC-3128: High priority transactions should work
with WSREP.

Issue: when wsrep is running, high priority transactions weren't able to
kill normal priority transactions. This basically broke the scenario
where a PXC node is also part of a normal replication setup.

Root cause: We intentionally broke this feature in 5.7, in commit
5be95d8ff766. The comment/commit message explains that galera used a
different mechanism and thus it was disabled.

Compared to that statement codership fixed HPTs also in 5.7, in commit
f2dd26e10785, by translating the HPT kill logic into wsrep functions.

After merging the codership fix in 5.7, we never reverted our
workaround.

Fix:

* Reverted 5be95d8ff766
* Backported 03a80d175c70b from PXC-8.0.
* Backported some of the high priority tests to the galera suite to ensure
  that they don't break in the future
* This commit also improves the start_transactin_high_prio mtr include
  so it works when used together with --debug

Testing Link: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc57-test-mtr/63/console
Note: Most tests are failing because of missing dependencies. I have reported PXC-3342 for tracking them. 