### PR TITLE
PXC-3243 : BF aborting a stored procedure hangs

### DIFF
--- a/mysql-test/suite/galera/r/galera_migrate.result
+++ b/mysql-test/suite/galera/r/galera_migrate.result
@@ -80,3 +80,6 @@ DROP USER sst;
 CALL mtr.add_suppression("InnoDB: Error: Table \"mysql\"\\.\"innodb_index_stats\" not found");
 CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");
 CALL mtr.add_suppression("Host name '[0-9a-zA-Z\.\-]+' could not be resolved.*");
+CALL mtr.add_suppression("InnoDB: Error: Table \"mysql\"\\.\"innodb_index_stats\" not found");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");
+CALL mtr.add_suppression("Host name '[0-9a-zA-Z\.\-]+' could not be resolved.*");

--- a/mysql-test/suite/galera/r/galera_sp_bf_abort2.result
+++ b/mysql-test/suite/galera/r/galera_sp_bf_abort2.result
@@ -1,0 +1,270 @@
+# Node 1
+CREATE DATABASE database1;
+USE database1;
+CREATE PROCEDURE proc_with_transaction()
+BEGIN
+START TRANSACTION;
+UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+INSERT INTO t1 VALUES (10, "from sp");
+COMMIT;
+END|
+CREATE PROCEDURE proc_with_transaction_continue_handler()
+BEGIN
+DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+START TRANSACTION;
+UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+INSERT INTO t1 VALUES (10, "from sp continue");
+COMMIT;
+END|
+CREATE PROCEDURE proc_with_transaction_exit_handler()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+START TRANSACTION;
+UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+INSERT INTO t1 VALUES (10, "from sp exit");
+COMMIT;
+END|
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_exit_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_continue_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_exit_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp exit
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp exit
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_continue_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp continue
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp continue
+DROP TABLE t1;
+DROP DATABASE database1;

--- a/mysql-test/suite/galera/t/galera_migrate.test
+++ b/mysql-test/suite/galera/t/galera_migrate.test
@@ -233,3 +233,8 @@ DROP USER sst;
 CALL mtr.add_suppression("InnoDB: Error: Table \"mysql\"\\.\"innodb_index_stats\" not found");
 CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");
 CALL mtr.add_suppression("Host name '[0-9a-zA-Z\.\-]+' could not be resolved.*");
+
+--connection node_4
+CALL mtr.add_suppression("InnoDB: Error: Table \"mysql\"\\.\"innodb_index_stats\" not found");
+CALL mtr.add_suppression("Hostname '[0-9a-zA-Z\.\-]+' does not resolve to '127.0.0.2'.");
+CALL mtr.add_suppression("Host name '[0-9a-zA-Z\.\-]+' could not be resolved.*");

--- a/mysql-test/suite/galera/t/galera_sp_bf_abort2.inc
+++ b/mysql-test/suite/galera/t/galera_sp_bf_abort2.inc
@@ -1,0 +1,76 @@
+
+# Setup the test on node 1
+--connection node_1
+--echo # Node 1
+--let $wsrep_local_bf_aborts_before = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
+
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+
+# Invoke the SP
+--connection node_1a
+--echo # Node 1a
+USE database1;
+
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+--send_eval CALL $galera_sp_bf_abort_proc
+
+# Ensure that we have reached the sync point
+--connection node_1
+--echo # Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+
+# Force the thread on node1 to be aborted (by making a change on node2)
+--connection node_2
+--echo # Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+
+
+--connection node_1
+--echo # Node 1
+# Ensure that the update from node2 has reached node1
+--let $wait_condition = SELECT f2 = 'from node2' FROM database1.t1 WHERE f1 = 1;
+--source include/wait_condition.inc
+
+# Signal the thread to continue
+# The update from node2 should have bf aborted the op on node1
+SET DEBUG_SYNC = "now SIGNAL continue";
+
+--connection node_1a
+--echo # Node 1a
+
+if ($galera_sp_bf_abort2_expect_error)
+{
+	--error ER_LOCK_DEADLOCK
+	--reap
+}
+if (!$galera_sp_bf_abort2_expect_error)
+{
+	--reap	
+}
+
+--connection node_1
+--echo # Node 1
+
+--let $wsrep_local_bf_aborts_after = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
+--let $assert_text = wsrep_local_bf_aborts has been incremented once
+--let $assert_cond = $wsrep_local_bf_aborts_after - $wsrep_local_bf_aborts_before = 1 AS wsrep_local_bf_aborts_increment;
+--source include/assert.inc
+
+
+SELECT * FROM database1.t1;
+
+SET DEBUG_SYNC = "RESET";
+
+--connection node_2
+--echo # Node 2
+SELECT * FROM database1.t1;
+
+--connection node_1
+DROP TABLE t1;
+

--- a/mysql-test/suite/galera/t/galera_sp_bf_abort2.test
+++ b/mysql-test/suite/galera/t/galera_sp_bf_abort2.test
@@ -1,0 +1,151 @@
+#
+# PXC-3243: Test BF-aborting during a transaction in an SP
+# This tests the behavior while an SP is BF-aborted during
+# an operation in a transaction within the SP.
+#
+
+--source include/have_debug_sync.inc
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+
+
+# Test setup
+--echo # Node 1
+--connection node_1
+CREATE DATABASE database1;
+USE database1;
+
+DELIMITER |;
+CREATE PROCEDURE proc_with_transaction()
+BEGIN
+  START TRANSACTION;
+    UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+    INSERT INTO t1 VALUES (10, "from sp");
+  COMMIT;
+END|
+
+CREATE PROCEDURE proc_with_transaction_continue_handler()
+BEGIN
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+  START TRANSACTION;
+    UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+    INSERT INTO t1 VALUES (10, "from sp continue");
+  COMMIT;
+END|
+
+CREATE PROCEDURE proc_with_transaction_exit_handler()
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+  START TRANSACTION;
+    UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+    INSERT INTO t1 VALUES (10, "from sp exit");
+  COMMIT;
+END|
+DELIMITER ;|
+
+# Determine initial number of connections (set $count_sessions)
+--source include/count_sessions.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+# ------------------------------------
+# Test 1a: no handlers, wsrep_retry_autocommit=0
+# The call to the SP will fail and return an error.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+--let $galera_sp_bf_abort_proc = proc_with_transaction
+--let $galera_sp_bf_abort2_expect_error = 1
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 1b: exit handler, wsrep_retry_autocommit=0
+# The call to the SP will fail and return an error.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_exit_handler
+--let $galera_sp_bf_abort2_expect_error = 1
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 1c: continue handler, wsrep_retry_autocommit=0
+# The call to the SP will fail and return an error.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_continue_handler
+--let $galera_sp_bf_abort2_expect_error = 1
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 2a: no handlers, wsrep_retry_autocommit=1
+# The first call to the SP will fail, but it will be retried
+# and will return success.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+--let $galera_sp_bf_abort_proc = proc_with_transaction
+
+# No error as the SP is retried
+--let $galera_sp_bf_abort2_expect_error = 0
+
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 2b: exit handler, wsrep_retry_autocommit=1
+# The first call to the SP will fail, but it will be retried
+# and will return success.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_exit_handler
+
+# No error as the SP is retried
+--let $galera_sp_bf_abort2_expect_error = 0
+
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 2c: continue handler, wsrep_retry_autocommit=1
+# The first call to the SP will fail, but it will be retried
+# and will return success.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_continue_handler
+
+# No error as the SP is retried
+--let $galera_sp_bf_abort2_expect_error = 0
+
+--source galera_sp_bf_abort2.inc
+
+
+# Test cleanup
+--connection node_1a
+DROP DATABASE database1;
+
+--connection default
+--disconnect node_1a
+
+# Wait until we have reached the initial number of connections
+# or more than the sleep time above (10 seconds) has passed.
+# $count_sessions
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8716,6 +8716,10 @@ wsrep_error:
 func_exit:
 	innobase_active_small();
 
+#ifdef WITH_WSREP
+	DEBUG_SYNC(user_thd, "ha_innobase_end_of_write_row");
+#endif /* WITH_WSREP */
+
 	if (UNIV_UNLIKELY(share->ib_table->is_corrupt)) {
 		DBUG_RETURN(HA_ERR_CRASHED);
 	}
@@ -9208,6 +9212,12 @@ ha_innobase::update_row(
 	innobase_srv_conc_exit_innodb(trx);
 
 func_exit:
+#ifdef WITH_WSREP
+	if (trx_is_interrupted(trx)) {
+		error = DB_INTERRUPTED;
+	}
+#endif /* WITH_WSREP */
+
 	int err = convert_error_code_to_mysql(error,
 					    prebuilt->table->flags, user_thd);
 
@@ -9367,6 +9377,12 @@ wsrep_error:
 			  && share->ib_table->is_corrupt)) {
 		DBUG_RETURN(HA_ERR_CRASHED);
 	}
+
+#ifdef WITH_WSREP
+	if (trx_is_interrupted(trx)) {
+		error = DB_INTERRUPTED;
+	}
+#endif /* WITH_WSREP */
 
 	DBUG_RETURN(convert_error_code_to_mysql(
 			    error, prebuilt->table->flags, user_thd));


### PR DESCRIPTION
Issue
When running a SP with a transaction insde, BF-aborting the SP
can cause the system to hang.

Solution
This happens because the transaction is holding onto a lock,
but the BF-abort is aborting a statement, which may not be the
one holding the lock.
This change will force the BF-abort to propagate and abort and retry
the SP, not the statement.