### PR TITLE
PXC-3352 [5.7]: Unexpected ERROR 1205 modifying a child table in a FK relationship

### DIFF
--- a/mysql-test/suite/galera/r/galera-index-online-fk.result
+++ b/mysql-test/suite/galera/r/galera-index-online-fk.result
@@ -1,0 +1,750 @@
+CREATE TABLE parent (a INT PRIMARY KEY, b INT NOT NULL) ENGINE = InnoDB;
+INSERT INTO parent VALUES(1,2),(2,3);
+CREATE INDEX tb ON parent(b);
+INSERT INTO parent VALUES(10,20),(20,30);
+CREATE TABLE child (a1 INT PRIMARY KEY, a2 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON child(a2);
+INSERT INTO child VALUES(10,20);
+ALTER TABLE child ADD FOREIGN KEY(a2) REFERENCES parent(b),
+ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Adding foreign keys needs foreign_key_checks=OFF. Try ALGORITHM=COPY.
+SET foreign_key_checks = 0;
+ALTER TABLE child ADD CONSTRAINT fk_1 FOREIGN KEY (a2)
+REFERENCES parent(b) ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+ALTER TABLE child ADD CONSTRAINT fk_1 FOREIGN KEY (a2)
+REFERENCES parent(b) ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Duplicate foreign key constraint name 'test/fk_1'
+SET foreign_key_checks = 1;
+INSERT INTO child VALUES(1,2),(2,3);
+INSERT INTO child VALUES(4,4);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a2`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE)
+SELECT * FROM parent;
+a	b
+1	2
+2	3
+10	20
+20	30
+SET foreign_key_checks = 0;
+ALTER TABLE child ADD CONSTRAINT fk_20 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_20' in the referenced table 'parent'
+SHOW WARNINGS;
+Level	Code	Message
+Error	1822	Failed to add the foreign key constaint. Missing index for constraint 'fk_20' in the referenced table 'parent'
+SHOW ERRORS;
+Level	Code	Message
+Error	1822	Failed to add the foreign key constaint. Missing index for constraint 'fk_20' in the referenced table 'parent'
+CREATE INDEX idx1 on parent(a, b);
+ALTER TABLE child ADD CONSTRAINT fk_10 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ALTER TABLE child ADD CONSTRAINT fk_2 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE, ADD INDEX idx1(a1,a2),
+ALGORITHM = INPLACE;
+ALTER TABLE child ADD CONSTRAINT fk_3 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE;
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+test/fk_10	test/child	test/parent	2	5
+test/fk_2	test/child	test/parent	2	5
+test/fk_3	test/child	test/parent	2	5
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+test/fk_10	a1	a	0
+test/fk_10	a2	b	1
+test/fk_2	a1	a	0
+test/fk_2	a2	b	1
+test/fk_3	a1	a	0
+test/fk_3	a2	b	1
+SET foreign_key_checks = 1;
+INSERT INTO child VALUES(5,4);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a2`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE)
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1` int(11) NOT NULL,
+  `a2` int(11) DEFAULT NULL,
+  PRIMARY KEY (`a1`),
+  KEY `tb` (`a2`),
+  KEY `idx1` (`a1`,`a2`),
+  CONSTRAINT `fk_1` FOREIGN KEY (`a2`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_10` FOREIGN KEY (`a1`, `a2`) REFERENCES `parent` (`a`, `b`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_2` FOREIGN KEY (`a1`, `a2`) REFERENCES `parent` (`a`, `b`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_3` FOREIGN KEY (`a1`, `a2`) REFERENCES `parent` (`a`, `b`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+DELETE FROM parent where a = 1;
+SELECT * FROM child;
+a1	a2
+1	NULL
+2	3
+10	20
+SET foreign_key_checks = 0;
+SET DEBUG = '+d,innodb_test_open_ref_fail';
+ALTER TABLE child ADD CONSTRAINT fk_4 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+SET DEBUG = '-d,innodb_test_open_ref_fail';
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+test/fk_10	test/child	test/parent	2	5
+test/fk_2	test/child	test/parent	2	5
+test/fk_3	test/child	test/parent	2	5
+test/fk_4	test/child	test/parent	2	5
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+test/fk_10	a1	a	0
+test/fk_10	a2	b	1
+test/fk_2	a1	a	0
+test/fk_2	a2	b	1
+test/fk_3	a1	a	0
+test/fk_3	a2	b	1
+test/fk_4	a1	a	0
+test/fk_4	a2	b	1
+SELECT t2.name, t1.name FROM information_schema.innodb_sys_columns t1, information_schema.innodb_sys_tables t2 WHERE t1.table_id = t2.table_id AND t2.name LIKE "%child" ORDER BY t1.name;
+name	name
+test/child	a1
+test/child	a2
+SELECT NAME FROM information_schema.INNODB_SYS_TABLES WHERE NAME not like 'sys\/%';
+NAME
+SYS_DATAFILES
+SYS_FOREIGN
+SYS_FOREIGN_COLS
+SYS_TABLESPACES
+SYS_VIRTUAL
+SYS_ZIP_DICT
+SYS_ZIP_DICT_COLS
+mysql/engine_cost
+mysql/gtid_executed
+mysql/help_category
+mysql/help_keyword
+mysql/help_relation
+mysql/help_topic
+mysql/innodb_index_stats
+mysql/innodb_table_stats
+mysql/plugin
+mysql/server_cost
+mysql/servers
+mysql/slave_master_info
+mysql/slave_relay_log_info
+mysql/slave_worker_info
+mysql/time_zone
+mysql/time_zone_leap_second
+mysql/time_zone_name
+mysql/time_zone_transition
+mysql/time_zone_transition_type
+test/child
+test/parent
+INSERT INTO child VALUES(5,4);
+SET foreign_key_checks = 1;
+INSERT INTO child VALUES(6,5);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`child`, CONSTRAINT `fk_1` FOREIGN KEY (`a2`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE)
+SET foreign_key_checks = 0;
+CREATE TABLE `#parent` (a INT PRIMARY KEY, b INT NOT NULL) ENGINE = InnoDB;
+CREATE INDEX tb ON `#parent`(a, b);
+CREATE TABLE `#child` (a1 INT PRIMARY KEY, a2 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON `#child`(a1, a2);
+SET DEBUG = '+d,innodb_test_no_foreign_idx';
+ALTER TABLE `#child` ADD CONSTRAINT fk_40 FOREIGN KEY (a1, a2)
+REFERENCES `#parent`(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_40' in the foreign table '#child'
+SHOW ERRORS;
+Level	Code	Message
+Error	1821	Failed to add the foreign key constaint. Missing index for constraint 'fk_40' in the foreign table '#child'
+SET DEBUG = '-d,innodb_test_no_foreign_idx';
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+test/fk_10	test/child	test/parent	2	5
+test/fk_2	test/child	test/parent	2	5
+test/fk_3	test/child	test/parent	2	5
+test/fk_4	test/child	test/parent	2	5
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+test/fk_10	a1	a	0
+test/fk_10	a2	b	1
+test/fk_2	a1	a	0
+test/fk_2	a2	b	1
+test/fk_3	a1	a	0
+test/fk_3	a2	b	1
+test/fk_4	a1	a	0
+test/fk_4	a2	b	1
+SET DEBUG = '+d,innodb_test_no_reference_idx';
+ALTER TABLE child ADD CONSTRAINT fk_42 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_42' in the referenced table 'parent'
+SHOW ERRORS;
+Level	Code	Message
+Error	1822	Failed to add the foreign key constaint. Missing index for constraint 'fk_42' in the referenced table 'parent'
+SET DEBUG = '-d,innodb_test_no_reference_idx';
+SET DEBUG = '+d,innodb_test_wrong_fk_option';
+ALTER TABLE child ADD CONSTRAINT fk_42 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constraint on table 'child'. Incorrect options in FOREIGN KEY constraint 'test/fk_42'
+SET DEBUG = '-d,innodb_test_wrong_fk_option';
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+test/fk_10	test/child	test/parent	2	5
+test/fk_2	test/child	test/parent	2	5
+test/fk_3	test/child	test/parent	2	5
+test/fk_4	test/child	test/parent	2	5
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+test/fk_10	a1	a	0
+test/fk_10	a2	b	1
+test/fk_2	a1	a	0
+test/fk_2	a2	b	1
+test/fk_3	a1	a	0
+test/fk_3	a2	b	1
+test/fk_4	a1	a	0
+test/fk_4	a2	b	1
+SET DEBUG = '+d,innodb_test_cannot_add_fk_system';
+ALTER TABLE `#child` ADD CONSTRAINT fk_43 FOREIGN KEY (a1, a2)
+REFERENCES `#parent`(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constraint 'test/fk_43' to system tables
+SHOW ERRORS;
+Level	Code	Message
+Error	1823	Failed to add the foreign key constraint 'test/fk_43' to system tables
+SET DEBUG = '-d,innodb_test_cannot_add_fk_system';
+DROP TABLE `#child`;
+DROP TABLE `#parent`;
+SET foreign_key_checks = 0;
+ALTER TABLE child ADD CONSTRAINT fk_5 FOREIGN KEY (a2) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ADD CONSTRAINT fk_6 FOREIGN KEY (a1, a2)
+REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+test/fk_10	test/child	test/parent	2	5
+test/fk_2	test/child	test/parent	2	5
+test/fk_3	test/child	test/parent	2	5
+test/fk_4	test/child	test/parent	2	5
+test/fk_5	test/child	test/parent	1	6
+test/fk_6	test/child	test/parent	2	5
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+test/fk_10	a1	a	0
+test/fk_10	a2	b	1
+test/fk_2	a1	a	0
+test/fk_2	a2	b	1
+test/fk_3	a1	a	0
+test/fk_3	a2	b	1
+test/fk_4	a1	a	0
+test/fk_4	a2	b	1
+test/fk_5	a2	b	0
+test/fk_6	a1	a	0
+test/fk_6	a2	b	1
+DROP TABLE child;
+DROP TABLE parent;
+CREATE TABLE parent (a INT PRIMARY KEY, b INT NOT NULL) ENGINE = InnoDB;
+INSERT INTO parent VALUES(1,2),(2,3);
+CREATE INDEX tb ON parent(b);
+INSERT INTO parent VALUES(10,20),(20,30);
+CREATE TABLE child (a1 INT PRIMARY KEY, a2 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON child(a2);
+INSERT INTO child VALUES(10,20);
+SET foreign_key_checks = 0;
+ALTER TABLE child DROP INDEX tb, ADD CONSTRAINT fk_4 FOREIGN KEY (a2)
+REFERENCES parent(b) ON DELETE CASCADE ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1` int(11) NOT NULL,
+  `a2` int(11) DEFAULT NULL,
+  PRIMARY KEY (`a1`),
+  KEY `fk_4` (`a2`),
+  CONSTRAINT `fk_4` FOREIGN KEY (`a2`) REFERENCES `parent` (`b`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_4	test/child	test/parent	1	5
+SELECT * FROM information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_4	a2	b	0
+SET foreign_key_checks = 1;
+DROP TABLE child;
+DROP TABLE parent;
+CREATE TABLE parent (a INT PRIMARY KEY, b INT NOT NULL) ENGINE = InnoDB;
+INSERT INTO parent VALUES(1,2),(2,3);
+CREATE INDEX tb ON parent(b);
+INSERT INTO parent VALUES(10,20),(20,30);
+CREATE TABLE child (a1 INT PRIMARY KEY, a2 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON child(a2);
+SET foreign_key_checks = 0;
+ALTER TABLE child CHANGE a2 a3 INT,
+ADD CONSTRAINT fk_1 FOREIGN KEY (a2) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR 42000: Key column 'a2' doesn't exist in table
+ALTER TABLE child CHANGE a2 a3 INT,
+ADD CONSTRAINT fk_1 FOREIGN KEY (a3) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+DROP TABLE child;
+DROP TABLE parent;
+CREATE TABLE parent (a INT PRIMARY KEY, b INT NOT NULL) ENGINE = InnoDB;
+INSERT INTO parent VALUES(1,2),(2,3);
+CREATE INDEX tb ON parent(b);
+INSERT INTO parent VALUES(10,20),(20,30);
+CREATE TABLE child (a1 INT NOT NULL, a2 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON child(a2);
+SET foreign_key_checks = 0;
+SET DEBUG = '+d,innodb_test_cannot_add_fk_system';
+ALTER TABLE child ADD PRIMARY KEY idx (a3), CHANGE a1 a3 INT,
+ADD CONSTRAINT fk_1 FOREIGN KEY (a2) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constraint 'test/fk_1' to system tables
+SET DEBUG = '-d,innodb_test_cannot_add_fk_system';
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+SELECT t2.name, t1.name FROM information_schema.innodb_sys_columns t1, information_schema.innodb_sys_tables t2 WHERE t1.table_id = t2.table_id AND t2.name LIKE "%child" ORDER BY t1.name;
+name	name
+test/child	a1
+test/child	a2
+SELECT NAME FROM information_schema.INNODB_SYS_TABLES WHERE NAME not like 'sys\/%';
+NAME
+SYS_DATAFILES
+SYS_FOREIGN
+SYS_FOREIGN_COLS
+SYS_TABLESPACES
+SYS_VIRTUAL
+SYS_ZIP_DICT
+SYS_ZIP_DICT_COLS
+mysql/engine_cost
+mysql/gtid_executed
+mysql/help_category
+mysql/help_keyword
+mysql/help_relation
+mysql/help_topic
+mysql/innodb_index_stats
+mysql/innodb_table_stats
+mysql/plugin
+mysql/server_cost
+mysql/servers
+mysql/slave_master_info
+mysql/slave_relay_log_info
+mysql/slave_worker_info
+mysql/time_zone
+mysql/time_zone_leap_second
+mysql/time_zone_name
+mysql/time_zone_transition
+mysql/time_zone_transition_type
+test/child
+test/parent
+ALTER TABLE child ADD PRIMARY KEY idx (a3), CHANGE a1 a3 INT,
+ADD CONSTRAINT fk_1 FOREIGN KEY (a2) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+SELECT t2.name, t1.name FROM information_schema.innodb_sys_columns t1, information_schema.innodb_sys_tables t2 WHERE t1.table_id = t2.table_id AND t2.name LIKE "%child" ORDER BY t1.name;
+name	name
+test/child	a2
+test/child	a3
+SELECT NAME FROM information_schema.INNODB_SYS_TABLES WHERE NAME not like 'sys\/%';
+NAME
+SYS_DATAFILES
+SYS_FOREIGN
+SYS_FOREIGN_COLS
+SYS_TABLESPACES
+SYS_VIRTUAL
+SYS_ZIP_DICT
+SYS_ZIP_DICT_COLS
+mysql/engine_cost
+mysql/gtid_executed
+mysql/help_category
+mysql/help_keyword
+mysql/help_relation
+mysql/help_topic
+mysql/innodb_index_stats
+mysql/innodb_table_stats
+mysql/plugin
+mysql/server_cost
+mysql/servers
+mysql/slave_master_info
+mysql/slave_relay_log_info
+mysql/slave_worker_info
+mysql/time_zone
+mysql/time_zone_leap_second
+mysql/time_zone_name
+mysql/time_zone_transition
+mysql/time_zone_transition_type
+test/child
+test/parent
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a3` int(11) NOT NULL,
+  `a2` int(11) DEFAULT NULL,
+  PRIMARY KEY (`a3`),
+  KEY `tb` (`a2`),
+  CONSTRAINT `fk_1` FOREIGN KEY (`a2`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+DROP TABLE child;
+CREATE TABLE child (a1 INT NOT NULL, a2 INT) ENGINE = InnoDB;
+ALTER TABLE child ADD PRIMARY KEY idx (a1),
+ADD CONSTRAINT fk_1 FOREIGN KEY (a2) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+SELECT * from information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+SELECT * from information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a2	b	0
+SELECT t2.name, t1.name FROM information_schema.innodb_sys_columns t1, information_schema.innodb_sys_tables t2 WHERE t1.table_id = t2.table_id AND t2.name LIKE "%child" ORDER BY t1.name;
+name	name
+test/child	a1
+test/child	a2
+SELECT NAME FROM information_schema.INNODB_SYS_TABLES WHERE NAME not like 'sys\/%';
+NAME
+SYS_DATAFILES
+SYS_FOREIGN
+SYS_FOREIGN_COLS
+SYS_TABLESPACES
+SYS_VIRTUAL
+SYS_ZIP_DICT
+SYS_ZIP_DICT_COLS
+mysql/engine_cost
+mysql/gtid_executed
+mysql/help_category
+mysql/help_keyword
+mysql/help_relation
+mysql/help_topic
+mysql/innodb_index_stats
+mysql/innodb_table_stats
+mysql/plugin
+mysql/server_cost
+mysql/servers
+mysql/slave_master_info
+mysql/slave_relay_log_info
+mysql/slave_worker_info
+mysql/time_zone
+mysql/time_zone_leap_second
+mysql/time_zone_name
+mysql/time_zone_transition
+mysql/time_zone_transition_type
+test/child
+test/parent
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1` int(11) NOT NULL,
+  `a2` int(11) DEFAULT NULL,
+  PRIMARY KEY (`a1`),
+  KEY `fk_1` (`a2`),
+  CONSTRAINT `fk_1` FOREIGN KEY (`a2`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+DROP TABLE child;
+CREATE TABLE child (a1 INT NOT NULL, a2 INT) ENGINE = InnoDB;
+ALTER TABLE child CHANGE a1 a3 INT,
+ADD CONSTRAINT fk_1 FOREIGN KEY (a3) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+SELECT * from information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_1	test/child	test/parent	1	6
+SELECT * from information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_1	a3	b	0
+SELECT t2.name, t1.name FROM information_schema.innodb_sys_columns t1, information_schema.innodb_sys_tables t2 WHERE t1.table_id = t2.table_id AND t2.name LIKE "%child" ORDER BY t1.name;
+name	name
+test/child	a2
+test/child	a3
+SELECT NAME FROM information_schema.INNODB_SYS_TABLES WHERE NAME not like 'sys\/%';
+NAME
+SYS_DATAFILES
+SYS_FOREIGN
+SYS_FOREIGN_COLS
+SYS_TABLESPACES
+SYS_VIRTUAL
+SYS_ZIP_DICT
+SYS_ZIP_DICT_COLS
+mysql/engine_cost
+mysql/gtid_executed
+mysql/help_category
+mysql/help_keyword
+mysql/help_relation
+mysql/help_topic
+mysql/innodb_index_stats
+mysql/innodb_table_stats
+mysql/plugin
+mysql/server_cost
+mysql/servers
+mysql/slave_master_info
+mysql/slave_relay_log_info
+mysql/slave_worker_info
+mysql/time_zone
+mysql/time_zone_leap_second
+mysql/time_zone_name
+mysql/time_zone_transition
+mysql/time_zone_transition_type
+test/child
+test/parent
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a3` int(11) DEFAULT NULL,
+  `a2` int(11) DEFAULT NULL,
+  KEY `fk_1` (`a3`),
+  CONSTRAINT `fk_1` FOREIGN KEY (`a3`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+DROP TABLE child;
+CREATE TABLE child (a1 INT NOT NULL, a2 INT) ENGINE = InnoDB;
+ALTER TABLE child ADD PRIMARY KEY idx (a3), CHANGE a1 a3 INT,
+ADD CONSTRAINT fk_1 FOREIGN KEY (a3) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constraint on table 'child'. Incorrect options in FOREIGN KEY constraint 'test/fk_1'
+DROP TABLE parent;
+DROP TABLE child;
+CREATE TABLE parent (a INT PRIMARY KEY, b INT NOT NULL, c INT) ENGINE = InnoDB;
+INSERT INTO parent VALUES(1,2,3),(2,3,4);
+CREATE INDEX tb ON parent(b);
+CREATE TABLE child (a1 INT NOT NULL, a2 INT, a3 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON child(a2);
+ALTER TABLE child
+ADD CONSTRAINT fk_a FOREIGN KEY (a2) REFERENCES parent(b)
+ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+ALTER TABLE child
+ADD CONSTRAINT fk_b FOREIGN KEY (a1) REFERENCES parent(a),
+ALGORITHM = INPLACE;
+ALTER TABLE child CHANGE a2 a2_new INT, CHANGE a1 a1_new INT;
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1_new` int(11) DEFAULT NULL,
+  `a2_new` int(11) DEFAULT NULL,
+  `a3` int(11) DEFAULT NULL,
+  KEY `tb` (`a2_new`),
+  KEY `fk_b` (`a1_new`),
+  CONSTRAINT `fk_a` FOREIGN KEY (`a2_new`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_b` FOREIGN KEY (`a1_new`) REFERENCES `parent` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+SELECT * from information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_a	test/child	test/parent	1	6
+test/fk_b	test/child	test/parent	1	0
+SELECT * from information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_a	a2_new	b	0
+test/fk_b	a1_new	a	0
+ALTER TABLE child
+ADD CONSTRAINT fk_new_1 FOREIGN KEY (a1_new) REFERENCES parent(b),
+ADD CONSTRAINT fk_new_2 FOREIGN KEY (a2_new) REFERENCES parent(a),
+ADD CONSTRAINT fk_new_3 FOREIGN KEY (a3) REFERENCES parent(c),
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_new_3' in the referenced table 'parent'
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1_new` int(11) DEFAULT NULL,
+  `a2_new` int(11) DEFAULT NULL,
+  `a3` int(11) DEFAULT NULL,
+  KEY `tb` (`a2_new`),
+  KEY `fk_b` (`a1_new`),
+  CONSTRAINT `fk_a` FOREIGN KEY (`a2_new`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_b` FOREIGN KEY (`a1_new`) REFERENCES `parent` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+SELECT * from information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_a	test/child	test/parent	1	6
+test/fk_b	test/child	test/parent	1	0
+SELECT * from information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_a	a2_new	b	0
+test/fk_b	a1_new	a	0
+ALTER TABLE child
+ADD CONSTRAINT fk_new_1 FOREIGN KEY (a1_new) REFERENCES parent(b),
+ADD CONSTRAINT fk_new_2 FOREIGN KEY (a2_new) REFERENCES parent(a),
+ADD CONSTRAINT fk_new_3 FOREIGN KEY (a3) REFERENCES parent(a),
+ALGORITHM = INPLACE;
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1_new` int(11) DEFAULT NULL,
+  `a2_new` int(11) DEFAULT NULL,
+  `a3` int(11) DEFAULT NULL,
+  KEY `tb` (`a2_new`),
+  KEY `fk_new_1` (`a1_new`),
+  KEY `fk_new_3` (`a3`),
+  CONSTRAINT `fk_a` FOREIGN KEY (`a2_new`) REFERENCES `parent` (`b`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_b` FOREIGN KEY (`a1_new`) REFERENCES `parent` (`a`),
+  CONSTRAINT `fk_new_1` FOREIGN KEY (`a1_new`) REFERENCES `parent` (`b`),
+  CONSTRAINT `fk_new_2` FOREIGN KEY (`a2_new`) REFERENCES `parent` (`a`),
+  CONSTRAINT `fk_new_3` FOREIGN KEY (`a3`) REFERENCES `parent` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+SELECT * from information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_a	test/child	test/parent	1	6
+test/fk_b	test/child	test/parent	1	0
+test/fk_new_1	test/child	test/parent	1	0
+test/fk_new_2	test/child	test/parent	1	0
+test/fk_new_3	test/child	test/parent	1	0
+SELECT * from information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_a	a2_new	b	0
+test/fk_b	a1_new	a	0
+test/fk_new_1	a1_new	b	0
+test/fk_new_2	a2_new	a	0
+test/fk_new_3	a3	a	0
+DROP TABLE child;
+CREATE TABLE child (a1 INT NOT NULL, a2 INT, a3 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON child(a2);
+ALTER TABLE child ADD PRIMARY KEY idx (a1),
+ADD CONSTRAINT fk_new_1 FOREIGN KEY (a1) REFERENCES parent(b),
+ADD CONSTRAINT fk_new_2 FOREIGN KEY (a2) REFERENCES parent(a),
+ADD CONSTRAINT fk_new_3 FOREIGN KEY (a3) REFERENCES parent(c),
+ALGORITHM = INPLACE;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_new_3' in the referenced table 'parent'
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1` int(11) NOT NULL,
+  `a2` int(11) DEFAULT NULL,
+  `a3` int(11) DEFAULT NULL,
+  KEY `tb` (`a2`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+SELECT * from information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+SELECT * from information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+ALTER TABLE child ADD PRIMARY KEY idx (a1),
+ADD CONSTRAINT fk_new_1 FOREIGN KEY (a1) REFERENCES parent(b),
+ADD CONSTRAINT fk_new_2 FOREIGN KEY (a2) REFERENCES parent(a),
+ADD CONSTRAINT fk_new_3 FOREIGN KEY (a3) REFERENCES parent(a),
+ALGORITHM = INPLACE;
+SHOW CREATE TABLE child;
+Table	Create Table
+child	CREATE TABLE `child` (
+  `a1` int(11) NOT NULL,
+  `a2` int(11) DEFAULT NULL,
+  `a3` int(11) DEFAULT NULL,
+  PRIMARY KEY (`a1`),
+  KEY `tb` (`a2`),
+  KEY `fk_new_3` (`a3`),
+  CONSTRAINT `fk_new_1` FOREIGN KEY (`a1`) REFERENCES `parent` (`b`),
+  CONSTRAINT `fk_new_2` FOREIGN KEY (`a2`) REFERENCES `parent` (`a`),
+  CONSTRAINT `fk_new_3` FOREIGN KEY (`a3`) REFERENCES `parent` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+SELECT * from information_schema.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/fk_new_1	test/child	test/parent	1	0
+test/fk_new_2	test/child	test/parent	1	0
+test/fk_new_3	test/child	test/parent	1	0
+SELECT * from information_schema.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/fk_new_1	a1	b	0
+test/fk_new_2	a2	a	0
+test/fk_new_3	a3	a	0
+SET foreign_key_checks = 1;
+DROP TABLE child;
+DROP TABLE parent;
+CREATE TABLE Parent (a INT PRIMARY KEY, b INT NOT NULL) ENGINE = InnoDB;
+INSERT INTO Parent VALUES(1,2),(2,3);
+CREATE INDEX tb ON Parent(b);
+INSERT INTO Parent VALUES(10,20),(20,30);
+CREATE TABLE Child (a1 INT PRIMARY KEY, a2 INT) ENGINE = InnoDB;
+CREATE INDEX tb ON Child(a2);
+INSERT INTO Child VALUES(10,20);
+SET foreign_key_checks = 0;
+ALTER TABLE Child ADD CONSTRAINT fk_1 FOREIGN KEY (a2)
+REFERENCES Parent(b) ON DELETE SET NULL ON UPDATE CASCADE,
+ALGORITHM = INPLACE;
+DROP TABLE Child;
+DROP TABLE Parent;
+CREATE TABLE `t2`(a int,c int,d int) ENGINE=INNODB;
+CREATE TABLE `t3`(a int,c int,d int) ENGINE=INNODB;
+CREATE INDEX idx ON t3(a);
+ALTER TABLE `t2` ADD CONSTRAINT `fw` FOREIGN KEY (`c`) REFERENCES t3 (a);
+ALTER TABLE `t2` ADD CONSTRAINT `e` foreign key (`d`) REFERENCES t3(a);
+ALTER TABLE `t3` ADD CONSTRAINT `e` foreign key (`c`) REFERENCES `t2`(`c`) ON UPDATE SET NULL;
+ERROR HY000: Failed to add the foreign key constraint 'test/e' to system tables
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_FOREIGN;
+ID	FOR_NAME	REF_NAME	N_COLS	TYPE
+test/e	test/t2	test/t3	1	0
+test/fw	test/t2	test/t3	1	0
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_FOREIGN_COLS;
+ID	FOR_COL_NAME	REF_COL_NAME	POS
+test/e	d	a	0
+test/fw	c	a	0
+DROP TABLE t2;
+DROP TABLE t3;
+# Bug #17449901	 TABLE DISAPPEARS WHEN ALTERING
+# WITH FOREIGN KEY CHECKS OFF
+create table t1(f1 int,primary key(f1))engine=innodb;
+create table t2(f2 int,f3 int,key t(f2,f3),foreign key(f2) references t1(f1))engine=innodb;
+SET foreign_key_checks=0;
+drop index t on t2;
+ERROR HY000: Cannot drop index 't': needed in a foreign key constraint
+drop table t2;
+drop table t1;
+create table t1(f1 int ,primary key(f1))engine=innodb;
+create table t2(f2 int,f3 int, key t(f2),foreign key(f2) references t1(f1))engine=innodb;
+SET foreign_key_checks = 0;
+alter table t2 drop key t,algorithm=inplace;
+ERROR HY000: Cannot drop index 't': needed in a foreign key constraint
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `f2` int(11) DEFAULT NULL,
+  `f3` int(11) DEFAULT NULL,
+  KEY `t` (`f2`),
+  CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`f2`) REFERENCES `t1` (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table t2;
+drop table t1;
+create table t1(f1 int ,primary key(f1))engine=innodb;
+create table t2(f2 int,f3 int, key t(f2),key t1(f2,f3),
+foreign key(f2) references t1(f1))engine=innodb;
+SET foreign_key_checks = 0;
+alter table t2 drop key t,algorithm=inplace;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `f2` int(11) DEFAULT NULL,
+  `f3` int(11) DEFAULT NULL,
+  KEY `t1` (`f2`,`f3`),
+  CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`f2`) REFERENCES `t1` (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+drop table t2;
+drop table t1;
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported. Reason: Adding foreign keys needs foreign_key_checks=OFF");
+CALL mtr.add_suppression("Duplicate foreign key constraint name");
+CALL mtr.add_suppression("Failed to add the foreign key constaint");
+CALL mtr.add_suppression("Key column .* doesn't exist in table");
+CALL mtr.add_suppression("Unknown column");
+CALL mtr.add_suppression("Failed to add the foreign key constraint on table .*");
+CALL mtr.add_suppression("Failed to add the foreign key constraint .* to system tables*");
+CALL mtr.add_suppression("Cannot drop index .*: needed in a foreign key constraint");

--- a/mysql-test/suite/galera/r/galera_fk_lock_parent_update_child.result
+++ b/mysql-test/suite/galera/r/galera_fk_lock_parent_update_child.result
@@ -1,0 +1,156 @@
+SET GLOBAL innodb_lock_wait_timeout = 5;
+
+# ===========================================================================
+# Case 1: Delete a row from the child table.
+# Expectation: Delete should be successful.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`)) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+SELECT * FROM parent_t WHERE id = 1 FOR UPDATE;
+id
+1
+DELETE FROM child_t WHERE parent_id = 1;
+COMMIT;
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Case 2: Update non-referenced field of the child table.
+# Expectation: Update should fail with lock wait timeout error.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`)) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+SELECT * FROM parent_t WHERE id = 1 FOR UPDATE;
+id
+1
+UPDATE child_t SET id = id - 1;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+COMMIT;
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Case 3: Update non-referenced field of the child table and unlock the parent row.
+# Expectation: Update should be successful.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`)) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+SELECT * FROM parent_t WHERE id = 1 FOR UPDATE;
+id
+1
+UPDATE child_t SET id = id - 1;
+ROLLBACK;
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Case 4: Update referenced field of the child table.
+# Expectation: Update should fail with lock wait timeout error.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`)) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+SELECT * FROM parent_t WHERE id = 1 FOR UPDATE;
+id
+1
+UPDATE child_t SET parent_id=3 WHERE parent_id=1;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ROLLBACK;
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Case 5: Update referenced field of the child table and unlock the parent row.
+# Expectation: Update should be successful.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`)) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+SELECT * FROM parent_t WHERE id = 1 FOR UPDATE;
+id
+1
+UPDATE child_t SET parent_id=3 WHERE parent_id=1;
+ROLLBACK;
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Case 6: Delete a row from the child table from node2.
+# Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`) ON UPDATE CASCADE) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+UPDATE parent_t SET id = id * 10;
+DELETE FROM child_t WHERE parent_id = 1;
+COMMIT;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Case 7: Update non-referenced field in the child table from node2.
+# Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`) ON UPDATE CASCADE) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+UPDATE parent_t SET id = id * 10;
+UPDATE child_t SET id = id - 1;
+COMMIT;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Case 8: Update referenced field in the child table from node2.
+# Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+# ===========================================================================
+CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+REFERENCES `parent_t` (`id`) ON UPDATE CASCADE) ENGINE = INNODB;
+INSERT INTO parent_t VALUES (), (), (), (), ();
+INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+BEGIN;
+UPDATE parent_t SET id = id * 10;
+UPDATE child_t SET parent_id=3 WHERE parent_id=1;
+COMMIT;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+DROP TABLE child_t;
+DROP TABLE parent_t;
+
+# ===========================================================================
+# Test Cleanup
+# ===========================================================================

--- a/mysql-test/suite/galera/r/galera_foreign_key.result
+++ b/mysql-test/suite/galera/r/galera_foreign_key.result
@@ -1,0 +1,159 @@
+#
+# Bug #19027905 ASSERT RET.SECOND DICT_CREATE_FOREIGN_CONSTRAINTS_LOW
+# DICT_CREATE_FOREIGN_CONSTR
+#
+create table t1 (f1 int primary key) engine=InnoDB;
+create table t2 (f1 int primary key,
+constraint c1 foreign key (f1) references t1(f1),
+constraint c1 foreign key (f1) references t1(f1)) engine=InnoDB;
+ERROR HY000: Cannot add foreign key constraint
+create table t2 (f1 int primary key,
+constraint c1 foreign key (f1) references t1(f1)) engine=innodb;
+alter table t2 add constraint c1 foreign key (f1) references t1(f1);
+ERROR 23000: Can't write; duplicate key in table '#sql-temporary'
+set foreign_key_checks = 0;
+alter table t2 add constraint c1 foreign key (f1) references t1(f1);
+ERROR HY000: Duplicate foreign key constraint name 'test/c1'
+drop table t2, t1;
+#
+# Bug #20031243 CREATE TABLE FAILS TO CHECK IF FOREIGN KEY COLUMN
+# NULL/NOT NULL MISMATCH
+#
+set foreign_key_checks = 1;
+show variables like 'foreign_key_checks';
+Variable_name	Value
+foreign_key_checks	ON
+CREATE TABLE t1
+(a INT NOT NULL,
+b INT NOT NULL,
+INDEX idx(a)) ENGINE=InnoDB;
+CREATE TABLE t2
+(a INT KEY,
+b INT,
+INDEX ind(b),
+FOREIGN KEY (b) REFERENCES t1(a) ON DELETE CASCADE ON UPDATE CASCADE)
+ENGINE=InnoDB;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) NOT NULL,
+  `b` int(11) NOT NULL,
+  KEY `idx` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `a` int(11) NOT NULL,
+  `b` int(11) DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `ind` (`b`),
+  CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`b`) REFERENCES `t1` (`a`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+INSERT INTO t1 VALUES (1, 80);
+INSERT INTO t1 VALUES (2, 81);
+INSERT INTO t1 VALUES (3, 82);
+INSERT INTO t1 VALUES (4, 83);
+INSERT INTO t1 VALUES (5, 84);
+INSERT INTO t2 VALUES (51, 1);
+INSERT INTO t2 VALUES (52, 2);
+INSERT INTO t2 VALUES (53, 3);
+INSERT INTO t2 VALUES (54, 4);
+INSERT INTO t2 VALUES (55, 5);
+SELECT a, b FROM t1 ORDER BY a;
+a	b
+1	80
+2	81
+3	82
+4	83
+5	84
+SELECT a, b FROM t2 ORDER BY a;
+a	b
+51	1
+52	2
+53	3
+54	4
+55	5
+INSERT INTO t2 VALUES (56, 6);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`b`) REFERENCES `t1` (`a`) ON DELETE CASCADE ON UPDATE CASCADE)
+ALTER TABLE t1 CHANGE a id INT;
+SELECT id, b FROM t1 ORDER BY id;
+id	b
+1	80
+2	81
+3	82
+4	83
+5	84
+SELECT a, b FROM t2 ORDER BY a;
+a	b
+51	1
+52	2
+53	3
+54	4
+55	5
+# Operations on child table
+INSERT INTO t2 VALUES (56, 6);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`b`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE)
+UPDATE t2 SET b = 99 WHERE a = 51;
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`b`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE)
+DELETE FROM t2 WHERE a = 53;
+SELECT id, b FROM t1 ORDER BY id;
+id	b
+1	80
+2	81
+3	82
+4	83
+5	84
+SELECT a, b FROM t2 ORDER BY a;
+a	b
+51	1
+52	2
+54	4
+55	5
+# Operations on parent table
+DELETE FROM t1 WHERE id = 1;
+UPDATE t1 SET id = 50 WHERE id = 5;
+SELECT id, b FROM t1 ORDER BY id;
+id	b
+2	81
+3	82
+4	83
+50	84
+SELECT a, b FROM t2 ORDER BY a;
+a	b
+52	2
+54	4
+55	50
+DROP TABLE t2, t1;
+#
+# bug#25126722 FOREIGN KEY CONSTRAINT NAME IS NULL AFTER RESTART
+# base bug#24818604 [GR]
+#
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+CREATE TABLE t2 (c1 INT PRIMARY KEY, FOREIGN KEY (c1) REFERENCES t1(c1));
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (1);
+SELECT unique_constraint_name FROM information_schema.referential_constraints
+WHERE table_name = 't2';
+unique_constraint_name
+PRIMARY
+[connection node_1]
+# restart
+[connection node_2]
+# restart
+SET SESSION wsrep_sync_wait = 0;
+SELECT unique_constraint_name FROM information_schema.referential_constraints
+WHERE table_name = 't2';
+unique_constraint_name
+PRIMARY
+SELECT * FROM t1;
+c1
+1
+SELECT unique_constraint_name FROM information_schema.referential_constraints
+WHERE table_name = 't2';
+unique_constraint_name
+PRIMARY
+CALL mtr.add_suppression("Cannot add foreign key constraint");
+CALL mtr.add_suppression("Can't write; duplicate key in table");
+CALL mtr.add_suppression("Duplicate foreign key constraint name");
+DROP TABLE t2;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_high_prio_trx_fk.result
+++ b/mysql-test/suite/galera/r/galera_high_prio_trx_fk.result
@@ -1,0 +1,34 @@
+CREATE TABLE t1 (c1 INT PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (c2 INT PRIMARY KEY,
+FOREIGN KEY (c2) REFERENCES t1(c1))ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+# On Connection 1
+START TRANSACTION;
+DELETE FROM t1 WHERE c1 = 1;
+# On Connection 2
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+INSERT INTO t2 VALUES(1);
+COMMIT;
+# On connection 1
+COMMIT;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+DROP TABLE t2, t1;
+CREATE TABLE t1 (c1 INT PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (c2 INT PRIMARY KEY,
+FOREIGN KEY (c2) REFERENCES t1(c1)
+ON UPDATE CASCADE)ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+# On Connection 1
+START TRANSACTION;
+UPDATE t1 SET C1=2 where C1 = 1;
+# On Connection 2
+include/start_transaction_high_prio.inc
+START TRANSACTION /* HIGH PRIORITY */;
+INSERT INTO t2 VALUES (1);
+COMMIT;
+
+# On connection 1
+COMMIT;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+DROP TABLE t2, t1;

--- a/mysql-test/suite/galera/r/galera_stored_fk.result
+++ b/mysql-test/suite/galera/r/galera_stored_fk.result
@@ -1,0 +1,72 @@
+# Create statement with FK on base column of stored column
+create table t1(f1 int, f2 int as(f1) stored,
+foreign key(f1) references t2(f1) on delete cascade)engine=innodb;
+ERROR HY000: Cannot add foreign key constraint
+# adding new stored column during alter table copy operation.
+create table t1(f1 int primary key);
+create table t2(f1 int not null, f2 int as (f1) virtual,
+foreign key(f1) references t1(f1) on update cascade)engine=innodb;
+alter table t2 add column f3 int as (f1) stored, add column f4 int as (f1) virtual;
+ERROR HY000: Error on rename of 'OLD_FILE_NAME' to 'NEW_FILE_NAME' (errno: 150 - Foreign key constraint is incorrectly formed)
+drop table t2, t1;
+# adding foreign key constraint for base columns during alter copy.
+create table t1(f1 int primary key);
+create table t2(f1 int not null, f2 int as (f1) stored);
+alter table t2 add foreign key(f1) references t1(f1) on update cascade, algorithm=copy;
+ERROR HY000: Cannot add foreign key constraint
+drop table t2, t1;
+# adding foreign key constraint for base columns during online alter.
+create table t1(f1 int primary key);
+create table t2(f1 int not null, f2 int as (f1) stored);
+set foreign_key_checks = 0;
+alter table t2 add foreign key(f1) references t1(f1) on update cascade, algorithm=inplace;
+ERROR HY000: Cannot add foreign key on the base column of stored column. 
+drop table t2, t1;
+# adding stored column via online alter.
+create table t1(f1 int primary key);
+create table t2(f1 int not null,
+foreign key(f1) references t1(f1) on update cascade)engine=innodb;
+alter table t2 add column f2 int as (f1) stored, algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
+drop table t2, t1;
+set foreign_key_checks = 1;
+#
+# BUG#26731689 FK ON TABLE WITH GENERATED COLS: ASSERTION POS < N_DEF
+#
+SET @foreign_key_checks_saved = @@foreign_key_checks;
+SET foreign_key_checks=0;
+DROP TABLE IF EXISTS s,t;
+CREATE TABLE s (a INT, b INT GENERATED ALWAYS AS (0) STORED,  c INT,
+d INT GENERATED ALWAYS AS (0) VIRTUAL, e INT) ENGINE=innodb;
+CREATE TABLE t (a INT) ENGINE=innodb;
+ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (e) REFERENCES t(a) ON UPDATE SET null;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'c' in the referenced table 't'
+ALTER  TABLE t ADD PRIMARY KEY(a);
+ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (e) REFERENCES t(a) ON UPDATE SET null;
+DROP TABLE s,t;
+CREATE TABLE s (a INT GENERATED ALWAYS AS (0) VIRTUAL,
+b INT GENERATED ALWAYS AS (0) STORED,  c INT) ENGINE=innodb;
+CREATE TABLE t (a INT) ENGINE=innodb;
+ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (c) REFERENCES t(a) ON UPDATE SET null;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'c' in the referenced table 't'
+ALTER  TABLE t ADD PRIMARY KEY(a);
+ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (c) REFERENCES t(a) ON UPDATE SET null;
+DROP TABLE s,t;
+CREATE TABLE s (a INT,  b INT GENERATED ALWAYS AS (0) STORED) ENGINE=innodb;
+CREATE TABLE t (a INT PRIMARY KEY) ENGINE=innodb;
+ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (a) REFERENCES t(a) ON UPDATE SET null;
+DROP TABLE s,t;
+CREATE TABLE s (a INT, b INT) ENGINE=innodb;
+CREATE TABLE t (a INT) ENGINE=innodb;
+ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (a) REFERENCES t(a) ON UPDATE SET null;
+ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'c' in the referenced table 't'
+ALTER  TABLE t ADD PRIMARY KEY(a);
+ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (a) REFERENCES t(a) ON UPDATE SET null;
+DROP TABLE s,t;
+SET @@foreign_key_checks = @foreign_key_checks_saved;
+CALL mtr.add_suppression("Cannot add foreign key constraint");
+CALL mtr.add_suppression("Duplicate foreign key constraint name");
+CALL mtr.add_suppression("Failed to add the foreign key constaint.");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported for this operation.");
+CALL mtr.add_suppression("Slave SQL: Error 'Error on rename");
+CALL mtr.add_suppression("Cannot add foreign key on the base column of stored column.");

--- a/mysql-test/suite/galera/r/galera_virtual_fk.result
+++ b/mysql-test/suite/galera/r/galera_virtual_fk.result
@@ -1,0 +1,831 @@
+#
+# Bug#22469130: FOREIGN KEY ON DELETE CASCADE NOT ALLOWED
+#               WHEN A VIRTUAL INDEX EXISTS.
+# UPDATE CASCADE
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL, KEY(fld2),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# UPDATE SET NULL
+CREATE TABLE t1(fld1 INT NOT NULL, fld2 INT NOT NULL PRIMARY KEY,
+KEY(fld1));
+CREATE TABLE t2(fld1 INT, fld2 INT AS (fld1) VIRTUAL, KEY(fld2),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON UPDATE SET NULL);
+INSERT INTO t1 VALUES(1, 2);
+INSERT INTO t2 VALUES(1, DEFAULT);
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+NULL
+SELECT * FROM t2;
+fld1	fld2
+NULL	NULL
+DROP TABLE t2, t1;
+# DELETE CASCADE
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT, fld2 INT AS (fld1) VIRTUAL, KEY(fld2),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON DELETE CASCADE);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+INSERT INTO t2 VALUES(1, DEFAULT);
+INSERT INTO t2 VALUES(2, DEFAULT);
+DELETE FROM t1 WHERE fld1= 1;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# DELETE SET NULL
+CREATE TABLE t1(fld1 INT NOT NULL, fld2 INT NOT NULL PRIMARY KEY, KEY(fld1));
+CREATE TABLE t2(fld1 INT, fld2 INT AS (fld1) VIRTUAL, KEY(fld2),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON DELETE SET NULL);
+INSERT INTO t1 VALUES(1, 1);
+INSERT INTO t1 VALUES(2, 2);
+INSERT INTO t2 VALUES(1, DEFAULT);
+INSERT INTO t2 VALUES(2, DEFAULT);
+DELETE FROM t1 WHERE fld1= 1;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+NULL
+2
+SELECT * FROM t2;
+fld1	fld2
+NULL	NULL
+2	2
+DROP TABLE t2, t1;
+# VIRTUAL INDEX CONTAINS FK CONSTRAINT COLUMN
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT, fld3 INT AS (fld2) VIRTUAL,
+KEY(fld3, fld1),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1, fld2) VALUES(1, 3);
+UPDATE t1 SET fld1= 2;
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+3	2
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld3	x	x	x	x	x
+SELECT * FROM t2;
+fld1	fld2	fld3
+2	3	3
+DROP TABLE t2, t1;
+# Multiple level of VIRTUAL columns.
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL,
+fld3 INT AS (fld2) VIRTUAL, KEY(fld3), KEY(fld2),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1) VALUES(1);
+UPDATE t1 SET fld1= 2;
+SELECT fld2 FROM t2;
+fld2
+2
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld3 FROM t2;
+fld3
+2
+EXPLAIN SELECT fld3 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld3	x	x	x	x	x
+SELECT * FROM t2;
+fld1	fld2	fld3
+2	2	2
+DROP TABLE t2, t1;
+# Drop the VIRTUAL INDEX using alter copy ALGORITHM
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL, KEY vk(fld2),
+KEY(fld1), FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1) VALUES(1);
+UPDATE t1 SET fld1= 2;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+2	2
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+ALTER TABLE t2 DROP INDEX vk, ALGORITHM= COPY;
+UPDATE t1 SET fld1= 3;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+3	3
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+DROP TABLE t2, t1;
+# Drop the VIRTUAL INDEX using INPLACE alter ALGORITHM
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL,
+KEY vk(fld2), KEY(fld1), FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1) VALUES(1);
+UPDATE t1 SET fld1= 2;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+2	2
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+ALTER TABLE t2 DROP INDEX vk, ALGORITHM= COPY;
+UPDATE t1 SET fld1= 3;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+3	3
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+DROP TABLE t2, t1;
+# Add the VIRTUAL INDEX using COPY alter ALGORITHM
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL,
+KEY(fld1), FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1) VALUES(1);
+UPDATE t1 SET fld1= 2;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+2	2
+ALTER TABLE t2 ADD INDEX vk(fld2), ALGORITHM= COPY;
+UPDATE t1 SET fld1= 3;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+3	3
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+DROP TABLE t2, t1;
+# Add the VIRTUAL INDEX using INPLACE alter ALGORITHM
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,fld2 INT AS (fld1) VIRTUAL,
+KEY(fld1), FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1) VALUES(1);
+UPDATE t1 SET fld1= 2;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+2	2
+ALTER TABLE t2 ADD INDEX vk(fld2), ALGORITHM= INPLACE;
+UPDATE t1 SET fld1= 3;
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+3	3
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+DROP TABLE t2, t1;
+# Drop the VIRTUAL INDEX contains fk constraint column
+# using alter copy ALGORITHM
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT NOT NULL,
+fld3 INT AS (fld2) VIRTUAL, KEY vk(fld3, fld1),
+KEY(fld1), FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1, fld2) VALUES(1, 2);
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	vk	x	x	x	x	x
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+2	2
+ALTER TABLE t2 DROP INDEX vk, ALGORITHM= COPY;
+UPDATE t1 SET fld1= 3;
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+2	3
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+DROP TABLE t2, t1;
+# Drop the VIRTUAL INDEX which contains fk constraint column
+# using INPLACE alter operation
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT NOT NULL,
+fld3 INT AS (fld2) VIRTUAL, KEY vk(fld3, fld1),
+KEY(fld1), FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1, fld2) VALUES(1, 2);
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	vk	x	x	x	x	x
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+2	2
+alter TABLE t2 DROP INDEX vk, ALGORITHM= INPLACE;
+UPDATE t1 SET fld1= 3;
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+2	3
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+DROP TABLE t2, t1;
+# Add the VIRTUAL INDEX contains fk constraint column
+# using copy alter operatiON
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT NOT NULL,
+fld3 INT AS (fld2) VIRTUAL, KEY(fld1),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON UPDATE CASCADE);
+INSERT INTO t1(fld1) VALUES(1);
+INSERT INTO t2(fld1, fld2) VALUES(1, 2);
+UPDATE t1 SET fld1= 2;
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+2	2
+alter TABLE t2 ADD INDEX vk(fld3, fld1), ALGORITHM= COPY;
+UPDATE t1 SET fld1= 3;
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+2	3
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	vk	x	x	x	x	x
+DROP TABLE t2, t1;
+# Cascading UPDATEs and DELETEs for the multiple
+# fk dependent TABLEs
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL,
+KEY(fld1), KEY(fld2, fld1),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON UPDATE CASCADE);
+CREATE TABLE t3(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL,
+KEY(fld2, fld1),
+FOREIGN KEY(fld1) REFERENCES t2(fld1) ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2(fld1) VALUES(1), (2);
+INSERT INTO t3(fld1) VALUES(1), (2);
+UPDATE t1 SET fld1= 4 WHERE fld1= 1;
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+2	2
+4	4
+EXPLAIN SELECT fld2, fld1 FROM t3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t3	x	index	x	fld2	x	x	x	x	x
+SELECT fld2, fld1 FROM t3;
+fld2	fld1
+2	2
+4	4
+DROP TABLE t3, t2, t1;
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT NOT NULL,
+fld3 INT AS (fld2) VIRTUAL, KEY(fld3, fld1), KEY(fld1),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON UPDATE CASCADE);
+CREATE TABLE t3(fld1 INT NOT NULL, fld2 INT NOT NULL,
+fld3 INT AS (fld2) VIRTUAL, KEY(fld3, fld1),
+FOREIGN KEY(fld1) REFERENCES t2(fld1) ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2 VALUES(1, 1, DEFAULT), (2, 2, default);
+INSERT INTO t3 VALUES(1, 1, DEFAULT), (2, 2, default);
+UPDATE t1 SET fld1= 4 WHERE fld1= 1;
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld3	x	x	x	x	x
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+1	4
+2	2
+EXPLAIN SELECT fld3, fld1 FROM t3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t3	x	index	x	fld3	x	x	x	x	x
+SELECT fld3, fld1 FROM t3;
+fld3	fld1
+1	4
+2	2
+DROP TABLE t3, t2, t1;
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL,
+KEY(fld1), KEY(fld2, fld1),
+FOREIGN KEY(fld1) REFERENCES t1(fld1) ON DELETE CASCADE);
+CREATE TABLE t3(fld1 INT NOT NULL, fld2 INT AS (fld1) VIRTUAL,
+KEY(fld2, fld1), FOREIGN KEY(fld1) REFERENCES t2(fld1)
+ON DELETE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2(fld1) VALUES(1), (2);
+INSERT INTO t3(fld1) VALUES(1), (2);
+DELETE FROM t1 WHERE fld1= 1;
+EXPLAIN SELECT fld2, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2, fld1 FROM t2;
+fld2	fld1
+2	2
+EXPLAIN SELECT fld2, fld1 FROM t3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t3	x	index	x	fld2	x	x	x	x	x
+SELECT fld2, fld1 FROM t3;
+fld2	fld1
+2	2
+DROP TABLE t3, t2, t1;
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL, fld2 INT NOT NULL,
+fld3 INT AS (fld2) VIRTUAL,
+KEY(fld3, fld1), KEY(fld1),
+FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON DELETE CASCADE);
+CREATE TABLE t3(fld1 INT NOT NULL, fld2 INT NOT NULL,
+fld3 INT AS (fld2) VIRTUAL, KEY(fld3, fld1),
+FOREIGN KEY(fld1) REFERENCES t2(fld1)
+ON DELETE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2 VALUES(1, 1, DEFAULT), (2, 2, default);
+INSERT INTO t3 VALUES(1, 1, DEFAULT), (2, 2, default);
+DELETE FROM t1 WHERE fld1= 1;
+EXPLAIN SELECT fld3, fld1 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld3	x	x	x	x	x
+SELECT fld3, fld1 FROM t2;
+fld3	fld1
+2	2
+EXPLAIN SELECT fld3, fld1 FROM t3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t3	x	index	x	fld3	x	x	x	x	x
+SELECT fld3, fld1 FROM t3;
+fld3	fld1
+2	2
+DROP TABLE t3, t2, t1;
+# RENAME TABLE
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+KEY(fld2, fld1),
+FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON DELETE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2 VALUES(1, DEFAULT), (2, default);
+RENAME TABLE t2 to t3;
+DELETE FROM t1 WHERE fld1= 1;
+EXPLAIN SELECT fld2, fld1 FROM t3;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t3	x	index	x	fld2	x	x	x	x	x
+SELECT fld2, fld1 FROM t3;
+fld2	fld1
+2	2
+DROP TABLE t3, t1;
+# FOREIGN_KEY_CHECKS disabled DURING INPLACE ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2 VALUES(1, DEFAULT), (2, default);
+SET foreign_key_checks = 0;
+ALTER TABLE t2 ADD INDEX vk(fld2), ALGORITHM=INPLACE;
+SET foreign_key_checks = 1;
+UPDATE t1 SET fld1= 3 WHERE fld1= 2;
+SELECT fld2 FROM t2;
+fld2
+1
+3
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	vk	x	x	x	x	x
+DROP TABLE t2, t1;
+# GENERATED COLUMN COMPUTATION FAILS when SQL_MODE
+# is set to ERROR_FOR_DIVISION_BY_ZERO
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (100/fld1) VIRTUAL,
+KEY(fld2),
+FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2 VALUES(1, DEFAULT), (2, default);
+UPDATE t1 SET fld1= 0 WHERE fld1= 2;
+ERROR 22012: Division by 0
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+50
+100
+DROP TABLE t2, t1;
+# CHANGE SQL_MODE and try the ERROR_FOR_DIVISION_BY_ZERO
+SET sql_mode = STRICT_ALL_TABLES;
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (100/fld1) VIRTUAL,
+KEY(fld2),
+FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1), (2);
+INSERT INTO t2 VALUES(1, DEFAULT), (2, default);
+UPDATE t1 SET fld1= 0 WHERE fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+NULL
+100
+SELECT * FROM t2;
+fld1	fld2
+1	100
+0	NULL
+DROP TABLE t2, t1;
+SET sql_mode = default;
+# ADD FOREIGN CONSTRAINT USING COPY
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL, KEY(fld2));
+ALTER TABLE t2 ADD FOREIGN KEY (fld1)
+REFERENCES t1(fld1) ON UPDATE CASCADE,
+ALGORITHM=copy;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# ADD FOREIGN CONSTRAINT USING INPLACE
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL, KEY(fld2));
+SET foreign_key_checks = 0;
+ALTER TABLE t2 ADD FOREIGN KEY (fld1)
+REFERENCES t1(fld1) ON UPDATE CASCADE,
+ALGORITHM=inplace;
+SET foreign_key_checks = 1;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# DROP FOREIGN CONSTRAINT USING COPY
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL, KEY(fld2),
+CONSTRAINT fidx FOREIGN KEY (fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+ALTER TABLE t2 DROP FOREIGN KEY fidx, ALGORITHM=COPY;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+1
+SELECT * FROM t2;
+fld1	fld2
+1	1
+DROP TABLE t2, t1;
+# DROP FOREIGN CONSTRAINT USING INPLACE
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL, KEY(fld2),
+CONSTRAINT fidx FOREIGN KEY (fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+SET foreign_key_checks = 0;
+ALTER TABLE t2 DROP FOREIGN KEY fidx, ALGORITHM=INPLACE;
+SET foreign_key_checks = 1;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+1
+SELECT * FROM t2;
+fld1	fld2
+1	1
+DROP TABLE t2, t1;
+# ADD VC INDEX and ADD FK IN SAME COPY ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+ALTER TABLE t2 ADD INDEX(fld2), ADD FOREIGN KEY (fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE, ALGORITHM=copy;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# ADD VC INDEX and ADD FK IN SAME INPLACE ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+SET foreign_key_checks = 0;
+ALTER TABLE t2 ADD INDEX(fld2), ADD FOREIGN KEY (fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE, ALGORITHM=inplace;
+SET foreign_key_checks = 1;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# ADD VC INDEX and DROP FK IN SAME COPY ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+CONSTRAINT fidx FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+ALTER TABLE t2 ADD INDEX(fld2), DROP FOREIGN KEY fidx, ALGORITHM=copy;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+1
+SELECT * FROM t2;
+fld1	fld2
+1	1
+DROP TABLE t2, t1;
+# ADD VC INDEX and DROP FK IN SAME INPLACE ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+CONSTRAINT fidx FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+SET foreign_key_checks = 0;
+ALTER TABLE t2 ADD INDEX(fld2), DROP FOREIGN KEY fidx, ALGORITHM=inplace;
+SET foreign_key_checks = 1;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	index	x	fld2	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+1
+SELECT * FROM t2;
+fld1	fld2
+1	1
+DROP TABLE t2, t1;
+# DROP VC INDEX and ADD FK IN SAME COPY ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+KEY idx(fld2));
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+ALTER TABLE t2 DROP INDEX idx, ADD FOREIGN KEY (fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE, ALGORITHM=COPY;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# DROP VC INDEX and ADD FK IN SAME INPLACE ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+KEY idx(fld2));
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+SET foreign_key_checks = 0;
+ALTER TABLE t2 DROP INDEX idx, ADD FOREIGN KEY (fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE, ALGORITHM=INPLACE;
+SET foreign_key_checks = 1;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+2
+SELECT * FROM t2;
+fld1	fld2
+2	2
+DROP TABLE t2, t1;
+# DROP VC INDEX and DROP FK IN SAME COPY ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+KEY idx(fld2),
+CONSTRAINT fidx FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+ALTER TABLE t2 DROP KEY idx, DROP FOREIGN KEY fidx, ALGORITHM=COPY;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+1
+SELECT * FROM t2;
+fld1	fld2
+1	1
+DROP TABLE t2, t1;
+# DROP VC INDEX and DROP FK IN SAME INPLACE ALTER
+CREATE TABLE t1(fld1 INT NOT NULL PRIMARY KEY);
+CREATE TABLE t2(fld1 INT NOT NULL,
+fld2 INT AS (fld1) VIRTUAL,
+KEY idx(fld2),
+CONSTRAINT fidx FOREIGN KEY(fld1) REFERENCES t1(fld1)
+ON UPDATE CASCADE);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1, DEFAULT);
+SET foreign_key_checks = 0;
+ALTER TABLE t2 DROP KEY idx, DROP FOREIGN KEY fidx, ALGORITHM=INPLACE;
+SET foreign_key_checks = 1;
+UPDATE t1 SET fld1= 2;
+EXPLAIN SELECT fld2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+x	x	t2	x	ALL	x	NULL	x	x	x	x	x
+SELECT fld2 FROM t2;
+fld2
+1
+SELECT * FROM t2;
+fld1	fld2
+1	1
+DROP TABLE t2, t1;
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (f1 INT NOT NULL, f2 INT AS (f1) VIRTUAL,
+KEY (f1, f2), FOREIGN KEY(f1) REFERENCES t1(f1))ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2(f1) VALUES(1);
+EXPLAIN SELECT f1, f2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	index	NULL	f1	9	NULL	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2` from `test`.`t2`
+SELECT f1, f2 FROM t2;
+f1	f2
+1	1
+INSERT INTO t2(f1) VALUES(2);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`f1`) REFERENCES `t1` (`f1`))
+DROP TABLE t2, t1;
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (f1 INT NOT NULL, f2 INT AS (f1) VIRTUAL,
+KEY (f1, f2), FOREIGN KEY(f1) REFERENCES t1(f1)
+ON UPDATE CASCADE)ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2(f1) VALUES(1);
+EXPLAIN SELECT f1, f2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	index	NULL	f1	9	NULL	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2` from `test`.`t2`
+SELECT f1, f2 FROM t2;
+f1	f2
+1	1
+UPDATE t1 SET f1 = 2 WHERE f1 = 1;
+EXPLAIN SELECT f1, f2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	index	NULL	f1	9	NULL	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2` from `test`.`t2`
+SELECT f1, f2 FROM t2;
+f1	f2
+2	2
+DROP TABLE t2, t1;
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (f1 INT NOT NULL, f2 INT AS (f1) VIRTUAL,
+KEY (f1, f2))ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2(f1) VALUES(1);
+SET FOREIGN_KEY_CHECKS = 0;
+ALTER TABLE t2 ADD FOREIGN KEY (f1) REFERENCES t1(f1)
+ON UPDATE CASCADE, ALGORITHM=INPLACE;
+SET FOREIGN_KEY_CHECKS = 1;
+UPDATE t1 SET f1 = 3;
+EXPLAIN SELECT f1, f2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	index	NULL	f1	9	NULL	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2` from `test`.`t2`
+SELECT f1, f2 FROM t2;
+f1	f2
+3	3
+DROP TABLE t2, t1;
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (f1 INT NOT NULL, f2 INT AS (f1) VIRTUAL,
+KEY (f1, f2))ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2(f1) VALUES(1);
+ALTER TABLE t2 ADD FOREIGN KEY (f1) REFERENCES t1(f1)
+ON UPDATE CASCADE, ALGORITHM=COPY;
+UPDATE t1 SET f1 = 3;
+EXPLAIN SELECT f1, f2 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	index	NULL	f1	9	NULL	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f2` AS `f2` from `test`.`t2`
+SELECT f1, f2 FROM t2;
+f1	f2
+3	3
+DROP TABLE t2, t1;
+CREATE TABLE t1(f1 INT NOT NULL, PRIMARY KEY(f1))ENGINE=INNODB;
+CREATE TABLE t2(f1 INT NOT NULL, f2 INT AS (1) VIRTUAL,
+f3 INT AS (2) VIRTUAL,
+FOREIGN KEY idx (f1) REFERENCES t1(f1) ON UPDATE CASCADE,
+KEY idx1 (f2, f1, f3))ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2(f1) VALUES(1);
+ALTER TABLE t2 DROP COLUMN f2, ALGORITHM=INPLACE;
+UPDATE t1 SET f1 = 3;
+EXPLAIN SELECT f1, f3 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	index	NULL	idx1	9	NULL	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f3` AS `f3` from `test`.`t2`
+SELECT f1, f3 FROM t2;
+f1	f3
+3	2
+DROP TABLE t2, t1;
+CREATE TABLE t1(f1 INT NOT NULL, PRIMARY KEY(f1))ENGINE=INNODB;
+CREATE TABLE t2(f1 INT NOT NULL, f2 INT AS (1) VIRTUAL,
+f3 INT AS (2) VIRTUAL,
+FOREIGN KEY idx (f1) REFERENCES t1(f1) ON UPDATE CASCADE,
+KEY idx1 (f2, f1, f3))ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2(f1) VALUES(1);
+ALTER TABLE t2 DROP COLUMN f2, ALGORITHM=COPY;
+UPDATE t1 SET f1 = 3;
+EXPLAIN SELECT f1, f3 FROM t2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	index	NULL	idx1	9	NULL	1	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`f1` AS `f1`,`test`.`t2`.`f3` AS `f3` from `test`.`t2`
+SELECT f1, f3 FROM t2;
+f1	f3
+3	2
+DROP TABLE t2, t1;

--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -13,9 +13,7 @@ MW-286 : Fails due to timing issue. Parallel transaction should be running while
 MW-360 : drop temporary table is bin logged (PS issue)
 galera#500 : Issue#330 2018-05-16 CODERSHIP https://github.com/codership/mysql-wsrep/issues/330
 galera_as_slave_replication_bundle : GCF-912 0000-00-00 CODERSHIP feature no longer works in 5.7
-galera_fk_multitable : Bug#80821 0000-00-00 CODERSHIP fails due to Oracle bug http://bugs.mysql.com/bug.php?id=80821
 galera_kill_nochanges : mysql-wsrep#24 0000-00-00 CODERSHIP Galera server does not restart properly if killed
-galera_toi_ddl_fk_insert : qa#39 0000-00-00 CODERSHIP galera_toi_ddl_fk_insert fails sporadically
 galera_as_slave_preordered : Intermittent failure (duplicate entry) observed in mtr.
 galera_toi_ddl_online : fails randomly with "deadlock error" as sequence of action is causing an issue.
 galera_garbd : Failing to find the garbd binary after new minimal image change.

--- a/mysql-test/suite/galera/t/galera-index-online-fk.test
+++ b/mysql-test/suite/galera/t/galera-index-online-fk.test
@@ -1,0 +1,22 @@
+--source include/have_debug.inc
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--source suite/innodb/t/innodb-index-online-fk.test
+
+
+# Test Suppresions
+
+--connection node_2
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported. Reason: Adding foreign keys needs foreign_key_checks=OFF");
+CALL mtr.add_suppression("Duplicate foreign key constraint name");
+CALL mtr.add_suppression("Failed to add the foreign key constaint");
+CALL mtr.add_suppression("Key column .* doesn't exist in table");
+CALL mtr.add_suppression("Unknown column");
+CALL mtr.add_suppression("Failed to add the foreign key constraint on table .*");
+CALL mtr.add_suppression("Failed to add the foreign key constraint .* to system tables*");
+CALL mtr.add_suppression("Cannot drop index .*: needed in a foreign key constraint");
+
+--connection node_1
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_fk_lock_parent_update_child.test
+++ b/mysql-test/suite/galera/t/galera_fk_lock_parent_update_child.test
@@ -1,0 +1,276 @@
+# ==== Purpose ====
+#
+# This test verifies that, in a foreign key relationship, update/delete on
+# child table are handled properly when the parent key is locked.
+#
+# ==== Implementation ====
+#
+# 1. Create a two node cluster.
+# 2. Create a parent and a child tables.
+# 3. With few rows being locked on the parent table, test the below scenarios.
+#
+#    3.1: Delete a row from the child table.
+#         Expectation: Delete should be successful.
+#
+#    3.2: Update non-referenced field of the child table.
+#         Expectation: Update should fail with lock wait timeout error.
+#
+#    3.3: Update non-referenced field of the child table and unlock the parent row.
+#         Expectation: Update should be successful.
+#
+#    3.4: Update referenced field of the child table.
+#         Expectation: Update should fail with lock wait timeout error.
+#
+#    3.5: Update referenced field of the child table and unlock the parent row.
+#         Expectation: Update should be successful.
+#
+#    3.6: Delete a row from the child table from node2.
+#         Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+#
+#    3.7: Update non-referenced field in the child table from node2.
+#         Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+#
+#    3.8: Update referenced field in the child table from node2.
+#         Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+#
+# 4. Cleanup
+#
+# ==== References ====
+#
+# PXC-3352: Unexpected ERROR 1205 modifying a child table in a FK relationship
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--let $saved_innodb_lock_wait_timeout = `SELECT @@GLOBAL.innodb_lock_wait_timeout`
+SET GLOBAL innodb_lock_wait_timeout = 5;
+
+# ===========================================================================
+# Create helper files for test setup and teardown.
+# ===========================================================================
+
+# Create tables, insert data and and lock parent row.
+--write_file $MYSQLTEST_VARDIR/tmp/fk_test_setup.inc
+    --connection con1
+    CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+    CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+                          CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+                          REFERENCES `parent_t` (`id`)) ENGINE = INNODB;
+
+    INSERT INTO parent_t VALUES (), (), (), (), ();
+    INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+
+    BEGIN;
+    SELECT * FROM parent_t WHERE id = 1 FOR UPDATE;
+EOF
+
+--write_file $MYSQLTEST_VARDIR/tmp/fk_test_cascade_setup.inc
+    --connection con1
+    CREATE TABLE parent_t (id INT AUTO_INCREMENT PRIMARY KEY )ENGINE = INNODB;
+    CREATE TABLE child_t (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT,
+                          CONSTRAINT `FK_child_parent_id` FOREIGN KEY (`parent_id`)
+                          REFERENCES `parent_t` (`id`) ON UPDATE CASCADE) ENGINE = INNODB;
+
+    INSERT INTO parent_t VALUES (), (), (), (), ();
+    INSERT INTO child_t (parent_id) SELECT id FROM parent_t;
+
+    BEGIN;
+    UPDATE parent_t SET id = id * 10;
+EOF
+
+# Wait till the transaction from node_2 to be replicated.
+--write_file $MYSQLTEST_VARDIR/tmp/fk_test_sync_node1.inc
+    --connection node_1
+    --let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+    --let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+    --source include/wait_condition_with_debug.inc
+EOF
+
+# Validate the data across nodes and perform cleanup.
+--write_file $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+    # Validation
+    --let $galera_diff_statement = SELECT * FROM parent_t;
+    --source include/galera_diff.inc
+    --let $galera_diff_statement = SELECT * FROM child_t;
+    --source include/galera_diff.inc
+
+    # Cleanup
+    --connection con1
+    DROP TABLE child_t;
+    DROP TABLE parent_t;
+EOF
+
+# ===========================================================================
+# Test starts from here.
+# ===========================================================================
+
+# Create auxiliary connections on node1.
+--connect(con1, 127.0.0.1, root, , test, $NODE_MYPORT_1)
+--connect(con2, 127.0.0.1, root, , test, $NODE_MYPORT_1)
+
+--echo
+--echo # ===========================================================================
+--echo # Case 1: Delete a row from the child table.
+--echo # Expectation: Delete should be successful.
+--echo # ===========================================================================
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_setup.inc
+--connection con2
+DELETE FROM child_t WHERE parent_id = 1;
+
+--connection con1
+COMMIT;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Case 2: Update non-referenced field of the child table.
+--echo # Expectation: Update should fail with lock wait timeout error.
+--echo # ===========================================================================
+--source $MYSQLTEST_VARDIR/tmp/fk_test_setup.inc
+
+--connection con2
+--error ER_LOCK_WAIT_TIMEOUT
+UPDATE child_t SET id = id - 1;
+
+--connection con1
+COMMIT;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Case 3: Update non-referenced field of the child table and unlock the parent row.
+--echo # Expectation: Update should be successful.
+--echo # ===========================================================================
+--source $MYSQLTEST_VARDIR/tmp/fk_test_setup.inc
+
+--connection con2
+--send UPDATE child_t SET id = id - 1
+
+--connection con1
+--sleep 1
+ROLLBACK;
+
+--connection con2
+--reap
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Case 4: Update referenced field of the child table.
+--echo # Expectation: Update should fail with lock wait timeout error.
+--echo # ===========================================================================
+--source $MYSQLTEST_VARDIR/tmp/fk_test_setup.inc
+
+--connection con2
+--error ER_LOCK_WAIT_TIMEOUT
+UPDATE child_t SET parent_id=3 WHERE parent_id=1;
+
+--connection con1
+ROLLBACK;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Case 5: Update referenced field of the child table and unlock the parent row.
+--echo # Expectation: Update should be successful.
+--echo # ===========================================================================
+--source $MYSQLTEST_VARDIR/tmp/fk_test_setup.inc
+
+--connection con2
+--send UPDATE child_t SET parent_id=3 WHERE parent_id=1
+
+--connection con1
+--sleep 1
+ROLLBACK;
+
+# Without the fix for PXC-3352, the below reap will fail with ER_LOCK_WAIT_TIMEOUT
+--connection con2
+--reap
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Case 6: Delete a row from the child table from node2.
+--echo # Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+--echo # ===========================================================================
+--source $MYSQLTEST_VARDIR/tmp/fk_test_cascade_setup.inc
+
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_2
+DELETE FROM child_t WHERE parent_id = 1;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_sync_node1.inc
+
+--connection con1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Case 7: Update non-referenced field in the child table from node2.
+--echo # Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+--echo # ===========================================================================
+--source $MYSQLTEST_VARDIR/tmp/fk_test_cascade_setup.inc
+
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_2
+UPDATE child_t SET id = id - 1;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_sync_node1.inc
+
+--connection con1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Case 8: Update referenced field in the child table from node2.
+--echo # Expectation: Commit on node1 should fail with deadlock error due to BF abort.
+--echo # ===========================================================================
+--source $MYSQLTEST_VARDIR/tmp/fk_test_cascade_setup.inc
+
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_2
+UPDATE child_t SET parent_id=3 WHERE parent_id=1;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_sync_node1.inc
+
+--connection con1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+--source $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--echo
+--echo # ===========================================================================
+--echo # Test Cleanup
+--echo # ===========================================================================
+--remove_file $MYSQLTEST_VARDIR/tmp/fk_test_setup.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/fk_test_cascade_setup.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/fk_test_sync_node1.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/fk_test_validate_and_teardown.inc
+
+--disconnect con1
+--disconnect con2
+
+--connection node_1
+--disable_query_log
+--eval SET GLOBAL innodb_lock_wait_timeout = $saved_innodb_lock_wait_timeout
+--enable_query_log
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_foreign_key.test
+++ b/mysql-test/suite/galera/t/galera_foreign_key.test
@@ -1,0 +1,149 @@
+#
+# See suite/innodb/t/foreign_key.test
+#
+
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--echo #
+--echo # Bug #19027905 ASSERT RET.SECOND DICT_CREATE_FOREIGN_CONSTRAINTS_LOW
+--echo # DICT_CREATE_FOREIGN_CONSTR
+--echo #
+
+create table t1 (f1 int primary key) engine=InnoDB;
+--error ER_CANNOT_ADD_FOREIGN
+create table t2 (f1 int primary key,
+constraint c1 foreign key (f1) references t1(f1),
+constraint c1 foreign key (f1) references t1(f1)) engine=InnoDB; 
+create table t2 (f1 int primary key,
+   constraint c1 foreign key (f1) references t1(f1)) engine=innodb;
+
+--replace_regex /#sql-[0-9a-f_]*'/#sql-temporary'/
+--error ER_DUP_KEY
+alter table t2 add constraint c1 foreign key (f1) references t1(f1); 
+
+set foreign_key_checks = 0;
+--error ER_FK_DUP_NAME
+alter table t2 add constraint c1 foreign key (f1) references t1(f1); 
+
+drop table t2, t1;
+
+--echo #
+--echo # Bug #20031243 CREATE TABLE FAILS TO CHECK IF FOREIGN KEY COLUMN
+--echo # NULL/NOT NULL MISMATCH
+--echo #
+
+set foreign_key_checks = 1;
+show variables like 'foreign_key_checks';
+
+CREATE TABLE t1
+(a INT NOT NULL,
+ b INT NOT NULL,
+ INDEX idx(a)) ENGINE=InnoDB;
+
+CREATE TABLE t2
+(a INT KEY,
+ b INT,
+ INDEX ind(b),
+ FOREIGN KEY (b) REFERENCES t1(a) ON DELETE CASCADE ON UPDATE CASCADE)
+ ENGINE=InnoDB;
+
+show create table t1;
+show create table t2;
+
+INSERT INTO t1 VALUES (1, 80);
+INSERT INTO t1 VALUES (2, 81);
+INSERT INTO t1 VALUES (3, 82);
+INSERT INTO t1 VALUES (4, 83);
+INSERT INTO t1 VALUES (5, 84);
+
+INSERT INTO t2 VALUES (51, 1);
+INSERT INTO t2 VALUES (52, 2);
+INSERT INTO t2 VALUES (53, 3);
+INSERT INTO t2 VALUES (54, 4);
+INSERT INTO t2 VALUES (55, 5);
+
+SELECT a, b FROM t1 ORDER BY a;
+SELECT a, b FROM t2 ORDER BY a;
+
+--error ER_NO_REFERENCED_ROW_2
+INSERT INTO t2 VALUES (56, 6);
+
+ALTER TABLE t1 CHANGE a id INT;
+
+SELECT id, b FROM t1 ORDER BY id;
+SELECT a, b FROM t2 ORDER BY a;
+
+--echo # Operations on child table
+--error ER_NO_REFERENCED_ROW_2
+INSERT INTO t2 VALUES (56, 6);
+--error ER_NO_REFERENCED_ROW_2
+UPDATE t2 SET b = 99 WHERE a = 51;
+DELETE FROM t2 WHERE a = 53;
+SELECT id, b FROM t1 ORDER BY id;
+SELECT a, b FROM t2 ORDER BY a;
+
+--echo # Operations on parent table
+DELETE FROM t1 WHERE id = 1;
+UPDATE t1 SET id = 50 WHERE id = 5;
+SELECT id, b FROM t1 ORDER BY id;
+SELECT a, b FROM t2 ORDER BY a;
+
+DROP TABLE t2, t1;
+
+--echo #
+--echo # bug#25126722 FOREIGN KEY CONSTRAINT NAME IS NULL AFTER RESTART
+--echo # base bug#24818604 [GR]
+--echo #
+
+CREATE TABLE t1 (c1 INT PRIMARY KEY);
+CREATE TABLE t2 (c1 INT PRIMARY KEY, FOREIGN KEY (c1) REFERENCES t1(c1));
+
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (1);
+
+SELECT unique_constraint_name FROM information_schema.referential_constraints
+WHERE table_name = 't2';
+
+# node1 has wsrep_cluster_address=gcomm:// in my.cnf, and since is not the last
+# server in the cluster to shutdown, it will have safe_to_bootstrap set to 0 in
+# the grastate.dat file and makes the bootstrap to fail. So, remove the
+# grastate.dat files to restart both the servers.
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/grastate.dat
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+--connection node_1
+--echo [connection node_1]
+--source include/restart_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+--connection node_2
+--echo [connection node_2]
+--source include/restart_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1
+SELECT unique_constraint_name FROM information_schema.referential_constraints
+WHERE table_name = 't2';
+
+SELECT * FROM t1;
+
+SELECT unique_constraint_name FROM information_schema.referential_constraints
+WHERE table_name = 't2';
+
+# Test suppressions
+--connection node_2
+CALL mtr.add_suppression("Cannot add foreign key constraint");
+CALL mtr.add_suppression("Can't write; duplicate key in table");
+CALL mtr.add_suppression("Duplicate foreign key constraint name");
+
+DROP TABLE t2;
+DROP TABLE t1;
+
+--connection node_1
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_high_prio_trx_fk.test
+++ b/mysql-test/suite/galera/t/galera_high_prio_trx_fk.test
@@ -1,0 +1,69 @@
+# Scenario:
+# T1=({R(PARENT), W(PARENT)})
+# T2=({R(CHILD), W(CHILD), C}, HIGH_PRIORITY).
+#
+# Outcome: T1 must abort, T2 must commit.
+#
+# See mysql-test/suite/innodb/t/high_prio_trx_fk.test
+
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (c1 INT PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (c2 INT PRIMARY KEY,
+		 FOREIGN KEY (c2) REFERENCES t1(c1))ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+
+--connect(con1, localhost, root,,test)
+--connect(con2, localhost, root,,test)
+
+--echo # On Connection 1
+--connection con1
+START TRANSACTION;
+DELETE FROM t1 WHERE c1 = 1;
+
+--echo # On Connection 2
+--connection con2
+--source include/start_transaction_high_prio.inc
+INSERT INTO t2 VALUES(1);
+COMMIT;
+
+--echo # On connection 1
+--connection con1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+connection default;
+
+DROP TABLE t2, t1;
+
+# UPDATE CASCADE FOREIGN KEY CONSTRAINT
+
+CREATE TABLE t1 (c1 INT PRIMARY KEY)ENGINE=INNODB;
+CREATE TABLE t2 (c2 INT PRIMARY KEY,
+		 FOREIGN KEY (c2) REFERENCES t1(c1)
+		 ON UPDATE CASCADE)ENGINE=INNODB;
+INSERT INTO t1 VALUES(1);
+
+--echo # On Connection 1
+--connection con1
+START TRANSACTION;
+UPDATE t1 SET C1=2 where C1 = 1;
+
+--echo # On Connection 2
+--connection con2
+--source include/start_transaction_high_prio.inc
+INSERT INTO t2 VALUES (1);
+COMMIT;
+--disconnect con2
+
+--echo
+--echo # On connection 1
+--connection con1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+--disconnect con1
+connection default;
+
+DROP TABLE t2, t1;
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_stored_fk.test
+++ b/mysql-test/suite/galera/t/galera_stored_fk.test
@@ -1,0 +1,17 @@
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--source suite/innodb/t/stored_fk.test
+
+# Test suppressions
+--connection node_2
+CALL mtr.add_suppression("Cannot add foreign key constraint");
+CALL mtr.add_suppression("Duplicate foreign key constraint name");
+CALL mtr.add_suppression("Failed to add the foreign key constaint.");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported for this operation.");
+CALL mtr.add_suppression("Slave SQL: Error 'Error on rename");
+CALL mtr.add_suppression("Cannot add foreign key on the base column of stored column.");
+
+--connection node_1
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_virtual_fk.test
+++ b/mysql-test/suite/galera/t/galera_virtual_fk.test
@@ -1,0 +1,7 @@
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--source suite/innodb/t/virtual_fk.test
+
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -420,10 +420,8 @@ wsrep_row_upd_check_foreign_constraints(
 		NOT break the constraint. */
 
 		if (foreign->foreign_index == index
-		    && (node->is_delete
-			|| row_upd_changes_first_fields_binary(
-				entry, index, node->update,
-				foreign->n_fields))) {
+		    && row_upd_changes_first_fields_binary(
+		        entry, index, node->update, foreign->n_fields)) {
 
 			if (foreign->referenced_table == NULL) {
 				foreign->referenced_table = 
@@ -2496,6 +2494,16 @@ row_upd_sec_index_entry(
 				case DB_NO_REFERENCED_ROW:
 					err = DB_SUCCESS;
 					break;
+				/* We can expect DB_LOCK_WAIT when the transaction that blocked
+				our lock was rolled back or committed while we were waiting
+				for the lock. In such cases, we can retry the operation.
+
+				See row_mysql_handle_errors() and
+				row_update_for_mysql_using_upd_graph()
+				for more details.*/
+
+				case DB_LOCK_WAIT:
+					break;
 				case DB_DEADLOCK:
 					if (wsrep_debug) {
 						ib::warn() << "WSREP: sec index FK check fail for deadlock"
@@ -2504,7 +2512,6 @@ row_upd_sec_index_entry(
 					}
 					break;
 				case DB_LOCK_WAIT_TIMEOUT:
-				case DB_LOCK_WAIT:
 					err = DB_LOCK_WAIT_TIMEOUT;
 					break;
 				default:


### PR DESCRIPTION
PXC-3352: Unexpected ERROR 1205 modifying a child table in a FK relationship

https://jira.percona.com/browse/PXC-3352

Problem
-------
When deleting/updating from a child table in a FK relationship, if the
parent table's referenced rows are locked, the operation on a child table
failed with lock wait timeout error when the parent table is unlocked.

Analysis
--------
1. For DELETE query

This is the stacktrace of the DELETE query while waiting for the parent
rows to be unlocked.
```
__pthread_cond_wait
os_event::wait
os_event::wait_low
os_event_wait_low
lock_wait_suspend_thread
row_ins_check_foreign_constraint
wsrep_row_upd_check_foreign_constraint 
row_upd_sec_index_entry
row_upd_sec_step
row_upd
row_upd_step
row_update_for_mysql_using_upd_graph
row_update_for_mysql
```
However, the same DELETE query doesn't wait in PS-5.7. 

In PS-5.7, when a row is being modified by an UPDATE/DELETE query, it even
updates the secondary index if there any index defined on the table. While
doing that, it first marks the row as deleted in the secondary index and
inserts into the index with the new value if it is an UPDATE query. This
updation of secondary index is necessary only for UPDATE queries and there
is no need to do the same for DELETE queries.

However, the same was not being done properly in PXC-5.7 because of the
special handling in WSREP for the foreign keys in InnoDB. This made even
the DELETE query to inadvertently update the secondary index
(row_ins_check_foreign_constraint()) thereby trying to lock the parent
table and thus causing lock wait timeout error.

2. For UPDATE query

During Update/Delete, whenever we fail to acquire lock on a row, the
transaction status is to DB_LOCK_WAIT and transaction enters into wait
state waiting for the row to be unlocked; and when the row is unlocked, the
operation is retried.

However, in case of PXC, the temporary DB_LOCK_WAIT during foreign key
checks was being translated into a permanent DB_LOCK_WAIT_TIMEOUT because
of the fallthrough in the error handling code thereby causing the queyr to
fail without retrying the operation.


Fix
---
1. The server is made to behave same way as of the PS-5.7 by removing the
check for DELETE query in `wsrep_row_upd_check_foreign_constraints()`
function which caused the thread to enter the wait.

2. DB_LOCK_WAIT error is now properly handled and the server retries the
operation.

Additionally, this patch 

1. Adds new foreign key tests in galera suite invoking their respective
test from InnoDB with galera enabled.
2. Re-enables the disabled `galera_fk_multitable` and
`galera_toi_ddl_fk_insert` test cases.

Testing
---
v1 - Jenkins: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/51/testReport/
v2 - Jenkins: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/57/testReport/


Note to Reviewers:
---
* Many tests in the above link are failing because the galera suite was run with higher value of `--parallel` causing making ports to be unavailable during the test run. To address this issue, [PXC-3364](https://jira.percona.com/browse/PXC-3364) has been reported.