### PR TITLE
5.7 - Implemented PXC-3092 (Log warning at startup if keyring is specified …

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
@@ -1,3 +1,5 @@
+CALL mtr.add_suppression("You have enabled keyring plugin. SST encryption is mandatory.");
+include/assert_grep.inc [Keyring plugin requires SST encryption]
 SELECT 1;
 1
 1

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
@@ -8,9 +8,17 @@
 --source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+CALL mtr.add_suppression("You have enabled keyring plugin. SST encryption is mandatory.");
 
 # Force a restart at the end of the test
 --source include/force_restart.inc
+
+--let $assert_text = Keyring plugin requires SST encryption
+--let $assert_select = You have enabled keyring plugin. SST encryption is mandatory.
+--let $assert_count = 1
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
 
 SELECT 1;
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5033,6 +5033,23 @@ a file name for --log-bin-index option", opt_binlog_index_name);
   }
   plugins_are_initialized= TRUE;  /* Don't separate from init function */
 
+#ifdef WITH_WSREP
+  static const LEX_CSTRING keyring_vault_name= {
+      C_STRING_WITH_LEN("keyring_vault")};
+  static const LEX_CSTRING keyring_name= {C_STRING_WITH_LEN("keyring_file")};
+  if (!pxc_encrypt_cluster_traffic &&
+      (plugin_is_ready(keyring_vault_name, MYSQL_KEYRING_PLUGIN) ||
+       plugin_is_ready(keyring_name, MYSQL_KEYRING_PLUGIN)))
+  {
+    WSREP_WARN(
+        "You have enabled keyring plugin. SST encryption is mandatory. "
+        "Please enable pxc_encrypt_cluster_traffic. Check "
+        "https://www.percona.com/doc/percona-xtradb-cluster/%u.%u/security/"
+        "encrypt-traffic.html#encrypt-sst for more details.",
+        MYSQL_VERSION_MAJOR, MYSQL_VERSION_MINOR);
+  }
+#endif
+
   Session_tracker session_track_system_variables_check;
   LEX_STRING var_list;
   char *tmp_str;


### PR DESCRIPTION
…but cluster traffic encryption is turned off)

https://jira.percona.com/browse/PXC-3092

Added a new WSREP warning to notify customer that keyring is enabled but
pxc_encrypt_cluster_traffic is disabled.