### PR TITLE
8.0 PXC-3146 : Galera/SST is not looking default data directory location …

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_pxc_encrypt.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_pxc_encrypt.result
@@ -1,3 +1,13 @@
 SELECT 1;
 1
 1
+[connection node_2]
+# Restart node2 using relative paths for SSL certs
+# Shutting down node2
+# restarting node2 (with SST)
+# restart:--defaults-file=RELATIVE_SSL_CERTS_FILE
+SET SESSION wsrep_sync_wait = 0;
+SELECT 1;
+1
+1
+# restart:<hidden args>

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_pxc_encrypt.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_pxc_encrypt.test
@@ -2,20 +2,75 @@
 # This test checks the pxc-encrypt-cluster-traffic option (auto SSL config).
 # Initial SST happens via xtrabackup, so there is not much to do in the body of the test
 #
+# Also tests certs that are specified using relative paths (certs are in the datadir)
+#
 
 --source include/big_test.inc
 --source include/galera_cluster.inc
 
---disable_query_log
---connection node_1
-call mtr.add_suppression("Failed to initialize TLS for channel");
-call mtr.add_suppression("Failed to set up SSL because");
---connection node_2
-call mtr.add_suppression("Failed to initialize TLS for channel");
-call mtr.add_suppression("Failed to set up SSL because");
---enable_query_log
+# --------------------------------
+# Test 1: Just check that the cluster started correctly.
+# --------------------------------
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
 
 SELECT 1;
 
+# --------------------------------
+# Test 2: Test that the server starts up with SSL certs specified
+# using relative paths (place the certs in the datadir)
+# --------------------------------
+
+# Create cnf file with relative paths
+--let $RELATIVE_SSL_CERTS_FILE = $MYSQLTEST_VARDIR/tmp/galera_sst_xtrabackup-v2_pxc_encrypt.test.cnf
+--copy_file $MYSQLTEST_VARDIR/my.cnf $RELATIVE_SSL_CERTS_FILE
+--append_file $RELATIVE_SSL_CERTS_FILE
+	[mysqld]
+	ssl-ca=cacert.pem
+	ssl-key=server-key.pem
+	ssl-cert=server-cert.pem
+
+	[sst]
+	ssl_dhparams=dhparams.pem
+EOF
+
+--connection node_2
+--echo [connection node_2]
+--let $MYSQLD_DATADIR=`SELECT @@datadir`
+
+# copy over the server-side PEM files needed for SSL
+--copy_file $MYSQL_TEST_DIR/std_data/cacert.pem $MYSQLD_DATADIR/cacert.pem
+--copy_file $MYSQL_TEST_DIR/std_data/server-cert.pem $MYSQLD_DATADIR/server-cert.pem
+--copy_file $MYSQL_TEST_DIR/std_data/server-key.pem $MYSQLD_DATADIR/server-key.pem
+--copy_file $MYSQL_TEST_DIR/std_data/dhparams.pem $MYSQLD_DATADIR/dhparams.pem
+
+--echo # Restart node2 using relative paths for SSL certs
+--echo # Shutting down node2
+--source include/shutdown_mysqld.inc
+
+# remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# restart the server with relative cert paths (SST)
+--echo # restarting node2 (with SST)
+--let $start_mysqld_params = "--defaults-file=$RELATIVE_SSL_CERTS_FILE"
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--replace_result $RELATIVE_SSL_CERTS_FILE RELATIVE_SSL_CERTS_FILE
+--source include/start_mysqld.inc
+
+SET SESSION wsrep_sync_wait = 0;
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 --source include/wait_condition.inc
+
+SELECT 1;
+
+# cleanup
+--let $restart_hide_args=1
+--let $restart_parameters = "restart:"
+--source include/restart_mysqld.inc
+
+--remove_file $MYSQLD_DATADIR/cacert.pem
+--remove_file $MYSQLD_DATADIR/server-cert.pem
+--remove_file $MYSQLD_DATADIR/server-key.pem
+--remove_file $MYSQLD_DATADIR/dhparams.pem
+--remove_file $RELATIVE_SSL_CERTS_FILE

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -998,3 +998,32 @@ function cat_file_to_stderr()
     cat $file_path >&2
     echo "EOF:" >&2
 }
+
+
+# Returns the absolute path from a path to a file (with a filename)
+#   If a relative path is given as an argument, the absolute path
+#   is generated from the current path.
+#
+# Globals:
+#   None
+#
+# Parameters:
+#   Argument 1: path to a file
+#
+# Returns 0 if successful (path exists) and the absolute path is output.
+# Returns non-zero otherwise
+#
+function get_absolute_path()
+{
+    local path="$1"
+    local abs_path retvalue
+    local filename
+
+    filename=$(basename "${path}")
+    abs_path=$(cd "$(dirname "${path}")" && pwd)
+    retvalue=$?
+    [[ $retvalue -ne 0 ]] && return $retvalue
+
+    printf "%s/%s" "${abs_path}" "${filename}"
+    return 0
+}


### PR DESCRIPTION
…for SSL certs

Issue
SST does not use relative paths in the SSL key/cert/ca options.
So it requires the full absolute path.

Solution
Have the SST script convert the relative paths into absolute paths
(assuming that the current working directory is the data dir).