### PR TITLE
PXC-3415 Fix wsrep_provider_version

### DIFF
--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -75,10 +75,6 @@ Prefix: %{_sysconfdir}
  %define scons_args %{nil}
 %endif
 
-%if %{undefined galera_version}
- %define galera_version 3.31
-%endif
-
 %if %{undefined galera_revision}
  %define galera_revision %{revision}
 %endif
@@ -811,8 +807,8 @@ pushd percona-xtradb-cluster-galera
 #  RPM_OPT_FLAGS=
 %endif
 
-scons %{?_smp_mflags}  revno=%{galera_revision} version=%{galera_version} psi=1 boost_pool=0 libgalera_smm.so %{scons_arch} %{scons_args}
-scons %{?_smp_mflags}  revno=%{galera_revision} version=%{galera_version} boost_pool=0 garb/garbd %{scons_arch} %{scons_args}
+scons %{?_smp_mflags}  revno=%{galera_revision} psi=1 boost_pool=0 libgalera_smm.so %{scons_arch} %{scons_args}
+scons %{?_smp_mflags}  revno=%{galera_revision} boost_pool=0 garb/garbd %{scons_arch} %{scons_args}
 popd
 
 


### PR DESCRIPTION
Remove "galera_version" scons parameter from RPM spec as it is done for debian OSes and since it is taken by default from https://github.com/percona/galera/blob/b06e760d1edd6966472f5da3077f05b8b76e5f6f/SConstruct#L167