### PR TITLE
PXC-3424: Fix error handling when donor is not able to serve SST (8.0)

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_failure.result
+++ b/mysql-test/suite/galera/r/galera_sst_failure.result
@@ -1,0 +1,7 @@
+CALL mtr.add_suppression(".*WSREP: SST failed.*");
+CALL mtr.add_suppression(".*WSREP: .* State transfer to .* failed: -125 .Operation canceled.*");
+include/assert.inc [node_1 should be in SYNC state after serving SST to node_2]
+SET GLOBAL debug = "+d,wsrep_sst_donate_cb_fails";
+include/assert.inc [node_1 should go back to SYNC state]
+SET GLOBAL debug = "-d,wsrep_sst_donate_cb_fails";
+cleanup

--- a/mysql-test/suite/galera/t/galera_sst_failure.test
+++ b/mysql-test/suite/galera/t/galera_sst_failure.test
@@ -1,0 +1,45 @@
+# Test if donor node goes back to SYNC state after it desyncs for donating
+# another node, but failing to start SST.
+
+--source include/have_debug.inc
+--source include/galera_cluster.inc
+
+--connection node_1
+CALL mtr.add_suppression(".*WSREP: SST failed.*");
+CALL mtr.add_suppression(".*WSREP: .* State transfer to .* failed: -125 .Operation canceled.*");
+
+--let $assert_text=node_1 should be in SYNC state after serving SST to node_2
+--let $wsrep_local_state_comment = query_get_value(SHOW STATUS LIKE 'wsrep_local_state_comment', Value, 1)
+--let $assert_cond= "$wsrep_local_state_comment" = "Synced"
+--source include/assert.inc
+
+# Setup node_1 to fail SST on next SST request
+SET GLOBAL debug = "+d,wsrep_sst_donate_cb_fails";
+
+# Restart node 2 forcing SST
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+# Remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# As SST fails on donor side, the joiner will abort
+--let $error_log= $MYSQLTEST_VARDIR/tmp/test_error_log.err
+--let $mysqld2=$MYSQLD --defaults-group-suffix=.2 --defaults-file=$PATH_CONFIG_FILE --wsrep-provider-options='base_port=$NODE_GALERAPORT_2' --console > $error_log 2>&1
+--error 134
+--exec $mysqld2
+--remove_file $error_log
+
+# node_1 should go back to SYNC state
+--connection node_1
+--let $assert_text=node_1 should go back to SYNC state
+--let $wsrep_local_state_comment = query_get_value(SHOW STATUS LIKE 'wsrep_local_state_comment', Value, 1)
+--let $assert_cond= "$wsrep_local_state_comment" = "Synced"
+--source include/assert.inc
+
+# cleanup
+SET GLOBAL debug = "-d,wsrep_sst_donate_cb_fails";
+
+--connection node_2
+--echo cleanup
+--source include/start_mysqld.inc


### PR DESCRIPTION
1. Improved error handling in wsrep_sst_donate_cb
2. Fixed sst script termination on joiner side. sst_process variable was
   cleared just after sst script startup. That prevented signaling sst
   script from wsrep_sst_cancel()
3. Removed 'timeout' use sfrom wsrep_sst_xtrabackup-v2.sh. Having
   'timeout' prevented graceful and instant script termination.
   As 'timeout' creates its own process group it was not killed when
   SIGTERM signal was sent to wsrep_sst_xtrabackup-v2 script, causing
   socat to keep opened ports till the end of timeout and mysqld waiting
   in 'defunct' state for its child processes to terminate. If during
   this time mysqld was started again, SST script failed as sockets were
   still used by old instance of socat.