### PR TITLE
PXC-3445 : MTR test failures in 8.0.20

### DIFF
--- a/mysql-test/suite/galera/t/MW-328B.test
+++ b/mysql-test/suite/galera/t/MW-328B.test
@@ -19,8 +19,10 @@ SET SESSION wsrep_retry_autocommit = 0;
 
 while ($count)
 {
-  --error 0,ER_LOCK_DEADLOCK
+  --disable_warnings
+  --error 0,ER_LOCK_DEADLOCK,ER_ERROR_DURING_COMMIT
   INSERT IGNORE INTO t2 SELECT f2 FROM t1;
+  --enable_warnings
 
   --disable_result_log
   --error 0

--- a/mysql-test/suite/galera_sr/r/galera-features#56.result
+++ b/mysql-test/suite/galera_sr/r/galera-features#56.result
@@ -29,6 +29,10 @@ COUNT(*) = 5
 #node-1
 DROP TABLE t1;
 DROP TABLE ten;
+#node-1
+CALL mtr.add_suppression("Failed to init table");
+CALL mtr.add_suppression("Error deleting row");
+CALL mtr.add_suppression("init_for_index_scan failed to read first record");
 #node-2
 CALL mtr.add_suppression("Failed to init table");
 CALL mtr.add_suppression("Error deleting row");

--- a/mysql-test/suite/galera_sr/t/galera-features#56.test
+++ b/mysql-test/suite/galera_sr/t/galera-features#56.test
@@ -63,9 +63,16 @@ SELECT COUNT(*) = 5 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system use
 DROP TABLE t1;
 DROP TABLE ten;
 
+--connection node_1
+--echo #node-1
+# These error messages can appear if the node op is BF-aborted
+CALL mtr.add_suppression("Failed to init table");
+CALL mtr.add_suppression("Error deleting row");
+CALL mtr.add_suppression("init_for_index_scan failed to read first record");
+
 --connection node_2
 --echo #node-2
-# These error messages can appear if the node2 op is BF-aborted
+# These error messages can appear if the node op is BF-aborted
 CALL mtr.add_suppression("Failed to init table");
 CALL mtr.add_suppression("Error deleting row");
 CALL mtr.add_suppression("init_for_index_scan failed to read first record");


### PR DESCRIPTION
Issue
Tests fail (sometimes) in PXC 8.0.20

Solution
Fix the tests:
galera.MW-328B : code can fail with ER_ERROR_DURING_COMMIT due to locking changes
galera_sr.galera-features#56 : code can fail on both nodes (but more often on node2)