### PR TITLE
8.0 PXC-3191 : cluster cannot update wsrep_* tables if in super_read_only

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_super_read_only.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_super_read_only.result
@@ -1,7 +1,60 @@
 SELECT 1;
 1
 1
+[connection node_2]
+"# restarting node2 (no SST)"
+# restart:<hidden args>
 SET SESSION wsrep_sync_wait = 0;
-# restart
-SET GLOBAL super_read_only = OFF;
-SET GLOBAL read_only = OFF;
+SELECT 1;
+1
+1
+include/assert_grep.inc [Could not find warnings about super-read-only]
+"# shutting down node2"
+SET SESSION wsrep_sync_wait = 0;
+"# restarting node2 (with SST)"
+# restart:<hidden args>
+SET SESSION wsrep_sync_wait = 0;
+SELECT 1;
+1
+1
+include/assert_grep.inc [Could not find warnings about super-read-only]
+"# shutting down node2"
+[connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+"# shutting down node1"
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+"# restarting node1 (bootstrapped with super-read-only)"
+# restart:<hidden args>
+SET SESSION wsrep_sync_wait = 0;
+SELECT 1;
+1
+1
+include/assert_grep.inc [Could not find warnings about super-read-only in the logs]
+[connection node_2]
+"# starting node2 (no SST)"
+# restart:<hidden args>
+SET SESSION wsrep_sync_wait = 0;
+SELECT 1;
+1
+1
+include/assert_grep.inc [Could not find warnings about super-read-only in the donor logs]
+include/assert_grep.inc [Could not find warnings about super-read-only in the joiner logs]
+[connection node_2]
+"# shutting down node2"
+SET SESSION wsrep_sync_wait = 0;
+"# restarting node2 (with SST)"
+# restart:<hidden args>
+SET SESSION wsrep_sync_wait = 0;
+SELECT 1;
+1
+1
+include/assert_grep.inc [Could not find warnings about super-read-only in the joiner logs]
+include/assert_grep.inc [Could not find warnings about super-read-only in the donor logs]
+"# restarting node1"
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+# restart:<hidden args>
+"# restarting node2"
+[connection node_2]
+# restart:<hidden args>

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_super_read_only.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_super_read_only.test
@@ -1,26 +1,235 @@
 #
-# This test checks the pxc-encrypt-cluster-traffic option (auto SSL config).
-# Initial SST happens via xtrabackup, so there is not much to do in the body of the test
+# This test checks that the cluster starts up (without error)
+# if super-read-only=ON.  This will check server startup
+# as well as the SST process.
 #
 
 --source include/big_test.inc
+--source include/have_util_sed.inc
 --source include/galera_cluster.inc
-
-SELECT 1;
 
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 --source include/wait_condition.inc
 
+SELECT 1;
+
+# --------------------------------
+# Test 1: Joiner node is super-read-only
+# --------------------------------
+
+--let $SUPER_READ_ONLY_CONFIG_FILE = $MYSQLTEST_VARDIR/tmp/galera_sst_xtrabackup-v2_super_read_only.test.cnf
+--copy_file $MYSQLTEST_VARDIR/my.cnf $SUPER_READ_ONLY_CONFIG_FILE
+--append_file $SUPER_READ_ONLY_CONFIG_FILE
+	[mysqld]
+	super_read_only=ON
+EOF
+
+# --------------------------------
+# Test 1a: Joiner (node2) is super-read-only (no SST)
+# --------------------------------
+
+# restart the node2 with super-read-only=ON (no SST)
 --connection node_2
+--echo [connection node_2]
+
+--echo "# restarting node2 (no SST)"
+--let $restart_hide_args=1
+--let $restart_parameters = "restart: --defaults-file=$SUPER_READ_ONLY_CONFIG_FILE"
+--source include/restart_mysqld.inc
+
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+SELECT 1;
+
+# We should not find the super-read-only warnings in the logs
+--let $assert_text = Could not find warnings about super-read-only
+--let $assert_select = super-read-only
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+
+# --------------------------------
+# Test 1b: Joiner (node2) is super-read-only (with SST)
+# --------------------------------
+--echo "# shutting down node2"
 SET SESSION wsrep_sync_wait = 0;
 --source include/shutdown_mysqld.inc
+
+# remove the grastate.dat file to force an SST
 --remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
---exec sed -i '/^\[mysqld.2\]/a super_read_only=ON' $MYSQLTEST_VARDIR/my.cnf
+
+# restart the server with super-read-only=ON (SST)
+--echo "# restarting node2 (with SST)"
+--let $restart_hide_args=1
+--let $start_mysqld_params = "--defaults-file=$SUPER_READ_ONLY_CONFIG_FILE"
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --source include/start_mysqld.inc
 
-#cleanup
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+SELECT 1;
+
+# We should not find the super-read-only warnings in the logs
+--let $assert_text = Could not find warnings about super-read-only
+--let $assert_select = super-read-only
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+
+# --------------------------------
+# Test 2: Bootstrapped node is super-read-only
+# Restart node1 (it should startup as bootstrapped)
+# --------------------------------
+
+# Shutdown the cluster
+--echo "# shutting down node2"
 --connection node_2
-SET GLOBAL super_read_only = OFF;
-SET GLOBAL read_only = OFF;
---exec sed -i '/^super_read_only=ON/d' $MYSQLTEST_VARDIR/my.cnf
+--echo [connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+--source include/shutdown_mysqld.inc
+
+--echo "# shutting down node1"
+--connection node_1
+--echo [connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+--source include/shutdown_mysqld.inc
+
+# ensure that we can startup with grastate.dat
+--exec $SED -i "s/safe_to_bootstrap:[ \t]*0/safe_to_bootstrap: 1/" $MYSQLTEST_VARDIR/mysqld.1/data/grastate.dat
+
+# restart node1 with super-read-only=ON (SST)
+--echo "# restarting node1 (bootstrapped with super-read-only)"
+--let $restart_hide_args=1
+--let $start_mysqld_params = "--defaults-file=$SUPER_READ_ONLY_CONFIG_FILE --wsrep-new-cluster"
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+SELECT 1;
+
+# We should not find the super-read-only warnings in the logs
+--let $assert_text = Could not find warnings about super-read-only in the logs
+--let $assert_select = super-read-only
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+
+# --------------------------------
+# Test 3: Donor node (node1) is super-read-only
+# --------------------------------
+
+# --------------------------------
+# Test 3a: Donor (node2) is super-read-only (no SST)
+# --------------------------------
+
+--connection node_2
+--echo [connection node_2]
+--echo "# starting node2 (no SST)"
+--let $restart_hide_args=1
+--let $start_mysqld_params = "--defaults-file=$SUPER_READ_ONLY_CONFIG_FILE"
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+SELECT 1;
+
+# We should not find the super-read-only warnings in the logs
+--let $assert_text = Could not find warnings about super-read-only in the donor logs
+--let $assert_select = super-read-only
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+# We should not find the super-read-only warnings in the logs
+--let $assert_text = Could not find warnings about super-read-only in the joiner logs
+--let $assert_select = super-read-only
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+# --------------------------------
+# Test 3b: Donor (node2) is super-read-only (with SST)
+# --------------------------------
+
+--connection node_2
+--echo [connection node_2]
+--echo "# shutting down node2"
+SET SESSION wsrep_sync_wait = 0;
+--source include/shutdown_mysqld.inc
+
+# remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# restart node2 with super-read-only=ON (SST)
+--echo "# restarting node2 (with SST)"
+--let $restart_hide_args=1
+--let $start_mysqld_params = "--defaults-file=$SUPER_READ_ONLY_CONFIG_FILE"
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+SELECT 1;
+
+# We should not find the super-read-only warnings in the logs
+--let $assert_text = Could not find warnings about super-read-only in the joiner logs
+--let $assert_select = super-read-only
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+# We should not find the super-read-only warnings in the logs
+--let $assert_text = Could not find warnings about super-read-only in the donor logs
+--let $assert_select = super-read-only
+--let $assert_count = 0
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+#cleanup
+--echo "# restarting node1"
+--connection node_1
+--echo [connection node_1]
+
+SET SESSION wsrep_sync_wait = 0;
+--source include/shutdown_mysqld.inc
+
+# ensure that we can bootstrap with grastate.dat
+--exec $SED -i "s/safe_to_bootstrap:[ \t]*0/safe_to_bootstrap: 1/" $MYSQLTEST_VARDIR/mysqld.1/data/grastate.dat
+
+# restart node1
+--let $restart_hide_args=1
+--let $start_mysqld_params = ""
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+
+
+--echo "# restarting node2"
+--connection node_2
+--echo [connection node_2]
+--let $restart_hide_args=1
+--let $restart_parameters = "restart:"
+--source include/restart_mysqld.inc
+
+--remove_file $SUPER_READ_ONLY_CONFIG_FILE

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -791,7 +791,7 @@ function run_post_processing_steps()
         --log-error=${mysqld_err_log} \
         --log_output=NONE \
         --server-id=1 \
-        --super_read_only=OFF \
+        --read_only=OFF --super_read_only=OFF \
         --pid-file=${mysql_upgrade_dir_path}/mysqld.pid \
         --socket=$upgrade_socket \
         --datadir=$datadir --wsrep_provider=none"

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -213,6 +213,10 @@ static int lock_tables_check(THD *thd, TABLE **tables, size_t count,
       performance_schema tables.
     */
     if (!(flags & MYSQL_LOCK_IGNORE_GLOBAL_READ_ONLY) && !t->s->tmp_table &&
+#ifdef WITH_WSREP
+        !is_wsrep_system_table(t->s->db.str, t->s->db.length,
+                               t->s->table_name.str, t->s->table_name.length) &&
+#endif /* WITH_WSREP */
         !is_perfschema_db(t->s->db.str, t->s->db.length)) {
       if (t->reginfo.lock_type >= TL_WRITE_ALLOW_WRITE &&
           check_readonly(thd, true))

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -349,6 +349,10 @@ bool some_non_temp_table_to_be_updated(THD *thd, TABLE_LIST *tables) {
       in readonly mode.
     */
     if (table->updating && !find_temporary_table(thd, table) &&
+#ifdef WITH_WSREP
+        !is_wsrep_system_table(table->db, table->db_length, table->table_name,
+                               table->table_name_length) &&
+#endif /* WITH_WSREP */
         !is_perfschema_db(table->db, table->db_length))
       return true;
   }
@@ -447,7 +451,7 @@ void init_sql_command_flags(void) {
   server_command_flags[COM_TIME] |= CF_SKIP_WSREP_CHECK;
   server_command_flags[COM_INIT_DB] |= CF_SKIP_WSREP_CHECK;
   server_command_flags[COM_END] |= CF_SKIP_WSREP_CHECK;
-  server_command_flags[COM_FIELD_LIST]   |= CF_SKIP_WSREP_CHECK;
+  server_command_flags[COM_FIELD_LIST] |= CF_SKIP_WSREP_CHECK;
 
   /*
     COM_QUERY and COM_SET_OPTION are allowed to pass the early COM_xxx filter,

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -159,6 +159,14 @@ LEX_CSTRING GTID_EXECUTED_NAME = {STRING_WITH_LEN("gtid_executed")};
 /* Keyword for parsing generated column functions */
 LEX_CSTRING PARSE_GCOL_KEYWORD = {STRING_WITH_LEN("parse_gcol_expr")};
 
+#ifdef WITH_WSREP
+/* WSREP schema DB name */
+LEX_CSTRING WSREP_DB_NAME = {STRING_WITH_LEN("mysql")};
+
+/* WSREP tablename prefix */
+LEX_CSTRING WSREP_TABLE_PREFIX = {STRING_WITH_LEN("wsrep_")};
+#endif /* WITH_WSREP */
+
 /* Functions defined in this file */
 
 static Item *create_view_field(THD *thd, TABLE_LIST *view, Item **field_ref,

--- a/sql/table.h
+++ b/sql/table.h
@@ -3930,6 +3930,12 @@ extern LEX_CSTRING RLI_INFO_NAME;
 extern LEX_CSTRING MI_INFO_NAME;
 extern LEX_CSTRING WORKER_INFO_NAME;
 
+#ifdef WITH_WSREP
+/* WSREP tables */
+extern LEX_CSTRING WSREP_DB_NAME;
+extern LEX_CSTRING WSREP_TABLE_PREFIX;
+#endif /* WITH_WSREP */
+
 inline bool is_infoschema_db(const char *name, size_t len) {
   return (
       INFORMATION_SCHEMA_NAME.length == len &&
@@ -3958,6 +3964,18 @@ inline bool is_user_table(TABLE *table) {
   const char *name = table->s->table_name.str;
   return strncmp(name, tmp_file_prefix, tmp_file_prefix_length);
 }
+
+#ifdef WITH_WSREP
+inline bool is_wsrep_system_table(const char *db_name, size_t db_len,
+                                  const char *table_name, size_t table_len) {
+  return (
+      WSREP_DB_NAME.length == db_len &&
+      !native_strncasecmp(db_name, WSREP_DB_NAME.str, WSREP_DB_NAME.length) &&
+      WSREP_TABLE_PREFIX.length < table_len &&
+      !native_strncasecmp(table_name, WSREP_TABLE_PREFIX.str,
+                          WSREP_TABLE_PREFIX.length));
+}
+#endif
 
 bool is_simple_order(ORDER *order);
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -344,6 +344,10 @@ PSI_file_info all_galera_files[] = {
 typedef std::vector<void *> wsrep_psi_key_vec_t;
 static wsrep_psi_key_vec_t wsrep_psi_key_vec;
 
+LEX_CSTRING PXC_INTERNAL_SESSION_USER = {
+    STRING_WITH_LEN("mysql.pxc.internal.session")};
+LEX_CSTRING PXC_INTERNAL_SESSION_HOST = {STRING_WITH_LEN("localhost")};
+
 /*!
  * @brief a callback to create PFS instrumented mutex/condition variables
  *
@@ -2284,16 +2288,16 @@ void wsrep_to_isolation_end(THD *thd) {
       wsrep_thd_client_state_str(req), wsrep_thd_transaction_state_str(req), \
       req->get_command(), req->lex->sql_command,                             \
       (req->rewritten_query().length()                                       \
-                ? wsrep_thd_rewritten_query(req).c_ptr_safe()                \
-                : req->query().str),                                         \
+           ? wsrep_thd_rewritten_query(req).c_ptr_safe()                     \
+           : req->query().str),                                              \
                                                                              \
       gra->thread_id(), (long long)wsrep_thd_trx_seqno(gra),                 \
       wsrep_thd_client_mode_str(gra), wsrep_thd_client_state_str(gra),       \
       wsrep_thd_transaction_state_str(gra), gra->get_command(),              \
       gra->lex->sql_command,                                                 \
       (gra->rewritten_query().length()                                       \
-            ? wsrep_thd_rewritten_query(gra).c_ptr_safe()                    \
-            : gra->query().str));
+           ? wsrep_thd_rewritten_query(gra).c_ptr_safe()                     \
+           : gra->query().str));
 
 bool wsrep_handle_mdl_conflict(const MDL_context *requestor_ctx,
                                MDL_ticket *ticket, const MDL_key *key) {
@@ -2541,7 +2545,4 @@ bool wsrep_consistency_check(THD *thd) {
  thd->rewritten_query() in place.
  This is to avoid interference of PXC specific part with generic server part.
  */
-String wsrep_thd_rewritten_query(THD *thd)
-{
-  return thd->rewritten_query();
-}
+String wsrep_thd_rewritten_query(THD *thd) { return thd->rewritten_query(); }

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -316,9 +316,9 @@ extern wsrep_seqno_t wsrep_locked_seqno;
     if (victim_thd) WSREP_LOG_CONFLICT_THD(victim_thd, "Victim thread");      \
   }
 
-#define WSREP_QUERY(thd)                                           \
-  ((!opt_general_log_raw) && thd->rewritten_query().length()       \
-       ? wsrep_thd_rewritten_query(thd).c_ptr_safe()               \
+#define WSREP_QUERY(thd)                                     \
+  ((!opt_general_log_raw) && thd->rewritten_query().length() \
+       ? wsrep_thd_rewritten_query(thd).c_ptr_safe()         \
        : thd->query().str)
 
 // Use this for logging output received from the SST scripts
@@ -535,5 +535,11 @@ class wsrep_scope_guard {
  private:
   std::function<void()> _scope_leave;
 };
+
+/**
+ * User/Host components for the PXC internal session user.
+ */
+extern LEX_CSTRING PXC_INTERNAL_SESSION_USER;
+extern LEX_CSTRING PXC_INTERNAL_SESSION_HOST;
 
 #endif /* WSREP_MYSQLD_H */

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1063,10 +1063,11 @@ static MYSQL_SESSION setup_server_session(bool initialize_thread) {
         "Failed to fetch the security context when contacting the server");
     return NULL;
   }
-  if (security_context_lookup(sc, "mysql.pxc.internal.session", "localhost",
-                              NULL, NULL)) {
+  if (security_context_lookup(sc, PXC_INTERNAL_SESSION_USER.str,
+                              PXC_INTERNAL_SESSION_HOST.str, NULL, NULL)) {
     cleanup_server_session(session, initialize_thread);
-    WSREP_ERROR("Error accessing server with user:mysql.pxc.internal.session");
+    WSREP_ERROR("Error accessing server with user:%s@%s",
+                PXC_INTERNAL_SESSION_USER.str, PXC_INTERNAL_SESSION_HOST.str);
     return NULL;
   }
   // Turn wsrep off here (because the server session has it's own THD object)

--- a/storage/innobase/lock/lock0wait.cc
+++ b/storage/innobase/lock/lock0wait.cc
@@ -209,8 +209,8 @@ static bool wsrep_is_BF_lock_timeout(trx_t *trx) {
                << " Trx id: " << trx_get_id_for_print(trx)
                << " WSREP trx_id: " << wsrep_thd_transaction_id(trx->mysql_thd)
                << " Seqno: " << wsrep_thd_trx_seqno(trx->mysql_thd) << "\n"
-               << " Query: " << innobase_get_stmt_unsafe(trx->mysql_thd,
-                                                         &unused);
+               << " Query: "
+               << innobase_get_stmt_unsafe(trx->mysql_thd, &unused);
     srv_print_innodb_monitor = true;
     srv_print_innodb_lock_monitor = true;
     os_event_set(srv_monitor_event);


### PR DESCRIPTION
Issue
If super-read-only=ON, the system cannot start up correctly. There are
two problems (1) we cannot modify the wsrep_xxx system tables and (2) the
SST donor cannot create/modify the mysql.pxc.sst.user to perform the
backup

Solution
(1) skip the readonly checks if we are modifying a wsrep_xxx table
(2) skip the readonly checks if we are running as the PXC internal
    session user.