### PR TITLE
PXC-3407: Move symlinking to lib into if statement

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -470,14 +470,13 @@ fi
                         echo "Copying lib ${lib_realpath_basename}"
                         cp ${lib_realpath} lib/private
 
-                        echo "Symlinking lib from ${lib_realpath_basename} to ${lib_without_version_suffix}"
-                        cd lib/
-                        ln -s private/${lib_realpath_basename} ${lib_without_version_suffix}
-                        cd -
-                        if [ ${lib_realpath_basename} != ${lib_without_version_suffix} ]; then
-                            cd lib/private
+                        if [ ${lib_realpath_basename} != ${lib_without_version_suffix} ] && [ ! -L lib/${lib_without_version_suffix} ]; then
+                            echo "Symlinking lib from ${lib_realpath_basename} to ${lib_without_version_suffix}"
+                            cd lib/
+                            ln -s private/${lib_realpath_basename} ${lib_without_version_suffix}
+                            cd private
                             ln -s ${lib_realpath_basename} ${lib_without_version_suffix}
-                            cd -
+                            cd ../../
                         fi
 
                         patchelf --set-soname ${lib_without_version_suffix} lib/private/${lib_realpath_basename}


### PR DESCRIPTION
Ramesh reported that QA pipeline fails https://pxc.cd.percona.com/job/qa-pxc-5.7-pipeline/77/execution/node/54/log/

It was caused by heimdal libs, xenial has two `libkrb5.so` and only one should be copied & symlinked

Link to build: https://rel.cd.percona.com/job/percona-xtradb-cluster-57-bintar/31/