### PR TITLE
PXC-3243 : BF aborting a stored procedure hangs

### DIFF
--- a/mysql-test/suite/galera/r/galera_sp_bf_abort2.result
+++ b/mysql-test/suite/galera/r/galera_sp_bf_abort2.result
@@ -1,0 +1,270 @@
+# Node 1
+CREATE DATABASE database1;
+USE database1;
+CREATE PROCEDURE proc_with_transaction()
+BEGIN
+START TRANSACTION;
+UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+INSERT INTO t1 VALUES (10, "from sp");
+COMMIT;
+END|
+CREATE PROCEDURE proc_with_transaction_continue_handler()
+BEGIN
+DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+START TRANSACTION;
+UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+INSERT INTO t1 VALUES (10, "from sp continue");
+COMMIT;
+END|
+CREATE PROCEDURE proc_with_transaction_exit_handler()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+START TRANSACTION;
+UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+INSERT INTO t1 VALUES (10, "from sp exit");
+COMMIT;
+END|
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_exit_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_continue_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_exit_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp exit
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp exit
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_continue_handler;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp continue
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from sp
+3	from sp
+4	from sp
+10	from sp continue
+DROP TABLE t1;
+DROP DATABASE database1;

--- a/mysql-test/suite/galera/t/galera_sp_bf_abort2.inc
+++ b/mysql-test/suite/galera/t/galera_sp_bf_abort2.inc
@@ -1,0 +1,76 @@
+
+# Setup the test on node 1
+--connection node_1
+--echo # Node 1
+--let $wsrep_local_bf_aborts_before = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
+
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+
+# Invoke the SP
+--connection node_1a
+--echo # Node 1a
+USE database1;
+
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+--send_eval CALL $galera_sp_bf_abort_proc
+
+# Ensure that we have reached the sync point
+--connection node_1
+--echo # Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+
+# Force the thread on node1 to be aborted (by making a change on node2)
+--connection node_2
+--echo # Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+
+
+--connection node_1
+--echo # Node 1
+# Ensure that the update from node2 has reached node1
+--let $wait_condition = SELECT f2 = 'from node2' FROM database1.t1 WHERE f1 = 1;
+--source include/wait_condition.inc
+
+# Signal the thread to continue
+# The update from node2 should have bf aborted the op on node1
+SET DEBUG_SYNC = "now SIGNAL continue";
+
+--connection node_1a
+--echo # Node 1a
+
+if ($galera_sp_bf_abort2_expect_error)
+{
+	--error ER_LOCK_DEADLOCK
+	--reap
+}
+if (!$galera_sp_bf_abort2_expect_error)
+{
+	--reap
+}
+
+--connection node_1
+--echo # Node 1
+
+--let $wsrep_local_bf_aborts_after = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
+--let $assert_text = wsrep_local_bf_aborts has been incremented once
+--let $assert_cond = $wsrep_local_bf_aborts_after - $wsrep_local_bf_aborts_before = 1 AS wsrep_local_bf_aborts_increment;
+--source include/assert.inc
+
+
+SELECT * FROM database1.t1;
+
+SET DEBUG_SYNC = "RESET";
+
+--connection node_2
+--echo # Node 2
+SELECT * FROM database1.t1;
+
+--connection node_1
+DROP TABLE t1;
+

--- a/mysql-test/suite/galera/t/galera_sp_bf_abort2.test
+++ b/mysql-test/suite/galera/t/galera_sp_bf_abort2.test
@@ -1,0 +1,151 @@
+#
+# PXC-3243: Test BF-aborting during a transaction in an SP
+# This tests the behavior while an SP is BF-aborted during
+# an operation in a transaction within the SP.
+#
+
+--source include/have_debug_sync.inc
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+
+
+# Test setup
+--echo # Node 1
+--connection node_1
+CREATE DATABASE database1;
+USE database1;
+
+DELIMITER |;
+CREATE PROCEDURE proc_with_transaction()
+BEGIN
+  START TRANSACTION;
+    UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+    INSERT INTO t1 VALUES (10, "from sp");
+  COMMIT;
+END|
+
+CREATE PROCEDURE proc_with_transaction_continue_handler()
+BEGIN
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+  START TRANSACTION;
+    UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+    INSERT INTO t1 VALUES (10, "from sp continue");
+  COMMIT;
+END|
+
+CREATE PROCEDURE proc_with_transaction_exit_handler()
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+  START TRANSACTION;
+    UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+    INSERT INTO t1 VALUES (10, "from sp exit");
+  COMMIT;
+END|
+DELIMITER ;|
+
+# Determine initial number of connections (set $count_sessions)
+--source include/count_sessions.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+# ------------------------------------
+# Test 1a: no handlers, wsrep_retry_autocommit=0
+# The call to the SP will fail and return an error.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+--let $galera_sp_bf_abort_proc = proc_with_transaction
+--let $galera_sp_bf_abort2_expect_error = 1
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 1b: exit handler, wsrep_retry_autocommit=0
+# The call to the SP will fail and return an error.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_exit_handler
+--let $galera_sp_bf_abort2_expect_error = 1
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 1c: continue handler, wsrep_retry_autocommit=0
+# The call to the SP will fail and return an error.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 0;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_continue_handler
+--let $galera_sp_bf_abort2_expect_error = 1
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 2a: no handlers, wsrep_retry_autocommit=1
+# The first call to the SP will fail, but it will be retried
+# and will return success.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+--let $galera_sp_bf_abort_proc = proc_with_transaction
+
+# No error as the SP is retried
+--let $galera_sp_bf_abort2_expect_error = 0
+
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 2b: exit handler, wsrep_retry_autocommit=1
+# The first call to the SP will fail, but it will be retried
+# and will return success.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_exit_handler
+
+# No error as the SP is retried
+--let $galera_sp_bf_abort2_expect_error = 0
+
+--source galera_sp_bf_abort2.inc
+
+
+# ------------------------------------
+# Test 2c: continue handler, wsrep_retry_autocommit=1
+# The first call to the SP will fail, but it will be retried
+# and will return success.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_continue_handler
+
+# No error as the SP is retried
+--let $galera_sp_bf_abort2_expect_error = 0
+
+--source galera_sp_bf_abort2.inc
+
+
+# Test cleanup
+--connection node_1a
+DROP DATABASE database1;
+
+--connection default
+--disconnect node_1a
+
+# Wait until we have reached the initial number of connections
+# or more than the sleep time above (10 seconds) has passed.
+# $count_sessions
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6207,17 +6207,30 @@ finish:
                                      "MYSQL_AUDIT_QUERY_NESTED_STATUS_END");
 #endif /* !EMBEDDED_LIBRARY */
 
-    /* report error issued during command execution */
-    if (thd->killed_errno())
-      thd->send_kill_message();
-    if (thd->is_error() || (thd->variables.option_bits & OPTION_MASTER_SQL_ERROR))
-      trans_rollback_stmt(thd);
 #ifdef WITH_WSREP
-    else if (thd->sp_runtime_ctx &&
-             (thd->wsrep_conflict_state == MUST_ABORT ||
-              thd->wsrep_conflict_state == CERT_FAILURE ||
-              thd->wsrep_conflict_state == ABORTED))
+
+    mysql_mutex_lock(&thd->LOCK_wsrep_thd);
+
+    const int killed_errno(thd->killed_errno());
+    const bool is_error(thd->is_error());
+    const THD::killed_state killed(thd->killed);
+    const bool has_sp_runtime_ctx(thd->sp_runtime_ctx != NULL);
+    const wsrep_conflict_state conflict_state(wsrep_thd_conflict_state(thd));
+
+    mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
+
+    /* report error issued during command execution */
+    if (killed_errno)
+      thd->send_kill_message();
+    if (is_error || (thd->variables.option_bits & OPTION_MASTER_SQL_ERROR))
+      trans_rollback_stmt(thd);
+    else if (has_sp_runtime_ctx &&
+             (conflict_state == MUST_ABORT ||
+              conflict_state == CERT_FAILURE ||
+              conflict_state == ABORTED))
     {
+      trans_rollback_stmt(thd);
+
       /*
         The error was cleared, but THD was aborted by wsrep and
         wsrep_conflict_state is still set accordingly. This
@@ -6225,12 +6238,50 @@ finish:
         that declares a handler that catches ER_LOCK_DEADLOCK error.
         In which case the error may have been cleared in method
         sp_rcontext::handle_sql_condition().
+
+        PXC-3243
+        If BF-aborted, do not clear the conflict-state/killed variables.
+        Let the error propagate upward (if this was called from an SP),
+        to ensure that the locks are cleared.
       */
-      trans_rollback_stmt(thd);
-      thd->wsrep_conflict_state= NO_CONFLICT;
-      thd->killed= THD::NOT_KILLED;
+      if (conflict_state != MUST_ABORT)
+      {
+        thd->wsrep_conflict_state= NO_CONFLICT;
+        thd->killed= THD::NOT_KILLED;
+      }
     }
-#endif /* WITH_WSREP */
+    else
+    {
+      /* If commit fails, we should be able to reset the OK status. */
+      thd->get_stmt_da()->set_overwrite_status(true);
+      trans_commit_stmt(thd);
+      thd->get_stmt_da()->set_overwrite_status(false);
+    }
+    if (killed == THD::KILL_QUERY ||
+        killed == THD::KILL_TIMEOUT ||
+        killed == THD::KILL_BAD_DATA)
+    {
+      /*
+        PXC-3243
+        To handle the error in an SP, the thd->killed must be propagated
+        back up to the SP call so that the trans_rollback_stmt()
+        can be invoked for the SP call.
+
+        So leaving thd->killed unchanged will ensure that sp_head::execute
+        will set the err_status to true.
+       */
+      if (!has_sp_runtime_ctx || conflict_state != MUST_ABORT)
+      {
+        thd->killed= THD::NOT_KILLED;
+        thd->reset_query_for_display();
+      }
+    }
+#else
+    /* report error issued during command execution */
+    if (thd->killed_errno())
+      thd->send_kill_message();
+    if (thd->is_error() || (thd->variables.option_bits & OPTION_MASTER_SQL_ERROR))
+      trans_rollback_stmt(thd);
     else
     {
       /* If commit fails, we should be able to reset the OK status. */
@@ -6245,6 +6296,7 @@ finish:
       thd->killed= THD::NOT_KILLED;
       thd->reset_query_for_display();
     }
+#endif /* WITH_WSREP */
   }
 
 #ifdef WITH_WSREP

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9713,6 +9713,10 @@ wsrep_error:
 func_exit:
 	innobase_active_small();
 
+#ifdef WITH_WSREP
+	DEBUG_SYNC(m_user_thd, "ha_innobase_end_of_write_row");
+#endif /* WITH_WSREP */
+
 	if (UNIV_UNLIKELY(m_share && m_share->ib_table
 			  && m_share->ib_table->is_corrupt)) {
 		DBUG_RETURN(HA_ERR_CRASHED);
@@ -10431,6 +10435,12 @@ func_exit:
 	err = convert_error_code_to_mysql(
 		error, m_prebuilt->table->flags, m_user_thd);
 
+#ifdef WITH_WSREP
+	if (trx_is_interrupted(trx)) {
+		error = DB_INTERRUPTED;
+	}
+#endif /* WITH_WSREP */
+
 	/* If success and no columns were updated. */
 	if (err == 0 && uvect->n_fields == 0) {
 
@@ -10598,6 +10608,12 @@ wsrep_error:
 			  && m_share->ib_table->is_corrupt)) {
 		DBUG_RETURN(HA_ERR_CRASHED);
 	}
+
+#ifdef WITH_WSREP
+	if (trx_is_interrupted(trx)) {
+		error = DB_INTERRUPTED;
+	}
+#endif /* WITH_WSREP */
 
 	DBUG_RETURN(convert_error_code_to_mysql(
 			    error, m_prebuilt->table->flags, m_user_thd));


### PR DESCRIPTION
Issue
When running a SP with a transaction insde, BF-aborting the SP
can cause the system to hang.

Solution
This happens because the transaction is holding onto a lock,
but the BF-abort is aborting a statement, which may not be the
one holding the lock.
This change will force the BF-abort to propagate and abort and retry
the SP, not the statement.