### PR TITLE
PXC-3353 Modify error handling in Garbd when donor crashes during SST or when an invalid donor name is passed to it

### DIFF
--- a/cmake/dev-helper.cmake
+++ b/cmake/dev-helper.cmake
@@ -6,8 +6,16 @@ if(WITH_GALERA_DEV)
   INCLUDE(ProcessorCount)
   ProcessorCount(CPU_COUNT)
 
+  IF(CMAKE_BUILD_TYPE_UPPER STREQUAL "DEBUG" OR WITH_DEBUG)
+    SET(GALERA_DEBUG 0)
+  ELSE()
+    SET(GALERA_DEBUG 2)
+  ENDIF()
+
+  MESSAGE(STATUS "Configuring Galera to use debug=${GALERA_DEBUG}")
+
   # Add a custom target for later refreshes
-  ADD_CUSTOM_TARGET(galera ALL scons -j ${CPU_COUNT} tests=0
+  ADD_CUSTOM_TARGET(galera ALL scons -j ${CPU_COUNT} tests=0 debug=${GALERA_DEBUG}
     COMMAND ${CMAKE_COMMAND} -E copy 
     "${CMAKE_CURRENT_SOURCE_DIR}/percona-xtradb-cluster-galera/garb/garbd"
     "${CMAKE_CURRENT_BINARY_DIR}/runtime_output_directory/garbd"

--- a/mysql-test/include/wait_proc_to_finish.inc
+++ b/mysql-test/include/wait_proc_to_finish.inc
@@ -17,7 +17,7 @@
 
 if (!$pid_file)
 {
-  --die ERROR IN TEST: 'pid_file' parameter specified
+  --die ERROR IN TEST: 'pid_file' parameter is not specified
 }
 
 --let _PID_FILE = $pid_file

--- a/mysql-test/suite/galera/r/galera_garbd_invalid_donor_name.result
+++ b/mysql-test/suite/galera/r/galera_garbd_invalid_donor_name.result
@@ -1,0 +1,18 @@
+#
+# 1. Create a two node cluster.
+#
+# 2. Shutdown node2 and use its ports for garbd.
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+Variable_name	Value
+wsrep_flow_control_interval	[ 100, 100 ]
+
+# 3. Start garbd in background with an invalid donor name and wait till garbd is shutdown.
+#
+# 4. Restart node2
+[connection node_2]
+# restart
+# 5. Verify that the reason for the shutdown is logged in the garbd log.
+include/assert_grep.inc [Appropriate message has been written to the garbd log explaining the reason for the shutdown.]
+CALL mtr.add_suppression("Member .*garb.* requested state transfer from 'invalid_donor', but it is impossible to select State Transfer donor: No route to host");
+#
+# 6. Cleanup

--- a/mysql-test/suite/galera/r/galera_garbd_sst_failure.result
+++ b/mysql-test/suite/galera/r/galera_garbd_sst_failure.result
@@ -1,0 +1,31 @@
+#
+# 1. Create a two node cluster.
+#
+# 2. Shutdown node2 and use its ports for garbd.
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+Variable_name	Value
+wsrep_flow_control_interval	[ 100, 100 ]
+#
+# 3. Add a debug point on node1 to stop after reading xid from InnoDB.
+# Adding debug point 'stop_after_reading_xid' to @@GLOBAL.debug
+#
+# 4. Start garbd in background and wait till node1 reads the
+#    wsrep_xid from InnoDB.
+[connection node_1]
+SET SESSION wsrep_sync_wait=0;
+SET DEBUG_SYNC='now wait_for read_xid';
+#
+# 5. Kill node1 and wait till SST failure is handled and garbd is shutdown.
+Killing server ...
+#
+# 6. Restart node1 and node2
+[connection node_1]
+# restart
+[connection node_2]
+# restart
+#
+# 7. Verify that the reason for the shutdown is logged in the garbd log.
+include/assert_grep.inc [Appropriate message has been written to the garbd log explaining the reason for the shutdown.]
+CALL mtr.add_suppression("Member .*garb.* requested state transfer from 'node1', but it is impossible to select State Transfer donor: No route to host");
+#
+# 8. Cleanup

--- a/mysql-test/suite/galera/t/galera_garbd_invalid_donor_name.test
+++ b/mysql-test/suite/galera/t/galera_garbd_invalid_donor_name.test
@@ -1,0 +1,84 @@
+# ==== Purpose ====
+#
+# This test verifies that garbd shuts down smoothly when an invalid donor name
+# is passed to it.
+#
+# ==== Implementation ====
+#
+# 1. Create a two node cluster.
+# 2. Shutdown node2 and use its ports for garbd.
+# 3. Start garbd in background with an invalid donor name and wait till garbd is shutdown.
+# 4. Restart node2
+# 5. Verify that the reason for the shutdown is logged in the error log.
+# 6. Cleanup
+#
+# ==== References ====
+#
+# PXC-3353: Modify error handling to close the communication channels and abort
+#           the joiner node when donor crashes
+
+# Test a single node with an arbitrator.  Startup a 2-node cluster, shut down
+# node 2, and use it's ports for the garbd.
+#
+
+--echo #
+--echo # 1. Create a two node cluster.
+--source include/galera_cluster.inc
+
+--echo #
+--echo # 2. Shutdown node2 and use its ports for garbd.
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+# Wait for the cluster size to become 1
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+
+--echo
+--echo # 3. Start garbd in background with an invalid donor name and wait till garbd is shutdown.
+--let $PID_FILE= $MYSQLTEST_VARDIR/tmp/garbd.pid
+--let $GARBD_LOG_FILE= $MYSQLTEST_VARDIR/tmp/garbd.log
+
+# Set the evs.inactive_timeout to ensure that the node will shutdown 6 seconds after it is
+# killed.  This is set to 6 seconds because evs.inactive_timeout > evs.suspect_timeout (PT5S)
+--let $command = "`dirname $WSREP_PROVIDER`/../bin/garbd"
+--let $command_opt = --sst="xtrabackup-v2:127.0.0.1:9999/xtrabackup_sst//1" --donor invalid_donor --address "gcomm://127.0.0.1:$NODE_GALERAPORT_1" --group my_wsrep_cluster --options 'evs.inactive_timeout=PT6S;base_port=$NODE_GALERAPORT_2' > $GARBD_LOG_FILE 2>&1
+--source include/start_proc_in_background.inc
+
+--source include/wait_proc_to_finish.inc
+
+--echo #
+--echo # 4. Restart node2
+--connection node_2
+--echo [connection node_2]
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+# Wait for the cluster size to become 2
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--echo # 5. Verify that the reason for the shutdown is logged in the garbd log.
+--let $assert_select= Garbd exiting with error: State transfer request failed: 113 \(No route to host\)
+--let $assert_text= Appropriate message has been written to the garbd log explaining the reason for the shutdown.
+--let $assert_count= 1
+--let $assert_file= $GARBD_LOG_FILE
+--source include/assert_grep.inc
+
+# Add test suppressions
+--connection node_1
+CALL mtr.add_suppression("Member .*garb.* requested state transfer from 'invalid_donor', but it is impossible to select State Transfer donor: No route to host");
+
+--echo #
+--echo # 6. Cleanup
+--remove_file $GARBD_LOG_FILE
+--remove_file $PID_FILE

--- a/mysql-test/suite/galera/t/galera_garbd_sst_failure.test
+++ b/mysql-test/suite/galera/t/galera_garbd_sst_failure.test
@@ -1,0 +1,121 @@
+# ==== Purpose ====
+#
+# This test verifies that garbd shuts down smoothly when donor node is killed
+# while SST is in progress.
+#
+# ==== Implementation ====
+#
+# 1. Create a two node cluster.
+# 2. Shutdown node2 and use its ports for garbd.
+# 3. Add a debug point on node1 to stop after reading xid from InnoDB.
+# 4. Start garbd in background and wait till node1 reads the wsrep_xid from
+#    InnoDB.
+# 5. Kill node1 and wait till SST failure is handled and garbd is shutdown.
+# 6. Restart node1 and node2
+# 7. Verify that the reason for the shutdown is logged in the error log.
+# 8. Cleanup
+#
+# ==== References ====
+#
+# PXC-3353: Modify error handling to close the communication channels and abort
+#           the joiner node when donor crashes
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+--echo #
+--echo # 1. Create a two node cluster.
+--source include/galera_cluster.inc
+
+--echo #
+--echo # 2. Shutdown node2 and use its ports for garbd.
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+# Wait for the cluster size to become 1
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+SHOW STATUS LIKE 'wsrep_flow_control_interval';
+
+--echo #
+--echo # 3. Add a debug point on node1 to stop after reading xid from InnoDB.
+--let $debug_point= stop_after_reading_xid
+--source include/add_debug_point.inc
+
+--echo #
+--echo # 4. Start garbd in background and wait till node1 reads the
+--echo #    wsrep_xid from InnoDB.
+--let $PID_FILE= $MYSQLTEST_VARDIR/tmp/garbd.pid
+--let $GARBD_LOG_FILE= $MYSQLTEST_VARDIR/tmp/garbd.log
+
+# Test a single node with an arbitrator.  Startup a 2-node cluster, shut down
+# node 2, and use it's ports for the garbd.
+#
+# Set the evs.inactive_timeout to ensure that the node will shutdown 6
+# seconds after it is killed. This is set to 6 seconds because
+# evs.inactive_timeout > evs.suspect_timeout (PT5S)
+--let $command = "`dirname $WSREP_PROVIDER`/../bin/garbd"
+--let $command_opt = --sst="xtrabackup-v2:127.0.0.1:9999/xtrabackup_sst//1" --donor node1 --address "gcomm://127.0.0.1:$NODE_GALERAPORT_1" --group my_wsrep_cluster --options 'evs.inactive_timeout=PT6S;base_port=$NODE_GALERAPORT_2' > $GARBD_LOG_FILE 2>&1
+--source include/start_proc_in_background.inc
+
+--connection node_1
+--echo [connection node_1]
+SET SESSION wsrep_sync_wait=0;
+SET DEBUG_SYNC='now wait_for read_xid';
+
+--echo #
+--echo # 5. Kill node1 and wait till SST failure is handled and garbd is shutdown.
+--source include/kill_galera.inc
+--source include/wait_proc_to_finish.inc
+
+# node1 has wsrep_cluster_address=gcomm:// in my.cnf, and since is not the last
+# server to shutdown, it will have safe_to_bootstrap set to 0 in the
+# grastate.dat file and makes the bootstrap to fail.
+#
+# Remove the grastate.dat files to restart the cluster.
+--error 0,1
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/grastate.dat
+--error 0,1
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+--echo #
+--echo # 6. Restart node1 and node2
+--connection node_1
+--echo [connection node_1]
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+--connection node_2
+--echo [connection node_2]
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+# Wait for the cluster size to become 2
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--echo #
+--echo # 7. Verify that the reason for the shutdown is logged in the garbd log.
+--let $assert_select= Garbd exiting with error: State transfer request failed: 113 \(No route to host\)
+--let $assert_text= Appropriate message has been written to the garbd log explaining the reason for the shutdown.
+--let $assert_count= 1
+--let $assert_file= $GARBD_LOG_FILE
+--source include/assert_grep.inc
+
+# Add test suppressions
+--connection node_1
+CALL mtr.add_suppression("Member .*garb.* requested state transfer from 'node1', but it is impossible to select State Transfer donor: No route to host");
+
+--echo #
+--echo # 8. Cleanup
+--remove_file $GARBD_LOG_FILE
+--remove_file $PID_FILE


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3353

Problem
-------
When the donor node is killed while SST is in progress or when an
invalid donor is passed, the garbd hung forever waiting for the receiver
queue to get empty.

Analysis
--------
In both of the above cases, GCS (group_find_node_by_name()) considered
these errors as EHOSTUNREACH (No Route to Host), and triggers the
shutdown of garbd.

While the garbd main thread performs cleanup, the receiver thread would
still be queuing the received actions to the receiver queue until it
exits. So, this would result in the receiver queue to have a few
received actions which shall never be applied by the applier/main
thread.

When the main thread is performing the cleanup of the GCS
(gcs_destroy()), it sees the receiver queue to be not empty
(fifo_flush()) and thus ends up waiting on the conditional variable for
there will be no one to signal as all threads are already joined.

The garbd log will have

```
2020-09-16 09:18:19.664  INFO: recv_thread() joined.
2020-09-16 09:18:19.664  INFO: Closing replication queue.
2020-09-16 09:18:19.664  INFO: Closing slave action queue.
2020-09-16 09:18:19.664  WARN: Waiting for 2 items to be fetched.
... hangs ...
```
Stacktrace of the hang

```
(gdb) bt
futex_wait_cancelable
__pthread_cond_wait_common
__pthread_cond_wait
fifo_flush
gu_fifo_destroy
gcs_destroy
garb::Gcs::~Gcs
garb::RecvLoop::RecvLoop
garb::main
main
```

Fix
---
Modified the error handling to empty the contents of the receiver queue
when garbd is exiting.

Additionally, this commit
1. Modifies the cmake/dev-helper.cmake to build the galera library in debug
    mode when the server is built with -DWITH_GALERA_DEV
2. Updates the galera pointer.

Testing
-------
Jenkins: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/90/testReport/

Summary: The test `galera.galera_garbd_sst_failure` failed because of the missing `have_debug_sync.inc`. Other test failures are sporadic in nature.