### PR TITLE
PXC-3442: Fixed wsrep checkpoint assertion when DML executed in TOI (5.6)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_log_slave_updates.result
+++ b/mysql-test/suite/galera/r/pxc_log_slave_updates.result
@@ -1,0 +1,6 @@
+CREATE TABLE t1 (a INT PRIMARY KEY);
+CREATE TABLE t2 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+INSERT INTO t2 SELECT /*!99997*/ * FROM t1;
+include/assert.inc [node_1 should be alive and t2 should contain one row]
+DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/pxc_log_slave_updates.cnf
+++ b/mysql-test/suite/galera/t/pxc_log_slave_updates.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+log_slave_updates=ON

--- a/mysql-test/suite/galera/t/pxc_log_slave_updates.test
+++ b/mysql-test/suite/galera/t/pxc_log_slave_updates.test
@@ -1,0 +1,22 @@
+#
+# Test that executing INSERT INTO ... SELECT in TOI mode, like pt-table-checksum
+# tool does, does not cause cluster node to crash if started with 
+# log_slave_updates=ON option.
+#
+--source include/galera_cluster.inc
+
+--connection node_1
+CREATE TABLE t1 (a INT PRIMARY KEY);
+CREATE TABLE t2 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+
+--connection node_2
+INSERT INTO t2 SELECT /*!99997*/ * FROM t1;
+
+--connection node_1
+--let $assert_text = node_1 should be alive and t2 should contain one row
+--let $assert_cond = [SELECT COUNT(*) FROM t2] = 1
+--source include/assert.inc
+
+# cleanup
+DROP TABLE t1, t2;


### PR DESCRIPTION
Problem:
We have the case when REPLACE INTO ... SELECT or INSERT INTO ... SELECT
is executed as TOI. This is done by pt-table-checksum tool.
In such case statement execution causes InnoDB commit and storing of
xid_seqno (wsrep_apply_cb) and then because of TOI, storing of xid_seqno
is requested again from wsrep_commit_cb with the same xid_seqno.

Solution:
Allow current and new values be the same, without introducing new flags
and logic to prevent double storing	of the same value. This solution is
a backport of assertion condition from 8.0 branch.