### PR TITLE
[8.0] PXC-3418: Cluster node locked up with alter table and concurrent RW load

### DIFF
--- a/mysql-test/suite/galera/r/galera_alter_table_big.result
+++ b/mysql-test/suite/galera/r/galera_alter_table_big.result
@@ -1,0 +1,4452 @@
+SET sql_mode = 'NO_ENGINE_SUBSTITUTION';
+SET SESSION information_schema_stats_expiry=0;
+create table t1 (
+col1 int not null auto_increment primary key,
+col2 varchar(30) not null,
+col3 varchar (20) not null,
+col4 varchar(4) not null,
+col5 enum('PENDING', 'ACTIVE', 'DISABLED') not null,
+col6 int not null, to_be_deleted int);
+insert into t1 values (2,4,3,5,"PENDING",1,7);
+alter table t1
+add column col4_5 varchar(20) not null after col4,
+add column col7 varchar(30) not null after col5,
+add column col8 datetime not null, drop column to_be_deleted,
+change column col2 fourth varchar(30) not null after col3,
+modify column col6 int not null first;
+select * from t1;
+col6	col1	col3	fourth	col4	col4_5	col5	col7	col8
+1	2	3	4	5		PENDING		0000-00-00 00:00:00
+drop table t1;
+create table t1 (bandID MEDIUMINT UNSIGNED NOT NULL PRIMARY KEY, payoutID SMALLINT UNSIGNED NOT NULL) engine=myisam;
+insert into t1 (bandID,payoutID) VALUES (1,6),(2,6),(3,4),(4,9),(5,10),(6,1),(7,12),(8,12);
+alter table t1 add column new_col int, order by payoutid,bandid;
+select * from t1;
+bandID	payoutID	new_col
+6	1	NULL
+3	4	NULL
+1	6	NULL
+2	6	NULL
+4	9	NULL
+5	10	NULL
+7	12	NULL
+8	12	NULL
+alter table t1 order by bandid,payoutid;
+select * from t1;
+bandID	payoutID	new_col
+1	6	NULL
+2	6	NULL
+3	4	NULL
+4	9	NULL
+5	10	NULL
+6	1	NULL
+7	12	NULL
+8	12	NULL
+drop table t1;
+create table t1 (bandID MEDIUMINT UNSIGNED NOT NULL PRIMARY KEY, payoutID SMALLINT UNSIGNED NOT NULL) engine=InnoDB;
+insert into t1 (bandID,payoutID) VALUES (1,6),(2,6),(3,4),(4,9),(5,10),(6,1),(7,12),(8,12);
+alter table t1 add column new_col int, order by payoutid,bandid;
+Warnings:
+Warning	1105	ORDER BY ignored as there is a user-defined clustered index in the table 't1'
+select * from t1;
+bandID	payoutID	new_col
+1	6	NULL
+2	6	NULL
+3	4	NULL
+4	9	NULL
+5	10	NULL
+6	1	NULL
+7	12	NULL
+8	12	NULL
+alter table t1 order by bandid,payoutid;
+Warnings:
+Warning	1105	ORDER BY ignored as there is a user-defined clustered index in the table 't1'
+select * from t1;
+bandID	payoutID	new_col
+1	6	NULL
+2	6	NULL
+3	4	NULL
+4	9	NULL
+5	10	NULL
+6	1	NULL
+7	12	NULL
+8	12	NULL
+drop table t1;
+CREATE TABLE t1 (
+GROUP_ID int(10) unsigned DEFAULT '0' NOT NULL,
+LANG_ID smallint(5) unsigned DEFAULT '0' NOT NULL,
+NAME varchar(80) DEFAULT '' NOT NULL,
+PRIMARY KEY (GROUP_ID,LANG_ID),
+KEY NAME (NAME));
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+ALTER TABLE t1 CHANGE NAME NAME CHAR(80) not null;
+SHOW FULL COLUMNS FROM t1;
+Field	Type	Collation	Null	Key	Default	Extra	Privileges	Comment
+GROUP_ID	int unsigned	NULL	NO	PRI	0		#	
+LANG_ID	smallint unsigned	NULL	NO	PRI	0		#	
+NAME	char(80)	utf8mb4_0900_ai_ci	NO	MUL	NULL		#	
+DROP TABLE t1;
+create table t1 (n int);
+insert into t1 values(9),(3),(12),(10);
+alter table t1 order by n;
+select * from t1;
+n
+3
+9
+10
+12
+drop table t1;
+CREATE TABLE t1 (
+id int(11) unsigned NOT NULL default '0',
+category_id tinyint(4) unsigned NOT NULL default '0',
+type_id tinyint(4) unsigned NOT NULL default '0',
+body text NOT NULL,
+user_id int(11) unsigned NOT NULL default '0',
+status enum('new','old') NOT NULL default 'new',
+PRIMARY KEY (id)
+) ENGINE=MyISAM;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+ALTER TABLE t1 ORDER BY t1.id, t1.status, t1.type_id, t1.user_id, t1.body;
+DROP TABLE t1;
+CREATE TABLE t1 (AnamneseId int(10) unsigned NOT NULL auto_increment,B BLOB,PRIMARY KEY (AnamneseId)) engine=myisam;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+insert into t1 values (null,"hello");
+LOCK TABLES t1 WRITE;
+ALTER TABLE t1 ADD Column new_col int not null;
+UNLOCK TABLES;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+DROP TABLE t1;
+create table t1 (i int unsigned not null auto_increment primary key);
+insert into t1 values (null),(null),(null),(null);
+alter table t1 drop i,add i int unsigned not null auto_increment, drop primary key, add primary key (i);
+select * from t1;
+i
+1
+2
+3
+4
+drop table t1;
+create table t1 (name char(15));
+insert into t1 (name) values ("current");
+create database mysqltest;
+create table mysqltest.t1 (name char(15));
+insert into mysqltest.t1 (name) values ("mysqltest");
+select * from t1;
+name
+current
+select * from mysqltest.t1;
+name
+mysqltest
+alter table t1 rename mysqltest.t1;
+ERROR 42S01: Table 't1' already exists
+select * from t1;
+name
+current
+select * from mysqltest.t1;
+name
+mysqltest
+drop table t1;
+drop database mysqltest;
+create table t1 (n1 int not null, n2 int, n3 int, n4 float,
+unique(n1),
+key (n1, n2, n3, n4),
+key (n2, n3, n4, n1),
+key (n3, n4, n1, n2),
+key (n4, n1, n2, n3) ) engine=Myisam;
+alter table t1 disable keys;
+show keys from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	n1	1	n1	A	0	NULL	NULL		BTREE			YES	NULL
+t1	1	n1_2	1	n1	A	NULL	NULL	NULL		BTREE	disabled		YES	NULL
+t1	1	n1_2	2	n2	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n1_2	3	n3	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n1_2	4	n4	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n2	1	n2	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n2	2	n3	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n2	3	n4	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n2	4	n1	A	NULL	NULL	NULL		BTREE	disabled		YES	NULL
+t1	1	n3	1	n3	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n3	2	n4	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n3	3	n1	A	NULL	NULL	NULL		BTREE	disabled		YES	NULL
+t1	1	n3	4	n2	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n4	1	n4	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n4	2	n1	A	NULL	NULL	NULL		BTREE	disabled		YES	NULL
+t1	1	n4	3	n2	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+t1	1	n4	4	n3	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+insert into t1 values(10,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(9,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(8,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(7,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(6,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(5,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(4,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(3,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(2,RAND()*1000,RAND()*1000,RAND());
+insert into t1 values(1,RAND()*1000,RAND()*1000,RAND());
+alter table t1 enable keys;
+show keys from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	n1	1	n1	A	10	NULL	NULL		BTREE			YES	NULL
+t1	1	n1_2	1	n1	A	10	NULL	NULL		BTREE			YES	NULL
+t1	1	n1_2	2	n2	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n1_2	3	n3	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n1_2	4	n4	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n2	1	n2	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n2	2	n3	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n2	3	n4	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n2	4	n1	A	10	NULL	NULL		BTREE			YES	NULL
+t1	1	n3	1	n3	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n3	2	n4	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n3	3	n1	A	10	NULL	NULL		BTREE			YES	NULL
+t1	1	n3	4	n2	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n4	1	n4	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n4	2	n1	A	10	NULL	NULL		BTREE			YES	NULL
+t1	1	n4	3	n2	A	10	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	n4	4	n3	A	10	NULL	NULL	YES	BTREE			YES	NULL
+drop table t1;
+create table t1 (i int unsigned not null auto_increment primary key);
+alter table t1 rename t2;
+alter table t2 rename t1, add c char(10) comment "no comment";
+show columns from t1;
+Field	Type	Null	Key	Default	Extra
+i	int unsigned	NO	PRI	NULL	auto_increment
+c	char(10)	YES		NULL	
+drop table t1;
+create table t1 (a int, b int);
+insert into t1 values(1,100), (2,100), (3, 100);
+insert into t1 values(1,99), (2,99), (3, 99);
+insert into t1 values(1,98), (2,98), (3, 98);
+insert into t1 values(1,97), (2,97), (3, 97);
+insert into t1 values(1,96), (2,96), (3, 96);
+insert into t1 values(1,95), (2,95), (3, 95);
+insert into t1 values(1,94), (2,94), (3, 94);
+insert into t1 values(1,93), (2,93), (3, 93);
+insert into t1 values(1,92), (2,92), (3, 92);
+insert into t1 values(1,91), (2,91), (3, 91);
+insert into t1 values(1,90), (2,90), (3, 90);
+insert into t1 values(1,89), (2,89), (3, 89);
+insert into t1 values(1,88), (2,88), (3, 88);
+insert into t1 values(1,87), (2,87), (3, 87);
+insert into t1 values(1,86), (2,86), (3, 86);
+insert into t1 values(1,85), (2,85), (3, 85);
+insert into t1 values(1,84), (2,84), (3, 84);
+insert into t1 values(1,83), (2,83), (3, 83);
+insert into t1 values(1,82), (2,82), (3, 82);
+insert into t1 values(1,81), (2,81), (3, 81);
+insert into t1 values(1,80), (2,80), (3, 80);
+insert into t1 values(1,79), (2,79), (3, 79);
+insert into t1 values(1,78), (2,78), (3, 78);
+insert into t1 values(1,77), (2,77), (3, 77);
+insert into t1 values(1,76), (2,76), (3, 76);
+insert into t1 values(1,75), (2,75), (3, 75);
+insert into t1 values(1,74), (2,74), (3, 74);
+insert into t1 values(1,73), (2,73), (3, 73);
+insert into t1 values(1,72), (2,72), (3, 72);
+insert into t1 values(1,71), (2,71), (3, 71);
+insert into t1 values(1,70), (2,70), (3, 70);
+insert into t1 values(1,69), (2,69), (3, 69);
+insert into t1 values(1,68), (2,68), (3, 68);
+insert into t1 values(1,67), (2,67), (3, 67);
+insert into t1 values(1,66), (2,66), (3, 66);
+insert into t1 values(1,65), (2,65), (3, 65);
+insert into t1 values(1,64), (2,64), (3, 64);
+insert into t1 values(1,63), (2,63), (3, 63);
+insert into t1 values(1,62), (2,62), (3, 62);
+insert into t1 values(1,61), (2,61), (3, 61);
+insert into t1 values(1,60), (2,60), (3, 60);
+insert into t1 values(1,59), (2,59), (3, 59);
+insert into t1 values(1,58), (2,58), (3, 58);
+insert into t1 values(1,57), (2,57), (3, 57);
+insert into t1 values(1,56), (2,56), (3, 56);
+insert into t1 values(1,55), (2,55), (3, 55);
+insert into t1 values(1,54), (2,54), (3, 54);
+insert into t1 values(1,53), (2,53), (3, 53);
+insert into t1 values(1,52), (2,52), (3, 52);
+insert into t1 values(1,51), (2,51), (3, 51);
+insert into t1 values(1,50), (2,50), (3, 50);
+insert into t1 values(1,49), (2,49), (3, 49);
+insert into t1 values(1,48), (2,48), (3, 48);
+insert into t1 values(1,47), (2,47), (3, 47);
+insert into t1 values(1,46), (2,46), (3, 46);
+insert into t1 values(1,45), (2,45), (3, 45);
+insert into t1 values(1,44), (2,44), (3, 44);
+insert into t1 values(1,43), (2,43), (3, 43);
+insert into t1 values(1,42), (2,42), (3, 42);
+insert into t1 values(1,41), (2,41), (3, 41);
+insert into t1 values(1,40), (2,40), (3, 40);
+insert into t1 values(1,39), (2,39), (3, 39);
+insert into t1 values(1,38), (2,38), (3, 38);
+insert into t1 values(1,37), (2,37), (3, 37);
+insert into t1 values(1,36), (2,36), (3, 36);
+insert into t1 values(1,35), (2,35), (3, 35);
+insert into t1 values(1,34), (2,34), (3, 34);
+insert into t1 values(1,33), (2,33), (3, 33);
+insert into t1 values(1,32), (2,32), (3, 32);
+insert into t1 values(1,31), (2,31), (3, 31);
+insert into t1 values(1,30), (2,30), (3, 30);
+insert into t1 values(1,29), (2,29), (3, 29);
+insert into t1 values(1,28), (2,28), (3, 28);
+insert into t1 values(1,27), (2,27), (3, 27);
+insert into t1 values(1,26), (2,26), (3, 26);
+insert into t1 values(1,25), (2,25), (3, 25);
+insert into t1 values(1,24), (2,24), (3, 24);
+insert into t1 values(1,23), (2,23), (3, 23);
+insert into t1 values(1,22), (2,22), (3, 22);
+insert into t1 values(1,21), (2,21), (3, 21);
+insert into t1 values(1,20), (2,20), (3, 20);
+insert into t1 values(1,19), (2,19), (3, 19);
+insert into t1 values(1,18), (2,18), (3, 18);
+insert into t1 values(1,17), (2,17), (3, 17);
+insert into t1 values(1,16), (2,16), (3, 16);
+insert into t1 values(1,15), (2,15), (3, 15);
+insert into t1 values(1,14), (2,14), (3, 14);
+insert into t1 values(1,13), (2,13), (3, 13);
+insert into t1 values(1,12), (2,12), (3, 12);
+insert into t1 values(1,11), (2,11), (3, 11);
+insert into t1 values(1,10), (2,10), (3, 10);
+insert into t1 values(1,9), (2,9), (3, 9);
+insert into t1 values(1,8), (2,8), (3, 8);
+insert into t1 values(1,7), (2,7), (3, 7);
+insert into t1 values(1,6), (2,6), (3, 6);
+insert into t1 values(1,5), (2,5), (3, 5);
+insert into t1 values(1,4), (2,4), (3, 4);
+insert into t1 values(1,3), (2,3), (3, 3);
+insert into t1 values(1,2), (2,2), (3, 2);
+insert into t1 values(1,1), (2,1), (3, 1);
+alter table t1 add unique (a,b), add key (b);
+show keys from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	3	NULL	NULL	YES	BTREE			YES	NULL
+t1	0	a	2	b	A	300	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	100	NULL	NULL	YES	BTREE			YES	NULL
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+show keys from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	3	NULL	NULL	YES	BTREE			YES	NULL
+t1	0	a	2	b	A	300	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	100	NULL	NULL	YES	BTREE			YES	NULL
+drop table t1;
+CREATE TABLE t1 (
+Host varchar(16) binary NOT NULL default '',
+User varchar(16) binary NOT NULL default '',
+PRIMARY KEY  (Host,User)
+) ENGINE=MyISAM;
+Warnings:
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+ALTER TABLE t1 DISABLE KEYS;
+LOCK TABLES t1 WRITE;
+INSERT INTO t1 VALUES ('localhost','root'),('localhost',''),('games','monty');
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	PRIMARY	1	Host	A	NULL	NULL	NULL		BTREE			YES	NULL
+t1	0	PRIMARY	2	User	A	0	NULL	NULL		BTREE			YES	NULL
+ALTER TABLE t1 ENABLE KEYS;
+UNLOCK TABLES;
+CHECK TABLES t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;
+CREATE TABLE t1 (
+Host varchar(16) binary NOT NULL default '',
+User varchar(16) binary NOT NULL default '',
+PRIMARY KEY  (Host,User),
+KEY  (Host)
+) ENGINE=MyISAM;
+Warnings:
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+ALTER TABLE t1 DISABLE KEYS;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	PRIMARY	1	Host	A	NULL	NULL	NULL		BTREE			YES	NULL
+t1	0	PRIMARY	2	User	A	0	NULL	NULL		BTREE			YES	NULL
+t1	1	Host	1	Host	A	NULL	NULL	NULL		BTREE	disabled		YES	NULL
+LOCK TABLES t1 WRITE;
+INSERT INTO t1 VALUES ('localhost','root'),('localhost','');
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	PRIMARY	1	Host	A	NULL	NULL	NULL		BTREE			YES	NULL
+t1	0	PRIMARY	2	User	A	0	NULL	NULL		BTREE			YES	NULL
+t1	1	Host	1	Host	A	NULL	NULL	NULL		BTREE	disabled		YES	NULL
+ALTER TABLE t1 ENABLE KEYS;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	PRIMARY	1	Host	A	NULL	NULL	NULL		BTREE			YES	NULL
+t1	0	PRIMARY	2	User	A	2	NULL	NULL		BTREE			YES	NULL
+t1	1	Host	1	Host	A	1	NULL	NULL		BTREE			YES	NULL
+UNLOCK TABLES;
+CHECK TABLES t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+LOCK TABLES t1 WRITE;
+ALTER TABLE t1 RENAME t2;
+UNLOCK TABLES;
+select * from t2;
+Host	User
+localhost	
+localhost	root
+DROP TABLE t2;
+CREATE TABLE t1 (
+Host varchar(16) binary NOT NULL default '',
+User varchar(16) binary NOT NULL default '',
+PRIMARY KEY  (Host,User),
+KEY  (Host)
+) ENGINE=MyISAM;
+Warnings:
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+LOCK TABLES t1 WRITE;
+ALTER TABLE t1 DISABLE KEYS;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	PRIMARY	1	Host	A	NULL	NULL	NULL		BTREE			YES	NULL
+t1	0	PRIMARY	2	User	A	0	NULL	NULL		BTREE			YES	NULL
+t1	1	Host	1	Host	A	NULL	NULL	NULL		BTREE	disabled		YES	NULL
+DROP TABLE t1;
+create table t1 (a int);
+alter table t1 rename to ``;
+ERROR 42000: Incorrect table name ''
+rename table t1 to ``;
+ERROR 42000: Incorrect table name ''
+drop table t1;
+drop table if exists t1, t2;
+Warnings:
+Note	1051	Unknown table 'test.t1'
+Note	1051	Unknown table 'test.t2'
+create table t1 ( a varchar(10) not null primary key ) engine=myisam;
+create table t2 ( a varchar(10) not null primary key ) engine=merge union=(t1);
+flush tables;
+alter table t1 modify a varchar(10);
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `a` varchar(10) NOT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=MRG_MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci UNION=(`t1`)
+flush tables;
+alter table t1 modify a varchar(10) not null;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `a` varchar(10) NOT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=MRG_MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci UNION=(`t1`)
+drop table if exists t1, t2;
+create table t1 (a int, b int, c int, d int, e int, f int, g int, h int,i int, primary key (a,b,c,d,e,f,g,i,h)) engine=MyISAM;
+insert into t1 (a) values(1);
+Warnings:
+Warning	1364	Field 'b' doesn't have a default value
+Warning	1364	Field 'c' doesn't have a default value
+Warning	1364	Field 'd' doesn't have a default value
+Warning	1364	Field 'e' doesn't have a default value
+Warning	1364	Field 'f' doesn't have a default value
+Warning	1364	Field 'g' doesn't have a default value
+Warning	1364	Field 'h' doesn't have a default value
+Warning	1364	Field 'i' doesn't have a default value
+show table status like 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	MyISAM	10	Fixed	1	37	X	X	X	X	X	X	X	X	utf8mb4_0900_ai_ci	NULL		
+alter table t1 modify a int;
+show table status like 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	MyISAM	10	Fixed	1	37	X	X	X	X	X	X	X	X	utf8mb4_0900_ai_ci	NULL		
+drop table t1;
+create table t1 (a int not null, b int not null, c int not null, d int not null, e int not null, f int not null, g int not null, h int not null,i int not null, primary key (a,b,c,d,e,f,g,i,h)) engine=MyISAM;
+insert into t1 (a) values(1);
+Warnings:
+Warning	1364	Field 'b' doesn't have a default value
+Warning	1364	Field 'c' doesn't have a default value
+Warning	1364	Field 'd' doesn't have a default value
+Warning	1364	Field 'e' doesn't have a default value
+Warning	1364	Field 'f' doesn't have a default value
+Warning	1364	Field 'g' doesn't have a default value
+Warning	1364	Field 'h' doesn't have a default value
+Warning	1364	Field 'i' doesn't have a default value
+show table status like 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	MyISAM	10	Fixed	1	37	X	X	X	X	X	X	X	X	utf8mb4_0900_ai_ci	NULL		
+drop table t1;
+set names koi8r;
+create table t1 (a char(10) character set koi8r);
+insert into t1 values ('����');
+Warnings:
+Warning	1265	Data truncated for column 'a' at row 1
+select a,hex(a) from t1;
+a	hex(a)
+����	EFBFBDEFBFBDEFBFBDEF
+alter table t1 change a a char(10) character set cp1251;
+Warnings:
+Warning	1366	Incorrect string value: '\xBD\xEF\xBF\xBD\xEF\xBF...' for column 'a' at row 1
+select a,hex(a) from t1;
+a	hex(a)
+�?�?�?�	CEA93FCEA93FCEA93FCE
+alter table t1 change a a binary(4);
+Warnings:
+Warning	1265	Data truncated for column 'a' at row 1
+select a,hex(a) from t1;
+a	hex(a)
+Ω?�	CEA93FCE
+alter table t1 change a a char(10) character set cp1251;
+select a,hex(a) from t1;
+a	hex(a)
+�?�	CEA93FCE
+alter table t1 change a a char(10) character set koi8r;
+select a,hex(a) from t1;
+a	hex(a)
+�?�	EFBF3FEF
+alter table t1 change a a varchar(10) character set cp1251;
+select a,hex(a) from t1;
+a	hex(a)
+�?�	CEA93FCE
+alter table t1 change a a char(10) character set koi8r;
+select a,hex(a) from t1;
+a	hex(a)
+�?�	EFBF3FEF
+alter table t1 change a a text character set cp1251;
+select a,hex(a) from t1;
+a	hex(a)
+�?�	CEA93FCE
+alter table t1 change a a char(10) character set koi8r;
+select a,hex(a) from t1;
+a	hex(a)
+�?�	EFBF3FEF
+delete from t1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` char(10) CHARACTER SET koi8r COLLATE koi8r_general_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 DEFAULT CHARACTER SET latin1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` char(10) CHARACTER SET koi8r COLLATE koi8r_general_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+alter table t1 CONVERT TO CHARACTER SET latin1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` char(10) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+alter table t1 DEFAULT CHARACTER SET cp1251;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` char(10) CHARACTER SET latin1 COLLATE latin1_swedish_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=cp1251
+drop table t1;
+create table t1 (myblob longblob,mytext longtext)
+default charset latin1 collate latin1_general_cs;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `myblob` longblob,
+  `mytext` longtext COLLATE latin1_general_cs
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs
+alter table t1 character set latin2;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `myblob` longblob,
+  `mytext` longtext CHARACTER SET latin1 COLLATE latin1_general_cs
+) ENGINE=InnoDB DEFAULT CHARSET=latin2
+drop table t1;
+CREATE TABLE t1 (a int PRIMARY KEY, b INT UNIQUE);
+ALTER TABLE t1 DROP PRIMARY KEY;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  UNIQUE KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 DROP PRIMARY KEY;
+ERROR 42000: Can't DROP 'PRIMARY'; check that column/key exists
+DROP TABLE t1;
+create table t1 (a int, b int, key(a));
+insert into t1 values (1,1), (2,2);
+alter table t1 drop key no_such_key;
+ERROR 42000: Can't DROP 'no_such_key'; check that column/key exists
+alter table t1 drop key a;
+drop table t1;
+CREATE TABLE T12207(a int) ENGINE=MYISAM;
+ALTER TABLE T12207 DISCARD TABLESPACE;
+ERROR HY000: Table storage engine for 'T12207' doesn't have this option
+DROP TABLE T12207;
+create table t1 (a text) character set koi8r;
+insert into t1 values (_koi8r'����');
+select hex(a) from t1;
+hex(a)
+EFBFBDEFBFBDEFBFBDEFBFBD
+alter table t1 convert to character set cp1251;
+Warnings:
+Warning	1366	Incorrect string value: '\xBD\xEF\xBF\xBD\xEF\xBF...' for column 'a' at row 1
+select hex(a) from t1;
+hex(a)
+CEA93FCEA93FCEA93FCEA93F
+drop table t1;
+create table t1 ( a timestamp );
+alter table t1 add unique ( a(1) );
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+drop table t1;
+create table t1 (a int, key(a)) engine=myisam;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+"this used not to disable the index"
+alter table t1 modify a int, disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+alter table t1 enable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+alter table t1 modify a bigint, disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+alter table t1 enable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+alter table t1 add b char(10), disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+alter table t1 add c decimal(10,2), enable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+"this however did"
+alter table t1 disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+desc t1;
+Field	Type	Null	Key	Default	Extra
+a	bigint	YES	MUL	NULL	
+b	char(10)	YES		NULL	
+c	decimal(10,2)	YES		NULL	
+alter table t1 add d decimal(15,5);
+"The key should still be disabled"
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+drop table t1;
+"Now will test with one unique index"
+create table t1(a int, b char(10), unique(a)) engine=myisam;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+alter table t1 disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+alter table t1 enable keys;
+"If no copy on noop change, this won't touch the data file"
+"Unique index, no change"
+alter table t1 modify a int, disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+"Change the type implying data copy"
+"Unique index, no change"
+alter table t1 modify a bigint, disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+alter table t1 modify a bigint;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+alter table t1 modify a int;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+drop table t1;
+"Now will test with one unique and one non-unique index"
+create table t1(a int, b char(10), unique(a), key(b)) engine=myisam;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+alter table t1 disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+alter table t1 enable keys;
+"If no copy on noop change, this won't touch the data file"
+"The non-unique index will be disabled"
+alter table t1 modify a int, disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+alter table t1 enable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+"Change the type implying data copy"
+"The non-unique index will be disabled"
+alter table t1 modify a bigint, disable keys;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+"Change again the type, but leave the indexes as_is"
+alter table t1 modify a int;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+"Try the same. When data is no copied on similar tables, this is noop"
+alter table t1 modify a int;
+show indexes from t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+t1	1	b	1	b	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+drop table t1;
+create database mysqltest;
+create table t1 (c1 int);
+alter table t1 rename mysqltest.t1;
+drop table t1;
+ERROR 42S02: Unknown table 'test.t1'
+alter table mysqltest.t1 rename t1;
+drop table t1;
+create table t1 (c1 int);
+use mysqltest;
+drop database mysqltest;
+alter table test.t1 rename t1;
+ERROR 3D000: No database selected
+alter table test.t1 rename test.t1;
+use test;
+drop table t1;
+CREATE TABLE t1(a INT) ENGINE=MyISAM ROW_FORMAT=FIXED;
+CREATE INDEX i1 ON t1(a);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  KEY `i1` (`a`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=FIXED
+DROP INDEX i1 ON t1;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=FIXED
+DROP TABLE t1;
+CREATE TABLE bug24219 (a INT, INDEX(a)) ENGINE=MyISAM;
+SHOW INDEX FROM bug24219;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+bug24219	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+ALTER TABLE bug24219 RENAME TO bug24219_2, DISABLE KEYS;
+SHOW INDEX FROM bug24219_2;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+bug24219_2	1	a	1	a	A	NULL	NULL	NULL	YES	BTREE	disabled		YES	NULL
+DROP TABLE bug24219_2;
+create table table_24562(
+section int,
+subsection int,
+title varchar(50));
+insert into table_24562 values
+(1, 0, "Introduction"),
+(1, 1, "Authors"),
+(1, 2, "Acknowledgements"),
+(2, 0, "Basics"),
+(2, 1, "Syntax"),
+(2, 2, "Client"),
+(2, 3, "Server"),
+(3, 0, "Intermediate"),
+(3, 1, "Complex queries"),
+(3, 2, "Stored Procedures"),
+(3, 3, "Stored Functions"),
+(4, 0, "Advanced"),
+(4, 1, "Replication"),
+(4, 2, "Load balancing"),
+(4, 3, "High availability"),
+(5, 0, "Conclusion");
+select * from table_24562;
+section	subsection	title
+1	0	Introduction
+1	1	Authors
+1	2	Acknowledgements
+2	0	Basics
+2	1	Syntax
+2	2	Client
+2	3	Server
+3	0	Intermediate
+3	1	Complex queries
+3	2	Stored Procedures
+3	3	Stored Functions
+4	0	Advanced
+4	1	Replication
+4	2	Load balancing
+4	3	High availability
+5	0	Conclusion
+alter table table_24562 add column reviewer varchar(20),
+order by title;
+select * from table_24562;
+section	subsection	title	reviewer
+1	2	Acknowledgements	NULL
+4	0	Advanced	NULL
+1	1	Authors	NULL
+2	0	Basics	NULL
+2	2	Client	NULL
+3	1	Complex queries	NULL
+5	0	Conclusion	NULL
+4	3	High availability	NULL
+3	0	Intermediate	NULL
+1	0	Introduction	NULL
+4	2	Load balancing	NULL
+4	1	Replication	NULL
+2	3	Server	NULL
+3	3	Stored Functions	NULL
+3	2	Stored Procedures	NULL
+2	1	Syntax	NULL
+update table_24562 set reviewer="Me" where section=2;
+update table_24562 set reviewer="You" where section=3;
+alter table table_24562
+order by section ASC, subsection DESC;
+select * from table_24562;
+section	subsection	title	reviewer
+1	2	Acknowledgements	NULL
+1	1	Authors	NULL
+1	0	Introduction	NULL
+2	3	Server	Me
+2	2	Client	Me
+2	1	Syntax	Me
+2	0	Basics	Me
+3	3	Stored Functions	You
+3	2	Stored Procedures	You
+3	1	Complex queries	You
+3	0	Intermediate	You
+4	3	High availability	NULL
+4	2	Load balancing	NULL
+4	1	Replication	NULL
+4	0	Advanced	NULL
+5	0	Conclusion	NULL
+alter table table_24562
+order by table_24562.subsection ASC, table_24562.section DESC;
+select * from table_24562;
+section	subsection	title	reviewer
+5	0	Conclusion	NULL
+4	0	Advanced	NULL
+3	0	Intermediate	You
+2	0	Basics	Me
+1	0	Introduction	NULL
+4	1	Replication	NULL
+3	1	Complex queries	You
+2	1	Syntax	Me
+1	1	Authors	NULL
+4	2	Load balancing	NULL
+3	2	Stored Procedures	You
+2	2	Client	Me
+1	2	Acknowledgements	NULL
+4	3	High availability	NULL
+3	3	Stored Functions	You
+2	3	Server	Me
+alter table table_24562 order by 12;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '12' at line 1
+alter table table_24562 order by (section + 12);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(section + 12)' at line 1
+alter table table_24562 order by length(title);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(title)' at line 1
+alter table table_24562 order by (select 12 from dual);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(select 12 from dual)' at line 1
+alter table table_24562 order by no_such_col;
+ERROR 42S22: Unknown column 'no_such_col' in 'order clause'
+drop table table_24562;
+create table t1 (mycol int(10) not null);
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+alter table t1 alter column mycol set default 0;
+desc t1;
+Field	Type	Null	Key	Default	Extra
+mycol	int	NO		0	
+drop table t1;
+create table t1(id int(8) primary key auto_increment) engine=heap;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+insert into t1 values (null);
+insert into t1 values (null);
+select * from t1;
+id
+1
+3
+alter table t1 auto_increment = 50;
+alter table t1 engine = myisam;
+insert into t1 values (null);
+select * from t1;
+id
+1
+3
+51
+alter table t1 engine = heap;
+insert into t1 values (null);
+select * from t1;
+id
+1
+3
+51
+53
+drop table t1;
+set sql_mode= default;
+create table t1(f1 int) engine=myisam;
+alter table t1 add column f2 datetime not null, add column f21 date not null;
+insert into t1 values(1,'2000-01-01','2000-01-01');
+alter table t1 add column f3 datetime not null;
+ERROR 22007: Incorrect datetime value: '0000-00-00 00:00:00' for column 'f3' at row 1
+alter table t1 add column f3 date not null;
+ERROR 22007: Incorrect date value: '0000-00-00' for column 'f3' at row 1
+alter table t1 add column f4 datetime not null default '2002-02-02',
+add column f41 date not null;
+ERROR 22007: Incorrect date value: '0000-00-00' for column 'f41' at row 1
+alter table t1 add column f4 datetime not null default '2002-02-02',
+add column f41 date not null default '2002-02-02';
+select * from t1;
+f1	f2	f21	f4	f41
+1	2000-01-01 00:00:00	2000-01-01	2002-02-02 00:00:00	2002-02-02
+drop table t1;
+create table t1 (v varchar(32));
+insert into t1 values ('def'),('abc'),('hij'),('3r4f');
+select * from t1;
+v
+def
+abc
+hij
+3r4f
+alter table t1 change v v2 varchar(32);
+select * from t1;
+v2
+def
+abc
+hij
+3r4f
+alter table t1 change v2 v varchar(64);
+select * from t1;
+v
+def
+abc
+hij
+3r4f
+update t1 set v = 'lmn' where v = 'hij';
+select * from t1;
+v
+def
+abc
+lmn
+3r4f
+alter table t1 add i int auto_increment not null primary key first;
+select * from t1;
+i	v
+1	def
+2	abc
+3	lmn
+4	3r4f
+update t1 set i=5 where i=3;
+select * from t1;
+i	v
+1	def
+2	abc
+4	3r4f
+5	lmn
+alter table t1 change i i bigint;
+select * from t1;
+i	v
+1	def
+2	abc
+4	3r4f
+5	lmn
+alter table t1 add unique key (i, v);
+select * from t1 where i between 2 and 4 and v in ('def','3r4f','lmn');
+i	v
+4	3r4f
+drop table t1;
+create table t1 (t varchar(255) default null, key t (t(80)))
+engine=myisam default charset=latin1;
+alter table t1 change t t text;
+drop table t1;
+CREATE TABLE t1 (a varchar(500));
+ALTER TABLE t1 ADD b GEOMETRY NOT NULL SRID 0, ADD SPATIAL INDEX(b);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` varchar(500) DEFAULT NULL,
+  `b` geometry NOT NULL /*!80003 SRID 0 */,
+  SPATIAL KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD KEY(b(50));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` varchar(500) DEFAULT NULL,
+  `b` geometry NOT NULL /*!80003 SRID 0 */,
+  SPATIAL KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD c POINT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` varchar(500) DEFAULT NULL,
+  `b` geometry NOT NULL /*!80003 SRID 0 */,
+  `c` point DEFAULT NULL,
+  SPATIAL KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+CREATE TABLE t2 (a INT, KEY (a(20)));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+ALTER TABLE t1 ADD d INT;
+ALTER TABLE t1 ADD KEY (d(20));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+ALTER TABLE t1 ADD e GEOMETRY NOT NULL, ADD SPATIAL KEY (e(30));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+DROP TABLE t1;
+CREATE TABLE t1 (s CHAR(8) BINARY);
+Warnings:
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+INSERT INTO t1 VALUES ('test');
+SELECT LENGTH(s) FROM t1;
+LENGTH(s)
+4
+ALTER TABLE t1 MODIFY s CHAR(10) BINARY;
+Warnings:
+Warning	1287	'BINARY as attribute of a type' is deprecated and will be removed in a future release. Please use a CHARACTER SET clause with _bin collation instead
+SELECT LENGTH(s) FROM t1;
+LENGTH(s)
+4
+DROP TABLE t1;
+CREATE TABLE t1 (s BINARY(8));
+INSERT INTO t1 VALUES ('test');
+SELECT LENGTH(s) FROM t1;
+LENGTH(s)
+8
+SELECT HEX(s) FROM t1;
+HEX(s)
+7465737400000000
+ALTER TABLE t1 MODIFY s BINARY(10);
+SELECT HEX(s) FROM t1;
+HEX(s)
+74657374000000000000
+SELECT LENGTH(s) FROM t1;
+LENGTH(s)
+10
+DROP TABLE t1;
+CREATE TABLE t1 (v VARCHAR(3), b INT);
+INSERT INTO t1 VALUES ('abc', 5);
+SELECT * FROM t1;
+v	b
+abc	5
+ALTER TABLE t1 MODIFY COLUMN v VARCHAR(4);
+SELECT * FROM t1;
+v	b
+abc	5
+DROP TABLE t1;
+create table t1 (a tinytext character set latin1);
+alter table t1 convert to character set utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` text CHARACTER SET utf8 COLLATE utf8_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+drop table t1;
+create table t1 (a mediumtext character set latin1);
+alter table t1 convert to character set utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` longtext CHARACTER SET utf8 COLLATE utf8_general_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+drop table t1;
+End of 5.0 tests
+create table t1 (i int);
+create table t3 (j int);
+insert into t1 values ();
+insert into t3 values ();
+lock table t1 write, t3 read;
+alter table t1 modify i int default 1;
+insert into t1 values ();
+select * from t1;
+i
+NULL
+1
+alter table t1 change i c char(10) default "Two";
+insert into t1 values ();
+select * from t1;
+c
+NULL
+1
+Two
+alter table t1 modify c char(10) default "Three", rename to t2;
+select * from t1;
+ERROR HY000: Table 't1' was not locked with LOCK TABLES
+select * from t2;
+c
+NULL
+1
+Two
+select * from t3;
+j
+NULL
+unlock tables;
+insert into t2 values ();
+select * from t2;
+c
+NULL
+1
+Two
+Three
+lock table t2 write, t3 read;
+alter table t2 change c vc varchar(100) default "Four", rename to t1;
+select * from t1;
+vc
+NULL
+1
+Two
+Three
+select * from t2;
+ERROR HY000: Table 't2' was not locked with LOCK TABLES
+select * from t3;
+j
+NULL
+unlock tables;
+insert into t1 values ();
+select * from t1;
+vc
+NULL
+1
+Two
+Three
+Four
+drop tables t1, t3;
+CREATE TABLE `t+1` (c1 INT);
+ALTER TABLE  `t+1` RENAME `t+2`;
+CREATE TABLE `t+1` (c1 INT);
+ALTER TABLE  `t+1` RENAME `t+2`;
+ERROR 42S01: Table 't+2' already exists
+DROP TABLE   `t+1`, `t+2`;
+CREATE TEMPORARY TABLE `tt+1` (c1 INT);
+ALTER TABLE  `tt+1` RENAME `tt+2`;
+CREATE TEMPORARY TABLE `tt+1` (c1 INT);
+ALTER TABLE  `tt+1` RENAME `tt+2`;
+ERROR 42S01: Table 'tt+2' already exists
+SHOW CREATE TABLE `tt+1`;
+Table	Create Table
+tt+1	CREATE TEMPORARY TABLE `tt+1` (
+  `c1` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SHOW CREATE TABLE `tt+2`;
+Table	Create Table
+tt+2	CREATE TEMPORARY TABLE `tt+2` (
+  `c1` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE   `tt+1`, `tt+2`;
+CREATE TABLE `#sql1` (c1 INT);
+CREATE TABLE `@0023sql2` (c1 INT);
+SHOW TABLES;
+Tables_in_test
+#sql1
+@0023sql2
+RENAME TABLE `#sql1`     TO `@0023sql1`;
+RENAME TABLE `@0023sql2` TO `#sql2`;
+SHOW TABLES;
+Tables_in_test
+#sql2
+@0023sql1
+ALTER TABLE `@0023sql1`  RENAME `#sql-1`;
+ALTER TABLE `#sql2`      RENAME `@0023sql-2`;
+SHOW TABLES;
+Tables_in_test
+#sql-1
+@0023sql-2
+INSERT INTO `#sql-1`     VALUES (1);
+INSERT INTO `@0023sql-2` VALUES (2);
+DROP TABLE `#sql-1`, `@0023sql-2`;
+CREATE TEMPORARY TABLE `#sql1` (c1 INT);
+CREATE TEMPORARY TABLE `@0023sql2` (c1 INT);
+SHOW TABLES;
+Tables_in_test
+ALTER TABLE `#sql1`      RENAME `@0023sql1`;
+ALTER TABLE `@0023sql2`  RENAME `#sql2`;
+SHOW TABLES;
+Tables_in_test
+INSERT INTO `#sql2`      VALUES (1);
+INSERT INTO `@0023sql1`  VALUES (2);
+SHOW CREATE TABLE `#sql2`;
+Table	Create Table
+#sql2	CREATE TEMPORARY TABLE `#sql2` (
+  `c1` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SHOW CREATE TABLE `@0023sql1`;
+Table	Create Table
+@0023sql1	CREATE TEMPORARY TABLE `@0023sql1` (
+  `c1` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE `#sql2`, `@0023sql1`;
+CREATE TABLE t1 (
+int_field INTEGER UNSIGNED NOT NULL,
+char_field CHAR(10),
+INDEX(`int_field`)
+);
+DESCRIBE t1;
+Field	Type	Null	Key	Default	Extra
+int_field	int unsigned	NO	MUL	NULL	
+char_field	char(10)	YES		NULL	
+SHOW INDEXES FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	int_field	1	int_field	A	0	NULL	NULL		BTREE			YES	NULL
+INSERT INTO t1 VALUES (1, "edno"), (1, "edno"), (2, "dve"), (3, "tri"), (5, "pet");
+"Non-copy data change - new frm, but old data and index files"
+ALTER TABLE t1
+CHANGE int_field unsigned_int_field INTEGER UNSIGNED NOT NULL,
+RENAME t2;
+SELECT * FROM t1 ORDER BY int_field;
+ERROR 42S02: Table 'test.t1' doesn't exist
+SELECT * FROM t2 ORDER BY unsigned_int_field;
+unsigned_int_field	char_field
+1	edno
+1	edno
+2	dve
+3	tri
+5	pet
+DESCRIBE t2;
+Field	Type	Null	Key	Default	Extra
+unsigned_int_field	int unsigned	NO	MUL	NULL	
+char_field	char(10)	YES		NULL	
+DESCRIBE t2;
+Field	Type	Null	Key	Default	Extra
+unsigned_int_field	int unsigned	NO	MUL	NULL	
+char_field	char(10)	YES		NULL	
+ALTER TABLE t2 MODIFY unsigned_int_field BIGINT UNSIGNED NOT NULL;
+DESCRIBE t2;
+Field	Type	Null	Key	Default	Extra
+unsigned_int_field	bigint unsigned	NO	MUL	NULL	
+char_field	char(10)	YES		NULL	
+DROP TABLE t2;
+CREATE TABLE t1 (f1 INT, f2 INT, f3 INT);
+INSERT INTO t1 VALUES (1, 2, NULL);
+SELECT * FROM t1;
+f1	f2	f3
+1	2	NULL
+ALTER TABLE t1 MODIFY COLUMN f3 INT AFTER f1;
+SELECT * FROM t1;
+f1	f3	f2
+1	NULL	2
+ALTER TABLE t1 MODIFY COLUMN f3 INT AFTER f2;
+SELECT * FROM t1;
+f1	f2	f3
+1	2	NULL
+DROP TABLE t1;
+create table t1 (c char(10) default "Two");
+lock table t1 write;
+insert into t1 values ();
+alter table t1 modify c char(10) default "Three";
+unlock tables;
+select * from t1;
+c
+Two
+check table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+drop table t1;
+CREATE TABLE t1 (id int, c int) character set latin1;
+INSERT INTO t1 VALUES (1,1);
+ALTER TABLE t1 CHANGE c d int;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE d c int;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 MODIFY c VARCHAR(10);
+affected rows: 1
+info: Records: 1  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE c d varchar(10);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE d c varchar(10);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+DROP TABLE t1;
+CREATE TABLE t1 (id int, c int) character set utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+INSERT INTO t1 VALUES (1,1);
+ALTER TABLE t1 CHANGE c d int;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE d c int;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 MODIFY c VARCHAR(10);
+affected rows: 1
+info: Records: 1  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE c d varchar(10);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE d c varchar(10);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+DROP TABLE t1;
+create table t1(f1 int not null, f2 int not null, key  (f1), key (f2)) engine=myisam;
+select index_length into @unpaked_keys_size from
+information_schema.tables where table_name='t1';
+alter table t1 pack_keys=1;
+select index_length into @paked_keys_size from
+information_schema.tables where table_name='t1';
+select (@unpaked_keys_size > @paked_keys_size);
+(@unpaked_keys_size > @paked_keys_size)
+1
+select max_data_length into @orig_max_data_length from
+information_schema.tables where table_name='t1';
+alter table t1 max_rows=100;
+select max_data_length into @changed_max_data_length from
+information_schema.tables where table_name='t1';
+select (@orig_max_data_length > @changed_max_data_length);
+(@orig_max_data_length > @changed_max_data_length)
+1
+drop table t1;
+CREATE TABLE t1(a INT AUTO_INCREMENT PRIMARY KEY,
+b ENUM('a', 'b', 'c') NOT NULL);
+INSERT INTO t1 (b) VALUES ('a'), ('c'), ('b'), ('b'), ('a');
+ALTER TABLE t1 MODIFY b ENUM('a', 'z', 'b', 'c') NOT NULL;
+SELECT * FROM t1;
+a	b
+1	a
+3	c
+5	b
+7	b
+9	a
+DROP TABLE t1;
+#
+# Bug#45567: Fast ALTER TABLE broken for enum and set
+#
+CREATE TABLE t1 (a ENUM('a1','a2'));
+INSERT INTO t1 VALUES ('a1'),('a2');
+# No copy: No modification
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+# No copy: Add new enumeration to the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','a3');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+# Copy: Modify and add new to the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','xx','a5');
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+# Copy: Remove from the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','xx');
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+# Copy: Add new enumeration
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','a0','xx');
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+# No copy: Add new enumerations to the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','a0','xx','a5','a6');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+DROP TABLE t1;
+CREATE TABLE t1 (a SET('a1','a2'));
+INSERT INTO t1 VALUES ('a1'),('a2');
+# No copy: No modification
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+# No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a3');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+# Copy: Modify and add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','xx','a5');
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+# Copy: Remove from the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','xx');
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+# Copy: Add new member
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','xx');
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+# No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','xx','a5','a6');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+# Copy: Numerical increase (pack length)
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','xx','a5','a6','a7','a8','a9','a10');
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+DROP TABLE t1;
+CREATE TABLE t1 (f1 TIMESTAMP NULL DEFAULT NULL,
+f2 INT(11) DEFAULT NULL) ENGINE=MYISAM DEFAULT CHARSET=utf8;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+INSERT INTO t1 VALUES (NULL, NULL), ("2009-10-09 11:46:19", 2);
+this should affect no rows as there is no real change
+ALTER TABLE t1 CHANGE COLUMN f1 f1_no_real_change TIMESTAMP NULL DEFAULT NULL;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+DROP TABLE t1;
+#
+# Bug #31145: ALTER TABLE DROP COLUMN, ADD COLUMN crashes (linux)
+#   or freezes (win) the server
+#
+CREATE TABLE t1 (a TEXT, id INT, b INT);
+ALTER TABLE t1 DROP COLUMN a, ADD COLUMN c TEXT FIRST;
+DROP TABLE t1;
+#
+# Test for bug #12652385 - "61493: REORDERING COLUMNS TO POSITION
+#                           FIRST CAN CAUSE DATA TO BE CORRUPTED".
+#
+# Use MyISAM engine as the fact that InnoDB doesn't support
+# in-place ALTER TABLE in cases when columns are being renamed
+# hides some bugs.
+create table t1 (i int, j int) engine=myisam;
+insert into t1 value (1, 2);
+# First, test for original problem described in the bug report.
+select * from t1;
+i	j
+1	2
+# Change of column order by the below ALTER TABLE statement should
+# affect both column names and column contents.
+alter table t1 modify column j int first;
+select * from t1;
+j	i
+2	1
+# Now test for similar problem with the same root.
+# The below ALTER TABLE should change not only the name but
+# also the value for the last column of the table.
+alter table t1 drop column i, add column k int default 0;
+select * from t1;
+j	k
+2	0
+# Clean-up.
+drop table t1;
+End of 5.1 tests
+CREATE TABLE t1(c CHAR(10),
+i INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY);
+INSERT INTO t1 VALUES('a',2),('b',4),('c',6);
+ALTER TABLE t1
+DROP i,
+ADD i INT UNSIGNED NOT NULL AUTO_INCREMENT,
+AUTO_INCREMENT = 1;
+DROP TABLE t1;
+CREATE TABLE t1 (a CHAR(1), PRIMARY KEY (a(255)));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+CREATE TABLE t1 (a CHAR(1));
+ALTER TABLE t1 ADD PRIMARY KEY (a(20));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+ALTER TABLE t1 ADD KEY (a(20));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+CREATE UNIQUE INDEX i1 ON t1 (a(20));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+CREATE INDEX i2 ON t1 (a(20));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+DROP TABLE t1;
+CREATE TABLE t1 (id int);
+INSERT INTO t1 VALUES (1), (2);
+ALTER TABLE t1 ADD COLUMN (f1 INT), ADD COLUMN (f2 INT), ADD KEY f2k(f2);
+DROP TABLE t1;
+#
+# Test for bug #53820 "ALTER a MEDIUMINT column table causes full
+#                      table copy".
+#
+CREATE TABLE t1 (a INT, b MEDIUMINT);
+INSERT INTO t1 VALUES (1, 1), (2, 2);
+# The below ALTER should not copy table and so no rows should
+# be shown as affected.
+ALTER TABLE t1 CHANGE a id INT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+DROP TABLE t1;
+#
+# Bug#11754461 CANNOT ALTER TABLE WHEN KEY PREFIX TOO LONG
+#
+CREATE DATABASE db1 CHARACTER SET utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+CREATE TABLE db1.t1 (bar TINYTEXT, KEY (bar(100)));
+ERROR 42000: Specified key was too long; max key length is 255 bytes
+CREATE TABLE db1.t1 (bar TINYTEXT, KEY (bar(85)));
+ALTER TABLE db1.t1 ADD baz INT;
+DROP DATABASE db1;
+# Additional coverage for refactoring which is made as part
+# of fix for bug #27480 "Extend CREATE TEMPORARY TABLES privilege
+# to allow temp table operations".
+#
+# At some point the below test case failed on assertion.
+CREATE TEMPORARY TABLE t1 (i int) ENGINE=MyISAM;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ERROR HY000: Table storage engine for 't1' doesn't have this option
+DROP TABLE t1;
+#
+# Bug#11938039 RE-EXECUTION OF FRM-ONLY ALTER TABLE WITH RENAME
+#              CLAUSE FAILS OR ABORTS SERVER.
+#
+create table t1 (a int);
+prepare stmt1 from 'alter table t1 alter column a set default 1, rename to t2';
+execute stmt1;
+rename table t2 to t1;
+# The below statement should succeed and not emit error or abort server.
+execute stmt1;
+deallocate prepare stmt1;
+drop table t2;
+# Bug#11748057 (formerly known as 34972): ALTER TABLE statement doesn't
+#                                         identify correct column name.
+#
+CREATE TABLE t1 (c1 int unsigned , c2 char(100) not null default '');
+ALTER TABLE t1 ADD c3 char(16) NOT NULL DEFAULT '' AFTER c2,
+MODIFY c2 char(100) NOT NULL DEFAULT '' AFTER c1;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int unsigned DEFAULT NULL,
+  `c2` char(100) NOT NULL DEFAULT '',
+  `c3` char(16) NOT NULL DEFAULT ''
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+#
+# WL#5534 Online ALTER, Phase 1
+#
+# Single thread tests.
+# See innodb_mysql_sync.test for multi thread tests.
+CREATE TABLE t1(a INT PRIMARY KEY, b INT) engine=InnoDB;
+CREATE TABLE m1(a INT PRIMARY KEY, b INT) engine=MyISAM;
+INSERT INTO t1 VALUES (1,1), (2,2);
+INSERT INTO m1 VALUES (1,1), (2,2);
+#
+# 1: Test ALGORITHM keyword
+#
+# --enable_info allows us to see how many rows were updated
+# by ALTER TABLE. in-place will show 0 rows, while copy > 0.
+ALTER TABLE t1 ADD INDEX i1(b);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 ADD INDEX i2(b), ALGORITHM= DEFAULT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i2' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i3(b), ALGORITHM= COPY;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i3' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM= INPLACE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i4' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i5(b), ALGORITHM= INVALID;
+ERROR HY000: Unknown ALGORITHM 'INVALID'
+ALTER TABLE m1 ENABLE KEYS;
+affected rows: 0
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= DEFAULT;
+affected rows: 0
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE;
+affected rows: 0
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+#
+# 2: Test ALGORITHM + old_alter_table
+#
+SET SESSION old_alter_table= 1;
+affected rows: 0
+ALTER TABLE t1 ADD INDEX i1(b);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 ADD INDEX i2(b), ALGORITHM= DEFAULT;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i2' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i3(b), ALGORITHM= COPY;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i3' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM= INPLACE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i4' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+SET SESSION old_alter_table= 0;
+affected rows: 0
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+#
+# 3: Test unsupported in-place operation
+#
+ALTER TABLE t1 ADD COLUMN (c1 INT);
+ALTER TABLE t1 ADD COLUMN (c2 INT), ALGORITHM= DEFAULT;
+ALTER TABLE t1 ADD COLUMN (c3 INT), ALGORITHM= COPY;
+ALTER TABLE t1 ADD COLUMN (c4 INT), ALGORITHM= INPLACE;
+ALTER TABLE t1 DROP COLUMN c1, DROP COLUMN c2, DROP COLUMN c3, DROP COLUMN c4;
+#
+# 4: Test LOCK keyword
+#
+ALTER TABLE t1 ADD INDEX i1(b), LOCK= DEFAULT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 ADD INDEX i2(b), LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
+ALTER TABLE t1 ADD INDEX i3(b), LOCK= SHARED;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i3' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i4(b), LOCK= EXCLUSIVE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i4' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i5(b), LOCK= INVALID;
+ERROR HY000: Unknown LOCK type 'INVALID'
+ALTER TABLE m1 ENABLE KEYS, LOCK= DEFAULT;
+ALTER TABLE m1 ENABLE KEYS, LOCK= NONE;
+ERROR 0A000: LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.
+ALTER TABLE m1 ENABLE KEYS, LOCK= SHARED;
+ERROR 0A000: LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.
+ALTER TABLE m1 ENABLE KEYS, LOCK= EXCLUSIVE;
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i3, DROP INDEX i4;
+#
+# 5: Test ALGORITHM + LOCK
+#
+ALTER TABLE t1 ADD INDEX i1(b), ALGORITHM= INPLACE, LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
+ALTER TABLE t1 ADD INDEX i2(b), ALGORITHM= INPLACE, LOCK= SHARED;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 ADD INDEX i3(b), ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i3' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM= COPY, LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.
+ALTER TABLE t1 ADD INDEX i5(b), ALGORITHM= COPY, LOCK= SHARED;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i5' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i6(b), ALGORITHM= COPY, LOCK= EXCLUSIVE;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i6' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE, LOCK= NONE;
+ERROR 0A000: LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE, LOCK= SHARED;
+ERROR 0A000: LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+affected rows: 0
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY, LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY, LOCK= SHARED;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY, LOCK= EXCLUSIVE;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+DROP TABLE t1, m1;
+#
+# 7: Which operations require copy and which can be done in-place?
+#
+# Test which ALTER TABLE operations are done in-place and
+# which operations are done using temporary table copy.
+#
+# --enable_info allows us to see how many rows were updated
+# by ALTER TABLE. in-place will show 0 rows, while copy > 0.
+#
+# Single operation tests
+CREATE TABLE ti1(a INT NOT NULL, b INT, c INT) engine=InnoDB;
+CREATE TABLE tm1(a INT NOT NULL, b INT, c INT) engine=MyISAM;
+CREATE TABLE ti2(a INT PRIMARY KEY AUTO_INCREMENT, b INT, c INT) engine=InnoDB;
+CREATE TABLE tm2(a INT PRIMARY KEY AUTO_INCREMENT, b INT, c INT) engine=MyISAM;
+INSERT INTO ti1 VALUES (1,1,1), (2,2,2);
+INSERT INTO ti2 VALUES (1,1,1), (2,2,2);
+INSERT INTO tm1 VALUES (1,1,1), (2,2,2);
+INSERT INTO tm2 VALUES (1,1,1), (2,2,2);
+ALTER TABLE ti1;
+affected rows: 0
+ALTER TABLE tm1;
+affected rows: 0
+ALTER TABLE ti1 ADD COLUMN d VARCHAR(200);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD COLUMN d VARCHAR(200);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD COLUMN d2 VARCHAR(200);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD COLUMN d2 VARCHAR(200);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD COLUMN e ENUM('a', 'b') FIRST;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD COLUMN e ENUM('a', 'b') FIRST;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD COLUMN f INT AFTER a;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD COLUMN f INT AFTER a;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD INDEX ii1(b);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD INDEX im1(b);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD UNIQUE INDEX ii2 (c);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD UNIQUE INDEX im2 (c);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD FULLTEXT INDEX ii3 (d);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	124	InnoDB rebuilding table to add column FTS_DOC_ID
+ALTER TABLE tm1 ADD FULLTEXT INDEX im3 (d);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD FULLTEXT INDEX ii4 (d2);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD FULLTEXT INDEX im4 (d2);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD PRIMARY KEY(a), ALGORITHM=INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: InnoDB presently supports one FULLTEXT index creation at a time. Try ALGORITHM=COPY.
+ALTER TABLE ti1 ADD PRIMARY KEY(a);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD PRIMARY KEY(a);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 DROP INDEX ii3;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 DROP INDEX im3;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 DROP COLUMN d2;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 DROP COLUMN d2;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ADD CONSTRAINT fi1 FOREIGN KEY (b) REFERENCES ti2(a);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ADD CONSTRAINT fm1 FOREIGN KEY (b) REFERENCES tm2(a);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ALTER COLUMN b SET DEFAULT 1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ALTER COLUMN b SET DEFAULT 1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 ALTER COLUMN b DROP DEFAULT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ALTER COLUMN b DROP DEFAULT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 CHANGE COLUMN f g INT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 CHANGE COLUMN f g INT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 CHANGE COLUMN g h VARCHAR(20);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 CHANGE COLUMN g h VARCHAR(20);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN e ENUM('a', 'b', 'c');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN e ENUM('a', 'b', 'c');
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN e INT;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN e INT;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN e INT AFTER h;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN e INT AFTER h;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN e INT FIRST;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN e INT FIRST;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN c INT NOT NULL;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN c INT NOT NULL;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN c INT NULL;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN c INT NULL;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN h VARCHAR(30);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN h VARCHAR(30);
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MODIFY COLUMN h VARCHAR(30) AFTER d;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MODIFY COLUMN h VARCHAR(30) AFTER d;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 DROP COLUMN h;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 DROP COLUMN h;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 DROP INDEX ii2;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 DROP INDEX im2;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 DROP PRIMARY KEY;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 DROP PRIMARY KEY;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 DROP FOREIGN KEY fi1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 DROP FOREIGN KEY fm1;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 RENAME TO ti3;
+affected rows: 0
+ALTER TABLE tm1 RENAME TO tm3;
+affected rows: 0
+ALTER TABLE ti3 RENAME TO ti1;
+affected rows: 0
+ALTER TABLE tm3 RENAME TO tm1;
+affected rows: 0
+ALTER TABLE ti1 ORDER BY b;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 ORDER BY b;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 CONVERT TO CHARACTER SET utf16;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 CONVERT TO CHARACTER SET utf16;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 DEFAULT CHARACTER SET utf8;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+ALTER TABLE tm1 DEFAULT CHARACTER SET utf8;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+ALTER TABLE ti1 FORCE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 FORCE;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 AUTO_INCREMENT 3;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 AUTO_INCREMENT 3;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 AVG_ROW_LENGTH 10;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 AVG_ROW_LENGTH 10;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 CHECKSUM 1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 CHECKSUM 1;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 COMMENT 'test';
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 COMMENT 'test';
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MAX_ROWS 100;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MAX_ROWS 100;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 MIN_ROWS 1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 MIN_ROWS 1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti1 PACK_KEYS 1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE tm1 PACK_KEYS 1;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+DROP TABLE ti1, ti2, tm1, tm2;
+# Tests of >1 operation (InnoDB)
+CREATE TABLE ti1(a INT PRIMARY KEY AUTO_INCREMENT, b INT) engine=InnoDB;
+INSERT INTO ti1(b) VALUES (1), (2);
+ALTER TABLE ti1 RENAME TO ti3, ADD INDEX ii1(b);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE ti3 DROP INDEX ii1, AUTO_INCREMENT 5;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+INSERT INTO ti3(b) VALUES (5);
+ALTER TABLE ti3 ADD INDEX ii1(b), AUTO_INCREMENT 7;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+INSERT INTO ti3(b) VALUES (7);
+SELECT * FROM ti3;
+a	b
+1	1
+3	2
+5	5
+7	7
+DROP TABLE ti3;
+#
+# 8: Scenario in which ALTER TABLE was returning an unwarranted
+#    ER_ILLEGAL_HA error at some point during work on this WL.
+#
+CREATE TABLE tm1(i INT DEFAULT 1) engine=MyISAM;
+ALTER TABLE tm1 ADD INDEX ii1(i), ALTER COLUMN i DROP DEFAULT;
+DROP TABLE tm1;
+#
+# Bug#11815557 60269: MYSQL SHOULD REJECT ATTEMPTS TO CREATE SYSTEM
+#                     TABLES IN INCORRECT ENGINE
+#
+# Note: This test assumes that only MyISAM and InnoDB supports system tables.
+#       If other engines are made to support system tables,
+#       then this test needs to be updated
+#
+use mysql;
+ALTER TABLE db ENGINE=memory;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.db]
+ALTER TABLE user ENGINE=memory;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.user]
+ALTER TABLE func ENGINE=csv;
+ERROR HY000: Storage engine 'CSV' does not support system tables. [mysql.func]
+ALTER TABLE servers ENGINE=merge;
+ERROR HY000: Storage engine 'MRG_MYISAM' does not support system tables. [mysql.servers]
+ALTER TABLE procs_priv ENGINE=memory;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.procs_priv]
+ALTER TABLE tables_priv ENGINE=heap;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.tables_priv]
+ALTER TABLE columns_priv ENGINE=csv;
+ERROR HY000: Storage engine 'CSV' does not support system tables. [mysql.columns_priv]
+ALTER TABLE time_zone ENGINE=merge;
+ERROR HY000: Storage engine 'MRG_MYISAM' does not support system tables. [mysql.time_zone]
+ALTER TABLE help_topic ENGINE=merge;
+ERROR HY000: Storage engine 'MRG_MYISAM' does not support system tables. [mysql.help_topic]
+CREATE TABLE db (dummy int) ENGINE=memory;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.db]
+CREATE TABLE user (dummy int) ENGINE=memory;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.user]
+CREATE TABLE func (dummy int) ENGINE=csv;
+ERROR HY000: Storage engine 'CSV' does not support system tables. [mysql.func]
+CREATE TABLE servers (dummy int) ENGINE=merge;
+ERROR HY000: Storage engine 'MRG_MYISAM' does not support system tables. [mysql.servers]
+CREATE TABLE procs_priv (dummy int) ENGINE=memory;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.procs_priv]
+CREATE TABLE tables_priv (dummy int) ENGINE=heap;
+ERROR HY000: Storage engine 'MEMORY' does not support system tables. [mysql.tables_priv]
+CREATE TABLE columns_priv (dummy int) ENGINE=csv;
+ERROR HY000: Storage engine 'CSV' does not support system tables. [mysql.columns_priv]
+CREATE TABLE time_zone (dummy int) ENGINE=merge;
+ERROR HY000: Storage engine 'MRG_MYISAM' does not support system tables. [mysql.time_zone]
+CREATE TABLE help_topic (dummy int) ENGINE=merge;
+ERROR HY000: Storage engine 'MRG_MYISAM' does not support system tables. [mysql.help_topic]
+use test;
+# End of Bug#11815557
+#
+# Tests for WL#6555 "Online rename index".
+#
+#
+# 1) Tests for syntax and semantics of ALTER TABLE RENAME
+#    KEY/INDEX result.
+#
+# 1.a) Both RENAME KEY and RENAME INDEX variants should be
+#      allowed and produce expected results.
+create table t1 (pk int primary key, i int, j int, key a(i));
+alter table t1 rename key a to b;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `b` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 rename index b to c;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# 1.b) It should be impossible to rename index that doesn't
+#      exists, dropped or added within the same ALTER TABLE.
+alter table t1 rename key d to e;
+ERROR 42000: Key 'd' doesn't exist in table 't1'
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 drop key c, rename key c to d;
+ERROR 42000: Key 'c' doesn't exist in table 't1'
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 add key d(j), rename key d to e;
+ERROR 42000: Key 'd' doesn't exist in table 't1'
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# 1.c) It should be impossible to rename index to a name
+#      which is already used by another index, or is used
+#      by index which is added within the same ALTER TABLE.
+alter table t1 add key d(j);
+alter table t1 rename key c to d;
+ERROR 42000: Duplicate key name 'd'
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`i`),
+  KEY `d` (`j`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 drop key d;
+alter table t1 add key d(j), rename key c to d;
+ERROR 42000: Duplicate key name 'd'
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# 1.d) It should be possible to rename index to a name
+#      which belongs to index which is dropped within the
+#      same ALTER TABLE.
+alter table t1 add key d(j);
+alter table t1 drop key c, rename key d to c;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`j`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# 1.e) We disallow renaming from/to PRIMARY as it might
+#      lead to some other key becoming "primary" internally,
+#      which will be interpreted as dropping/addition of
+#      primary key.
+alter table t1 rename key primary to d;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'primary to d' at line 1
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`j`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# Even using 'funny' syntax.
+alter table t1 rename key `primary` to d;
+ERROR 42000: Incorrect index name 'primary'
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`j`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 rename key c to primary;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'primary' at line 1
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`j`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 rename key c to `primary`;
+ERROR 42000: Incorrect index name 'primary'
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `i` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  PRIMARY KEY (`pk`),
+  KEY `c` (`j`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+drop table t1;
+#
+# 2) More complex tests for semantics of ALTER TABLE.
+#
+# 2.a) Check that standalone RENAME KEY works as expected
+#      for unique and non-unique indexes.
+create table t1 (a int, unique u(a), b int, key k(b));
+alter table t1 rename key u to uu;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  UNIQUE KEY `uu` (`a`),
+  KEY `k` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 rename key k to kk;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  UNIQUE KEY `uu` (`a`),
+  KEY `kk` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# 2.b) Check how that this clause can be mixed with other
+#      clauses which don't affect key or its columns.
+alter table t1 rename key kk to kkk, add column c int;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  UNIQUE KEY `uu` (`a`),
+  KEY `kkk` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 rename key uu to uuu, add key c(c);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  UNIQUE KEY `uuu` (`a`),
+  KEY `kkk` (`b`),
+  KEY `c` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 rename key kkk to k, drop key uuu;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  KEY `k` (`b`),
+  KEY `c` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t1 rename key k to kk, rename to t2;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  KEY `kk` (`b`),
+  KEY `c` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# 2.c) Check that this clause properly works even in case
+#      when it is mixed with clauses affecting columns in
+#      the key renamed.
+alter table t2 rename key c to cc, modify column c bigint not null first;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c` bigint NOT NULL,
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  KEY `kk` (`b`),
+  KEY `cc` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# Create multi-component key for next example.
+alter table t2 add unique u (a, b, c);
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c` bigint NOT NULL,
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  UNIQUE KEY `u` (`a`,`b`,`c`),
+  KEY `kk` (`b`),
+  KEY `cc` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+alter table t2 rename key u to uu, drop column b;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c` bigint NOT NULL,
+  `a` int DEFAULT NULL,
+  UNIQUE KEY `uu` (`a`,`c`),
+  KEY `cc` (`c`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+drop table t2;
+#
+# 3) Test coverage for handling of RENAME INDEX clause in
+#    various storage engines and using different ALTER
+#    algorithm.
+#
+# 3.a) Test coverage for simple storage engines (MyISAM/Heap).
+create table t1 (i int, key k(i)) engine=myisam;
+insert into t1 values (1);
+create table t2 (i int, key k(i)) engine=memory;
+insert into t2 values (1);
+# MyISAM and Heap should be able to handle key renaming in-place.
+alter table t1 algorithm=inplace, rename key k to kk;
+alter table t2 algorithm=inplace, rename key k to kk;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL,
+  KEY `kk` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int DEFAULT NULL,
+  KEY `kk` (`i`)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# So by default in-place algorithm should be chosen.
+# (ALTER TABLE should report 0 rows affected).
+alter table t1 rename key kk to kkk;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+alter table t2 rename key kk to kkk;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL,
+  KEY `kkk` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int DEFAULT NULL,
+  KEY `kkk` (`i`)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# Copy algorithm should work as well.
+alter table t1 algorithm=copy, rename key kkk to kkkk;
+alter table t2 algorithm=copy, rename key kkk to kkkk;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL,
+  KEY `kkkk` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int DEFAULT NULL,
+  KEY `kkkk` (`i`)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# When renaming is combined with other in-place operation
+# it still works as expected (i.e. works in-place).
+alter table t1 algorithm=inplace, rename key kkkk to k, alter column i set default 100;
+alter table t2 algorithm=inplace, rename key kkkk to k, alter column i set default 100;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT '100',
+  KEY `k` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int DEFAULT '100',
+  KEY `k` (`i`)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# Combining with non-inplace operation results in the whole ALTER
+# becoming non-inplace.
+alter table t1 algorithm=inplace, rename key k to kk, add column j int;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
+alter table t2 algorithm=inplace, rename key k to kk, add column j int;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
+drop table t1, t2;
+# 3.b) Basic tests for InnoDB. More tests can be found in
+#      innodb.innodb_rename_index*
+create table t1 (i int, key k(i)) engine=innodb;
+insert into t1 values (1);
+# Basic rename, inplace algorithm should be chosen
+alter table t1 algorithm=inplace, rename key k to kk;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL,
+  KEY `kk` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# copy algorithm should work as well.
+alter table t1 algorithm=copy, rename key kk to kkk;
+affected rows: 1
+info: Records: 1  Duplicates: 0  Warnings: 0
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL,
+  KEY `kkk` (`i`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+drop table t1;
+#
+# 4) Additional coverage for complex cases in which code
+#    in ALTER TABLE comparing old and new table version
+#    got confused.
+#
+# Once InnoDB starts to support in-place index renaming the result
+# of below statements should stay the same. Information about
+# indexes returned by SHOW CREATE TABLE (from .FRM) and by
+# InnoDB (from InnoDB data-dictionary) should be consistent.
+#
+create table t1 ( a int, b int, c int, d int,
+primary key (a), index i1 (b), index i2 (c) ) engine=innodb;
+alter table t1 add index i1 (d), rename index i1 to x;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `x` (`b`),
+  KEY `i2` (`c`),
+  KEY `i1` (`d`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+select i.name as k, f.name as c from information_schema.innodb_tables as t,
+information_schema.innodb_indexes as i,
+information_schema.innodb_fields as f
+where t.name='test/t1' and t.table_id = i.table_id and i.index_id = f.index_id
+order by k, c;
+k	c
+i1	d
+i2	c
+PRIMARY	a
+x	b
+drop table t1;
+create table t1 (a int, b int, c int, d int,
+primary key (a), index i1 (b), index i2 (c)) engine=innodb;
+alter table t1 add index i1 (d), rename index i1 to i2, drop index i2;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`b`),
+  KEY `i1` (`d`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+select i.name as k, f.name as c from information_schema.innodb_tables as t,
+information_schema.innodb_indexes as i,
+information_schema.innodb_fields as f
+where t.name='test/t1' and t.table_id = i.table_id and i.index_id = f.index_id
+order by k, c;
+k	c
+i1	d
+i2	b
+PRIMARY	a
+drop table t1;
+#
+# The below ALTER TABLE statement should either drop and recreate key
+# under new name, or simply rename it. It should not bring .FRM and
+# InnoDB data-dictionary out of sync thus causing asserts.
+#
+create table t1 (i int, key x(i)) engine=InnoDB;
+alter table t1 drop key x, add key X(i), alter column i set default 10;
+drop table t1;
+#
+# Coverage for changes to ALTER TABLE ... IMPORT/DISCARD TABLESPACE
+# code introduced by WL#6671 "Improve scalability by not using
+# thr_lock.c locks for InnoDB tables".
+#
+# Check that ALTER TABLE ... IMPORT/DISCARD TABLESPACE acquires X
+# metadata lock on the table even when executed under LOCK TABLES.
+#
+# Suppress error messages which will be generated by IMPORT TABLESPACE
+call mtr.add_suppression("Trying to import a tablespace, but could not open the tablespace file");
+call mtr.add_suppression("Operating system error number 2 in a file operation.");
+call mtr.add_suppression("The error means the system cannot find the path specified.");
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+#
+# 1) Check that ALTER TABLE ... IMPORT/DISCARD TABLESPACE on
+#    base table acquire X lock (when not under LOCK TABLES).
+#
+connect con1, localhost, root;
+# Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+connect con2, localhost, root;
+# Sending:
+ALTER TABLE t1 DISCARD TABLESPACE;
+connection default;
+# Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+connection con1;
+# Unblock ALTER TABLE DISCARD
+HANDLER t1 CLOSE;
+connection con2;
+# Reaping ALTER TABLE DISCARD
+connection con1;
+# Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+connection con2;
+# Sending:
+ALTER TABLE t1 IMPORT TABLESPACE;
+connection default;
+# Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+connection con1;
+# Unblock ALTER TABLE IMPORT
+HANDLER t1 CLOSE;
+connection con2;
+# Reaping ALTER TABLE IMPORT
+# It should fail as no tablespace was copied after DISCARD.
+ERROR HY000: Tablespace is missing for table `test`.`t1`.
+connection default;
+DROP TABLE t1;
+#
+# 2) ALTER TABLE ... IMPORT/DISCARD TABLESPACE on temporary table
+#    should not try to acquire X metadata lock on base table.
+#
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+connection con1;
+# Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+connection con2;
+CREATE TEMPORARY TABLE t1 (j INT) ENGINE=InnoDB;
+# Both DISCARD and IMPORT on temporary table should fail without
+# acquiring any locks and blocking.
+ALTER TABLE t1 DISCARD TABLESPACE;
+ERROR HY000: Cannot DISCARD/IMPORT tablespace associated with temporary table
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: Cannot DISCARD/IMPORT tablespace associated with temporary table
+DROP TEMPORARY TABLE t1;
+#
+# 3) Check that ALTER TABLE ... IMPORT/DISCARD TABLESPACE on
+#    base table under LOCK TABLES acquire X lock.
+#
+connection con2;
+LOCK TABLES t1 WRITE;
+# Sending:
+ALTER TABLE t1 DISCARD TABLESPACE;
+connection default;
+# Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+connection con1;
+# Unblock ALTER TABLE DISCARD
+HANDLER t1 CLOSE;
+connection con2;
+# Reaping ALTER TABLE DISCARD
+connection con1;
+# Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+connection con2;
+# Sending:
+ALTER TABLE t1 IMPORT TABLESPACE;
+connection default;
+# Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+connection con1;
+# Unblock ALTER TABLE IMPORT
+HANDLER t1 CLOSE;
+connection con2;
+# Reaping ALTER TABLE IMPORT
+# It should fail as no tablespace was copied after DISCARD.
+ERROR HY000: Tablespace is missing for table `test`.`t1`.
+UNLOCK TABLES;
+connection default;
+DROP TABLE t1;
+#
+# 4) Under LOCK TABLES, ALTER TABLE ... IMPORT/DISCARD TABLESPACE on
+#    temporary table should not try to acquire X metadata lock on base
+#    table.
+#
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+connection con1;
+# Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+connection con2;
+CREATE TEMPORARY TABLE t1 (j INT) ENGINE=InnoDB;
+LOCK TABLES t1 WRITE;
+# Both DISCARD and IMPORT on temporary table should fail without
+# acquiring any locks and blocking.
+ALTER TABLE t1 DISCARD TABLESPACE;
+ERROR HY000: Cannot DISCARD/IMPORT tablespace associated with temporary table
+ALTER TABLE t1 IMPORT TABLESPACE;
+ERROR HY000: Cannot DISCARD/IMPORT tablespace associated with temporary table
+UNLOCK TABLES;
+DROP TEMPORARY TABLE t1;
+connection con1;
+HANDLER t1 CLOSE;
+#
+# Clean-up.
+#
+disconnect con1;
+disconnect con2;
+connection default;
+DROP TABLE t1;
+SET sql_mode = default;
+#
+# BUG 19779365: INDEX COMMENT IN ADD INDEX IS IGNORED.
+#
+# After the patch, the alter table reflects the new
+# index comment or the lack of comment for the indexes.
+CREATE TABLE t1(fld1 int, key key1(fld1));
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE			YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'test';
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		test	YES	NULL
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test');
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		test	YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1);
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE			YES	NULL
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test');
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		test	YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'success';
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		success	YES	NULL
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'old comment');
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		old comment	YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'new comment';
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		new comment	YES	NULL
+DROP TABLE t1;
+#
+# Bug#19635706
+# Verify that it is possible to add a unique key to a not-NULL POINT 
+# column and that this key is promoted to primary key
+# 
+CREATE TABLE t1(a INT NOT NULL, b POINT NOT NULL) ENGINE=INNODB;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` point NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD UNIQUE INDEX (b);
+ERROR HY000: Spatial indexes can't be primary or unique indexes.
+# Note that SHOW CREATE TABLE does not list b as a primary key,
+# even though it was promoted. This appears to be the case also
+# for other column types.
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` point NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD UNIQUE INDEX (a);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` point NOT NULL,
+  UNIQUE KEY `a` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# Verify that the expected indices have been created by Innodb
+SELECT T.NAME AS TABLE_NAME, I.NAME AS INDEX_NAME,
+CASE I.TYPE 
+WHEN 0 THEN 'Secondary'
+            WHEN 1 THEN 'Clustered'
+            WHEN 2 THEN 'Unique'
+            WHEN 3 THEN 'Primary'
+            WHEN 32 THEN 'Full text'
+            WHEN 64 THEN 'Spatial'
+            ELSE 'Unknown'
+       END AS INDEX_TYPE,
+F.NAME AS FIELD_NAME, F.POS AS FIELD_POS FROM
+INFORMATION_SCHEMA.INNODB_TABLES AS T JOIN
+INFORMATION_SCHEMA.INNODB_INDEXES AS I JOIN
+INFORMATION_SCHEMA.INNODB_FIELDS AS F
+ON I.INDEX_ID = F.INDEX_ID AND I.TABLE_ID = T.TABLE_ID
+WHERE T.NAME = 'test/t1' ORDER BY I.NAME, F.NAME;
+TABLE_NAME	INDEX_NAME	INDEX_TYPE	FIELD_NAME	FIELD_POS
+test/t1	a	Primary	a	0
+DROP TABLE t1;
+#
+# BUG#16886196 - ALTER TABLE FAILS TO CONVERT TO PREFIX INDEX IN
+#                ALTER_COLUMN_EQUAL_PACK_LENGTH
+SET @orig_sql_mode = @@sql_mode;
+SET sql_mode= '';
+# Test with '767' as index size limit.
+CREATE TABLE t1(fld1 VARCHAR(767), KEY a(fld1)) charset latin1 ENGINE= INNODB
+ROW_FORMAT=COMPACT;
+# With patch for Bug#26848813, a warning is reported.
+ALTER TABLE t1 CHANGE fld1 fld1 VARCHAR(768), ALGORITHM= INPLACE;
+Warnings:
+Warning	1071	Specified key was too long; max key length is 767 bytes
+DROP TABLE t1;
+CREATE TABLE t1(fld1 VARCHAR(3072), KEY a(fld1)) charset latin1 ENGINE= INNODB,
+ROW_FORMAT=DYNAMIC;
+INSERT INTO t1 VALUES('a');
+ALTER TABLE t1 CHANGE fld1 fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+Warnings:
+Warning	1071	Specified key was too long; max key length is 3072 bytes
+# Without patch, the below statement will assert in a debug build.
+SELECT COUNT(*) FROM t1 WHERE fld1= 'a';
+COUNT(*)
+1
+# Cleanup.
+DROP TABLE t1;
+# Test with innodb prefix indexes up to 3072 bytes.
+CREATE TABLE t1(fld1 VARCHAR(3072), KEY a(fld1)) charset latin1 ENGINE= INNODB
+ROW_FORMAT= DYNAMIC;
+INSERT INTO t1 VALUES('a');
+ALTER TABLE t1 CHANGE fld1 fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+Warnings:
+Warning	1071	Specified key was too long; max key length is 3072 bytes
+# Without patch, the below statement will assert in a debug build.
+SELECT COUNT(*) FROM t1 WHERE fld1= 'a';
+COUNT(*)
+1
+# Cleanup.
+DROP TABLE t1;
+SET sql_mode= @orig_sql_mode;
+#
+#BUG#20106553: ALTER TABLE WHICH CHANGES INDEX COMMENT IS NOT
+#              LONGER INPLACE/FAST OPERATION.
+#Without the patch, the ALTER TABLE to change the index
+#comment using INPLACE algorithm reports an error.
+CREATE TABLE t1(fld1 int, key key1(fld1)) ENGINE= INNODB;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE			YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'test',
+ALGORITHM= INPLACE;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		test	YES	NULL
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test') ENGINE= MyISAM;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	NULL	NULL	NULL	YES	BTREE		test	YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1), ALGORITHM=INPLACE;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	NULL	NULL	NULL	YES	BTREE			YES	NULL
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test') ENGINE= INNODB;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		test	YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'success',
+ALGORITHM= INPLACE;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		success	YES	NULL
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'old comment') ENGINE=MyISAM;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	NULL	NULL	NULL	YES	BTREE		old comment	YES	NULL
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'new comment',
+ALGORITHM= INPLACE;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	NULL	NULL	NULL	YES	BTREE		new comment	YES	NULL
+DROP TABLE t1;
+#Test cases with merge threshold specified in the index comment.
+CREATE TABLE t1(fld1 int, key key1(fld1)) ENGINE=INNODB;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE			YES	NULL
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+MERGE_THRESHOLD
+50
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT
+'MERGE_THRESHOLD=45';
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		MERGE_THRESHOLD=45	YES	NULL
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+MERGE_THRESHOLD
+45
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'MERGE_THRESHOLD=40')
+ENGINE=INNODB;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		MERGE_THRESHOLD=40	YES	NULL
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+MERGE_THRESHOLD
+40
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1);
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE			YES	NULL
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+MERGE_THRESHOLD
+50
+DROP TABLE t1;
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'MERGE_THRESHOLD=40')
+ENGINE=INNODB;
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		MERGE_THRESHOLD=40	YES	NULL
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+MERGE_THRESHOLD
+40
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT
+'MERGE_THRESHOLD=45';
+SHOW INDEX FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	1	key1	1	fld1	A	0	NULL	NULL	YES	BTREE		MERGE_THRESHOLD=45	YES	NULL
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+MERGE_THRESHOLD
+45
+DROP TABLE t1;
+#
+# Bug#20748660 THD->MDL_CONTEXT.OWNS_EQUAL_OR_STRONGER_LOCK | CREATE_INFO->TABLESPACE
+#
+# A failing DISCARD/IMPORT TABLESPACE may leave the flag THD::tablespace_op
+# in an incorrect state, causing a succeeding statement to fail.
+
+# Create a tablespace with a table.
+CREATE TABLESPACE s ADD DATAFILE 's.ibd' ENGINE InnoDB;
+CREATE TABLE t (i int) TABLESPACE s ENGINE InnoDB;
+# The following statent will fail because the table is not partitioned.
+# Without the fix, the THD::tablespace_op flag will be left set.
+ALTER TABLE t DISCARD PARTITION p TABLESPACE;
+ERROR HY000: Partition management on a not partitioned table is not possible
+# Without the patch, this statement will inherit the tablespace_op flag
+# from the previous statement, causing the statement below to fail due
+# to not acquiring the required MDL lock.
+ALTER TABLE t TABLESPACE s;
+# Drop table and tablespace.
+DROP TABLE t;
+DROP TABLESPACE s ENGINE InnoDB;
+Warnings:
+Warning	1681	'ENGINE tablespace option' is deprecated and will be removed in a future release.
+#
+# Bug#20279241 - ALTER TABLE ... CHARACTER SET UTF8, CONVERT TO
+#                CHARACTER SET LATIN1 SHOULD FAIL
+#
+CREATE TABLE t1 (f1 INT);
+# Case 1: Alter table with CHARACTER SET X, CHARACTER SET X
+#         ALTER table operation should pass.
+ALTER TABLE t1 CHARACTER SET utf8, CHARACTER SET utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+# Case 2: Alter table with CHARACTER SET X, CONVERT TO CHARACTER SET X
+#         ALTER table operation should pass.
+ALTER TABLE t1 CHARACTER SET utf8, CONVERT TO CHARACTER SET utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+# Case 3: Alter table with CONVERT TO CHARACTER SET X, CHARACTER SET X
+#         ALTER table operation should pass.
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CHARACTER SET utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+# Case 4: Alter table with CONVERT TO CHARACTER SET X, CONVERT TO CHARACTER SET X
+#         ALTER table operation should pass.
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CONVERT TO CHARACTER SET utf8;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+# Case 5: Alter table with CHARACTER SET X, CONVERT TO CHARACTER SET Y
+#         Alter table operations should fail with an error "ER_CONFLICTING_DECLARATIONS".
+ALTER TABLE t1 CHARACTER SET utf8, CONVERT TO CHARACTER SET latin1;
+ERROR HY000: Conflicting declarations: 'CHARACTER SET utf8' and 'CHARACTER SET latin1'
+# Case 6: Alter table with CONVERT TO CHARACTER SET X, CHARACTER SET Y
+#         Alter table operations should fail with an error "ER_CONFLICTING_DECLARATIONS".
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CHARACTER SET latin1;
+ERROR HY000: Conflicting declarations: 'CHARACTER SET utf8' and 'CHARACTER SET latin1'
+# Case 7: Alter table with CONVERT TO CHARACTER SET X, CONVERT TO CHARACTER SET Y
+#         Alter table operations should fail with an error "ER_CONFLICTING_DECLARATIONS".
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CONVERT TO CHARACTER SET latin1;
+ERROR HY000: Conflicting declarations: 'CHARACTER SET utf8' and 'CHARACTER SET latin1'
+# Case 8: Alter table with CHARACTER SET X COLLATE INCORRECT_COLLATION_NAME
+#         Alter table operation should fail with an error "ER_COLLATION_CHARSET_MISMATCH"
+ALTER TABLE t1 CHARACTER SET utf8 COLLATE latin1_danish_ci;
+ERROR 42000: COLLATION 'latin1_danish_ci' is not valid for CHARACTER SET 'utf8'
+# Case 9: Alter table with CONVERT TO CHARACTER SET X COLLATE INCORRECT_COLLATION_NAME
+#         Alter table operation should fail with an error "ER_COLLATION_CHARSET_MISMATCH"
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8 COLLATE latin1_danish_ci;
+ERROR 42000: COLLATION 'latin1_danish_ci' is not valid for CHARACTER SET 'utf8'
+# Case 10: Alter table with CHARACTER SET X, CONVERT TO CHARACTER SET Y COLLATE INCORRECT_COLLATION_NAME
+#          Alter table operation should fail with an error "ER_COLLATION_CHARSET_MISMATCH"
+ALTER TABLE t1 CHARACTER SET latin1, CONVERT TO CHARACTER SET utf8 COLLATE latin1_danish_ci;
+ERROR 42000: COLLATION 'latin1_danish_ci' is not valid for CHARACTER SET 'utf8'
+DROP TABLE t1;
+#
+# BUG#20106837: ALTER TABLE WHICH DROPS AND ADDS THE SAME FULLTEXT
+#               INDEX IS NOT INPLACE/FAST.
+CREATE TABLE t1(fld1 varchar(200), FULLTEXT(fld1)) ENGINE=MyISAM;
+INSERT INTO t1 VALUES('ABCD');
+#Without patch, it was not fast a INPLACE ALTER.
+ALTER TABLE t1 DROP INDEX fld1, ADD FULLTEXT INDEX fld1(fld1);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+#Without patch, reports an error 'ER_ALTER_OPERATION_NOT_SUPPORTED'.
+ALTER TABLE t1 ALGORITHM=INPLACE, DROP INDEX fld1,
+ADD FULLTEXT INDEX fld1(fld1);
+DROP TABLE t1;
+#Test with InnoDB engine.
+CREATE TABLE t1(fld1 varchar(200), FULLTEXT(fld1)) ENGINE=INNODB;
+INSERT INTO t1 VALUES('ABCD');
+#Without patch, it was not fast a INPLACE ALTER.
+ALTER TABLE t1 DROP INDEX fld1, ADD FULLTEXT INDEX fld1(fld1);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+#Without patch, reports an error 'ER_ALTER_OPERATION_NOT_SUPPORTED'.
+ALTER TABLE t1 ALGORITHM=INPLACE, DROP INDEX fld1,
+ADD FULLTEXT INDEX fld1(fld1);
+DROP TABLE t1;
+#
+# Bug#20146455: FIND_KEY_CI RETURNS NULL, CAUSES CRASH IN
+#               FILL_ALTER_INPLACE_INFO
+#
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT,
+FOREIGN KEY (b) REFERENCES t1(a)) ENGINE= MyISAM;
+ALTER TABLE t1 RENAME INDEX b TO w, ADD FOREIGN KEY (b) REFERENCES t1(a);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `w` (`b`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT,
+FOREIGN KEY (b) REFERENCES t1(a)) ENGINE= InnoDB;
+ALTER TABLE t1 RENAME INDEX b TO w, ADD FOREIGN KEY (b) REFERENCES t1(a);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `w` (`b`),
+  CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`b`) REFERENCES `t1` (`a`),
+  CONSTRAINT `t1_ibfk_2` FOREIGN KEY (`b`) REFERENCES `t1` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+#
+# Bug#22017616: ASSERTION FAILED: TABLE_SHARE->IS_MISSING_PRIMARY_KEY()
+# == M_PREBUILT->CLUST_IND
+#
+# Ensure that adding indexes with virtual columns are not promoted to
+# primary keys
+#
+# Base line with normal column - should be promoted
+CREATE TABLE t0(a INT NOT NULL) ENGINE=INNODB;
+ALTER TABLE t0 ADD UNIQUE INDEX (a);
+# Case a: Create table with virtual unique not null column
+CREATE TABLE t1(a POINT GENERATED ALWAYS AS (POINT(1,1)) VIRTUAL UNIQUE NOT NULL) ENGINE=INNODB;
+ERROR HY000: 'Spatial index on virtual generated column' is not supported for generated columns.
+# Case b: Create table with index on virtual point column
+CREATE TABLE t2(a POINT GENERATED ALWAYS AS (POINT(1,1)) VIRTUAL NOT NULL, UNIQUE INDEX no_pk(a(1))) ENGINE=INNODB;
+ERROR HY000: 'Spatial index on virtual generated column' is not supported for generated columns.
+# Case c: Add unique index on virtual point column
+CREATE TABLE t3(a POINT GENERATED ALWAYS AS (POINT(1,1)) VIRTUAL NOT NULL)
+ENGINE=INNODB;
+# Case c: Add unique index on virtual point column
+ALTER TABLE t3 ADD UNIQUE INDEX (a(1));
+ERROR HY000: 'Spatial index on virtual generated column' is not supported for generated columns.
+SELECT * FROM t3;
+a
+# Case d: Add unique index on virtual blob column
+CREATE TABLE t4 (a BLOB, b BLOB GENERATED ALWAYS AS (a) VIRTUAL NOT NULL) ENGINE=INNODB;
+ALTER TABLE t4 ADD UNIQUE INDEX (b(1));
+SELECT * FROM t4;
+a	b
+# Query I_S to verify that 'a' is promoted to pk only when it
+# isn't virtual
+SELECT T.NAME AS TABLE_NAME, I.NAME AS INDEX_NAME,
+CASE (I.TYPE & 3)
+WHEN 3 THEN "yes"
+            ELSE "no" END AS IS_PRIMARY_KEY,
+F.NAME AS FIELD_NAME, F.POS AS FIELD_POS FROM
+INFORMATION_SCHEMA.INNODB_TABLES AS T JOIN
+INFORMATION_SCHEMA.INNODB_INDEXES AS I JOIN
+INFORMATION_SCHEMA.INNODB_FIELDS AS F
+ON I.INDEX_ID = F.INDEX_ID AND I.TABLE_ID = T.TABLE_ID
+WHERE T.NAME LIKE 'test/%' ORDER BY T.NAME, I.NAME, F.POS;
+TABLE_NAME	INDEX_NAME	IS_PRIMARY_KEY	FIELD_NAME	FIELD_POS
+test/t0	a	yes	a	0
+test/t4	b	no	b	0
+DROP TABLE t0;
+DROP TABLE t3;
+DROP TABLE t4;
+#
+# Bug #22141913  ASSERTION: !"INVALID KEY_PART->FIELDNR
+# FILL_DD_INDEX_ELEMENTS_FROM_KEY_PARTS
+#
+CREATE TABLE t (a TIMESTAMP(1) GENERATED ALWAYS AS (1) VIRTUAL,
+b INT GENERATED ALWAYS AS (1) VIRTUAL
+) ENGINE=INNODB;
+# The below ALTER asserts without the fix.
+ALTER TABLE t ADD  INDEX (b);
+DROP TABLE t;
+#
+# Bug#21345391: ALTER TABLE ... CONVERT TO CHARACTER SET NOT EFFECT
+#               AND REMAIN A TEMP TABLE
+CREATE TABLE t1 (fld1 INT PRIMARY KEY) ENGINE = INNODB CHARACTER SET gbk;
+ALTER TABLE t1 CONVERT TO CHARACTER SET UTF8, ALGORITHM = INPLACE;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+# Without fix, the CHARSET SET for table remains gbk.
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `fld1` int NOT NULL,
+  PRIMARY KEY (`fld1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+# Without fix, the temporary .frm file is not cleaned up.
+DROP TABLE t1;
+# Test cases added for coverage.
+# Reports an error for tables containing datatypes supporting
+# characters.
+CREATE TABLE t1 (fld1 CHAR(10) PRIMARY KEY) ENGINE = INNODB CHARACTER SET gbk;
+ALTER TABLE t1 CONVERT TO CHARACTER SET UTF8, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+DROP TABLE t1;
+# ALTER TABLE, CHARACTER SET operation.
+CREATE TABLE t1 (fld1 INT PRIMARY KEY, fld2 CHAR(10)) ENGINE = INNODB
+CHARACTER SET gbk;
+ALTER TABLE t1 CHARACTER SET UTF8, ALGORITHM = INPLACE;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `fld1` int NOT NULL,
+  `fld2` char(10) CHARACTER SET gbk DEFAULT NULL,
+  PRIMARY KEY (`fld1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+DROP TABLE t1;
+#
+# Bug#22227958: ASSERT IN DD::FILL_DD_TABLE_FROM_CREATE_INFO, DDL
+#
+# Verify that it is possible to set conflicting values for PACK_KEYS,
+# STATS_PERSISTENT CHECKSUM and DELAY_KEY_WRITE
+# The last value set should be displayed by SHOW CREATE TABLE.
+# Create table with conflicting values
+CREATE TABLE t1(i INT) ENGINE=INNODB PACK_KEYS=0 PACK_KEYS=1
+STATS_PERSISTENT=0 STATS_PERSISTENT=1 CHECKSUM=0 CHECKSUM=1
+DELAY_KEY_WRITE=0 DELAY_KEY_WRITE=1;
+# Should show PACK_KEYS=1 STATS_PERSISTENT=1
+# CHECKSUM=1 DELAY_KEY_WRITE=1
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci PACK_KEYS=1 STATS_PERSISTENT=1 CHECKSUM=1 DELAY_KEY_WRITE=1
+# Alter table with conflicting values
+ALTER TABLE t1 PACK_KEYS=1 PACK_KEYS=0 STATS_PERSISTENT=1 STATS_PERSISTENT=0 CHECKSUM=1 CHECKSUM=0 DELAY_KEY_WRITE=1 DELAY_KEY_WRITE=0;
+# Should show PACK_KEYS=0 STATS_PERSISTENT=0 (0 is default for CHECKSUM and DELAY_KEY_WRITE)
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci PACK_KEYS=0 STATS_PERSISTENT=0
+DROP TABLE t1;
+#
+# Bug#22740093: ERROR 1071 (42000): SPECIFIED KEY WAS TOO LONG
+#               ERROR WHILE DROPPING INDEX IN 5.7
+#
+CREATE TABLE t1(id INT PRIMARY KEY,
+name TINYTEXT,
+KEY nameloc (name(64))
+) DEFAULT CHARSET=utf8mb4;
+ERROR 42000: Specified key was too long; max key length is 255 bytes
+CREATE TABLE t1(id INT PRIMARY KEY,
+name TINYTEXT,
+KEY nameloc (name(63))
+) DEFAULT CHARSET=utf8mb4;
+ALTER TABLE t1 FORCE;
+ALTER TABLE t1 ADD INDEX idx (name(64), id);
+ERROR 42000: Specified key was too long; max key length is 255 bytes
+ALTER TABLE t1 ADD INDEX idx (name(63), id);
+DROP TABLE t1;
+CREATE TABLE t1(id INT PRIMARY KEY,
+name TEXT,
+KEY nameloc (name(64))
+) DEFAULT CHARSET=utf8mb4;
+ALTER TABLE t1 MODIFY COLUMN name TINYTEXT;
+ERROR 42000: Specified key was too long; max key length is 255 bytes
+DROP TABLE t1;
+#
+# BUG#16888677: OUT OF RANGE VALUE ACCEPTED FOR DATETIME COLUMN IN
+#               ALTER TABLE...ADD COLUMN
+SET @saved_sql_mode = @@session.sql_mode;
+# Test case with no SQL_MODE enabled.
+SET SESSION sql_mode= '';
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+# No warnings or error is reported
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+ALTER TABLE t1 ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM=COPY;
+DROP TABLE t1;
+# Test case with strict mode enabled.
+SET SESSION sql_mode= 'STRICT_ALL_TABLES';
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+# No warnings or error is reported
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+ALTER TABLE t1 ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM=COPY;
+DROP TABLE t1;
+# Test case with 'NO_ZERO_DATE' enabled.
+SET SESSION sql_mode= 'NO_ZERO_DATE';
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+# Warnings are reported after patch.
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+Warnings:
+Warning	1292	Incorrect datetime value: '0000-00-00 00:00:00' for column 'fld2' at row 1
+ALTER TABLE t1 ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM=COPY;
+Warnings:
+Warning	1264	Out of range value for column 'fld2' at row 1
+DROP TABLE t1;
+# Test case with both 'NO_ZERO_DATE and strict mode' enabled.
+SET SESSION sql_mode= @saved_sql_mode;
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+# Without patch, the following statement succeeds.
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+ERROR 22007: Incorrect datetime value: '0000-00-00 00:00:00' for column 'fld2' at row 1
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=COPY;
+ERROR 22007: Incorrect datetime value: '0000-00-00 00:00:00' for column 'fld2' at row 1
+TRUNCATE TABLE t1;
+# Operation below succeeds, since the table has no records.
+ALTER TABLE t1 ADD COLUMN fld4 DATETIME NOT NULL, ALGORITHM=INPLACE;
+DROP TABLE t1;
+#
+# Additional coverage for WL#7743 "New data dictionary: changes to
+# DDL-related parts of SE API". Check that ALTER TABLE INPLACE with
+# RENAME TO clause correctly handles FKs and triggers.
+#
+CREATE TABLE t1 (pk INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (fk INT, FOREIGN KEY (fk) REFERENCES t1 (pk)) ENGINE=InnoDB;
+ALTER TABLE t2 ADD COLUMN j INT, RENAME TO t3, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `fk` int DEFAULT NULL,
+  `j` int DEFAULT NULL,
+  KEY `fk` (`fk`),
+  CONSTRAINT `t3_ibfk_1` FOREIGN KEY (`fk`) REFERENCES `t1` (`pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t3;
+CREATE TRIGGER t1_bi BEFORE INSERT ON t1 FOR EACH ROW SET @a:=0;
+ALTER TABLE t1 ADD COLUMN j INT, RENAME TO t4, ALGORITHM=INPLACE;
+SELECT trigger_name, event_object_schema, event_object_table, action_statement
+FROM information_schema.triggers WHERE event_object_schema = 'test';
+TRIGGER_NAME	EVENT_OBJECT_SCHEMA	EVENT_OBJECT_TABLE	ACTION_STATEMENT
+t1_bi	test	t4	SET @a:=0
+DROP TABLE t4;
+
+Bug#25779239 ALTER TABLE FAILS WHEN DEFAULT
+CHARACTER SET CHANGES TO UTF8MB4
+
+CREATE TABLE t1(
+i INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY) charset latin1;
+ALTER TABLE t1
+DROP i,
+ADD i INT UNSIGNED NOT NULL AUTO_INCREMENT,
+AUTO_INCREMENT = 1;
+DROP TABLE t1;
+CREATE TABLE t1(
+i INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY) charset utf8mb4;
+ALTER TABLE t1
+DROP i,
+ADD i INT UNSIGNED NOT NULL AUTO_INCREMENT,
+AUTO_INCREMENT = 1;
+DROP TABLE t1;
+#
+# BUG#25385334: MYSQL 5.7 ERROR WITH ALTER TABLE MODIFY SYNTAX
+#               AND DATETIME TYPE.
+SET @saved_sql_mode = @@session.sql_mode;
+# Test case with both strict mode and 'NO_ZERO_DATE' enabled.
+CREATE TABLE t1 (fld1 INT, fld2 DATETIME NOT NULL) ENGINE= INNODB;
+CREATE TABLE t2 (fld1 INT, fld2 POINT NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES(1, '2000-01-01');
+INSERT INTO t2 values(1,  ST_PointFromText('POINT(10 10)'));
+# Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1;
+# Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL FIRST, ALGORITHM= COPY;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL FIRST, ALGORITHM= COPY;
+# Tests added for coverage.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+ADD COLUMN fld3 DATETIME NOT NULL;
+ERROR 22007: Incorrect datetime value: '0000-00-00 00:00:00' for column 'fld3' at row 1
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+ADD COLUMN fld3 MULTIPOINT NOT NULL;
+ERROR 22004: Invalid use of NULL value
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM= COPY;
+ERROR 22007: Incorrect datetime value: '0000-00-00 00:00:00' for column 'fld3' at row 1
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+ADD COLUMN fld3 MULTIPOINT NOT NULL, ALGORITHM= COPY;
+ERROR 22004: Invalid use of NULL value
+TRUNCATE TABLE t1;
+TRUNCATE TABLE t2;
+# Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1;
+# Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL FIRST, ALGORITHM= COPY;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL FIRST, ALGORITHM= COPY;
+# Tests added for coverage.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+ADD COLUMN fld3 DATETIME NOT NULL;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+ADD COLUMN fld3 MULTIPOINT NOT NULL;
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+ADD COLUMN fld4 DATETIME NOT NULL, ALGORITHM= COPY;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+ADD COLUMN fld4 MULTIPOINT NOT NULL, ALGORITHM= COPY;
+DROP TABLE t1, t2;
+# Test case when a non date column is converted to datetime column.
+# Test case without any sql mode enabled.
+SET SESSION sql_mode= '';
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+# No error or warning is reported.
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+DROP TABLE t1;
+# Test case with only 'NO_ZERO_DATE' enabled.
+SET SESSION sql_mode= 'NO_ZERO_DATE';
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+# Reports only a warning.
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+Warnings:
+Warning	1264	Out of range value for column 'fld1' at row 1
+DROP TABLE t1;
+SET SESSION sql_mode= 'STRICT_ALL_TABLES';
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+# No error or warning is reported.
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+DROP TABLE t1;
+# Test case with both STRICT MODE and 'NO_ZERO_DATE' enabled.
+SET SESSION sql_mode= @saved_sql_mode;
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+# Reports an error.
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+ERROR 22007: Incorrect datetime value: '0000-00-00' for column 'fld1' at row 1
+DROP TABLE t1;
+# Test case when a NULL column is converted to NOT NULL column
+CREATE TABLE t1 (fld0 DATETIME, fld1 INT, fld2 DATETIME NOT NULL) ENGINE= INNODB;
+CREATE TABLE t2 (fld0 POINT, fld1 INT, fld2 POINT NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01', 1, '2000-01-01');
+INSERT INTO t2 values(ST_PointFromText('POINT(10 10)'), 1,
+ST_PointFromText('POINT(10 10)'));
+# Reports an error without patch.
+ALTER TABLE t1 MODIFY fld0 DATETIME NOT NULL AFTER fld2;
+# Reports an error without patch
+ALTER TABLE t2 MODIFY fld0 POINT NOT NULL AFTER fld2;
+DROP TABLE t1, t2;
+# Test case demonstrating the NULL constraint check done by SE.
+CREATE TABLE t1 (fld0 DATETIME, fld1 INT, fld2 DATETIME NOT NULL) ENGINE= INNODB;
+CREATE TABLE t2 (fld0 POINT, fld1 INT, fld2 POINT NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES(NULL, 1, '2000-01-01');
+INSERT INTO t2 values(NULL, 1, ST_PointFromText('POINT(10 10)'));
+ALTER TABLE t1 MODIFY fld0 DATETIME NOT NULL;
+ERROR 22004: Invalid use of NULL value
+ALTER TABLE t2 MODIFY fld0 POINT NOT NULL;
+ERROR 22004: Invalid use of NULL value
+DROP TABLE t1, t2;
+#
+# WL#10761 : ALTER TABLE RENAME COLUMN
+#
+CREATE TABLE t1(a INT, b VARCHAR(30), c FLOAT);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` varchar(30) DEFAULT NULL,
+  `c` float DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+INSERT INTO t1 VALUES(1,'abcd',1.234);
+CREATE TABLE t2(a INT, b VARCHAR(30), c FLOAT) ENGINE=MyIsam;
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `a` int DEFAULT NULL,
+  `b` varchar(30) DEFAULT NULL,
+  `c` float DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+INSERT INTO t2 VALUES(1,'abcd',1.234);
+ALTER TABLE t1 RENAME COLUMN a TO a;
+ALTER TABLE t1 RENAME COLUMN a TO m;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `m` int DEFAULT NULL,
+  `b` varchar(30) DEFAULT NULL,
+  `c` float DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t1;
+m	b	c
+1	abcd	1.234
+ALTER TABLE t1 RENAME COLUMN m TO x,
+RENAME COLUMN b TO y,
+RENAME COLUMN c TO z;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `x` int DEFAULT NULL,
+  `y` varchar(30) DEFAULT NULL,
+  `z` float DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t1;
+x	y	z
+1	abcd	1.234
+ALTER TABLE t2 RENAME COLUMN a TO d, RENAME COLUMN b TO e, RENAME COLUMN c to f;
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `d` int DEFAULT NULL,
+  `e` varchar(30) DEFAULT NULL,
+  `f` float DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t2;
+d	e	f
+1	abcd	1.234
+ALTER TABLE t1 CHANGE COLUMN x a INT, RENAME COLUMN y TO b;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` varchar(30) DEFAULT NULL,
+  `z` float DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 CHANGE COLUMN z c DOUBLE, RENAME COLUMN b to b;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL,
+  `b` varchar(30) DEFAULT NULL,
+  `c` double DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 CHANGE COLUMN a b int, RENAME COLUMN b TO c, CHANGE COLUMN c d FLOAT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `b` int DEFAULT NULL,
+  `c` varchar(30) DEFAULT NULL,
+  `d` float DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD COLUMN zz INT, RENAME COLUMN d TO f;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `b` int DEFAULT NULL,
+  `c` varchar(30) DEFAULT NULL,
+  `f` float DEFAULT NULL,
+  `zz` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 DROP COLUMN zz, RENAME COLUMN c TO zz;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `b` int DEFAULT NULL,
+  `zz` varchar(30) DEFAULT NULL,
+  `f` float DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME COLUMN zz to c, DROP COLUMN f;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `b` int DEFAULT NULL,
+  `c` varchar(30) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD COLUMN d INT DEFAULT 5, RENAME COLUMN c TO b, DROP COLUMN b;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `b` varchar(30) DEFAULT NULL,
+  `d` int DEFAULT '5'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME COLUMN b TO d, RENAME COLUMN d TO b;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `d` varchar(30) DEFAULT NULL,
+  `b` int DEFAULT '5'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD KEY(b);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `d` varchar(30) DEFAULT NULL,
+  `b` int DEFAULT '5',
+  KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME COLUMN b TO bb;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `d` varchar(30) DEFAULT NULL,
+  `bb` int DEFAULT '5',
+  KEY `b` (`bb`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t1;
+d	bb
+abcd	5
+CREATE TABLE t3(a int, b int, KEY(b)) ENGINE=InnoDB;
+ALTER TABLE t3 ADD CONSTRAINT FOREIGN KEY(b) REFERENCES t1(bb);
+SHOW CREATE TABLE t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  KEY `b` (`b`),
+  CONSTRAINT `t3_ibfk_1` FOREIGN KEY (`b`) REFERENCES `t1` (`bb`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME COLUMN bb TO b;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `d` varchar(30) DEFAULT NULL,
+  `b` int DEFAULT '5',
+  KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t3 RENAME COLUMN b TO c;
+SHOW CREATE TABLE t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `a` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  KEY `b` (`c`),
+  CONSTRAINT `t3_ibfk_1` FOREIGN KEY (`c`) REFERENCES `t1` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+CREATE TABLE t4(a int);
+ALTER TABLE t4 RENAME COLUMN a TO aa, ALGORITHM = INPLACE;
+SHOW CREATE TABLE t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `aa` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t4 RENAME COLUMN aa TO a, ALGORITHM = COPY;
+SHOW CREATE TABLE t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `a` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t4;
+CREATE VIEW v1 AS SELECT d,e,f FROM t2;
+CREATE TRIGGER trg1 BEFORE UPDATE on t2 FOR EACH ROW SET NEW.d=OLD.d + 10;
+CREATE PROCEDURE sp1() INSERT INTO t2(d) VALUES(10);
+ALTER TABLE t2 RENAME COLUMN d TO g;
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `g` int DEFAULT NULL,
+  `e` varchar(30) DEFAULT NULL,
+  `f` float DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SHOW CREATE VIEW v1;
+View	Create View	character_set_client	collation_connection
+v1	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v1` AS select `t2`.`d` AS `d`,`t2`.`e` AS `e`,`t2`.`f` AS `f` from `t2`	utf8mb4	utf8mb4_0900_ai_ci
+Warnings:
+Warning	1356	View 'test.v1' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+SELECT * FROM v1;
+ERROR HY000: View 'test.v1' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+UPDATE t2 SET f = f + 10;
+ERROR 42S22: Unknown column 'd' in 'OLD'
+CALL sp1();
+ERROR 42S22: Unknown column 'd' in 'field list'
+DROP TRIGGER trg1;
+DROP PROCEDURE sp1;
+CREATE TABLE t_gen(a INT, b DOUBLE GENERATED ALWAYS AS (SQRT(a)));
+INSERT INTO t_gen(a) VALUES(4);
+SELECT * FROM t_gen;
+a	b
+4	2
+SHOW CREATE TABLE t_gen;
+Table	Create Table
+t_gen	CREATE TABLE `t_gen` (
+  `a` int DEFAULT NULL,
+  `b` double GENERATED ALWAYS AS (sqrt(`a`)) VIRTUAL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t_gen RENAME COLUMN a TO c, CHANGE COLUMN b b DOUBLE GENERATED ALWAYS AS (SQRT(c));
+SELECT * FROM t_gen;
+c	b
+4	2
+SHOW CREATE TABLE t_gen;
+Table	Create Table
+t_gen	CREATE TABLE `t_gen` (
+  `c` int DEFAULT NULL,
+  `b` double GENERATED ALWAYS AS (sqrt(`c`)) VIRTUAL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t_gen CHANGE COLUMN c a INT;
+ERROR HY000: Column 'c' has a generated column dependency.
+ALTER TABLE t_gen RENAME COLUMN c TO a;
+ERROR HY000: Column 'c' has a generated column dependency.
+DROP TABLE t_gen;
+CREATE TABLE foo (col1 INT);
+INSERT INTO foo VALUES (1), (2);
+ANALYZE TABLE foo UPDATE HISTOGRAM ON col1 WITH 10 BUCKETS;
+Table	Op	Msg_type	Msg_text
+test.foo	histogram	status	Histogram statistics created for column 'col1'.
+SELECT schema_name, table_name, column_name,
+JSON_REMOVE(histogram, '$."last-updated"')
+FROM information_schema.COLUMN_STATISTICS;
+SCHEMA_NAME	TABLE_NAME	COLUMN_NAME	JSON_REMOVE(histogram, '$."last-updated"')
+test	foo	col1	{"buckets": [[1, 0.5], [2, 1.0]], "data-type": "int", "null-values": 0.0, "collation-id": 8, "sampling-rate": 1.0, "histogram-type": "singleton", "number-of-buckets-specified": 10}
+ALTER TABLE foo RENAME COLUMN col1 TO col2;
+SELECT schema_name, table_name, column_name,
+JSON_REMOVE(histogram, '$."last-updated"')
+FROM information_schema.COLUMN_STATISTICS;
+SCHEMA_NAME	TABLE_NAME	COLUMN_NAME	JSON_REMOVE(histogram, '$."last-updated"')
+DROP TABLE foo;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `d` varchar(30) DEFAULT NULL,
+  `b` int DEFAULT '5',
+  KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME COLUMN b z;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'z' at line 1
+ALTER TABLE t1 RENAME COLUMN FROM b TO z;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FROM b TO z' at line 1
+ALTER TABLE t1 RENAME COLUMN b TO 1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '1' at line 1
+ALTER TABLE t1 RENAME COLUMN b TO e, RENAME COLUMN c TO e;
+ERROR 42S22: Unknown column 'c' in 't1'
+ALTER TABLE t1 ADD COLUMN z INT, RENAME COLUMN b TO z;
+ERROR 42S21: Duplicate column name 'z'
+ALTER TABLE t1 DROP COLUMN b, RENAME COLUMN b TO z;
+ERROR 42S22: Unknown column 'b' in 't1'
+ALTER TABLE t1 RENAME COLUMN b TO b, RENAME COLUMN b TO b;
+ERROR 42S22: Unknown column 'b' in 't1'
+ALTER TABLE t1 RENAME COLUMN b TO c3, DROP COLUMN c3;
+ERROR 42000: Can't DROP 'c3'; check that column/key exists
+ALTER TABLE t1 ADD COLUMN z INT, CHANGE COLUMN z y INT, DROP COLUMN y;
+ERROR 42S22: Unknown column 'z' in 't1'
+ALTER TABLE t1 ADD COLUMN z INT, RENAME COLUMN z TO y, DROP COLUMN y;
+ERROR 42S22: Unknown column 'z' in 't1'
+ALTER TABLE t1 RENAME COLUMN b TO `nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn`;
+ERROR 42000: Incorrect column name 'nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn'
+ALTER TABLE t1 CHANGE b `nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn` int;
+ERROR 42000: Identifier name 'nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn' is too long
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `d` varchar(30) DEFAULT NULL,
+  `b` int DEFAULT '5',
+  KEY `b` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t1;
+d	b
+abcd	5
+DROP VIEW v1;
+DROP TABLE t3,t1,t2;
+SET SESSION information_schema_stats_expiry=default;
+#
+# Bug#27252354: UNABLE TO CREATE INDEX WHEN DATE/DATETIME DATATYPES
+#               ARE USED WITH REQUIRED OPTION
+#
+CREATE TABLE t(a INT);
+INSERT INTO t VALUES ();
+ALTER TABLE t
+ADD COLUMN b DATE GENERATED ALWAYS AS ('1999-09-09') VIRTUAL NOT NULL;
+ALTER TABLE t
+ADD COLUMN c DATE GENERATED ALWAYS AS ('1999-09-09') STORED NOT NULL;
+ALTER TABLE t
+ADD COLUMN d DATE GENERATED ALWAYS AS (NULL) VIRTUAL NOT NULL;
+CREATE INDEX idx ON t(d);
+ERROR 23000: Column 'd' cannot be null
+ALTER TABLE t
+ADD COLUMN e DATE GENERATED ALWAYS AS (NULL) STORED NOT NULL;
+ERROR 23000: Column 'd' cannot be null
+SELECT * FROM t;
+a	b	c	d
+NULL	1999-09-09	1999-09-09	0000-00-00
+DROP TABLE t;
+#
+# Basic test coverage for ALGORITHM=INSTANT support on SQL-layer.
+#
+#
+# 1) Syntax.
+#
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 10, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT '10'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# ALGORITHM=INSTANT doesn't make sense with LOCK clause.
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 11, ALGORITHM=INSTANT, LOCK=NONE;
+ERROR HY000: Incorrect usage of ALGORITHM=INSTANT and LOCK=NONE/SHARED/EXCLUSIVE
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 12, ALGORITHM=INSTANT, LOCK=SHARED;
+ERROR HY000: Incorrect usage of ALGORITHM=INSTANT and LOCK=NONE/SHARED/EXCLUSIVE
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 13, ALGORITHM=INSTANT, LOCK=EXCLUSIVE;
+ERROR HY000: Incorrect usage of ALGORITHM=INSTANT and LOCK=NONE/SHARED/EXCLUSIVE
+# ALGORITHM=INSTANT and LOCK=DEFAULT are OK though.
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 13, ALGORITHM=INSTANT, LOCK=DEFAULT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT '13'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+#
+# 2) We support INSTANT algorithm for a few trivial metadata-only
+#    changes for InnoDB.
+#
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 14, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT '14'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ALTER COLUMN i DROP DEFAULT, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ADD COLUMN j ENUM('a', 'b', 'c');
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e'), ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int,
+  `j` enum('a','b','c','d','e') DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME TO t2, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int,
+  `j` enum('a','b','c','d','e') DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+#
+# 3) You can still use ALGORITHM=INPLACE for these operations
+#    (even though INSTANT algorithm will be used internally).
+#
+ALTER TABLE t2 RENAME TO t1, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int,
+  `j` enum('a','b','c','d','e') DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 15, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT '15',
+  `j` enum('a','b','c','d','e') DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ALTER COLUMN i DROP DEFAULT, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int,
+  `j` enum('a','b','c','d','e') DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e', 'f', 'g'), ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int,
+  `j` enum('a','b','c','d','e','f','g') DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+#
+# 4) However, some operations are not supported as INSTANT.
+#
+ALTER TABLE t1 ADD KEY(j), ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 15, DROP COLUMN j, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+#
+# 5) For MyISAM tables we support INSTANT algorithm for metadata-only
+#    changes as well.
+#
+DROP TABLE t1;
+CREATE TABLE t1 (i INT, j ENUM('a', 'b'), KEY(i)) ENGINE=MyISAM;
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 10, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT '10',
+  `j` enum('a','b') DEFAULT NULL,
+  KEY `i` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ALTER COLUMN i DROP DEFAULT, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int,
+  `j` enum('a','b') DEFAULT NULL,
+  KEY `i` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e'), ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int,
+  `j` enum('a','b','c','d','e') DEFAULT NULL,
+  KEY `i` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 CHANGE COLUMN i k INT, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `k` int DEFAULT NULL,
+  `j` enum('a','b','c','d','e') DEFAULT NULL,
+  KEY `i` (`k`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME INDEX i TO k, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `k` int DEFAULT NULL,
+  `j` enum('a','b','c','d','e') DEFAULT NULL,
+  KEY `k` (`k`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME TO t2, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `k` int DEFAULT NULL,
+  `j` enum('a','b','c','d','e') DEFAULT NULL,
+  KEY `k` (`k`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+#
+# 6) And you can still use ALGORITHM=INPLACE for the same operations
+#    for MyISAM tables too.
+#
+ALTER TABLE t2 RENAME TO t1, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `k` int DEFAULT NULL,
+  `j` enum('a','b','c','d','e') DEFAULT NULL,
+  KEY `k` (`k`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ALTER COLUMN k SET DEFAULT 11, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `k` int DEFAULT '11',
+  `j` enum('a','b','c','d','e') DEFAULT NULL,
+  KEY `k` (`k`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 ALTER COLUMN k DROP DEFAULT, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `k` int,
+  `j` enum('a','b','c','d','e') DEFAULT NULL,
+  KEY `k` (`k`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e', 'f', 'g'), ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `k` int,
+  `j` enum('a','b','c','d','e','f','g') DEFAULT NULL,
+  KEY `k` (`k`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 CHANGE COLUMN k i INT, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL,
+  `j` enum('a','b','c','d','e','f','g') DEFAULT NULL,
+  KEY `k` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t1 RENAME INDEX k TO i, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `i` int DEFAULT NULL,
+  `j` enum('a','b','c','d','e','f','g') DEFAULT NULL,
+  KEY `i` (`i`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+#
+# 7) Indeed, some options are not supported as INSTANT
+#
+ALTER TABLE t1 ADD COLUMN l INT, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 12, DROP COLUMN j, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+DROP TABLE t1;
+#
+# Bug#27864226: ASSERTION `(CREATE_INFO->USED_FIELDS & (1L << 8)) == 0 ||
+#
+CREATE TABLE t1 (a INT) ENGINE=INNODB;
+# Verify that ALTER can have both a CONVERT clause and a
+# DEFAULT CHARACTER SET clause with different charsets
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf16 COLLATE utf16_turkish_ci,
+DEFAULT CHARACTER SET utf16 COLLATE utf16_slovak_ci;
+# Verify that last default (utf16) overrides
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf16 COLLATE=utf16_slovak_ci
+DROP TABLE t1;
+#  BUG#27909771 - [MYSQL 8.0 GA DEBUG BUILD] ASSERTION `(*IDX_EL_IT)->IS_PREFIX() == STATIC_CAST<B
+#
+SET SQL_MODE='';
+CREATE TABLE t1 SELECT 100000000000000000000000000000000000000000000000000000000000000001 AS c1;
+Warnings:
+Warning	1264	Out of range value for column 'c1' at row 1
+ALTER TABLE t1 ADD INDEX (c1);
+DROP TABLE t1;
+SET SQL_MODE=default;
+#
+# BUG#26848813: INDEXED COLUMN CAN'T BE CHANGED FROM VARCHAR(15)
+#               TO VARCHAR(40) INSTANTANEOUSLY
+SET @orig_sql_mode = @@sql_mode;
+# Tests where an error is reported under strict mode when the index
+# limit exceeds the maximum supported length by SE.
+CREATE TABLE t1 (fld1 VARCHAR(768), KEY(fld1)) CHARSET latin1 ENGINE =InnoDB
+ROW_FORMAT= COMPACT;
+ERROR 42000: Specified key was too long; max key length is 767 bytes
+CREATE TABLE t2 (fld1 VARCHAR(3073), KEY(fld1)) CHARSET latin1 ENGINE= InnoDB;
+ERROR 42000: Specified key was too long; max key length is 3072 bytes
+# Test with innodb prefix indexes where the index limit is 767 bytes
+CREATE TABLE t1 (fld1 VARCHAR(767), KEY(fld1)) CHARSET latin1 ENGINE=INNODB
+ROW_FORMAT=COMPACT;
+ALTER TABLE t1 MODIFY fld1 VARCHAR(768), ALGORITHM= INPLACE;
+ERROR 42000: Specified key was too long; max key length is 767 bytes
+ALTER TABLE t1 MODIFY fld1 VARCHAR(768), ALGORITHM= COPY;
+ERROR 42000: Specified key was too long; max key length is 767 bytes
+# Test with innodb prefix indexes where the index limit is 3072 bytes
+CREATE TABLE t2 (fld1 VARCHAR(3072), KEY(fld1)) CHARSET latin1 ENGINE=INNODB
+ROW_FORMAT=DYNAMIC;
+ALTER TABLE t2 MODIFY fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+ERROR 42000: Specified key was too long; max key length is 3072 bytes
+ALTER TABLE t2 MODIFY fld1 VARCHAR(3073), ALGORITHM= COPY;
+ERROR 42000: Specified key was too long; max key length is 3072 bytes
+DROP TABLE t1, t2;
+SET sql_mode= '';
+# Test where the indexes are truncated to fit the index limit and
+# a warning is reported under non-strict mode when the index exceeds
+# the SE limit.
+CREATE TABLE t1 (fld1 VARCHAR(768), KEY(fld1)) ENGINE= InnoDB
+ROW_FORMAT=COMPACT;
+Warnings:
+Warning	1071	Specified key was too long; max key length is 767 bytes
+CREATE TABLE t2 (fld1 VARCHAR(3073), KEY(fld1)) ENGINE= InnoDB;
+Warnings:
+Warning	1071	Specified key was too long; max key length is 3072 bytes
+# Test with innodb prefix indexes where the index limit is 767 bytes.
+CREATE TABLE t3 (fld1 VARCHAR(767), KEY(fld1))ENGINE=INNODB ROW_FORMAT=COMPACT;
+Warnings:
+Warning	1071	Specified key was too long; max key length is 767 bytes
+ALTER TABLE t3 MODIFY fld1 VARCHAR(768), ALGORITHM= INPLACE;
+ALTER TABLE t3 MODIFY fld1 VARCHAR(800), ALGORITHM= COPY;
+# Test with innodb prefix indexes where the index limit is 3072 bytes.
+CREATE TABLE t4 (fld1 VARCHAR(3072), KEY(fld1))ENGINE=INNODB
+ROW_FORMAT=DYNAMIC;
+Warnings:
+Warning	1071	Specified key was too long; max key length is 3072 bytes
+ALTER TABLE t4 MODIFY fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+ALTER TABLE t4 MODIFY fld1 VARCHAR(3074), ALGORITHM= COPY;
+# For unique and primary keys, an error is reported even in non-strict
+# mode.
+CREATE TABLE t5(fld1 VARCHAR(768) PRIMARY KEY) ENGINE= InnoDB
+ROW_FORMAT=COMPACT;
+ERROR 42000: Specified key was too long; max key length is 767 bytes
+CREATE TABLE t5(fld1 VARCHAR(3073), UNIQUE KEY(fld1)) ENGINE= InnoDB;
+ERROR 42000: Specified key was too long; max key length is 3072 bytes
+DROP TABLE t1, t2, t3, t4;
+SET sql_mode= @orig_sql_mode;
+# Tests added for coverage.
+CREATE TABLE t1(fld1 VARCHAR(3), KEY(fld1)) ENGINE=MYISAM;
+# Conversion of unpacked keys to packed keys reports
+# error for INPLACE Alter.
+ALTER TABLE t1 MODIFY fld1 VARCHAR(10), ALGORITHM=INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
+# Succeeds with index rebuild.
+ALTER TABLE t1 MODIFY fld1 VARCHAR(10), ALGORITHM=COPY;
+# Succeeds since the row format is dynamic.
+CREATE TABLE t2(fld1 VARCHAR(768), KEY(fld1)) ENGINE= InnoDB ROW_FORMAT= DYNAMIC;
+# An error is reported when the index exceeds the column size
+# in both strict and non-strict mode.
+ALTER TABLE t2 ADD INDEX idx1(fld1(769));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+SET sql_mode= '';
+ALTER TABLE t2 ADD INDEX idx1(fld1(769));
+ERROR HY000: Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys
+# Cleanup.
+DROP TABLE t1, t2;
+SET sql_mode= @orig_sql_mode;
+#
+# BUG#27164393: ALTER COLUMN SET DEFAULT DOES NOT RETURN ERROR
+#               ON GENERATED COLUMNS
+CREATE TABLE t1(fld1 INT, fld2 INT GENERATED ALWAYS AS (-fld1) VIRTUAL,
+fld3 INT GENERATED ALWAYS AS (-fld1) STORED);
+# Without patch, does not report an error.
+ALTER TABLE t1 ALTER COLUMN fld2 SET DEFAULT -1;
+ERROR HY000: Incorrect usage of DEFAULT and generated column
+ALTER TABLE t1 ALTER COLUMN fld3 SET DEFAULT -1;
+ERROR HY000: Incorrect usage of DEFAULT and generated column
+# Tests added for coverage
+ALTER TABLE t1 CHANGE fld2 fld2 INT GENERATED ALWAYS AS (-fld1) DEFAULT -1;
+ERROR HY000: Incorrect usage of DEFAULT and generated column
+ALTER TABLE t1 MODIFY fld3 INT GENERATED ALWAYS AS (-fld1) STORED DEFAULT -1;
+ERROR HY000: Incorrect usage of DEFAULT and generated column
+DROP TABLE t1;
+#
+# BUG#27788685: NO WARNING WHEN TRUNCATING A STRING WITH DATA LOSS
+#
+SET GLOBAL max_allowed_packet=17825792;
+CREATE TABLE t1 (t1_fld1 TEXT) ENGINE=InnoDB;
+CREATE TABLE t2 (t2_fld1 MEDIUMTEXT) ENGINE=InnoDB;
+CREATE TABLE t3 (t3_fld1 LONGTEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (REPEAT('a',300));
+INSERT INTO t2 VALUES (REPEAT('b',65680));
+INSERT INTO t3 VALUES (REPEAT('c',16777300));
+SELECT LENGTH(t1_fld1) FROM t1;
+LENGTH(t1_fld1)
+300
+SELECT LENGTH(t2_fld1) FROM t2;
+LENGTH(t2_fld1)
+65680
+SELECT LENGTH(t3_fld1) FROM t3;
+LENGTH(t3_fld1)
+16777300
+# With strict mode
+SET SQL_MODE='STRICT_ALL_TABLES';
+Warnings:
+Warning	3135	'NO_ZERO_DATE', 'NO_ZERO_IN_DATE' and 'ERROR_FOR_DIVISION_BY_ZERO' sql modes should be used with strict mode. They will be merged with strict mode in a future release.
+ALTER TABLE t1 CHANGE `t1_fld1` `my_t1_fld1` TINYTEXT;
+ERROR 22001: Data too long for column 'my_t1_fld1' at row 1
+ALTER TABLE t2 CHANGE `t2_fld1` `my_t2_fld1` TEXT;
+ERROR 22001: Data too long for column 'my_t2_fld1' at row 1
+ALTER TABLE t3 CHANGE `t3_fld1` `my_t3_fld1` MEDIUMTEXT;
+ERROR 22001: Data too long for column 'my_t3_fld1' at row 1
+# With non-strict mode
+SET SQL_MODE='';
+ALTER TABLE t1 CHANGE `t1_fld1` `my_t1_fld1` TINYTEXT;
+Warnings:
+Warning	1265	Data truncated for column 'my_t1_fld1' at row 1
+ALTER TABLE t2 CHANGE `t2_fld1` `my_t2_fld1` TEXT;
+Warnings:
+Warning	1265	Data truncated for column 'my_t2_fld1' at row 1
+ALTER TABLE t3 CHANGE `t3_fld1` `my_t3_fld1` MEDIUMTEXT;
+Warnings:
+Warning	1265	Data truncated for column 'my_t3_fld1' at row 1
+SELECT LENGTH(my_t1_fld1) FROM t1;
+LENGTH(my_t1_fld1)
+44
+SELECT LENGTH(my_t2_fld1) FROM t2;
+LENGTH(my_t2_fld1)
+144
+SELECT LENGTH(my_t3_fld1) FROM t3;
+LENGTH(my_t3_fld1)
+84
+DROP TABLE t1, t2, t3;
+SET SQL_MODE=default;
+SET GLOBAL max_allowed_packet=default;
+#
+# Testing wl#11605: Alter table with character set conversion as
+# inplace operation, Step 1, NO INDEX
+#
+SET NAMES UTF8MB4;
+# VARCHAR(512): SWE7 -> BINARY
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET SWE7);
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# VARCHAR(512): ASCII -> BINARY
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET ASCII);
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# VARCHAR(512): UTF8MB4 -> BINARY
+# Not allowed because 512 binary chars cannot hold all 512 char
+# utf8mb4 strings
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET UTF8MB4);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5));
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET BINARY,
+ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# VARCHAR(512) CHARSET UTF8MB4 -> VARCHAR(2048) CHARSET BINARY:
+# Converting to BINARY and increasing the VARCHAR size accordingly is ok
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(2048) CHARSET BINARY,
+ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøå
+𐐀
+DROP TABLE t1;
+# Conversions requiring COPY algorithm
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET ASCII);
+INSERT INTO t1 VALUES ('a string');
+# VARCHAR(512): ASCII -> SWE7
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET SWE7, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# VARCHAR(512): ASCII -> UCS2
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET UCS2, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# VARCHAR(512): ASCII -> UTF8MB4
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET UTF8MB4,
+ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+DROP TABLE t1;
+# VARCHAR(512): UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET UTF8MB4,
+ALGORITHM = INPLACE;
+# Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøåtext
+𐐀
+DROP TABLE t1;
+# CHAR(1): UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 CHAR(1) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (0xc3a6), (0xc3b8);
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(1) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+c1
+æ
+ø
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æ
+ø
+𐐀
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` char(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+# CHAR(31): UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 CHAR(31) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(31) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+# Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøåtext
+𐐀
+DROP TABLE t1;
+# Crossing the boundary of 256 bytes usage, cannot be INPLACE.
+# 85*3 -> 85*4 and 64*3 -> 64*4
+CREATE TABLE t1(c1 CHAR(85) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(85) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+DROP TABLE t1;
+CREATE TABLE t1(c1 CHAR(64) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(64) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+SELECT * FROM t1;
+c1
+æøåtext
+DROP TABLE t1;
+# Increase in column size above 256 bytes should be inplace.
+# 86*3 -> 86*4
+CREATE TABLE t1(c1 CHAR(86) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(86) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+DROP TABLE t1;
+# Increase in column size within 256 bytes should be inplace.
+# 63*3 -> 63*4
+CREATE TABLE t1(c1 CHAR(63) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(63) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøåtext
+𐐀
+DROP TABLE t1;
+# TINYTEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 TINYTEXT CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 TINYTEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+# Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøåtext
+𐐀
+DROP TABLE t1;
+# TEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 TEXT CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 TEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+# Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøåtext
+𐐀
+DROP TABLE t1;
+# MEDIUMTEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 MEDIUMTEXT CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 MEDIUMTEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+# Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøåtext
+𐐀
+DROP TABLE t1;
+# LONGTEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 LONGTEXT CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 LONGTEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+# Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+æøåtext
+𐐀
+DROP TABLE t1;
+# ENUM: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES ('a');
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c', 0xf0909080) CHARSET UTF8MB4,
+ALGORITHM = INPLACE;
+# Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+c1
+a
+𐐀
+DROP TABLE t1;
+# ENUM: UTF8MB3 -> UTF8MB4: Inplace rejected, new value not at the end
+CREATE TABLE t1(c1 ENUM(0xc3a6,0xc3b8,0xc3a5) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM(0xc3a6,0xf0909080,0xc3b8,0xc3a5)
+CHARSET UTF8MB4, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+DROP TABLE t1;
+# ENUM: ASCII -> BINARY
+CREATE TABLE t1(c1 ENUM('a', 'b','c') CHARSET ASCII);
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# ENUM: SWE7 -> BINARY
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET SWE7);
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# ENUM: UTF8MB3 -> BINARY
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# ENUM: UTF8MB4 -> BINARY
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET UTF8MB4);
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# SET: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 SET('b',0xc3a6,0xc3b8,0xc3a5) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1 VALUES (CONCAT('b,', 0xc3a6));
+ALTER TABLE t1 MODIFY COLUMN c1 SET('b',0xc3a6,0xc3b8,0xc3a5,0xf0909080)
+CHARSET UTF8MB4, ALGORITHM = INPLACE;
+# Insert set value which can only be represented in utf8mb4
+INSERT INTO t1 VALUES (CONCAT('b,', 0xf0909080, ',', 0xc3b8));
+SELECT * FROM t1;
+c1
+b,æ
+b,ø,𐐀
+DROP TABLE t1;
+# SET: UTF8MB3 -> UTF8MB4: Inplace rejected, new value not at the end
+CREATE TABLE t1(c1 SET(0xc3a6,0xc3b8,0xc3a5) CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+ALTER TABLE t1 MODIFY COLUMN c1 SET(0xc3a6,0xf0909080,0xc3b8,0xc3a5)
+CHARSET UTF8MB4, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+DROP TABLE t1;
+# SET: ASCII -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET ASCII);
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# SET: SWE7 -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET SWE7);
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# SET: UTF8MB3 -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET UTF8MB3);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# SET: UTF8MB4 -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET UTF8MB4);
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+# SET operations
+CREATE TABLE t1 (a SET('a1','a2'));
+INSERT INTO t1 VALUES ('a1'),('a2');
+# No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a3'), ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES ('a2,a3');
+SELECT a FROM t1;
+a
+a1
+a2
+a2,a3
+# Copy: Modify and add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','xx','a5'), ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# Copy: Remove from the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2'), ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# Copy: Add new member in the middle
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','a3'), ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a3','a4'), ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES ('a3,a4');
+SELECT a FROM t1;
+a
+a1
+a2
+a2,a3
+a3,a4
+# Numerical increase (pack length), but adding to the end
+# It should be possible to do this inplace, but leads to crash in
+# DML on altered table.
+ALTER TABLE t1 MODIFY COLUMN a
+SET('a1','a2','a3','a4','a5','a6','a7','a8','a9','a10'), ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+DROP TABLE t1;
+# Change charset for Instantly added column
+# UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 int, c2 CHAR(1) CHARSET ASCII);
+INSERT INTO t1 VALUES(1,'a');
+ALTER TABLE t1 ADD COLUMN c3 VARCHAR(1) CHARSET UTF8MB3 DEFAULT 'b', ALGORITHM = INSTANT;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+SELECT * FROM t1;
+c1	c2	c3
+1	a	b
+ALTER TABLE t1 MODIFY COLUMN c3 VARCHAR(1) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+c1	c2	c3
+1	a	b
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int DEFAULT NULL,
+  `c2` char(1) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
+  `c3` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+# Change charset of columns used in virtual column
+# UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 int,
+c2 VARCHAR(1) CHARSET UTF8MB3,
+c3 VARCHAR(1) CHARSET UTF8MB3,
+c4 VARCHAR(2) GENERATED ALWAYS AS (CONCAT(c2,c3)) virtual);
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+INSERT INTO t1(c1,c2,c3) VALUES(1,'a','b');
+SELECT * FROM t1;
+c1	c2	c3	c4
+1	a	b	ab
+ALTER TABLE t1
+MODIFY COLUMN c2 VARCHAR(1) CHARSET UTF8MB4,
+MODIFY COLUMN c3 VARCHAR(1) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+c1	c2	c3	c4
+1	a	b	ab
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` int DEFAULT NULL,
+  `c2` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  `c3` varchar(1) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+  `c4` varchar(2) GENERATED ALWAYS AS (concat(`c2`,`c3`)) VIRTUAL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+# There are few negative scenarios
+# char length cannot be changed during inplace
+CREATE TABLE t1(c CHAR(1) CHARSET ASCII);
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+c
+a
+ALTER TABLE t1 MODIFY COLUMN c CHAR(4) CHARSET BINARY, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+ALTER TABLE t1 MODIFY COLUMN c CHAR(1) CHARSET BINARY, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+c
+a
+DROP TABLE t1;
+# Charset cannot be changed inplace for indexed columns
+CREATE TABLE t1(c VARCHAR(1) CHARSET ASCII UNIQUE KEY);
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+c
+a
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET BINARY, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+DROP TABLE t1;
+# Collation cannot be changed inplace for indexed columns even
+# if the character set stays the same (see bug#30386119).
+CREATE TABLE t1(c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci PRIMARY KEY);
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# Using the copy algorithm works.
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ALGORITHM = COPY;
+DROP TABLE t1;
+# Collation cannot be changed inplace for non-indexed columns if an index
+# on the column is added in the same statement.
+CREATE TABLE t1(c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci);
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD UNIQUE INDEX(c), ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# Using the copy algorithm works.
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD UNIQUE INDEX(c), ALGORITHM = COPY;
+DROP TABLE t1;
+# Add a composite index using a prefix key part.
+CREATE TABLE t1(i INT, c VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci);
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD INDEX idx(i, c(5)), ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+# Using the copy algorithm works.
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD INDEX idx(i, c(5)), ALGORITHM = COPY;
+DROP TABLE t1;
+# Collation can be changed inplace for indexed columns if the index is dropped
+# in the same statement.
+CREATE TABLE t1(c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci, UNIQUE INDEX idx(c));
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, DROP INDEX idx, ALGORITHM = INPLACE;
+DROP TABLE t1;
+# No change (charset or otherwise) which makes
+# Field::max_display_length exceed 255, can be done inplace
+CREATE TABLE t1(c VARCHAR(1) CHARSET ASCII);
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+c
+a
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(256) CHARSET BINARY, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(255) CHARSET BINARY, ALGORITHM = INPLACE;
+DROP TABLE t1;
+# table level charset change
+CREATE TABLE t1(c VARCHAR(1)) CHARSET ASCII;
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+c
+a
+ALTER TABLE t1 CONVERT TO CHARSET BINARY, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+c
+a
+DROP TABLE t1;
+SET NAMES default;
+#
+# Bug #29501324	ADD VIRTUAL FIRST + ADD COLUMN CAUSES ASSERTION FAILURE.
+#
+CREATE TABLE t1 (b INT);
+# The below ALTER TABLE causes assertion failure without the fix.
+ALTER TABLE t1 ADD gcol INT AS (b + 1) VIRTUAL FIRST, ADD COLUMN a INT;
+DROP TABLE t1;
+[connection node_2]
+CALL mtr.add_suppression("Specified key was too long");
+CALL mtr.add_suppression("Cannot change column type INPLACE. Try ALGORITHM=COPY.");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.");
+CALL mtr.add_suppression("Incorrect prefix key; the used key part isn't a string");
+CALL mtr.add_suppression("Incorrect datetime value: '0000-00-00' for column");
+CALL mtr.add_suppression("LOCK=NONE is not supported for this operation. Try LOCK=SHARED");
+CALL mtr.add_suppression("LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.");
+CALL mtr.add_suppression("Storage engine 'MEMORY' does not support system tables");
+CALL mtr.add_suppression("Table 't1' already exists");
+CALL mtr.add_suppression("Can't DROP 'PRIMARY'; check that column/key exists");
+CALL mtr.add_suppression("Unknown column 'no_such_col' in 'order clause'");
+CALL mtr.add_suppression("Incorrect datetime value: '0000-00-00 00:00:00' for column");
+CALL mtr.add_suppression("Can't DROP 'no_such_key'; check that column/key exists");
+CALL mtr.add_suppression("Unknown table 'test.t1'");
+CALL mtr.add_suppression("Incorrect date value: '0000-00-00' for column");
+CALL mtr.add_suppression("Table 't\\+2' already exists");
+CALL mtr.add_suppression("LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE");
+CALL mtr.add_suppression("Storage engine 'CSV' does not support system tables");
+CALL mtr.add_suppression("Storage engine 'InnoDB' does not support system tables.");
+CALL mtr.add_suppression("Storage engine 'MRG_MYISAM' does not support system tables");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported. Reason: InnoDB presently supports one FULLTEXT index creation at a time. Try ALGORITHM=COPY");
+CALL mtr.add_suppression("Incorrect index name 'primary'");
+CALL mtr.add_suppression("Invalid use of NULL value");
+CALL mtr.add_suppression("Data too long for column .* at row 1");
+CALL mtr.add_suppression("Key .* doesn't exist in table 't1'");
+CALL mtr.add_suppression("Duplicate key name '.*' on query");
+CALL mtr.add_suppression("Event 1 Query apply failed: 1");
+CALL mtr.add_suppression("Incorrect usage of ALGORITHM=INSTANT and LOCK=NONE/SHARED/EXCLUSIVE");
+CALL mtr.add_suppression("ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.");
+CALL mtr.add_suppression("Incorrect usage of DEFAULT and generated column");
+CALL mtr.add_suppression("Column 'd' cannot be null");
+CALL mtr.add_suppression("Incorrect column name 'nnnnnnnnnn.*");
+CALL mtr.add_suppression("Unknown column '.*' in 't1'");
+CALL mtr.add_suppression("Can't DROP '.*'; check that column/key exists");
+CALL mtr.add_suppression("Duplicate column name .* on query");
+CALL mtr.add_suppression("spatial indexes can't be primary or unique indexes.");
+CALL mtr.add_suppression("Spatial index on virtual generated column' is not supported for generated columns");
+CALL mtr.add_suppression("Column 'c' has a generated column dependency");
+[connection node_1]
+CALL mtr.add_suppression("While running PXC node in cluster mode it will skip binlogging of non-replicating DDL statement");

--- a/mysql-test/suite/galera/r/galera_alter_table_mdl.result
+++ b/mysql-test/suite/galera/r/galera_alter_table_mdl.result
@@ -1,0 +1,143 @@
+RESET MASTER;
+SET GLOBAL wsrep_sync_wait = 0;
+CREATE TABLE t1 (a INTEGER PRIMARY KEY);
+# --------------------------------
+# Test 1: Execute ALTER TABLE on node2 (Remote)
+# --------------------------------
+# Adding debug point 'halt_alter_table_after_lock_downgrade' to @@GLOBAL.debug
+ALTER TABLE t1 ENGINE = InnoDB;
+SET DEBUG_SYNC = 'now WAIT_FOR alter_table_inplace_after_downgrade';
+INSERT INTO test.t1 VALUES(10);
+SET SESSION wsrep_sync_wait = 0;
+include/assert.inc [INSERT query should be waiting for the metadata lock.]
+SET DEBUG_SYNC = 'now SIGNAL continue_inplace_alter';
+SET DEBUG_SYNC = 'RESET';
+SELECT * FROM t1;
+a
+10
+include/assert_binlog_events.inc [Anonymous_Gtid # Query/.*CREATE TABLE.* # Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid]
+# --------------------------------
+# Test 2: Execute ALTER TABLE on node1 (Local)
+# --------------------------------
+RESET MASTER;
+ALTER TABLE t1 ENGINE = InnoDB;;
+SET DEBUG_SYNC = 'now WAIT_FOR alter_table_inplace_after_downgrade';
+INSERT INTO test.t1 VALUES(11);
+SET SESSION wsrep_sync_wait = 0;
+include/assert.inc [INSERT query should be waiting for the metadata lock.]
+SET DEBUG_SYNC = 'now SIGNAL continue_inplace_alter';
+SET DEBUG_SYNC = 'RESET';
+SELECT * FROM t1;
+a
+10
+11
+include/assert_binlog_events.inc [Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid]
+# --------------------------------
+# Test 3: Testing with wsrep_OSU_method = "RSU"
+# --------------------------------
+RESET MASTER;
+SET SESSION wsrep_OSU_method = "RSU";
+ALTER TABLE t1 ENGINE = InnoDB;;
+SET DEBUG_SYNC = 'now WAIT_FOR alter_table_inplace_after_downgrade';
+INSERT INTO test.t1 VALUES(12);
+SET SESSION wsrep_sync_wait = 0;
+include/assert.inc [INSERT query should be waiting for the metadata lock.]
+SET DEBUG_SYNC = 'now SIGNAL continue_inplace_alter';
+SET DEBUG_SYNC = 'RESET';
+SELECT * FROM t1;
+a
+10
+11
+12
+SET SESSION wsrep_OSU_method = DEFAULT;
+include/assert_binlog_events.inc [Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid]
+# Removing debug point 'halt_alter_table_after_lock_downgrade' from @@GLOBAL.debug
+# --------------------------------
+# Test 4: Testing with ALGORITHM and LOCK syntax.
+# --------------------------------
+ALTER TABLE t1 ADD COLUMN b INTEGER;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 ADD INDEX i1(b), LOCK= DEFAULT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+# In the below tests, ALTER TABLE with LOCK=NONE is not supported for the
+# reason that it needs SHARED LOCK during the execution on the query.
+ALTER TABLE t1 ADD INDEX i2(b), LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
+ALTER TABLE t1 ADD INDEX i2(b), LOCK= SHARED;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i2' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i3(b), LOCK= EXCLUSIVE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i3' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM=INPLACE, LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM=INPLACE, LOCK= SHARED;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i4' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ADD INDEX i5(b), ALGORITHM=INPLACE, LOCK= EXCLUSIVE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	1831	Duplicate index 'i5' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t1 ENGINE=InnoDB, ALGORITHM= INPLACE, LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
+ALTER TABLE t1 ENGINE=InnoDB, ALGORITHM= INPLACE, LOCK= SHARED;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 ENGINE=InnoDB, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE COLUMN b c INT, ALGORITHM= INPLACE, LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
+ALTER TABLE t1 CHANGE COLUMN b c INT, ALGORITHM= INPLACE, LOCK= SHARED;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 CHANGE COLUMN c b INT, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `i2` (`b`),
+  KEY `i3` (`b`),
+  KEY `i4` (`b`),
+  KEY `i5` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+affected rows: 1
+ALTER TABLE t1 DROP INDEX i2, ALGORITHM= INPLACE, LOCK= DEFAULT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 DROP INDEX i3, ALGORITHM= INPLACE, LOCK= NONE;
+ERROR 0A000: LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
+ALTER TABLE t1 DROP INDEX i4, ALGORITHM= INPLACE, LOCK= SHARED;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 DROP INDEX i5, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= NONE;
+ERROR 0A000: LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.
+ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= SHARED;
+ERROR 0A000: LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.
+ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+affected rows: 0
+ALTER TABLE t2 RENAME TO t1, ALGORITHM= INPLACE, LOCK= DEFAULT;
+affected rows: 0
+CALL mtr.add_suppression("LOCK=NONE is not supported for this operation. Try LOCK=SHARED.");
+CALL mtr.add_suppression("LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.");
+CALL mtr.add_suppression("LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.");
+CALL mtr.add_suppression("Event 1 Query apply failed: 1");
+SET GLOBAL wsrep_sync_wait = 15;;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_alter_table_big.test
+++ b/mysql-test/suite/galera/t/galera_alter_table_big.test
@@ -1,0 +1,3575 @@
+#
+# Test for checking the functionalities of ALTER TABLE
+#
+# This test case is forked from the t/alter_table.test and has been modified as
+# per the Galera behavior.
+#
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+SET sql_mode = 'NO_ENGINE_SUBSTITUTION';
+
+SET SESSION information_schema_stats_expiry=0;
+
+create table t1 (
+col1 int not null auto_increment primary key,
+col2 varchar(30) not null,
+col3 varchar (20) not null,
+col4 varchar(4) not null,
+col5 enum('PENDING', 'ACTIVE', 'DISABLED') not null,
+col6 int not null, to_be_deleted int);
+insert into t1 values (2,4,3,5,"PENDING",1,7);
+alter table t1
+add column col4_5 varchar(20) not null after col4,
+add column col7 varchar(30) not null after col5,
+add column col8 datetime not null, drop column to_be_deleted,
+change column col2 fourth varchar(30) not null after col3,
+modify column col6 int not null first;
+select * from t1;
+drop table t1;
+
+create table t1 (bandID MEDIUMINT UNSIGNED NOT NULL PRIMARY KEY, payoutID SMALLINT UNSIGNED NOT NULL) engine=myisam;
+insert into t1 (bandID,payoutID) VALUES (1,6),(2,6),(3,4),(4,9),(5,10),(6,1),(7,12),(8,12);
+alter table t1 add column new_col int, order by payoutid,bandid;
+select * from t1;
+alter table t1 order by bandid,payoutid;
+select * from t1;
+drop table t1;
+
+# ORDER BY does not make sence for InnoDB tables,because InnoDB always orders table rows based on the clustered index
+create table t1 (bandID MEDIUMINT UNSIGNED NOT NULL PRIMARY KEY, payoutID SMALLINT UNSIGNED NOT NULL) engine=InnoDB;
+insert into t1 (bandID,payoutID) VALUES (1,6),(2,6),(3,4),(4,9),(5,10),(6,1),(7,12),(8,12);
+alter table t1 add column new_col int, order by payoutid,bandid;
+select * from t1;
+alter table t1 order by bandid,payoutid;
+select * from t1;
+drop table t1;
+
+# Check that pack_keys and dynamic length rows are not forced.
+
+CREATE TABLE t1 (
+GROUP_ID int(10) unsigned DEFAULT '0' NOT NULL,
+LANG_ID smallint(5) unsigned DEFAULT '0' NOT NULL,
+NAME varchar(80) DEFAULT '' NOT NULL,
+PRIMARY KEY (GROUP_ID,LANG_ID),
+KEY NAME (NAME));
+#show table status like "t1";
+ALTER TABLE t1 CHANGE NAME NAME CHAR(80) not null;
+--replace_column 8 #
+SHOW FULL COLUMNS FROM t1;
+DROP TABLE t1;
+
+#
+# Test of ALTER TABLE ... ORDER BY
+#
+
+create table t1 (n int);
+insert into t1 values(9),(3),(12),(10);
+alter table t1 order by n;
+select * from t1;
+drop table t1;
+
+CREATE TABLE t1 (
+  id int(11) unsigned NOT NULL default '0',
+  category_id tinyint(4) unsigned NOT NULL default '0',
+  type_id tinyint(4) unsigned NOT NULL default '0',
+  body text NOT NULL,
+  user_id int(11) unsigned NOT NULL default '0',
+  status enum('new','old') NOT NULL default 'new',
+  PRIMARY KEY (id)
+) ENGINE=MyISAM;
+
+ALTER TABLE t1 ORDER BY t1.id, t1.status, t1.type_id, t1.user_id, t1.body;
+DROP TABLE t1;
+
+#
+# The following combination found a hang-bug in MyISAM
+#
+
+CREATE TABLE t1 (AnamneseId int(10) unsigned NOT NULL auto_increment,B BLOB,PRIMARY KEY (AnamneseId)) engine=myisam;
+insert into t1 values (null,"hello");
+LOCK TABLES t1 WRITE;
+ALTER TABLE t1 ADD Column new_col int not null;
+UNLOCK TABLES;
+OPTIMIZE TABLE t1;
+DROP TABLE t1;
+
+#
+# Drop and add an auto_increment column
+#
+
+create table t1 (i int unsigned not null auto_increment primary key);
+insert into t1 values (null),(null),(null),(null);
+alter table t1 drop i,add i int unsigned not null auto_increment, drop primary key, add primary key (i);
+select * from t1;
+drop table t1;
+
+#
+# Bug #2628: 'alter table t1 rename mysqltest.t1' silently drops mysqltest.t1
+# if it exists
+#
+create table t1 (name char(15));
+insert into t1 (name) values ("current");
+create database mysqltest;
+create table mysqltest.t1 (name char(15));
+insert into mysqltest.t1 (name) values ("mysqltest");
+select * from t1;
+select * from mysqltest.t1;
+--error ER_TABLE_EXISTS_ERROR
+alter table t1 rename mysqltest.t1;
+select * from t1;
+select * from mysqltest.t1;
+drop table t1;
+drop database mysqltest;
+
+# Disable/Enable keys supported by Myisam only
+# ALTER TABLE ... ENABLE/DISABLE KEYS
+
+create table t1 (n1 int not null, n2 int, n3 int, n4 float,
+                unique(n1),
+                key (n1, n2, n3, n4),
+                key (n2, n3, n4, n1),
+                key (n3, n4, n1, n2),
+                key (n4, n1, n2, n3) ) engine=Myisam;
+alter table t1 disable keys;
+show keys from t1;
+#let $1=10000;
+let $1=10;
+while ($1)
+{
+ eval insert into t1 values($1,RAND()*1000,RAND()*1000,RAND());
+ dec $1;
+}
+alter table t1 enable keys;
+show keys from t1;
+drop table t1;
+
+#
+# Alter table and rename
+#
+
+create table t1 (i int unsigned not null auto_increment primary key);
+alter table t1 rename t2;
+alter table t2 rename t1, add c char(10) comment "no comment";
+show columns from t1;
+drop table t1;
+
+# implicit analyze
+
+create table t1 (a int, b int);
+let $1=100;
+while ($1)
+{
+ eval insert into t1 values(1,$1), (2,$1), (3, $1);
+ dec $1;
+}
+alter table t1 add unique (a,b), add key (b);
+show keys from t1;
+analyze table t1;
+show keys from t1;
+drop table t1;
+
+#
+# Test ALTER TABLE ENABLE/DISABLE keys when things are locked
+#
+
+CREATE TABLE t1 (
+  Host varchar(16) binary NOT NULL default '',
+  User varchar(16) binary NOT NULL default '',
+  PRIMARY KEY  (Host,User)
+) ENGINE=MyISAM;
+
+ALTER TABLE t1 DISABLE KEYS;
+LOCK TABLES t1 WRITE;
+INSERT INTO t1 VALUES ('localhost','root'),('localhost',''),('games','monty');
+SHOW INDEX FROM t1;
+ALTER TABLE t1 ENABLE KEYS;
+UNLOCK TABLES;
+CHECK TABLES t1;
+DROP TABLE t1;
+
+#
+# Test with two keys
+#
+
+CREATE TABLE t1 (
+  Host varchar(16) binary NOT NULL default '',
+  User varchar(16) binary NOT NULL default '',
+  PRIMARY KEY  (Host,User),
+  KEY  (Host)
+) ENGINE=MyISAM;
+
+ALTER TABLE t1 DISABLE KEYS;
+SHOW INDEX FROM t1;
+LOCK TABLES t1 WRITE;
+INSERT INTO t1 VALUES ('localhost','root'),('localhost','');
+SHOW INDEX FROM t1;
+ALTER TABLE t1 ENABLE KEYS;
+SHOW INDEX FROM t1;
+UNLOCK TABLES;
+CHECK TABLES t1;
+
+# Test RENAME with LOCK TABLES
+LOCK TABLES t1 WRITE;
+ALTER TABLE t1 RENAME t2;
+UNLOCK TABLES;
+select * from t2;
+DROP TABLE t2;
+
+#
+# Test disable keys with locking
+#
+CREATE TABLE t1 (
+  Host varchar(16) binary NOT NULL default '',
+  User varchar(16) binary NOT NULL default '',
+  PRIMARY KEY  (Host,User),
+  KEY  (Host)
+) ENGINE=MyISAM;
+
+LOCK TABLES t1 WRITE;
+ALTER TABLE t1 DISABLE KEYS;
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+#
+# BUG#4717 - check for valid table names
+#
+create table t1 (a int);
+--error ER_WRONG_TABLE_NAME
+alter table t1 rename to ``;
+--error ER_WRONG_TABLE_NAME
+rename table t1 to ``;
+drop table t1;
+
+#
+# BUG#6236 - ALTER TABLE MODIFY should set implicit NOT NULL on PK columns
+#
+drop table if exists t1, t2;
+create table t1 ( a varchar(10) not null primary key ) engine=myisam;
+create table t2 ( a varchar(10) not null primary key ) engine=merge union=(t1);
+flush tables;
+alter table t1 modify a varchar(10);
+show create table t2;
+flush tables;
+alter table t1 modify a varchar(10) not null;
+show create table t2;
+drop table if exists t1, t2;
+
+# The following is also part of bug #6236 (CREATE TABLE didn't properly count
+# not null columns for primary keys)
+
+create table t1 (a int, b int, c int, d int, e int, f int, g int, h int,i int, primary key (a,b,c,d,e,f,g,i,h)) engine=MyISAM;
+insert into t1 (a) values(1);
+--replace_column 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
+show table status like 't1';
+alter table t1 modify a int;
+--replace_column 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
+show table status like 't1';
+drop table t1;
+create table t1 (a int not null, b int not null, c int not null, d int not null, e int not null, f int not null, g int not null, h int not null,i int not null, primary key (a,b,c,d,e,f,g,i,h)) engine=MyISAM;
+insert into t1 (a) values(1);
+--replace_column 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
+show table status like 't1';
+drop table t1;
+
+#
+# Test that data get converted when character set is changed
+# Test that data doesn't get converted when src or dst is BINARY/BLOB
+#
+set names koi8r;
+create table t1 (a char(10) character set koi8r);
+insert into t1 values ('����');
+select a,hex(a) from t1;
+alter table t1 change a a char(10) character set cp1251;
+select a,hex(a) from t1;
+alter table t1 change a a binary(4);
+select a,hex(a) from t1;
+alter table t1 change a a char(10) character set cp1251;
+select a,hex(a) from t1;
+alter table t1 change a a char(10) character set koi8r;
+select a,hex(a) from t1;
+alter table t1 change a a varchar(10) character set cp1251;
+select a,hex(a) from t1;
+alter table t1 change a a char(10) character set koi8r;
+select a,hex(a) from t1;
+alter table t1 change a a text character set cp1251;
+select a,hex(a) from t1;
+alter table t1 change a a char(10) character set koi8r;
+select a,hex(a) from t1;
+delete from t1;
+
+#
+# Test ALTER TABLE .. CHARACTER SET ..
+#
+show create table t1;
+alter table t1 DEFAULT CHARACTER SET latin1;
+show create table t1;
+alter table t1 CONVERT TO CHARACTER SET latin1;
+show create table t1;
+alter table t1 DEFAULT CHARACTER SET cp1251;
+show create table t1;
+
+drop table t1;
+
+#
+# Bug#2821
+# Test that table CHARACTER SET does not affect blobs
+#
+create table t1 (myblob longblob,mytext longtext)
+default charset latin1 collate latin1_general_cs;
+show create table t1;
+alter table t1 character set latin2;
+show create table t1;
+drop table t1;
+
+#
+# Bug 2361 (Don't drop UNIQUE with DROP PRIMARY KEY)
+#
+
+CREATE TABLE t1 (a int PRIMARY KEY, b INT UNIQUE);
+ALTER TABLE t1 DROP PRIMARY KEY;
+SHOW CREATE TABLE t1;
+--error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t1 DROP PRIMARY KEY;
+DROP TABLE t1;
+
+# BUG#3899
+create table t1 (a int, b int, key(a));
+insert into t1 values (1,1), (2,2);
+--error ER_CANT_DROP_FIELD_OR_KEY
+alter table t1 drop key no_such_key;
+alter table t1 drop key a;
+drop table t1;
+
+#
+# BUG 12207 alter table ... discard table space on MyISAM table causes ERROR 2013 (HY000)
+#
+# Some platforms (Mac OS X, Windows) will send the error message using small letters.
+CREATE TABLE T12207(a int) ENGINE=MYISAM;
+--replace_result t12207 T12207
+--error ER_ILLEGAL_HA
+ALTER TABLE T12207 DISCARD TABLESPACE;
+DROP TABLE T12207;
+
+#
+# Bug #6479  ALTER TABLE ... changing charset fails for TEXT columns
+#
+# The column's character set was changed but the actual data was not
+# modified. In other words, the values were reinterpreted
+# as UTF8 instead of being converted.
+create table t1 (a text) character set koi8r;
+insert into t1 values (_koi8r'����');
+select hex(a) from t1;
+alter table t1 convert to character set cp1251;
+select hex(a) from t1;
+drop table t1;
+
+#
+# Test for bug #7884 "Able to add invalid unique index on TIMESTAMP prefix"
+# MySQL should not think that packed field with non-zero decimals is
+# geometry field and allow to create prefix index which is
+# shorter than packed field length.
+#
+create table t1 ( a timestamp );
+--error ER_WRONG_SUB_KEY
+alter table t1 add unique ( a(1) );
+drop table t1;
+
+#
+# Disable/Enable keys supported by Myisam only
+# Bug #24395: ALTER TABLE DISABLE KEYS doesn't work when modifying the table
+#
+# This problem happens if the data change is compatible.
+# Changing to the same type is compatible for example.
+#
+create table t1 (a int, key(a)) engine=myisam;
+show indexes from t1;
+--echo "this used not to disable the index"
+alter table t1 modify a int, disable keys;
+show indexes from t1;
+
+alter table t1 enable keys;
+show indexes from t1;
+
+alter table t1 modify a bigint, disable keys;
+show indexes from t1;
+
+alter table t1 enable keys;
+show indexes from t1;
+
+alter table t1 add b char(10), disable keys;
+show indexes from t1;
+
+alter table t1 add c decimal(10,2), enable keys;
+show indexes from t1;
+
+--echo "this however did"
+alter table t1 disable keys;
+show indexes from t1;
+
+desc t1;
+
+alter table t1 add d decimal(15,5);
+--echo "The key should still be disabled"
+show indexes from t1;
+
+drop table t1;
+
+--echo "Now will test with one unique index"
+create table t1(a int, b char(10), unique(a)) engine=myisam;
+show indexes from t1;
+alter table t1 disable keys;
+show indexes from t1;
+alter table t1 enable keys;
+
+--echo "If no copy on noop change, this won't touch the data file"
+--echo "Unique index, no change"
+alter table t1 modify a int, disable keys;
+show indexes from t1;
+
+--echo "Change the type implying data copy"
+--echo "Unique index, no change"
+alter table t1 modify a bigint, disable keys;
+show indexes from t1;
+
+alter table t1 modify a bigint;
+show indexes from t1;
+
+alter table t1 modify a int;
+show indexes from t1;
+
+drop table t1;
+
+--echo "Now will test with one unique and one non-unique index"
+create table t1(a int, b char(10), unique(a), key(b)) engine=myisam;
+show indexes from t1;
+alter table t1 disable keys;
+show indexes from t1;
+alter table t1 enable keys;
+
+
+--echo "If no copy on noop change, this won't touch the data file"
+--echo "The non-unique index will be disabled"
+alter table t1 modify a int, disable keys;
+show indexes from t1;
+alter table t1 enable keys;
+show indexes from t1;
+
+--echo "Change the type implying data copy"
+--echo "The non-unique index will be disabled"
+alter table t1 modify a bigint, disable keys;
+show indexes from t1;
+
+--echo "Change again the type, but leave the indexes as_is"
+alter table t1 modify a int;
+show indexes from t1;
+--echo "Try the same. When data is no copied on similar tables, this is noop"
+alter table t1 modify a int;
+show indexes from t1;
+
+drop table t1;
+
+
+#
+# Bug#11493 - Alter table rename to default database does not work without
+#             db name qualifying
+#
+create database mysqltest;
+create table t1 (c1 int);
+# Move table to other database.
+alter table t1 rename mysqltest.t1;
+# Assure that it has moved.
+--error ER_BAD_TABLE_ERROR
+drop table t1;
+# Move table back.
+alter table mysqltest.t1 rename t1;
+# Assure that it is back.
+drop table t1;
+# Now test for correct message if no database is selected.
+# Create t1 in 'test'.
+create table t1 (c1 int);
+# Change to other db.
+use mysqltest;
+# Drop the current db. This de-selects any db.
+drop database mysqltest;
+# Now test for correct message.
+--error ER_NO_DB_ERROR
+alter table test.t1 rename t1;
+# Check that explicit qualifying works even with no selected db.
+alter table test.t1 rename test.t1;
+# Go back to standard 'test' db.
+use test;
+drop table t1;
+
+#
+# ROW_FORMAT=FIXED supported by Myisam only
+# BUG#23404 - ROW_FORMAT=FIXED option is lost is an index is added to the
+# table
+#
+CREATE TABLE t1(a INT) ENGINE=MyISAM ROW_FORMAT=FIXED;
+CREATE INDEX i1 ON t1(a);
+SHOW CREATE TABLE t1;
+DROP INDEX i1 ON t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+#
+# Disable/Enable keys supported by Myisam only
+# Bug#24219 - ALTER TABLE ... RENAME TO ... , DISABLE KEYS leads to crash
+#
+
+CREATE TABLE bug24219 (a INT, INDEX(a)) ENGINE=MyISAM;
+
+SHOW INDEX FROM bug24219;
+
+ALTER TABLE bug24219 RENAME TO bug24219_2, DISABLE KEYS;
+
+SHOW INDEX FROM bug24219_2;
+
+DROP TABLE bug24219_2;
+
+#
+# Bug#24562 (ALTER TABLE ... ORDER BY ... with complex expression asserts)
+#
+
+create table table_24562(
+  section int,
+  subsection int,
+  title varchar(50));
+
+insert into table_24562 values
+(1, 0, "Introduction"),
+(1, 1, "Authors"),
+(1, 2, "Acknowledgements"),
+(2, 0, "Basics"),
+(2, 1, "Syntax"),
+(2, 2, "Client"),
+(2, 3, "Server"),
+(3, 0, "Intermediate"),
+(3, 1, "Complex queries"),
+(3, 2, "Stored Procedures"),
+(3, 3, "Stored Functions"),
+(4, 0, "Advanced"),
+(4, 1, "Replication"),
+(4, 2, "Load balancing"),
+(4, 3, "High availability"),
+(5, 0, "Conclusion");
+
+select * from table_24562;
+
+alter table table_24562 add column reviewer varchar(20),
+order by title;
+
+select * from table_24562;
+
+update table_24562 set reviewer="Me" where section=2;
+update table_24562 set reviewer="You" where section=3;
+
+alter table table_24562
+order by section ASC, subsection DESC;
+
+select * from table_24562;
+
+alter table table_24562
+order by table_24562.subsection ASC, table_24562.section DESC;
+
+select * from table_24562;
+
+--error ER_PARSE_ERROR
+alter table table_24562 order by 12;
+--error ER_PARSE_ERROR
+alter table table_24562 order by (section + 12);
+--error ER_PARSE_ERROR
+alter table table_24562 order by length(title);
+--error ER_PARSE_ERROR
+alter table table_24562 order by (select 12 from dual);
+
+--error ER_BAD_FIELD_ERROR
+alter table table_24562 order by no_such_col;
+
+drop table table_24562;
+
+# End of 4.1 tests
+
+#
+# Bug #14693 (ALTER SET DEFAULT doesn't work)
+#
+
+create table t1 (mycol int(10) not null);
+alter table t1 alter column mycol set default 0;
+desc t1;
+drop table t1;
+
+#
+# Bug#25262 Auto Increment lost when changing Engine type
+#
+
+create table t1(id int(8) primary key auto_increment) engine=heap;
+
+insert into t1 values (null);
+insert into t1 values (null);
+
+select * from t1;
+
+# Set auto increment to 50
+alter table t1 auto_increment = 50;
+
+# Alter to myisam
+alter table t1 engine = myisam;
+
+# This insert should get id 50
+insert into t1 values (null);
+select * from t1;
+
+# Alter to heap again
+alter table t1 engine = heap;
+insert into t1 values (null);
+select * from t1;
+
+drop table t1;
+
+#
+# Bug#27507: Wrong DATETIME value was allowed by ALTER TABLE in the
+#            NO_ZERO_DATE mode.
+#
+set sql_mode= default;
+create table t1(f1 int) engine=myisam;
+alter table t1 add column f2 datetime not null, add column f21 date not null;
+insert into t1 values(1,'2000-01-01','2000-01-01');
+--error 1292
+alter table t1 add column f3 datetime not null;
+--error 1292
+alter table t1 add column f3 date not null;
+--error 1292
+alter table t1 add column f4 datetime not null default '2002-02-02',
+  add column f41 date not null;
+alter table t1 add column f4 datetime not null default '2002-02-02',
+  add column f41 date not null default '2002-02-02';
+select * from t1;
+drop table t1;
+
+#
+# Some additional tests for new, faster alter table.  Note that most of the
+# whole alter table code is being tested all around the test suite already.
+#
+
+create table t1 (v varchar(32));
+insert into t1 values ('def'),('abc'),('hij'),('3r4f');
+select * from t1;
+# Fast alter, no copy performed
+alter table t1 change v v2 varchar(32);
+select * from t1;
+# Fast alter, no copy performed
+alter table t1 change v2 v varchar(64);
+select * from t1;
+update t1 set v = 'lmn' where v = 'hij';
+select * from t1;
+# Regular alter table
+alter table t1 add i int auto_increment not null primary key first;
+select * from t1;
+update t1 set i=5 where i=3;
+select * from t1;
+alter table t1 change i i bigint;
+select * from t1;
+alter table t1 add unique key (i, v);
+select * from t1 where i between 2 and 4 and v in ('def','3r4f','lmn');
+drop table t1;
+
+#
+# Bug#6073 "ALTER table minor glich": ALTER TABLE complains that an index
+# without # prefix is not allowed for TEXT columns, while index
+# is defined with prefix.
+#
+create table t1 (t varchar(255) default null, key t (t(80)))
+engine=myisam default charset=latin1;
+alter table t1 change t t text;
+drop table t1;
+
+#
+# Bug #26794: Adding an index with a prefix on a SPATIAL type breaks ALTER
+# TABLE
+#
+CREATE TABLE t1 (a varchar(500));
+
+ALTER TABLE t1 ADD b GEOMETRY NOT NULL SRID 0, ADD SPATIAL INDEX(b);
+SHOW CREATE TABLE t1;
+--error ER_WRONG_SUB_KEY
+ALTER TABLE t1 ADD KEY(b(50));
+SHOW CREATE TABLE t1;
+
+ALTER TABLE t1 ADD c POINT;
+SHOW CREATE TABLE t1;
+
+--error ER_WRONG_SUB_KEY
+CREATE TABLE t2 (a INT, KEY (a(20)));
+
+ALTER TABLE t1 ADD d INT;
+--error ER_WRONG_SUB_KEY
+ALTER TABLE t1 ADD KEY (d(20));
+
+# the 5.1 part of the test
+--error ER_WRONG_SUB_KEY
+ALTER TABLE t1 ADD e GEOMETRY NOT NULL, ADD SPATIAL KEY (e(30));
+
+DROP TABLE t1;
+
+#
+# Bug#18038  MySQL server corrupts binary columns data
+#
+
+CREATE TABLE t1 (s CHAR(8) BINARY);
+INSERT INTO t1 VALUES ('test');
+SELECT LENGTH(s) FROM t1;
+ALTER TABLE t1 MODIFY s CHAR(10) BINARY;
+SELECT LENGTH(s) FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (s BINARY(8));
+INSERT INTO t1 VALUES ('test');
+SELECT LENGTH(s) FROM t1;
+SELECT HEX(s) FROM t1;
+ALTER TABLE t1 MODIFY s BINARY(10);
+SELECT HEX(s) FROM t1;
+SELECT LENGTH(s) FROM t1;
+DROP TABLE t1;
+
+#
+# Bug#19386: Multiple alter causes crashed table
+# The trailing column would get corrupted data, or server could not even read
+# it.
+#
+
+CREATE TABLE t1 (v VARCHAR(3), b INT);
+INSERT INTO t1 VALUES ('abc', 5);
+SELECT * FROM t1;
+ALTER TABLE t1 MODIFY COLUMN v VARCHAR(4);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+
+#
+# Bug#31291 ALTER TABLE CONVERT TO CHARACTER SET does not change some data types
+#
+create table t1 (a tinytext character set latin1);
+alter table t1 convert to character set utf8;
+show create table t1;
+drop table t1;
+create table t1 (a mediumtext character set latin1);
+alter table t1 convert to character set utf8;
+show create table t1;
+drop table t1;
+
+--echo End of 5.0 tests
+
+#
+# Extended test coverage for ALTER TABLE behaviour under LOCK TABLES
+# It should be consistent across all platforms and for all engines
+# (Before 5.1 this was not true as behavior was different between
+# Unix/Windows and transactional/non-transactional tables).
+# See also innodb_mysql.test.
+# See alter_table-big.test for extended full ALTER TABLE RENAME coverage.
+#
+create table t1 (i int);
+create table t3 (j int);
+insert into t1 values ();
+insert into t3 values ();
+# Table which is altered under LOCK TABLES it should stay in list of locked
+# tables and be available after alter takes place unless ALTER contains RENAME
+# clause. We should see the new definition of table, of course.
+lock table t1 write, t3 read;
+# Example of so-called 'fast' ALTER TABLE
+alter table t1 modify i int default 1;
+insert into t1 values ();
+select * from t1;
+# And now full-blown ALTER TABLE
+alter table t1 change i c char(10) default "Two";
+insert into t1 values ();
+select * from t1;
+# If table is renamed then it should stay in the list of locked tables
+# under new name (unless SE doesn't support atomic DDL and it is an error).
+# 'Fast' ALTER TABLE with RENAME clause:
+alter table t1 modify c char(10) default "Three", rename to t2;
+--error ER_TABLE_NOT_LOCKED
+select * from t1;
+select * from t2;
+select * from t3;
+unlock tables;
+insert into t2 values ();
+select * from t2;
+lock table t2 write, t3 read;
+# Full ALTER TABLE with RENAME
+alter table t2 change c vc varchar(100) default "Four", rename to t1;
+select * from t1;
+--error ER_TABLE_NOT_LOCKED
+select * from t2;
+select * from t3;
+unlock tables;
+insert into t1 values ();
+select * from t1;
+drop tables t1, t3;
+
+
+#
+# Bug#18775 - Temporary table from alter table visible to other threads
+#
+# Check if special characters work and duplicates are detected.
+CREATE TABLE `t+1` (c1 INT);
+ALTER TABLE  `t+1` RENAME `t+2`;
+CREATE TABLE `t+1` (c1 INT);
+--error ER_TABLE_EXISTS_ERROR
+ALTER TABLE  `t+1` RENAME `t+2`;
+DROP TABLE   `t+1`, `t+2`;
+#
+# Same for temporary tables though these names do not become file names.
+CREATE TEMPORARY TABLE `tt+1` (c1 INT);
+ALTER TABLE  `tt+1` RENAME `tt+2`;
+CREATE TEMPORARY TABLE `tt+1` (c1 INT);
+--error ER_TABLE_EXISTS_ERROR
+ALTER TABLE  `tt+1` RENAME `tt+2`;
+SHOW CREATE TABLE `tt+1`;
+SHOW CREATE TABLE `tt+2`;
+DROP TABLE   `tt+1`, `tt+2`;
+#
+# Check if special characters as in tmp_file_prefix work.
+CREATE TABLE `#sql1` (c1 INT);
+CREATE TABLE `@0023sql2` (c1 INT);
+SHOW TABLES;
+RENAME TABLE `#sql1`     TO `@0023sql1`;
+RENAME TABLE `@0023sql2` TO `#sql2`;
+SHOW TABLES;
+ALTER TABLE `@0023sql1`  RENAME `#sql-1`;
+ALTER TABLE `#sql2`      RENAME `@0023sql-2`;
+SHOW TABLES;
+INSERT INTO `#sql-1`     VALUES (1);
+INSERT INTO `@0023sql-2` VALUES (2);
+DROP TABLE `#sql-1`, `@0023sql-2`;
+#
+# Same for temporary tables though these names do not become file names.
+CREATE TEMPORARY TABLE `#sql1` (c1 INT);
+CREATE TEMPORARY TABLE `@0023sql2` (c1 INT);
+SHOW TABLES;
+ALTER TABLE `#sql1`      RENAME `@0023sql1`;
+ALTER TABLE `@0023sql2`  RENAME `#sql2`;
+SHOW TABLES;
+INSERT INTO `#sql2`      VALUES (1);
+INSERT INTO `@0023sql1`  VALUES (2);
+SHOW CREATE TABLE `#sql2`;
+SHOW CREATE TABLE `@0023sql1`;
+DROP TABLE `#sql2`, `@0023sql1`;
+
+#
+# Bug #22369: Alter table rename combined with other alterations causes lost tables
+#
+# This problem happens if the data change is compatible.
+# Changing to the same type is compatible for example.
+#
+--enable_warnings
+CREATE TABLE t1 (
+  int_field INTEGER UNSIGNED NOT NULL,
+  char_field CHAR(10),
+  INDEX(`int_field`)
+);
+
+DESCRIBE t1;
+
+SHOW INDEXES FROM t1;
+
+INSERT INTO t1 VALUES (1, "edno"), (1, "edno"), (2, "dve"), (3, "tri"), (5, "pet");
+--echo "Non-copy data change - new frm, but old data and index files"
+ALTER TABLE t1
+  CHANGE int_field unsigned_int_field INTEGER UNSIGNED NOT NULL,
+  RENAME t2;
+
+--error ER_NO_SUCH_TABLE
+SELECT * FROM t1 ORDER BY int_field;
+SELECT * FROM t2 ORDER BY unsigned_int_field;
+DESCRIBE t2;
+DESCRIBE t2;
+ALTER TABLE t2 MODIFY unsigned_int_field BIGINT UNSIGNED NOT NULL;
+DESCRIBE t2;
+
+DROP TABLE t2;
+
+#
+# Bug#28427: Columns were renamed instead of moving by ALTER TABLE.
+#
+CREATE TABLE t1 (f1 INT, f2 INT, f3 INT);
+INSERT INTO t1 VALUES (1, 2, NULL);
+SELECT * FROM t1;
+ALTER TABLE t1 MODIFY COLUMN f3 INT AFTER f1;
+SELECT * FROM t1;
+ALTER TABLE t1 MODIFY COLUMN f3 INT AFTER f2;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+#
+# BUG#29957 - alter_table.test fails
+#
+create table t1 (c char(10) default "Two");
+lock table t1 write;
+insert into t1 values ();
+alter table t1 modify c char(10) default "Three";
+unlock tables;
+select * from t1;
+check table t1;
+drop table t1;
+
+#
+# Bug#33873: Fast ALTER TABLE doesn't work with multibyte character sets
+#
+
+CREATE TABLE t1 (id int, c int) character set latin1;
+INSERT INTO t1 VALUES (1,1);
+--enable_info
+ALTER TABLE t1 CHANGE c d int;
+ALTER TABLE t1 CHANGE d c int;
+ALTER TABLE t1 MODIFY c VARCHAR(10);
+ALTER TABLE t1 CHANGE c d varchar(10);
+ALTER TABLE t1 CHANGE d c varchar(10);
+--disable_info
+DROP TABLE t1;
+
+CREATE TABLE t1 (id int, c int) character set utf8;
+INSERT INTO t1 VALUES (1,1);
+--enable_info
+ALTER TABLE t1 CHANGE c d int;
+ALTER TABLE t1 CHANGE d c int;
+ALTER TABLE t1 MODIFY c VARCHAR(10);
+ALTER TABLE t1 CHANGE c d varchar(10);
+ALTER TABLE t1 CHANGE d c varchar(10);
+--disable_info
+DROP TABLE t1;
+
+#
+# pack_keys and max_data_length options are meant for Myisam tables
+# Bug#39372 "Smart" ALTER TABLE not so smart after all.
+#
+create table t1(f1 int not null, f2 int not null, key  (f1), key (f2)) engine=myisam;
+let $count= 50;
+--disable_query_log
+while ($count)
+{
+  EVAL insert into t1 values (1,1),(1,1),(1,1),(1,1),(1,1);
+  EVAL insert into t1 values (2,2),(2,2),(2,2),(2,2),(2,2);
+  dec $count ;
+}
+--enable_query_log
+
+select index_length into @unpaked_keys_size from
+information_schema.tables where table_name='t1';
+alter table t1 pack_keys=1;
+select index_length into @paked_keys_size from
+information_schema.tables where table_name='t1';
+select (@unpaked_keys_size > @paked_keys_size);
+
+select max_data_length into @orig_max_data_length from
+information_schema.tables where table_name='t1';
+alter table t1 max_rows=100;
+select max_data_length into @changed_max_data_length from
+information_schema.tables where table_name='t1';
+select (@orig_max_data_length > @changed_max_data_length);
+
+drop table t1;
+
+#
+# Bug #23113: Different behavior on altering ENUM fields between 5.0 and 5.1
+#
+CREATE TABLE t1(a INT AUTO_INCREMENT PRIMARY KEY,
+  b ENUM('a', 'b', 'c') NOT NULL);
+INSERT INTO t1 (b) VALUES ('a'), ('c'), ('b'), ('b'), ('a');
+ALTER TABLE t1 MODIFY b ENUM('a', 'z', 'b', 'c') NOT NULL;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Bug#45567: Fast ALTER TABLE broken for enum and set
+--echo #
+
+CREATE TABLE t1 (a ENUM('a1','a2'));
+INSERT INTO t1 VALUES ('a1'),('a2');
+--enable_info
+--echo # No copy: No modification
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2');
+--echo # No copy: Add new enumeration to the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','a3');
+--echo # Copy: Modify and add new to the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','xx','a5');
+--echo # Copy: Remove from the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','xx');
+--echo # Copy: Add new enumeration
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','a0','xx');
+--echo # No copy: Add new enumerations to the end
+ALTER TABLE t1 MODIFY COLUMN a ENUM('a1','a2','a0','xx','a5','a6');
+--disable_info
+DROP TABLE t1;
+
+CREATE TABLE t1 (a SET('a1','a2'));
+INSERT INTO t1 VALUES ('a1'),('a2');
+--enable_info
+--echo # No copy: No modification
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2');
+--echo # No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a3');
+--echo # Copy: Modify and add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','xx','a5');
+--echo # Copy: Remove from the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','xx');
+--echo # Copy: Add new member
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','xx');
+--echo # No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','xx','a5','a6');
+--echo # Copy: Numerical increase (pack length)
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','xx','a5','a6','a7','a8','a9','a10');
+--disable_info
+DROP TABLE t1;
+
+#
+# Bug#43508: Renaming timestamp or date column triggers table copy
+#
+
+CREATE TABLE t1 (f1 TIMESTAMP NULL DEFAULT NULL,
+                 f2 INT(11) DEFAULT NULL) ENGINE=MYISAM DEFAULT CHARSET=utf8;
+
+INSERT INTO t1 VALUES (NULL, NULL), ("2009-10-09 11:46:19", 2);
+
+--echo this should affect no rows as there is no real change
+--enable_info
+ALTER TABLE t1 CHANGE COLUMN f1 f1_no_real_change TIMESTAMP NULL DEFAULT NULL;
+--disable_info
+DROP TABLE t1;
+
+
+--echo #
+--echo # Bug #31145: ALTER TABLE DROP COLUMN, ADD COLUMN crashes (linux)
+--echo #   or freezes (win) the server
+--echo #
+
+CREATE TABLE t1 (a TEXT, id INT, b INT);
+ALTER TABLE t1 DROP COLUMN a, ADD COLUMN c TEXT FIRST;
+
+DROP TABLE t1;
+
+
+--echo #
+--echo # Test for bug #12652385 - "61493: REORDERING COLUMNS TO POSITION
+--echo #                           FIRST CAN CAUSE DATA TO BE CORRUPTED".
+--echo #
+--echo # Use MyISAM engine as the fact that InnoDB doesn't support
+--echo # in-place ALTER TABLE in cases when columns are being renamed
+--echo # hides some bugs.
+create table t1 (i int, j int) engine=myisam;
+insert into t1 value (1, 2);
+--echo # First, test for original problem described in the bug report.
+select * from t1;
+--echo # Change of column order by the below ALTER TABLE statement should
+--echo # affect both column names and column contents.
+alter table t1 modify column j int first;
+select * from t1;
+--echo # Now test for similar problem with the same root.
+--echo # The below ALTER TABLE should change not only the name but
+--echo # also the value for the last column of the table.
+alter table t1 drop column i, add column k int default 0;
+select * from t1;
+--echo # Clean-up.
+drop table t1;
+
+
+--echo End of 5.1 tests
+
+#
+# Bug #31031 ALTER TABLE regression in 5.0
+#
+#  The ALTER TABLE operation failed with
+#  ERROR 1089 (HY000): Incorrect sub part key; ...
+#
+CREATE TABLE t1(c CHAR(10),
+  i INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY);
+INSERT INTO t1 VALUES('a',2),('b',4),('c',6);
+ALTER TABLE t1
+  DROP i,
+  ADD i INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  AUTO_INCREMENT = 1;
+DROP TABLE t1;
+
+
+#
+# Bug#50542 5.5.x doesn't check length of key prefixes:
+#           corruption and crash results
+#
+# This case is related to Bug#31031 (above)
+# A statement where the index key is larger/wider than
+# the column type, should cause an error
+#
+--error ER_WRONG_SUB_KEY
+CREATE TABLE t1 (a CHAR(1), PRIMARY KEY (a(255)));
+
+# Test other variants of creating indices
+CREATE TABLE t1 (a CHAR(1));
+#  ALTER TABLE
+--error ER_WRONG_SUB_KEY
+ALTER TABLE t1 ADD PRIMARY KEY (a(20));
+--error ER_WRONG_SUB_KEY
+ALTER TABLE t1 ADD KEY (a(20));
+#  CREATE INDEX
+--error ER_WRONG_SUB_KEY
+CREATE UNIQUE INDEX i1 ON t1 (a(20));
+--error ER_WRONG_SUB_KEY
+CREATE INDEX i2 ON t1 (a(20));
+# cleanup
+DROP TABLE t1;
+
+
+#
+# Bug #45052    ALTER TABLE ADD COLUMN crashes server with multiple foreign key columns
+#   The alter table fails if 2 or more new fields added and
+#   also added a key with these fields
+#
+CREATE TABLE t1 (id int);
+INSERT INTO t1 VALUES (1), (2);
+ALTER TABLE t1 ADD COLUMN (f1 INT), ADD COLUMN (f2 INT), ADD KEY f2k(f2);
+DROP TABLE t1;
+
+
+--echo #
+--echo # Test for bug #53820 "ALTER a MEDIUMINT column table causes full
+--echo #                      table copy".
+--echo #
+CREATE TABLE t1 (a INT, b MEDIUMINT);
+INSERT INTO t1 VALUES (1, 1), (2, 2);
+--echo # The below ALTER should not copy table and so no rows should
+--echo # be shown as affected.
+--enable_info
+ALTER TABLE t1 CHANGE a id INT;
+--disable_info
+DROP TABLE t1;
+
+
+--echo #
+--echo # Bug#11754461 CANNOT ALTER TABLE WHEN KEY PREFIX TOO LONG
+--echo #
+
+CREATE DATABASE db1 CHARACTER SET utf8;
+--error ER_TOO_LONG_KEY
+CREATE TABLE db1.t1 (bar TINYTEXT, KEY (bar(100)));
+CREATE TABLE db1.t1 (bar TINYTEXT, KEY (bar(85)));
+ALTER TABLE db1.t1 ADD baz INT;
+
+DROP DATABASE db1;
+
+
+--echo # Additional coverage for refactoring which is made as part
+--echo # of fix for bug #27480 "Extend CREATE TEMPORARY TABLES privilege
+--echo # to allow temp table operations".
+--echo #
+--echo # At some point the below test case failed on assertion.
+
+CREATE TEMPORARY TABLE t1 (i int) ENGINE=MyISAM;
+
+--error ER_ILLEGAL_HA
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+DROP TABLE t1;
+
+
+--echo #
+--echo # Bug#11938039 RE-EXECUTION OF FRM-ONLY ALTER TABLE WITH RENAME
+--echo #              CLAUSE FAILS OR ABORTS SERVER.
+--echo #
+create table t1 (a int);
+prepare stmt1 from 'alter table t1 alter column a set default 1, rename to t2';
+execute stmt1;
+rename table t2 to t1;
+--echo # The below statement should succeed and not emit error or abort server.
+execute stmt1;
+deallocate prepare stmt1;
+drop table t2;
+
+
+--echo # Bug#11748057 (formerly known as 34972): ALTER TABLE statement doesn't
+--echo #                                         identify correct column name.
+--echo #
+
+CREATE TABLE t1 (c1 int unsigned , c2 char(100) not null default '');
+ALTER TABLE t1 ADD c3 char(16) NOT NULL DEFAULT '' AFTER c2,
+               MODIFY c2 char(100) NOT NULL DEFAULT '' AFTER c1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+
+--echo #
+--echo # WL#5534 Online ALTER, Phase 1
+--echo #
+
+--echo # Single thread tests.
+--echo # See innodb_mysql_sync.test for multi thread tests.
+
+CREATE TABLE t1(a INT PRIMARY KEY, b INT) engine=InnoDB;
+CREATE TABLE m1(a INT PRIMARY KEY, b INT) engine=MyISAM;
+INSERT INTO t1 VALUES (1,1), (2,2);
+INSERT INTO m1 VALUES (1,1), (2,2);
+
+--echo #
+--echo # 1: Test ALGORITHM keyword
+--echo #
+
+--echo # --enable_info allows us to see how many rows were updated
+--echo # by ALTER TABLE. in-place will show 0 rows, while copy > 0.
+
+--enable_info
+ALTER TABLE t1 ADD INDEX i1(b);
+ALTER TABLE t1 ADD INDEX i2(b), ALGORITHM= DEFAULT;
+ALTER TABLE t1 ADD INDEX i3(b), ALGORITHM= COPY;
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM= INPLACE;
+--error ER_UNKNOWN_ALTER_ALGORITHM
+ALTER TABLE t1 ADD INDEX i5(b), ALGORITHM= INVALID;
+
+ALTER TABLE m1 ENABLE KEYS;
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= DEFAULT;
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY;
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE;
+--disable_info
+
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+
+--echo #
+--echo # 2: Test ALGORITHM + old_alter_table
+--echo #
+
+--enable_info
+SET SESSION old_alter_table= 1;
+ALTER TABLE t1 ADD INDEX i1(b);
+ALTER TABLE t1 ADD INDEX i2(b), ALGORITHM= DEFAULT;
+ALTER TABLE t1 ADD INDEX i3(b), ALGORITHM= COPY;
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM= INPLACE;
+SET SESSION old_alter_table= 0;
+--disable_info
+
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i2, DROP INDEX i3, DROP INDEX i4;
+
+--echo #
+--echo # 3: Test unsupported in-place operation
+--echo #
+
+ALTER TABLE t1 ADD COLUMN (c1 INT);
+ALTER TABLE t1 ADD COLUMN (c2 INT), ALGORITHM= DEFAULT;
+ALTER TABLE t1 ADD COLUMN (c3 INT), ALGORITHM= COPY;
+ALTER TABLE t1 ADD COLUMN (c4 INT), ALGORITHM= INPLACE;
+
+ALTER TABLE t1 DROP COLUMN c1, DROP COLUMN c2, DROP COLUMN c3, DROP COLUMN c4;
+
+--echo #
+--echo # 4: Test LOCK keyword
+--echo #
+
+--enable_info
+ALTER TABLE t1 ADD INDEX i1(b), LOCK= DEFAULT;
+
+# Not supported because of PXC-3418
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ADD INDEX i2(b), LOCK= NONE;
+ALTER TABLE t1 ADD INDEX i3(b), LOCK= SHARED;
+ALTER TABLE t1 ADD INDEX i4(b), LOCK= EXCLUSIVE;
+--error ER_UNKNOWN_ALTER_LOCK
+ALTER TABLE t1 ADD INDEX i5(b), LOCK= INVALID;
+--disable_info
+
+ALTER TABLE m1 ENABLE KEYS, LOCK= DEFAULT;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE m1 ENABLE KEYS, LOCK= NONE;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE m1 ENABLE KEYS, LOCK= SHARED;
+ALTER TABLE m1 ENABLE KEYS, LOCK= EXCLUSIVE;
+
+ALTER TABLE t1 DROP INDEX i1, DROP INDEX i3, DROP INDEX i4;
+
+--echo #
+--echo # 5: Test ALGORITHM + LOCK
+--echo #
+
+--enable_info
+
+# Not supported because of PXC-3418
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ADD INDEX i1(b), ALGORITHM= INPLACE, LOCK= NONE;
+ALTER TABLE t1 ADD INDEX i2(b), ALGORITHM= INPLACE, LOCK= SHARED;
+ALTER TABLE t1 ADD INDEX i3(b), ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM= COPY, LOCK= NONE;
+ALTER TABLE t1 ADD INDEX i5(b), ALGORITHM= COPY, LOCK= SHARED;
+ALTER TABLE t1 ADD INDEX i6(b), ALGORITHM= COPY, LOCK= EXCLUSIVE;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE, LOCK= NONE;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE, LOCK= SHARED;
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY, LOCK= NONE;
+# This works because the lock will be SNW for the copy phase.
+# It will still require exclusive lock for actually enabling keys.
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY, LOCK= SHARED;
+ALTER TABLE m1 ENABLE KEYS, ALGORITHM= COPY, LOCK= EXCLUSIVE;
+--disable_info
+
+DROP TABLE t1, m1;
+
+
+--echo #
+--echo # 7: Which operations require copy and which can be done in-place?
+--echo #
+--echo # Test which ALTER TABLE operations are done in-place and
+--echo # which operations are done using temporary table copy.
+--echo #
+--echo # --enable_info allows us to see how many rows were updated
+--echo # by ALTER TABLE. in-place will show 0 rows, while copy > 0.
+--echo #
+
+--echo # Single operation tests
+
+CREATE TABLE ti1(a INT NOT NULL, b INT, c INT) engine=InnoDB;
+CREATE TABLE tm1(a INT NOT NULL, b INT, c INT) engine=MyISAM;
+CREATE TABLE ti2(a INT PRIMARY KEY AUTO_INCREMENT, b INT, c INT) engine=InnoDB;
+CREATE TABLE tm2(a INT PRIMARY KEY AUTO_INCREMENT, b INT, c INT) engine=MyISAM;
+INSERT INTO ti1 VALUES (1,1,1), (2,2,2);
+INSERT INTO ti2 VALUES (1,1,1), (2,2,2);
+INSERT INTO tm1 VALUES (1,1,1), (2,2,2);
+INSERT INTO tm2 VALUES (1,1,1), (2,2,2);
+
+--enable_info
+ALTER TABLE ti1;
+ALTER TABLE tm1;
+
+ALTER TABLE ti1 ADD COLUMN d VARCHAR(200);
+ALTER TABLE tm1 ADD COLUMN d VARCHAR(200);
+ALTER TABLE ti1 ADD COLUMN d2 VARCHAR(200);
+ALTER TABLE tm1 ADD COLUMN d2 VARCHAR(200);
+ALTER TABLE ti1 ADD COLUMN e ENUM('a', 'b') FIRST;
+ALTER TABLE tm1 ADD COLUMN e ENUM('a', 'b') FIRST;
+ALTER TABLE ti1 ADD COLUMN f INT AFTER a;
+ALTER TABLE tm1 ADD COLUMN f INT AFTER a;
+
+ALTER TABLE ti1 ADD INDEX ii1(b);
+ALTER TABLE tm1 ADD INDEX im1(b);
+ALTER TABLE ti1 ADD UNIQUE INDEX ii2 (c);
+ALTER TABLE tm1 ADD UNIQUE INDEX im2 (c);
+ALTER TABLE ti1 ADD FULLTEXT INDEX ii3 (d);
+ALTER TABLE tm1 ADD FULLTEXT INDEX im3 (d);
+ALTER TABLE ti1 ADD FULLTEXT INDEX ii4 (d2);
+ALTER TABLE tm1 ADD FULLTEXT INDEX im4 (d2);
+
+# Bug#14140038 INCONSISTENT HANDLING OF FULLTEXT INDEXES IN ALTER TABLE
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE ti1 ADD PRIMARY KEY(a), ALGORITHM=INPLACE;
+ALTER TABLE ti1 ADD PRIMARY KEY(a);
+ALTER TABLE tm1 ADD PRIMARY KEY(a);
+
+ALTER TABLE ti1 DROP INDEX ii3;
+ALTER TABLE tm1 DROP INDEX im3;
+
+ALTER TABLE ti1 DROP COLUMN d2;
+ALTER TABLE tm1 DROP COLUMN d2;
+
+ALTER TABLE ti1 ADD CONSTRAINT fi1 FOREIGN KEY (b) REFERENCES ti2(a);
+ALTER TABLE tm1 ADD CONSTRAINT fm1 FOREIGN KEY (b) REFERENCES tm2(a);
+
+ALTER TABLE ti1 ALTER COLUMN b SET DEFAULT 1;
+ALTER TABLE tm1 ALTER COLUMN b SET DEFAULT 1;
+ALTER TABLE ti1 ALTER COLUMN b DROP DEFAULT;
+ALTER TABLE tm1 ALTER COLUMN b DROP DEFAULT;
+
+# This will set both ALTER_COLUMN_NAME and COLUMN_DEFAULT_VALUE
+ALTER TABLE ti1 CHANGE COLUMN f g INT;
+ALTER TABLE tm1 CHANGE COLUMN f g INT;
+ALTER TABLE ti1 CHANGE COLUMN g h VARCHAR(20);
+ALTER TABLE tm1 CHANGE COLUMN g h VARCHAR(20);
+ALTER TABLE ti1 MODIFY COLUMN e ENUM('a', 'b', 'c');
+ALTER TABLE tm1 MODIFY COLUMN e ENUM('a', 'b', 'c');
+ALTER TABLE ti1 MODIFY COLUMN e INT;
+ALTER TABLE tm1 MODIFY COLUMN e INT;
+# This will set both ALTER_COLUMN_ORDER and COLUMN_DEFAULT_VALUE
+ALTER TABLE ti1 MODIFY COLUMN e INT AFTER h;
+ALTER TABLE tm1 MODIFY COLUMN e INT AFTER h;
+ALTER TABLE ti1 MODIFY COLUMN e INT FIRST;
+ALTER TABLE tm1 MODIFY COLUMN e INT FIRST;
+# This will set both ALTER_COLUMN_NOT_NULLABLE and COLUMN_DEFAULT_VALUE
+ALTER TABLE ti1 MODIFY COLUMN c INT NOT NULL;
+ALTER TABLE tm1 MODIFY COLUMN c INT NOT NULL;
+# This will set both ALTER_COLUMN_NULLABLE and COLUMN_DEFAULT_VALUE
+ALTER TABLE ti1 MODIFY COLUMN c INT NULL;
+ALTER TABLE tm1 MODIFY COLUMN c INT NULL;
+# This will set both ALTER_COLUMN_EQUAL_PACK_LENGTH and COLUMN_DEFAULT_VALUE
+ALTER TABLE ti1 MODIFY COLUMN h VARCHAR(30);
+ALTER TABLE tm1 MODIFY COLUMN h VARCHAR(30);
+ALTER TABLE ti1 MODIFY COLUMN h VARCHAR(30) AFTER d;
+ALTER TABLE tm1 MODIFY COLUMN h VARCHAR(30) AFTER d;
+
+ALTER TABLE ti1 DROP COLUMN h;
+ALTER TABLE tm1 DROP COLUMN h;
+
+ALTER TABLE ti1 DROP INDEX ii2;
+ALTER TABLE tm1 DROP INDEX im2;
+ALTER TABLE ti1 DROP PRIMARY KEY;
+ALTER TABLE tm1 DROP PRIMARY KEY;
+
+ALTER TABLE ti1 DROP FOREIGN KEY fi1;
+ALTER TABLE tm1 DROP FOREIGN KEY fm1;
+
+ALTER TABLE ti1 RENAME TO ti3;
+ALTER TABLE tm1 RENAME TO tm3;
+ALTER TABLE ti3 RENAME TO ti1;
+ALTER TABLE tm3 RENAME TO tm1;
+
+ALTER TABLE ti1 ORDER BY b;
+ALTER TABLE tm1 ORDER BY b;
+
+ALTER TABLE ti1 CONVERT TO CHARACTER SET utf16;
+ALTER TABLE tm1 CONVERT TO CHARACTER SET utf16;
+ALTER TABLE ti1 DEFAULT CHARACTER SET utf8;
+ALTER TABLE tm1 DEFAULT CHARACTER SET utf8;
+
+ALTER TABLE ti1 FORCE;
+ALTER TABLE tm1 FORCE;
+
+ALTER TABLE ti1 AUTO_INCREMENT 3;
+ALTER TABLE tm1 AUTO_INCREMENT 3;
+ALTER TABLE ti1 AVG_ROW_LENGTH 10;
+ALTER TABLE tm1 AVG_ROW_LENGTH 10;
+ALTER TABLE ti1 CHECKSUM 1;
+ALTER TABLE tm1 CHECKSUM 1;
+ALTER TABLE ti1 COMMENT 'test';
+ALTER TABLE tm1 COMMENT 'test';
+ALTER TABLE ti1 MAX_ROWS 100;
+ALTER TABLE tm1 MAX_ROWS 100;
+ALTER TABLE ti1 MIN_ROWS 1;
+ALTER TABLE tm1 MIN_ROWS 1;
+ALTER TABLE ti1 PACK_KEYS 1;
+ALTER TABLE tm1 PACK_KEYS 1;
+
+--disable_info
+DROP TABLE ti1, ti2, tm1, tm2;
+
+--echo # Tests of >1 operation (InnoDB)
+
+CREATE TABLE ti1(a INT PRIMARY KEY AUTO_INCREMENT, b INT) engine=InnoDB;
+INSERT INTO ti1(b) VALUES (1), (2);
+
+--enable_info
+ALTER TABLE ti1 RENAME TO ti3, ADD INDEX ii1(b);
+
+ALTER TABLE ti3 DROP INDEX ii1, AUTO_INCREMENT 5;
+--disable_info
+INSERT INTO ti3(b) VALUES (5);
+--enable_info
+ALTER TABLE ti3 ADD INDEX ii1(b), AUTO_INCREMENT 7;
+--disable_info
+INSERT INTO ti3(b) VALUES (7);
+SELECT * FROM ti3;
+
+DROP TABLE ti3;
+
+--echo #
+--echo # 8: Scenario in which ALTER TABLE was returning an unwarranted
+--echo #    ER_ILLEGAL_HA error at some point during work on this WL.
+--echo #
+
+CREATE TABLE tm1(i INT DEFAULT 1) engine=MyISAM;
+ALTER TABLE tm1 ADD INDEX ii1(i), ALTER COLUMN i DROP DEFAULT;
+DROP TABLE tm1;
+
+--echo #
+--echo # Bug#11815557 60269: MYSQL SHOULD REJECT ATTEMPTS TO CREATE SYSTEM
+--echo #                     TABLES IN INCORRECT ENGINE
+--echo #
+--echo # Note: This test assumes that only MyISAM and InnoDB supports system tables.
+--echo #       If other engines are made to support system tables,
+--echo #       then this test needs to be updated
+--echo #
+
+use mysql;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE db ENGINE=memory;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE user ENGINE=memory;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE func ENGINE=csv;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE servers ENGINE=merge;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE procs_priv ENGINE=memory;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE tables_priv ENGINE=heap;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE columns_priv ENGINE=csv;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE time_zone ENGINE=merge;
+--error ER_UNSUPPORTED_ENGINE
+ALTER TABLE help_topic ENGINE=merge;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE db (dummy int) ENGINE=memory;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE user (dummy int) ENGINE=memory;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE func (dummy int) ENGINE=csv;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE servers (dummy int) ENGINE=merge;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE procs_priv (dummy int) ENGINE=memory;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE tables_priv (dummy int) ENGINE=heap;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE columns_priv (dummy int) ENGINE=csv;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE time_zone (dummy int) ENGINE=merge;
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE help_topic (dummy int) ENGINE=merge;
+use test;
+--echo # End of Bug#11815557
+
+
+--echo #
+--echo # Tests for WL#6555 "Online rename index".
+--echo #
+
+--echo #
+--echo # 1) Tests for syntax and semantics of ALTER TABLE RENAME
+--echo #    KEY/INDEX result.
+--echo #
+--echo # 1.a) Both RENAME KEY and RENAME INDEX variants should be
+--echo #      allowed and produce expected results.
+create table t1 (pk int primary key, i int, j int, key a(i));
+alter table t1 rename key a to b;
+show create table t1;
+alter table t1 rename index b to c;
+show create table t1;
+
+--echo # 1.b) It should be impossible to rename index that doesn't
+--echo #      exists, dropped or added within the same ALTER TABLE.
+--error ER_KEY_DOES_NOT_EXITS
+alter table t1 rename key d to e;
+show create table t1;
+--error ER_KEY_DOES_NOT_EXITS
+alter table t1 drop key c, rename key c to d;
+show create table t1;
+--error ER_KEY_DOES_NOT_EXITS
+alter table t1 add key d(j), rename key d to e;
+show create table t1;
+
+--echo # 1.c) It should be impossible to rename index to a name
+--echo #      which is already used by another index, or is used
+--echo #      by index which is added within the same ALTER TABLE.
+alter table t1 add key d(j);
+--error ER_DUP_KEYNAME
+alter table t1 rename key c to d;
+show create table t1;
+alter table t1 drop key d;
+--error ER_DUP_KEYNAME
+alter table t1 add key d(j), rename key c to d;
+show create table t1;
+
+--echo # 1.d) It should be possible to rename index to a name
+--echo #      which belongs to index which is dropped within the
+--echo #      same ALTER TABLE.
+alter table t1 add key d(j);
+alter table t1 drop key c, rename key d to c;
+show create table t1;
+
+--echo # 1.e) We disallow renaming from/to PRIMARY as it might
+--echo #      lead to some other key becoming "primary" internally,
+--echo #      which will be interpreted as dropping/addition of
+--echo #      primary key.
+--error ER_PARSE_ERROR
+alter table t1 rename key primary to d;
+show create table t1;
+--echo # Even using 'funny' syntax.
+--error ER_WRONG_NAME_FOR_INDEX
+alter table t1 rename key `primary` to d;
+show create table t1;
+--error ER_PARSE_ERROR
+alter table t1 rename key c to primary;
+show create table t1;
+--error ER_WRONG_NAME_FOR_INDEX
+alter table t1 rename key c to `primary`;
+show create table t1;
+drop table t1;
+
+
+--echo #
+--echo # 2) More complex tests for semantics of ALTER TABLE.
+--echo #
+--echo # 2.a) Check that standalone RENAME KEY works as expected
+--echo #      for unique and non-unique indexes.
+create table t1 (a int, unique u(a), b int, key k(b));
+alter table t1 rename key u to uu;
+show create table t1;
+alter table t1 rename key k to kk;
+show create table t1;
+
+--echo # 2.b) Check how that this clause can be mixed with other
+--echo #      clauses which don't affect key or its columns.
+alter table t1 rename key kk to kkk, add column c int;
+show create table t1;
+alter table t1 rename key uu to uuu, add key c(c);
+show create table t1;
+alter table t1 rename key kkk to k, drop key uuu;
+show create table t1;
+alter table t1 rename key k to kk, rename to t2;
+show create table t2;
+
+--echo # 2.c) Check that this clause properly works even in case
+--echo #      when it is mixed with clauses affecting columns in
+--echo #      the key renamed.
+alter table t2 rename key c to cc, modify column c bigint not null first;
+show create table t2;
+--echo # Create multi-component key for next example.
+alter table t2 add unique u (a, b, c);
+show create table t2;
+alter table t2 rename key u to uu, drop column b;
+show create table t2;
+drop table t2;
+
+
+--echo #
+--echo # 3) Test coverage for handling of RENAME INDEX clause in
+--echo #    various storage engines and using different ALTER
+--echo #    algorithm.
+--echo #
+--echo # 3.a) Test coverage for simple storage engines (MyISAM/Heap).
+create table t1 (i int, key k(i)) engine=myisam;
+insert into t1 values (1);
+create table t2 (i int, key k(i)) engine=memory;
+insert into t2 values (1);
+--echo # MyISAM and Heap should be able to handle key renaming in-place.
+alter table t1 algorithm=inplace, rename key k to kk;
+alter table t2 algorithm=inplace, rename key k to kk;
+show create table t1;
+show create table t2;
+--echo # So by default in-place algorithm should be chosen.
+--echo # (ALTER TABLE should report 0 rows affected).
+--enable_info
+alter table t1 rename key kk to kkk;
+alter table t2 rename key kk to kkk;
+--disable_info
+show create table t1;
+show create table t2;
+--echo # Copy algorithm should work as well.
+alter table t1 algorithm=copy, rename key kkk to kkkk;
+alter table t2 algorithm=copy, rename key kkk to kkkk;
+show create table t1;
+show create table t2;
+--echo # When renaming is combined with other in-place operation
+--echo # it still works as expected (i.e. works in-place).
+alter table t1 algorithm=inplace, rename key kkkk to k, alter column i set default 100;
+alter table t2 algorithm=inplace, rename key kkkk to k, alter column i set default 100;
+show create table t1;
+show create table t2;
+--echo # Combining with non-inplace operation results in the whole ALTER
+--echo # becoming non-inplace.
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+alter table t1 algorithm=inplace, rename key k to kk, add column j int;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+alter table t2 algorithm=inplace, rename key k to kk, add column j int;
+drop table t1, t2;
+
+--echo # 3.b) Basic tests for InnoDB. More tests can be found in
+--echo #      innodb.innodb_rename_index*
+create table t1 (i int, key k(i)) engine=innodb;
+insert into t1 values (1);
+--echo # Basic rename, inplace algorithm should be chosen
+--enable_info
+alter table t1 algorithm=inplace, rename key k to kk;
+--disable_info
+show create table t1;
+--echo # copy algorithm should work as well.
+--enable_info
+alter table t1 algorithm=copy, rename key kk to kkk;
+--disable_info
+show create table t1;
+drop table t1;
+
+--echo #
+--echo # 4) Additional coverage for complex cases in which code
+--echo #    in ALTER TABLE comparing old and new table version
+--echo #    got confused.
+--echo #
+--echo # Once InnoDB starts to support in-place index renaming the result
+--echo # of below statements should stay the same. Information about
+--echo # indexes returned by SHOW CREATE TABLE (from .FRM) and by
+--echo # InnoDB (from InnoDB data-dictionary) should be consistent.
+--echo #
+create table t1 ( a int, b int, c int, d int,
+                  primary key (a), index i1 (b), index i2 (c) ) engine=innodb;
+alter table t1 add index i1 (d), rename index i1 to x;
+show create table t1;
+select i.name as k, f.name as c from information_schema.innodb_tables as t,
+                                     information_schema.innodb_indexes as i,
+                                     information_schema.innodb_fields as f
+where t.name='test/t1' and t.table_id = i.table_id and i.index_id = f.index_id
+order by k, c;
+drop table t1;
+create table t1 (a int, b int, c int, d int,
+                 primary key (a), index i1 (b), index i2 (c)) engine=innodb;
+alter table t1 add index i1 (d), rename index i1 to i2, drop index i2;
+show create table t1;
+select i.name as k, f.name as c from information_schema.innodb_tables as t,
+                                     information_schema.innodb_indexes as i,
+                                     information_schema.innodb_fields as f
+where t.name='test/t1' and t.table_id = i.table_id and i.index_id = f.index_id
+order by k, c;
+drop table t1;
+--echo #
+--echo # The below ALTER TABLE statement should either drop and recreate key
+--echo # under new name, or simply rename it. It should not bring .FRM and
+--echo # InnoDB data-dictionary out of sync thus causing asserts.
+--echo #
+create table t1 (i int, key x(i)) engine=InnoDB;
+alter table t1 drop key x, add key X(i), alter column i set default 10;
+drop table t1;
+
+
+--echo #
+--echo # Coverage for changes to ALTER TABLE ... IMPORT/DISCARD TABLESPACE
+--echo # code introduced by WL#6671 "Improve scalability by not using
+--echo # thr_lock.c locks for InnoDB tables".
+--echo #
+--echo # Check that ALTER TABLE ... IMPORT/DISCARD TABLESPACE acquires X
+--echo # metadata lock on the table even when executed under LOCK TABLES.
+--echo #
+
+--enable_connect_log
+--echo # Suppress error messages which will be generated by IMPORT TABLESPACE
+call mtr.add_suppression("Trying to import a tablespace, but could not open the tablespace file");
+call mtr.add_suppression("Operating system error number 2 in a file operation.");
+call mtr.add_suppression("The error means the system cannot find the path specified.");
+
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+
+--echo #
+--echo # 1) Check that ALTER TABLE ... IMPORT/DISCARD TABLESPACE on
+--echo #    base table acquire X lock (when not under LOCK TABLES).
+--echo #
+
+connect(con1, localhost, root);
+--echo # Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+
+connect(con2, localhost, root);
+--echo # Sending:
+--send ALTER TABLE t1 DISCARD TABLESPACE
+
+connection default;
+--echo # Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+let $wait_condition=
+  SELECT COUNT(*) = 1 FROM information_schema.processlist
+  WHERE state = "Waiting for table metadata lock" AND
+        info = "ALTER TABLE t1 DISCARD TABLESPACE";
+--source include/wait_condition.inc
+
+connection con1;
+--echo # Unblock ALTER TABLE DISCARD
+HANDLER t1 CLOSE;
+
+connection con2;
+--echo # Reaping ALTER TABLE DISCARD
+--reap
+
+connection con1;
+--echo # Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+
+connection con2;
+--echo # Sending:
+--send ALTER TABLE t1 IMPORT TABLESPACE
+
+connection default;
+--echo # Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+let $wait_condition=
+  SELECT COUNT(*) = 1 FROM information_schema.processlist
+  WHERE state = "Waiting for table metadata lock" AND
+        info = "ALTER TABLE t1 IMPORT TABLESPACE";
+--source include/wait_condition.inc
+
+connection con1;
+--echo # Unblock ALTER TABLE IMPORT
+HANDLER t1 CLOSE;
+
+connection con2;
+--echo # Reaping ALTER TABLE IMPORT
+--echo # It should fail as no tablespace was copied after DISCARD.
+--error ER_TABLESPACE_MISSING
+--reap
+
+connection default;
+DROP TABLE t1;
+
+--echo #
+--echo # 2) ALTER TABLE ... IMPORT/DISCARD TABLESPACE on temporary table
+--echo #    should not try to acquire X metadata lock on base table.
+--echo #
+
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+
+connection con1;
+--echo # Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+
+connection con2;
+CREATE TEMPORARY TABLE t1 (j INT) ENGINE=InnoDB;
+
+--echo # Both DISCARD and IMPORT on temporary table should fail without
+--echo # acquiring any locks and blocking.
+--error ER_CANNOT_DISCARD_TEMPORARY_TABLE
+ALTER TABLE t1 DISCARD TABLESPACE;
+--error ER_CANNOT_DISCARD_TEMPORARY_TABLE
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+DROP TEMPORARY TABLE t1;
+
+--echo #
+--echo # 3) Check that ALTER TABLE ... IMPORT/DISCARD TABLESPACE on
+--echo #    base table under LOCK TABLES acquire X lock.
+--echo #
+
+connection con2;
+LOCK TABLES t1 WRITE;
+--echo # Sending:
+--send ALTER TABLE t1 DISCARD TABLESPACE
+
+connection default;
+--echo # Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+let $wait_condition=
+  SELECT COUNT(*) = 1 FROM information_schema.processlist
+  WHERE state = "Waiting for table metadata lock" AND
+        info = "ALTER TABLE t1 DISCARD TABLESPACE";
+--source include/wait_condition.inc
+
+connection con1;
+--echo # Unblock ALTER TABLE DISCARD
+HANDLER t1 CLOSE;
+
+connection con2;
+--echo # Reaping ALTER TABLE DISCARD
+--reap
+
+connection con1;
+--echo # Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+
+connection con2;
+--echo # Sending:
+--send ALTER TABLE t1 IMPORT TABLESPACE
+
+connection default;
+--echo # Wait until ALTER TABLE is blocked since it tries to acquire X lock.
+let $wait_condition=
+  SELECT COUNT(*) = 1 FROM information_schema.processlist
+  WHERE state = "Waiting for table metadata lock" AND
+        info = "ALTER TABLE t1 IMPORT TABLESPACE";
+--source include/wait_condition.inc
+
+connection con1;
+--echo # Unblock ALTER TABLE IMPORT
+HANDLER t1 CLOSE;
+
+connection con2;
+--echo # Reaping ALTER TABLE IMPORT
+--echo # It should fail as no tablespace was copied after DISCARD.
+--error ER_TABLESPACE_MISSING
+--reap
+
+UNLOCK TABLES;
+
+connection default;
+DROP TABLE t1;
+
+--echo #
+--echo # 4) Under LOCK TABLES, ALTER TABLE ... IMPORT/DISCARD TABLESPACE on
+--echo #    temporary table should not try to acquire X metadata lock on base
+--echo #    table.
+--echo #
+
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+
+connection con1;
+--echo # Acquire S lock on table 't1'.
+HANDLER t1 OPEN;
+
+connection con2;
+CREATE TEMPORARY TABLE t1 (j INT) ENGINE=InnoDB;
+LOCK TABLES t1 WRITE;
+
+--echo # Both DISCARD and IMPORT on temporary table should fail without
+--echo # acquiring any locks and blocking.
+--error ER_CANNOT_DISCARD_TEMPORARY_TABLE
+ALTER TABLE t1 DISCARD TABLESPACE;
+--error ER_CANNOT_DISCARD_TEMPORARY_TABLE
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+UNLOCK TABLES;
+DROP TEMPORARY TABLE t1;
+
+connection con1;
+HANDLER t1 CLOSE;
+
+--echo #
+--echo # Clean-up.
+--echo #
+disconnect con1;
+--source include/wait_until_disconnected.inc
+disconnect con2;
+--source include/wait_until_disconnected.inc
+connection default;
+--disable_connect_log
+DROP TABLE t1;
+SET sql_mode = default;
+
+
+--echo #
+--echo # BUG 19779365: INDEX COMMENT IN ADD INDEX IS IGNORED.
+--echo #
+
+--echo # After the patch, the alter table reflects the new
+--echo # index comment or the lack of comment for the indexes.
+CREATE TABLE t1(fld1 int, key key1(fld1));
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'test';
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test');
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1);
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test');
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'success';
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+# Alter the comment, but keep the same comment length
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'old comment');
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'new comment';
+SHOW INDEX FROM t1;
+DROP TABLE t1; 
+
+
+--echo #
+--echo # Bug#19635706
+--echo # Verify that it is possible to add a unique key to a not-NULL POINT 
+--echo # column and that this key is promoted to primary key
+--echo # 
+
+CREATE TABLE t1(a INT NOT NULL, b POINT NOT NULL) ENGINE=INNODB;
+SHOW CREATE TABLE t1;
+--error ER_SPATIAL_UNIQUE_INDEX
+ALTER TABLE t1 ADD UNIQUE INDEX (b);
+
+--echo # Note that SHOW CREATE TABLE does not list b as a primary key,
+--echo # even though it was promoted. This appears to be the case also
+--echo # for other column types.
+SHOW CREATE TABLE t1;
+
+ALTER TABLE t1 ADD UNIQUE INDEX (a);
+SHOW CREATE TABLE t1;
+
+--echo # Verify that the expected indices have been created by Innodb
+SELECT T.NAME AS TABLE_NAME, I.NAME AS INDEX_NAME,
+       CASE I.TYPE 
+            WHEN 0 THEN 'Secondary'
+            WHEN 1 THEN 'Clustered'
+            WHEN 2 THEN 'Unique'
+            WHEN 3 THEN 'Primary'
+            WHEN 32 THEN 'Full text'
+            WHEN 64 THEN 'Spatial'
+            ELSE 'Unknown'
+       END AS INDEX_TYPE,
+       F.NAME AS FIELD_NAME, F.POS AS FIELD_POS FROM
+              INFORMATION_SCHEMA.INNODB_TABLES AS T JOIN
+              INFORMATION_SCHEMA.INNODB_INDEXES AS I JOIN
+              INFORMATION_SCHEMA.INNODB_FIELDS AS F
+              ON I.INDEX_ID = F.INDEX_ID AND I.TABLE_ID = T.TABLE_ID
+       WHERE T.NAME = 'test/t1' ORDER BY I.NAME, F.NAME;
+
+DROP TABLE t1;
+
+
+--echo #
+--echo # BUG#16886196 - ALTER TABLE FAILS TO CONVERT TO PREFIX INDEX IN
+--echo #                ALTER_COLUMN_EQUAL_PACK_LENGTH
+
+
+SET @orig_sql_mode = @@sql_mode;
+SET sql_mode= '';
+
+--echo # Test with '767' as index size limit.
+CREATE TABLE t1(fld1 VARCHAR(767), KEY a(fld1)) charset latin1 ENGINE= INNODB
+ROW_FORMAT=COMPACT;
+--echo # With patch for Bug#26848813, a warning is reported.
+ALTER TABLE t1 CHANGE fld1 fld1 VARCHAR(768), ALGORITHM= INPLACE;
+DROP TABLE t1;
+
+CREATE TABLE t1(fld1 VARCHAR(3072), KEY a(fld1)) charset latin1 ENGINE= INNODB,
+ROW_FORMAT=DYNAMIC;
+INSERT INTO t1 VALUES('a');
+ALTER TABLE t1 CHANGE fld1 fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+
+--echo # Without patch, the below statement will assert in a debug build.
+SELECT COUNT(*) FROM t1 WHERE fld1= 'a';
+
+--echo # Cleanup.
+DROP TABLE t1;
+
+--echo # Test with innodb prefix indexes up to 3072 bytes.
+
+CREATE TABLE t1(fld1 VARCHAR(3072), KEY a(fld1)) charset latin1 ENGINE= INNODB
+ROW_FORMAT= DYNAMIC;
+INSERT INTO t1 VALUES('a');
+ALTER TABLE t1 CHANGE fld1 fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+
+--echo # Without patch, the below statement will assert in a debug build.
+SELECT COUNT(*) FROM t1 WHERE fld1= 'a';
+
+--echo # Cleanup.
+DROP TABLE t1;
+SET sql_mode= @orig_sql_mode;
+
+
+
+--echo #
+--echo #BUG#20106553: ALTER TABLE WHICH CHANGES INDEX COMMENT IS NOT
+--echo #              LONGER INPLACE/FAST OPERATION.
+
+--echo #Without the patch, the ALTER TABLE to change the index
+--echo #comment using INPLACE algorithm reports an error.
+CREATE TABLE t1(fld1 int, key key1(fld1)) ENGINE= INNODB;
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'test',
+ALGORITHM= INPLACE;
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test') ENGINE= MyISAM;
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1), ALGORITHM=INPLACE;
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'test') ENGINE= INNODB;
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'success',
+ALGORITHM= INPLACE;
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+# Alter the comment, but keep the same comment length
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'old comment') ENGINE=MyISAM;
+SHOW INDEX FROM t1;
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT 'new comment',
+ALGORITHM= INPLACE;
+SHOW INDEX FROM t1;
+DROP TABLE t1;
+
+--echo #Test cases with merge threshold specified in the index comment.
+
+CREATE TABLE t1(fld1 int, key key1(fld1)) ENGINE=INNODB;
+SHOW INDEX FROM t1;
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT
+'MERGE_THRESHOLD=45';
+SHOW INDEX FROM t1;
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+DROP TABLE t1;
+
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'MERGE_THRESHOLD=40')
+ENGINE=INNODB;
+SHOW INDEX FROM t1;
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1);
+SHOW INDEX FROM t1;
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+DROP TABLE t1;
+
+CREATE TABLE t1(fld1 int, key key1(fld1) COMMENT 'MERGE_THRESHOLD=40')
+ENGINE=INNODB;
+SHOW INDEX FROM t1;
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+ALTER TABLE t1 DROP INDEX key1, ADD INDEX key1(fld1) COMMENT
+'MERGE_THRESHOLD=45';
+SHOW INDEX FROM t1;
+SELECT MERGE_THRESHOLD from INFORMATION_SCHEMA.INNODB_INDEXES WHERE NAME='key1';
+DROP TABLE t1;
+
+--echo #
+--echo # Bug#20748660 THD->MDL_CONTEXT.OWNS_EQUAL_OR_STRONGER_LOCK | CREATE_INFO->TABLESPACE
+--echo #
+--echo # A failing DISCARD/IMPORT TABLESPACE may leave the flag THD::tablespace_op
+--echo # in an incorrect state, causing a succeeding statement to fail.
+--echo
+--echo # Create a tablespace with a table.
+CREATE TABLESPACE s ADD DATAFILE 's.ibd' ENGINE InnoDB;
+CREATE TABLE t (i int) TABLESPACE s ENGINE InnoDB;
+
+--echo # The following statent will fail because the table is not partitioned.
+--echo # Without the fix, the THD::tablespace_op flag will be left set.
+--error ER_PARTITION_MGMT_ON_NONPARTITIONED
+ALTER TABLE t DISCARD PARTITION p TABLESPACE;
+
+--echo # Without the patch, this statement will inherit the tablespace_op flag
+--echo # from the previous statement, causing the statement below to fail due
+--echo # to not acquiring the required MDL lock.
+ALTER TABLE t TABLESPACE s;
+
+--echo # Drop table and tablespace.
+DROP TABLE t;
+DROP TABLESPACE s ENGINE InnoDB;
+
+--echo #
+--echo # Bug#20279241 - ALTER TABLE ... CHARACTER SET UTF8, CONVERT TO
+--echo #                CHARACTER SET LATIN1 SHOULD FAIL
+--echo #
+
+CREATE TABLE t1 (f1 INT);
+
+--echo # Case 1: Alter table with CHARACTER SET X, CHARACTER SET X
+--echo #         ALTER table operation should pass.
+ALTER TABLE t1 CHARACTER SET utf8, CHARACTER SET utf8;
+
+--echo # Case 2: Alter table with CHARACTER SET X, CONVERT TO CHARACTER SET X
+--echo #         ALTER table operation should pass.
+ALTER TABLE t1 CHARACTER SET utf8, CONVERT TO CHARACTER SET utf8;
+
+--echo # Case 3: Alter table with CONVERT TO CHARACTER SET X, CHARACTER SET X
+--echo #         ALTER table operation should pass.
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CHARACTER SET utf8;
+
+--echo # Case 4: Alter table with CONVERT TO CHARACTER SET X, CONVERT TO CHARACTER SET X
+--echo #         ALTER table operation should pass.
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CONVERT TO CHARACTER SET utf8;
+
+--echo # Case 5: Alter table with CHARACTER SET X, CONVERT TO CHARACTER SET Y
+--echo #         Alter table operations should fail with an error "ER_CONFLICTING_DECLARATIONS".
+--error ER_CONFLICTING_DECLARATIONS
+ALTER TABLE t1 CHARACTER SET utf8, CONVERT TO CHARACTER SET latin1;
+
+--echo # Case 6: Alter table with CONVERT TO CHARACTER SET X, CHARACTER SET Y
+--echo #         Alter table operations should fail with an error "ER_CONFLICTING_DECLARATIONS".
+--error ER_CONFLICTING_DECLARATIONS
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CHARACTER SET latin1;
+
+--echo # Case 7: Alter table with CONVERT TO CHARACTER SET X, CONVERT TO CHARACTER SET Y
+--echo #         Alter table operations should fail with an error "ER_CONFLICTING_DECLARATIONS".
+--error ER_CONFLICTING_DECLARATIONS
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8, CONVERT TO CHARACTER SET latin1;
+
+--echo # Case 8: Alter table with CHARACTER SET X COLLATE INCORRECT_COLLATION_NAME
+--echo #         Alter table operation should fail with an error "ER_COLLATION_CHARSET_MISMATCH"
+--error ER_COLLATION_CHARSET_MISMATCH
+ALTER TABLE t1 CHARACTER SET utf8 COLLATE latin1_danish_ci;
+
+--echo # Case 9: Alter table with CONVERT TO CHARACTER SET X COLLATE INCORRECT_COLLATION_NAME
+--echo #         Alter table operation should fail with an error "ER_COLLATION_CHARSET_MISMATCH"
+--error ER_COLLATION_CHARSET_MISMATCH
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf8 COLLATE latin1_danish_ci;
+
+--echo # Case 10: Alter table with CHARACTER SET X, CONVERT TO CHARACTER SET Y COLLATE INCORRECT_COLLATION_NAME
+--echo #          Alter table operation should fail with an error "ER_COLLATION_CHARSET_MISMATCH"
+--error ER_COLLATION_CHARSET_MISMATCH
+ALTER TABLE t1 CHARACTER SET latin1, CONVERT TO CHARACTER SET utf8 COLLATE latin1_danish_ci;
+
+# Clean-up
+DROP TABLE t1;
+
+--echo #
+--echo # BUG#20106837: ALTER TABLE WHICH DROPS AND ADDS THE SAME FULLTEXT
+--echo #               INDEX IS NOT INPLACE/FAST.
+
+CREATE TABLE t1(fld1 varchar(200), FULLTEXT(fld1)) ENGINE=MyISAM;
+INSERT INTO t1 VALUES('ABCD');
+
+--enable_info
+--echo #Without patch, it was not fast a INPLACE ALTER.
+ALTER TABLE t1 DROP INDEX fld1, ADD FULLTEXT INDEX fld1(fld1);
+--disable_info
+
+--echo #Without patch, reports an error 'ER_ALTER_OPERATION_NOT_SUPPORTED'.
+ALTER TABLE t1 ALGORITHM=INPLACE, DROP INDEX fld1,
+ADD FULLTEXT INDEX fld1(fld1);
+DROP TABLE t1;
+
+--echo #Test with InnoDB engine.
+CREATE TABLE t1(fld1 varchar(200), FULLTEXT(fld1)) ENGINE=INNODB;
+INSERT INTO t1 VALUES('ABCD');
+
+--enable_info
+--echo #Without patch, it was not fast a INPLACE ALTER.
+ALTER TABLE t1 DROP INDEX fld1, ADD FULLTEXT INDEX fld1(fld1);
+--disable_info
+
+--echo #Without patch, reports an error 'ER_ALTER_OPERATION_NOT_SUPPORTED'.
+ALTER TABLE t1 ALGORITHM=INPLACE, DROP INDEX fld1,
+ADD FULLTEXT INDEX fld1(fld1);
+DROP TABLE t1;
+
+
+--echo #
+--echo # Bug#20146455: FIND_KEY_CI RETURNS NULL, CAUSES CRASH IN
+--echo #               FILL_ALTER_INPLACE_INFO
+--echo #
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT,
+                 FOREIGN KEY (b) REFERENCES t1(a)) ENGINE= MyISAM;
+ALTER TABLE t1 RENAME INDEX b TO w, ADD FOREIGN KEY (b) REFERENCES t1(a);
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT,
+                 FOREIGN KEY (b) REFERENCES t1(a)) ENGINE= InnoDB;
+ALTER TABLE t1 RENAME INDEX b TO w, ADD FOREIGN KEY (b) REFERENCES t1(a);
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+
+--echo #
+--echo # Bug#22017616: ASSERTION FAILED: TABLE_SHARE->IS_MISSING_PRIMARY_KEY()
+--echo # == M_PREBUILT->CLUST_IND
+--echo #
+--echo # Ensure that adding indexes with virtual columns are not promoted to
+--echo # primary keys
+--echo #
+--echo # Base line with normal column - should be promoted
+CREATE TABLE t0(a INT NOT NULL) ENGINE=INNODB;
+ALTER TABLE t0 ADD UNIQUE INDEX (a);
+
+--echo # Case a: Create table with virtual unique not null column
+--error ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN
+CREATE TABLE t1(a POINT GENERATED ALWAYS AS (POINT(1,1)) VIRTUAL UNIQUE NOT NULL) ENGINE=INNODB;
+
+--echo # Case b: Create table with index on virtual point column
+--error ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN
+CREATE TABLE t2(a POINT GENERATED ALWAYS AS (POINT(1,1)) VIRTUAL NOT NULL, UNIQUE INDEX no_pk(a(1))) ENGINE=INNODB;
+
+--echo # Case c: Add unique index on virtual point column
+CREATE TABLE t3(a POINT GENERATED ALWAYS AS (POINT(1,1)) VIRTUAL NOT NULL)
+ENGINE=INNODB;
+--echo # Case c: Add unique index on virtual point column
+--error ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN
+ALTER TABLE t3 ADD UNIQUE INDEX (a(1));
+SELECT * FROM t3;
+
+--echo # Case d: Add unique index on virtual blob column
+CREATE TABLE t4 (a BLOB, b BLOB GENERATED ALWAYS AS (a) VIRTUAL NOT NULL) ENGINE=INNODB;
+ALTER TABLE t4 ADD UNIQUE INDEX (b(1));
+SELECT * FROM t4;
+
+--echo # Query I_S to verify that 'a' is promoted to pk only when it
+--echo # isn't virtual
+SELECT T.NAME AS TABLE_NAME, I.NAME AS INDEX_NAME,
+       CASE (I.TYPE & 3)
+            WHEN 3 THEN "yes"
+            ELSE "no" END AS IS_PRIMARY_KEY,
+       F.NAME AS FIELD_NAME, F.POS AS FIELD_POS FROM
+              INFORMATION_SCHEMA.INNODB_TABLES AS T JOIN
+              INFORMATION_SCHEMA.INNODB_INDEXES AS I JOIN
+              INFORMATION_SCHEMA.INNODB_FIELDS AS F
+              ON I.INDEX_ID = F.INDEX_ID AND I.TABLE_ID = T.TABLE_ID
+       WHERE T.NAME LIKE 'test/%' ORDER BY T.NAME, I.NAME, F.POS;
+
+
+DROP TABLE t0;
+DROP TABLE t3;
+DROP TABLE t4;
+
+
+--echo #
+--echo # Bug #22141913  ASSERTION: !"INVALID KEY_PART->FIELDNR
+--echo # FILL_DD_INDEX_ELEMENTS_FROM_KEY_PARTS
+--echo #
+
+CREATE TABLE t (a TIMESTAMP(1) GENERATED ALWAYS AS (1) VIRTUAL,
+                b INT GENERATED ALWAYS AS (1) VIRTUAL
+               ) ENGINE=INNODB;
+
+--echo # The below ALTER asserts without the fix.
+ALTER TABLE t ADD  INDEX (b);
+DROP TABLE t;
+
+
+--echo #
+--echo # Bug#21345391: ALTER TABLE ... CONVERT TO CHARACTER SET NOT EFFECT
+--echo #               AND REMAIN A TEMP TABLE
+
+CREATE TABLE t1 (fld1 INT PRIMARY KEY) ENGINE = INNODB CHARACTER SET gbk;
+ALTER TABLE t1 CONVERT TO CHARACTER SET UTF8, ALGORITHM = INPLACE;
+
+--echo # Without fix, the CHARSET SET for table remains gbk.
+SHOW CREATE TABLE t1;
+
+let $test_dir= `SELECT CONCAT(@@datadir, 'test/')`;
+
+--echo # Without fix, the temporary .frm file is not cleaned up.
+--list_files $test_dir `#sql-*.frm`
+
+DROP TABLE t1;
+
+--echo # Test cases added for coverage.
+
+--echo # Reports an error for tables containing datatypes supporting
+--echo # characters.
+
+CREATE TABLE t1 (fld1 CHAR(10) PRIMARY KEY) ENGINE = INNODB CHARACTER SET gbk;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 CONVERT TO CHARACTER SET UTF8, ALGORITHM = INPLACE;
+
+DROP TABLE t1;
+
+--echo # ALTER TABLE, CHARACTER SET operation.
+
+CREATE TABLE t1 (fld1 INT PRIMARY KEY, fld2 CHAR(10)) ENGINE = INNODB
+CHARACTER SET gbk;
+ALTER TABLE t1 CHARACTER SET UTF8, ALGORITHM = INPLACE;
+
+SHOW CREATE TABLE t1;
+
+let $test_dir= `SELECT CONCAT(@@datadir, 'test/')`;
+
+--list_files $test_dir `#sql-*.frm`
+
+DROP TABLE t1;
+
+--echo #
+--echo # Bug#22227958: ASSERT IN DD::FILL_DD_TABLE_FROM_CREATE_INFO, DDL
+--echo #
+--echo # Verify that it is possible to set conflicting values for PACK_KEYS,
+--echo # STATS_PERSISTENT CHECKSUM and DELAY_KEY_WRITE
+--echo # The last value set should be displayed by SHOW CREATE TABLE.
+
+--echo # Create table with conflicting values
+CREATE TABLE t1(i INT) ENGINE=INNODB PACK_KEYS=0 PACK_KEYS=1
+STATS_PERSISTENT=0 STATS_PERSISTENT=1 CHECKSUM=0 CHECKSUM=1
+DELAY_KEY_WRITE=0 DELAY_KEY_WRITE=1;
+
+--echo # Should show PACK_KEYS=1 STATS_PERSISTENT=1
+--echo # CHECKSUM=1 DELAY_KEY_WRITE=1
+SHOW CREATE TABLE t1;
+
+--echo # Alter table with conflicting values
+ALTER TABLE t1 PACK_KEYS=1 PACK_KEYS=0 STATS_PERSISTENT=1 STATS_PERSISTENT=0 CHECKSUM=1 CHECKSUM=0 DELAY_KEY_WRITE=1 DELAY_KEY_WRITE=0;
+
+--echo # Should show PACK_KEYS=0 STATS_PERSISTENT=0 (0 is default for CHECKSUM and DELAY_KEY_WRITE)
+SHOW CREATE TABLE t1;
+
+DROP TABLE t1;
+
+
+--echo #
+--echo # Bug#22740093: ERROR 1071 (42000): SPECIFIED KEY WAS TOO LONG
+--echo #               ERROR WHILE DROPPING INDEX IN 5.7
+--echo #
+
+# Before you were allowed to create a prefix key for TEXT columns
+# which were larger than the column length. The column length
+# for TINYBLOB is 255 bytes, while prefix length is in characters.
+--error ER_TOO_LONG_KEY
+CREATE TABLE t1(id INT PRIMARY KEY,
+                name TINYTEXT,
+                KEY nameloc (name(64))
+) DEFAULT CHARSET=utf8mb4;
+
+# 63 characters of 4 bytes each fit in 255 bytes.
+CREATE TABLE t1(id INT PRIMARY KEY,
+                name TINYTEXT,
+                KEY nameloc (name(63))
+) DEFAULT CHARSET=utf8mb4;
+
+# Check that we can rebuild the table without issue
+ALTER TABLE t1 FORCE;
+
+# Also check ALTER TABLE
+--error ER_TOO_LONG_KEY
+ALTER TABLE t1 ADD INDEX idx (name(64), id);
+ALTER TABLE t1 ADD INDEX idx (name(63), id);
+DROP TABLE t1;
+
+# Check that we can create a table with a prefix index of
+# 64 4-byte characters for a TEXT column.
+
+# 64 characters of 4 bytes each fit in 65535 bytes.
+CREATE TABLE t1(id INT PRIMARY KEY,
+                name TEXT,
+                KEY nameloc (name(64))
+) DEFAULT CHARSET=utf8mb4;
+
+# Check ALTER TABLE where we change the type of the
+# base column, reducing max field length, keeping the
+# length of the prefix key the same.
+--error ER_TOO_LONG_KEY
+ALTER TABLE t1 MODIFY COLUMN name TINYTEXT;
+DROP TABLE t1;
+
+
+--echo #
+--echo # BUG#16888677: OUT OF RANGE VALUE ACCEPTED FOR DATETIME COLUMN IN
+--echo #               ALTER TABLE...ADD COLUMN
+
+SET @saved_sql_mode = @@session.sql_mode;
+
+--echo # Test case with no SQL_MODE enabled.
+SET SESSION sql_mode= '';
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+
+--echo # No warnings or error is reported
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+ALTER TABLE t1 ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM=COPY;
+
+DROP TABLE t1;
+
+--echo # Test case with strict mode enabled.
+
+SET SESSION sql_mode= 'STRICT_ALL_TABLES';
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+
+--echo # No warnings or error is reported
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+ALTER TABLE t1 ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM=COPY;
+
+DROP TABLE t1;
+
+--echo # Test case with 'NO_ZERO_DATE' enabled.
+
+SET SESSION sql_mode= 'NO_ZERO_DATE';
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+
+--echo # Warnings are reported after patch.
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+ALTER TABLE t1 ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM=COPY;
+
+DROP TABLE t1;
+
+--echo # Test case with both 'NO_ZERO_DATE and strict mode' enabled.
+
+SET SESSION sql_mode= @saved_sql_mode;
+
+CREATE TABLE t1(fld1 DATE NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01');
+
+--echo # Without patch, the following statement succeeds.
+--error ER_TRUNCATED_WRONG_VALUE
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=INPLACE;
+--error ER_TRUNCATED_WRONG_VALUE
+ALTER TABLE t1 ADD COLUMN fld2 DATETIME NOT NULL, ALGORITHM=COPY;
+
+TRUNCATE TABLE t1;
+--echo # Operation below succeeds, since the table has no records.
+ALTER TABLE t1 ADD COLUMN fld4 DATETIME NOT NULL, ALGORITHM=INPLACE;
+DROP TABLE t1;
+
+
+--echo #
+--echo # Additional coverage for WL#7743 "New data dictionary: changes to
+--echo # DDL-related parts of SE API". Check that ALTER TABLE INPLACE with
+--echo # RENAME TO clause correctly handles FKs and triggers.
+--echo #
+CREATE TABLE t1 (pk INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (fk INT, FOREIGN KEY (fk) REFERENCES t1 (pk)) ENGINE=InnoDB;
+ALTER TABLE t2 ADD COLUMN j INT, RENAME TO t3, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t3;
+DROP TABLE t3;
+CREATE TRIGGER t1_bi BEFORE INSERT ON t1 FOR EACH ROW SET @a:=0;
+ALTER TABLE t1 ADD COLUMN j INT, RENAME TO t4, ALGORITHM=INPLACE;
+SELECT trigger_name, event_object_schema, event_object_table, action_statement
+  FROM information_schema.triggers WHERE event_object_schema = 'test';
+DROP TABLE t4;
+
+--echo
+--echo Bug#25779239 ALTER TABLE FAILS WHEN DEFAULT
+--echo              CHARACTER SET CHANGES TO UTF8MB4
+--echo
+
+CREATE TABLE t1(
+  i INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY) charset latin1;
+ALTER TABLE t1
+  DROP i,
+  ADD i INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  AUTO_INCREMENT = 1;
+DROP TABLE t1;
+
+CREATE TABLE t1(
+  i INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY) charset utf8mb4;
+ALTER TABLE t1
+  DROP i,
+  ADD i INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  AUTO_INCREMENT = 1;
+DROP TABLE t1;
+
+--echo #
+--echo # BUG#25385334: MYSQL 5.7 ERROR WITH ALTER TABLE MODIFY SYNTAX
+--echo #               AND DATETIME TYPE.
+
+SET @saved_sql_mode = @@session.sql_mode;
+
+--echo # Test case with both strict mode and 'NO_ZERO_DATE' enabled.
+CREATE TABLE t1 (fld1 INT, fld2 DATETIME NOT NULL) ENGINE= INNODB;
+CREATE TABLE t2 (fld1 INT, fld2 POINT NOT NULL) ENGINE= INNODB;
+
+INSERT INTO t1 VALUES(1, '2000-01-01');
+INSERT INTO t2 values(1,  ST_PointFromText('POINT(10 10)'));
+
+--echo # Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1;
+
+--echo # Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL FIRST, ALGORITHM= COPY;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL FIRST, ALGORITHM= COPY;
+
+--echo # Tests added for coverage.
+--error ER_TRUNCATED_WRONG_VALUE
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+               ADD COLUMN fld3 DATETIME NOT NULL;
+--error ER_INVALID_USE_OF_NULL
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+               ADD COLUMN fld3 MULTIPOINT NOT NULL;
+
+--error ER_TRUNCATED_WRONG_VALUE
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+               ADD COLUMN fld3 DATETIME NOT NULL, ALGORITHM= COPY;
+--error ER_INVALID_USE_OF_NULL
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+               ADD COLUMN fld3 MULTIPOINT NOT NULL, ALGORITHM= COPY;
+
+TRUNCATE TABLE t1;
+TRUNCATE TABLE t2;
+
+--echo # Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1;
+
+--echo # Without patch, the following statments report error.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL FIRST, ALGORITHM= COPY;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL FIRST, ALGORITHM= COPY;
+
+--echo # Tests added for coverage.
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+               ADD COLUMN fld3 DATETIME NOT NULL;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+               ADD COLUMN fld3 MULTIPOINT NOT NULL;
+
+ALTER TABLE t1 MODIFY fld2 DATETIME NOT NULL AFTER fld1,
+               ADD COLUMN fld4 DATETIME NOT NULL, ALGORITHM= COPY;
+ALTER TABLE t2 MODIFY fld2 POINT NOT NULL AFTER fld1,
+               ADD COLUMN fld4 MULTIPOINT NOT NULL, ALGORITHM= COPY;
+
+DROP TABLE t1, t2;
+
+--echo # Test case when a non date column is converted to datetime column.
+
+--echo # Test case without any sql mode enabled.
+SET SESSION sql_mode= '';
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+
+--echo # No error or warning is reported.
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+
+DROP TABLE t1;
+
+--echo # Test case with only 'NO_ZERO_DATE' enabled.
+SET SESSION sql_mode= 'NO_ZERO_DATE';
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+
+--echo # Reports only a warning.
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+
+DROP TABLE t1;
+
+SET SESSION sql_mode= 'STRICT_ALL_TABLES';
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+
+--echo # No error or warning is reported.
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+
+DROP TABLE t1;
+
+--echo # Test case with both STRICT MODE and 'NO_ZERO_DATE' enabled.
+SET SESSION sql_mode= @saved_sql_mode;
+CREATE TABLE t1 (fld1 char(25)) ENGINE= INNODB;
+INSERT INTO t1 VALUES('0000-00-00');
+
+--echo # Reports an error.
+--error ER_TRUNCATED_WRONG_VALUE
+ALTER TABLE t1 MODIFY fld1 DATETIME NOT NULL;
+
+DROP TABLE t1;
+
+--echo # Test case when a NULL column is converted to NOT NULL column
+CREATE TABLE t1 (fld0 DATETIME, fld1 INT, fld2 DATETIME NOT NULL) ENGINE= INNODB;
+CREATE TABLE t2 (fld0 POINT, fld1 INT, fld2 POINT NOT NULL) ENGINE= INNODB;
+INSERT INTO t1 VALUES('2000-01-01', 1, '2000-01-01');
+INSERT INTO t2 values(ST_PointFromText('POINT(10 10)'), 1,
+                      ST_PointFromText('POINT(10 10)'));
+
+--echo # Reports an error without patch.
+ALTER TABLE t1 MODIFY fld0 DATETIME NOT NULL AFTER fld2;
+
+--echo # Reports an error without patch
+ALTER TABLE t2 MODIFY fld0 POINT NOT NULL AFTER fld2;
+
+DROP TABLE t1, t2;
+
+--echo # Test case demonstrating the NULL constraint check done by SE.
+CREATE TABLE t1 (fld0 DATETIME, fld1 INT, fld2 DATETIME NOT NULL) ENGINE= INNODB;
+CREATE TABLE t2 (fld0 POINT, fld1 INT, fld2 POINT NOT NULL) ENGINE= INNODB;
+
+INSERT INTO t1 VALUES(NULL, 1, '2000-01-01');
+INSERT INTO t2 values(NULL, 1, ST_PointFromText('POINT(10 10)'));
+
+--error ER_INVALID_USE_OF_NULL
+ALTER TABLE t1 MODIFY fld0 DATETIME NOT NULL;
+
+--error ER_INVALID_USE_OF_NULL
+ALTER TABLE t2 MODIFY fld0 POINT NOT NULL;
+
+DROP TABLE t1, t2;
+
+
+--echo #
+--echo # WL#10761 : ALTER TABLE RENAME COLUMN
+--echo #
+
+CREATE TABLE t1(a INT, b VARCHAR(30), c FLOAT);
+SHOW CREATE TABLE t1;
+INSERT INTO t1 VALUES(1,'abcd',1.234);
+CREATE TABLE t2(a INT, b VARCHAR(30), c FLOAT) ENGINE=MyIsam;
+SHOW CREATE TABLE t2;
+INSERT INTO t2 VALUES(1,'abcd',1.234);
+
+# Rename one column
+ALTER TABLE t1 RENAME COLUMN a TO a;
+ALTER TABLE t1 RENAME COLUMN a TO m;
+SHOW CREATE TABLE t1;
+SELECT * FROM t1;
+
+# Rename multiple column
+ALTER TABLE t1 RENAME COLUMN m TO x,
+               RENAME COLUMN b TO y,
+               RENAME COLUMN c TO z;
+SHOW CREATE TABLE t1;
+SELECT * FROM t1;
+
+# Rename multiple columns with MyIsam Engine
+ALTER TABLE t2 RENAME COLUMN a TO d, RENAME COLUMN b TO e, RENAME COLUMN c to f;
+SHOW CREATE TABLE t2;
+SELECT * FROM t2;
+
+# Mix different ALTER operations with RENAME COLUMN
+ALTER TABLE t1 CHANGE COLUMN x a INT, RENAME COLUMN y TO b;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 CHANGE COLUMN z c DOUBLE, RENAME COLUMN b to b;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 CHANGE COLUMN a b int, RENAME COLUMN b TO c, CHANGE COLUMN c d FLOAT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ADD COLUMN zz INT, RENAME COLUMN d TO f;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 DROP COLUMN zz, RENAME COLUMN c TO zz;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 RENAME COLUMN zz to c, DROP COLUMN f;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ADD COLUMN d INT DEFAULT 5, RENAME COLUMN c TO b, DROP COLUMN b;
+SHOW CREATE TABLE t1;
+
+#Cyclic Rename
+ALTER TABLE t1 RENAME COLUMN b TO d, RENAME COLUMN d TO b;
+SHOW CREATE TABLE t1;
+
+# Rename with Indexes
+ALTER TABLE t1 ADD KEY(b);
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 RENAME COLUMN b TO bb;
+SHOW CREATE TABLE t1;
+SELECT * FROM t1;
+
+# Rename with Foreign keys.
+CREATE TABLE t3(a int, b int, KEY(b)) ENGINE=InnoDB;
+ALTER TABLE t3 ADD CONSTRAINT FOREIGN KEY(b) REFERENCES t1(bb);
+SHOW CREATE TABLE t3;
+ALTER TABLE t1 RENAME COLUMN bb TO b;
+SHOW CREATE TABLE t1;
+ALTER TABLE t3 RENAME COLUMN b TO c;
+SHOW CREATE TABLE t3;
+
+# Different Algorithm
+CREATE TABLE t4(a int);
+ALTER TABLE t4 RENAME COLUMN a TO aa, ALGORITHM = INPLACE;
+SHOW CREATE TABLE t4;
+ALTER TABLE t4 RENAME COLUMN aa TO a, ALGORITHM = COPY;
+SHOW CREATE TABLE t4;
+DROP TABLE t4;
+
+# View, Trigger and SP
+CREATE VIEW v1 AS SELECT d,e,f FROM t2;
+CREATE TRIGGER trg1 BEFORE UPDATE on t2 FOR EACH ROW SET NEW.d=OLD.d + 10;
+CREATE PROCEDURE sp1() INSERT INTO t2(d) VALUES(10);
+ALTER TABLE t2 RENAME COLUMN d TO g;
+SHOW CREATE TABLE t2;
+SHOW CREATE VIEW v1;
+--error ER_VIEW_INVALID
+SELECT * FROM v1;
+--error ER_BAD_FIELD_ERROR
+UPDATE t2 SET f = f + 10;
+--error ER_BAD_FIELD_ERROR
+CALL sp1();
+DROP TRIGGER trg1;
+DROP PROCEDURE sp1;
+
+# Generated Columns
+CREATE TABLE t_gen(a INT, b DOUBLE GENERATED ALWAYS AS (SQRT(a)));
+INSERT INTO t_gen(a) VALUES(4);
+SELECT * FROM t_gen;
+SHOW CREATE TABLE t_gen;
+ALTER TABLE t_gen RENAME COLUMN a TO c, CHANGE COLUMN b b DOUBLE GENERATED ALWAYS AS (SQRT(c));
+SELECT * FROM t_gen;
+SHOW CREATE TABLE t_gen;
+--error ER_DEPENDENT_BY_GENERATED_COLUMN
+ALTER TABLE t_gen CHANGE COLUMN c a INT;
+--error ER_DEPENDENT_BY_GENERATED_COLUMN
+ALTER TABLE t_gen RENAME COLUMN c TO a;
+DROP TABLE t_gen;
+
+## Histogram invalidation
+CREATE TABLE foo (col1 INT);
+INSERT INTO foo VALUES (1), (2);
+ANALYZE TABLE foo UPDATE HISTOGRAM ON col1 WITH 10 BUCKETS;
+# The following query should now list one entry for the column "col1"
+# Remove 'last-updated' from the histogram, since it will change on every
+SELECT schema_name, table_name, column_name,
+       JSON_REMOVE(histogram, '$."last-updated"')
+FROM information_schema.COLUMN_STATISTICS;
+ALTER TABLE foo RENAME COLUMN col1 TO col2;
+# It should not show an entry for "col1" now.
+SELECT schema_name, table_name, column_name,
+       JSON_REMOVE(histogram, '$."last-updated"')
+FROM information_schema.COLUMN_STATISTICS;
+DROP TABLE foo;
+
+#
+# Negative tests
+#
+SHOW CREATE TABLE t1;
+
+# Invalid Syntax
+--error ER_PARSE_ERROR
+ALTER TABLE t1 RENAME COLUMN b z;
+--error ER_PARSE_ERROR
+ALTER TABLE t1 RENAME COLUMN FROM b TO z;
+--error ER_PARSE_ERROR
+ALTER TABLE t1 RENAME COLUMN b TO 1;
+
+# Duplicate column name
+--error ER_BAD_FIELD_ERROR
+ALTER TABLE t1 RENAME COLUMN b TO e, RENAME COLUMN c TO e;
+--error ER_DUP_FIELDNAME
+ALTER TABLE t1 ADD COLUMN z INT, RENAME COLUMN b TO z;
+
+# Multiple operation on same column
+--error ER_BAD_FIELD_ERROR
+ALTER TABLE t1 DROP COLUMN b, RENAME COLUMN b TO z;
+--error ER_BAD_FIELD_ERROR
+ALTER TABLE t1 RENAME COLUMN b TO b, RENAME COLUMN b TO b;
+--error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t1 RENAME COLUMN b TO c3, DROP COLUMN c3;
+--error ER_BAD_FIELD_ERROR
+ALTER TABLE t1 ADD COLUMN z INT, CHANGE COLUMN z y INT, DROP COLUMN y;
+--error ER_BAD_FIELD_ERROR
+ALTER TABLE t1 ADD COLUMN z INT, RENAME COLUMN z TO y, DROP COLUMN y;
+
+# Invalid column name while renaming
+--error ER_WRONG_COLUMN_NAME
+ALTER TABLE t1 RENAME COLUMN b TO `nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn`;
+# This error is different compared to ALTER TABLE ... CHANGE command
+--error ER_TOO_LONG_IDENT
+ALTER TABLE t1 CHANGE b `nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn` int;
+
+SHOW CREATE TABLE t1;
+SELECT * FROM t1;
+
+# Cleanup
+DROP VIEW v1;
+DROP TABLE t3,t1,t2;
+SET SESSION information_schema_stats_expiry=default;
+
+--echo #
+--echo # Bug#27252354: UNABLE TO CREATE INDEX WHEN DATE/DATETIME DATATYPES
+--echo #               ARE USED WITH REQUIRED OPTION
+--echo #
+
+CREATE TABLE t(a INT);
+INSERT INTO t VALUES ();
+# Allow adding NOT NULL generated DATE columns to a non-empty table.
+ALTER TABLE t
+ADD COLUMN b DATE GENERATED ALWAYS AS ('1999-09-09') VIRTUAL NOT NULL;
+ALTER TABLE t
+ADD COLUMN c DATE GENERATED ALWAYS AS ('1999-09-09') STORED NOT NULL;
+# Constraints are not checked when adding virtual generated columns.
+ALTER TABLE t
+ADD COLUMN d DATE GENERATED ALWAYS AS (NULL) VIRTUAL NOT NULL;
+# Constraints are checked when adding an index on a virtual column.
+--error ER_BAD_NULL_ERROR
+CREATE INDEX idx ON t(d);
+# Constraints are checked when adding stored generated columns.
+--error ER_BAD_NULL_ERROR
+ALTER TABLE t
+ADD COLUMN e DATE GENERATED ALWAYS AS (NULL) STORED NOT NULL;
+SELECT * FROM t;
+DROP TABLE t;
+
+--echo #
+--echo # Basic test coverage for ALGORITHM=INSTANT support on SQL-layer.
+--echo #
+
+--echo #
+--echo # 1) Syntax.
+--echo #
+CREATE TABLE t1 (i INT) ENGINE=InnoDB;
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 10, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+--echo # ALGORITHM=INSTANT doesn't make sense with LOCK clause.
+--error ER_WRONG_USAGE
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 11, ALGORITHM=INSTANT, LOCK=NONE;
+--error ER_WRONG_USAGE
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 12, ALGORITHM=INSTANT, LOCK=SHARED;
+--error ER_WRONG_USAGE
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 13, ALGORITHM=INSTANT, LOCK=EXCLUSIVE;
+--echo # ALGORITHM=INSTANT and LOCK=DEFAULT are OK though.
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 13, ALGORITHM=INSTANT, LOCK=DEFAULT;
+SHOW CREATE TABLE t1;
+
+--echo #
+--echo # 2) We support INSTANT algorithm for a few trivial metadata-only
+--echo #    changes for InnoDB.
+--echo #
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 14, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ALTER COLUMN i DROP DEFAULT, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ADD COLUMN j ENUM('a', 'b', 'c');
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e'), ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 RENAME TO t2, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t2;
+
+--echo #
+--echo # 3) You can still use ALGORITHM=INPLACE for these operations
+--echo #    (even though INSTANT algorithm will be used internally).
+--echo #
+ALTER TABLE t2 RENAME TO t1, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 15, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ALTER COLUMN i DROP DEFAULT, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e', 'f', 'g'), ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+
+--echo #
+--echo # 4) However, some operations are not supported as INSTANT.
+--echo #
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ADD KEY(j), ALGORITHM=INSTANT;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 15, DROP COLUMN j, ALGORITHM=INSTANT;
+
+--echo #
+--echo # 5) For MyISAM tables we support INSTANT algorithm for metadata-only
+--echo #    changes as well.
+--echo #
+DROP TABLE t1;
+CREATE TABLE t1 (i INT, j ENUM('a', 'b'), KEY(i)) ENGINE=MyISAM;
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 10, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ALTER COLUMN i DROP DEFAULT, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e'), ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 CHANGE COLUMN i k INT, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 RENAME INDEX i TO k, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 RENAME TO t2, ALGORITHM=INSTANT;
+SHOW CREATE TABLE t2;
+
+--echo #
+--echo # 6) And you can still use ALGORITHM=INPLACE for the same operations
+--echo #    for MyISAM tables too.
+--echo #
+ALTER TABLE t2 RENAME TO t1, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ALTER COLUMN k SET DEFAULT 11, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 ALTER COLUMN k DROP DEFAULT, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 MODIFY COLUMN j ENUM('a', 'b', 'c', 'd', 'e', 'f', 'g'), ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 CHANGE COLUMN k i INT, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 RENAME INDEX k TO i, ALGORITHM=INPLACE;
+SHOW CREATE TABLE t1;
+
+--echo #
+--echo # 7) Indeed, some options are not supported as INSTANT
+--echo #
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ADD COLUMN l INT, ALGORITHM=INSTANT;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ALTER COLUMN i SET DEFAULT 12, DROP COLUMN j, ALGORITHM=INSTANT;
+DROP TABLE t1;
+
+--echo #
+--echo # Bug#27864226: ASSERTION `(CREATE_INFO->USED_FIELDS & (1L << 8)) == 0 ||
+--echo #
+
+CREATE TABLE t1 (a INT) ENGINE=INNODB;
+
+--echo # Verify that ALTER can have both a CONVERT clause and a
+--echo # DEFAULT CHARACTER SET clause with different charsets
+ALTER TABLE t1 CONVERT TO CHARACTER SET utf16 COLLATE utf16_turkish_ci,
+DEFAULT CHARACTER SET utf16 COLLATE utf16_slovak_ci;
+
+--echo # Verify that last default (utf16) overrides
+SHOW CREATE TABLE t1;
+
+DROP TABLE t1;
+
+--echo #  BUG#27909771 - [MYSQL 8.0 GA DEBUG BUILD] ASSERTION `(*IDX_EL_IT)->IS_PREFIX() == STATIC_CAST<B
+--echo #
+
+SET SQL_MODE='';
+CREATE TABLE t1 SELECT 100000000000000000000000000000000000000000000000000000000000000001 AS c1;
+ALTER TABLE t1 ADD INDEX (c1);
+DROP TABLE t1;
+SET SQL_MODE=default;
+
+--echo #
+--echo # BUG#26848813: INDEXED COLUMN CAN'T BE CHANGED FROM VARCHAR(15)
+--echo #               TO VARCHAR(40) INSTANTANEOUSLY
+
+SET @orig_sql_mode = @@sql_mode;
+
+--echo # Tests where an error is reported under strict mode when the index
+--echo # limit exceeds the maximum supported length by SE.
+
+--error ER_TOO_LONG_KEY
+CREATE TABLE t1 (fld1 VARCHAR(768), KEY(fld1)) CHARSET latin1 ENGINE =InnoDB
+ROW_FORMAT= COMPACT;
+
+--error ER_TOO_LONG_KEY
+CREATE TABLE t2 (fld1 VARCHAR(3073), KEY(fld1)) CHARSET latin1 ENGINE= InnoDB;
+
+--echo # Test with innodb prefix indexes where the index limit is 767 bytes
+CREATE TABLE t1 (fld1 VARCHAR(767), KEY(fld1)) CHARSET latin1 ENGINE=INNODB
+ROW_FORMAT=COMPACT;
+
+--error ER_TOO_LONG_KEY
+ALTER TABLE t1 MODIFY fld1 VARCHAR(768), ALGORITHM= INPLACE;
+
+--error ER_TOO_LONG_KEY
+ALTER TABLE t1 MODIFY fld1 VARCHAR(768), ALGORITHM= COPY;
+
+--echo # Test with innodb prefix indexes where the index limit is 3072 bytes
+CREATE TABLE t2 (fld1 VARCHAR(3072), KEY(fld1)) CHARSET latin1 ENGINE=INNODB
+ROW_FORMAT=DYNAMIC;
+
+--error ER_TOO_LONG_KEY
+ALTER TABLE t2 MODIFY fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+
+--error ER_TOO_LONG_KEY
+ALTER TABLE t2 MODIFY fld1 VARCHAR(3073), ALGORITHM= COPY;
+
+DROP TABLE t1, t2;
+
+SET sql_mode= '';
+
+--enable_warnings
+
+--echo # Test where the indexes are truncated to fit the index limit and
+--echo # a warning is reported under non-strict mode when the index exceeds
+--echo # the SE limit.
+CREATE TABLE t1 (fld1 VARCHAR(768), KEY(fld1)) ENGINE= InnoDB
+ROW_FORMAT=COMPACT;
+CREATE TABLE t2 (fld1 VARCHAR(3073), KEY(fld1)) ENGINE= InnoDB;
+
+--echo # Test with innodb prefix indexes where the index limit is 767 bytes.
+CREATE TABLE t3 (fld1 VARCHAR(767), KEY(fld1))ENGINE=INNODB ROW_FORMAT=COMPACT;
+
+ALTER TABLE t3 MODIFY fld1 VARCHAR(768), ALGORITHM= INPLACE;
+
+ALTER TABLE t3 MODIFY fld1 VARCHAR(800), ALGORITHM= COPY;
+
+--echo # Test with innodb prefix indexes where the index limit is 3072 bytes.
+CREATE TABLE t4 (fld1 VARCHAR(3072), KEY(fld1))ENGINE=INNODB
+ROW_FORMAT=DYNAMIC;
+
+ALTER TABLE t4 MODIFY fld1 VARCHAR(3073), ALGORITHM= INPLACE;
+
+ALTER TABLE t4 MODIFY fld1 VARCHAR(3074), ALGORITHM= COPY;
+
+--echo # For unique and primary keys, an error is reported even in non-strict
+--echo # mode.
+
+--error ER_TOO_LONG_KEY
+CREATE TABLE t5(fld1 VARCHAR(768) PRIMARY KEY) ENGINE= InnoDB
+ROW_FORMAT=COMPACT;
+
+--error ER_TOO_LONG_KEY
+CREATE TABLE t5(fld1 VARCHAR(3073), UNIQUE KEY(fld1)) ENGINE= InnoDB;
+
+DROP TABLE t1, t2, t3, t4;
+
+SET sql_mode= @orig_sql_mode;
+
+--echo # Tests added for coverage.
+CREATE TABLE t1(fld1 VARCHAR(3), KEY(fld1)) ENGINE=MYISAM;
+
+--echo # Conversion of unpacked keys to packed keys reports
+--echo # error for INPLACE Alter.
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 MODIFY fld1 VARCHAR(10), ALGORITHM=INPLACE;
+
+--echo # Succeeds with index rebuild.
+ALTER TABLE t1 MODIFY fld1 VARCHAR(10), ALGORITHM=COPY;
+
+--echo # Succeeds since the row format is dynamic.
+CREATE TABLE t2(fld1 VARCHAR(768), KEY(fld1)) ENGINE= InnoDB ROW_FORMAT= DYNAMIC;
+
+--echo # An error is reported when the index exceeds the column size
+--echo # in both strict and non-strict mode.
+--error ER_WRONG_SUB_KEY
+ALTER TABLE t2 ADD INDEX idx1(fld1(769));
+
+SET sql_mode= '';
+
+--error ER_WRONG_SUB_KEY
+ALTER TABLE t2 ADD INDEX idx1(fld1(769));
+
+--echo # Cleanup.
+DROP TABLE t1, t2;
+SET sql_mode= @orig_sql_mode;
+
+
+--echo #
+--echo # BUG#27164393: ALTER COLUMN SET DEFAULT DOES NOT RETURN ERROR
+--echo #               ON GENERATED COLUMNS
+
+
+CREATE TABLE t1(fld1 INT, fld2 INT GENERATED ALWAYS AS (-fld1) VIRTUAL,
+                fld3 INT GENERATED ALWAYS AS (-fld1) STORED); 
+
+--echo # Without patch, does not report an error.
+--error ER_WRONG_USAGE
+ALTER TABLE t1 ALTER COLUMN fld2 SET DEFAULT -1;
+
+--error ER_WRONG_USAGE
+ALTER TABLE t1 ALTER COLUMN fld3 SET DEFAULT -1;
+
+--echo # Tests added for coverage
+--error ER_WRONG_USAGE
+ALTER TABLE t1 CHANGE fld2 fld2 INT GENERATED ALWAYS AS (-fld1) DEFAULT -1;
+
+--error ER_WRONG_USAGE
+ALTER TABLE t1 MODIFY fld3 INT GENERATED ALWAYS AS (-fld1) STORED DEFAULT -1;
+
+DROP TABLE t1;
+
+
+--echo #
+--echo # BUG#27788685: NO WARNING WHEN TRUNCATING A STRING WITH DATA LOSS
+--echo #
+
+--enable_warnings
+SET GLOBAL max_allowed_packet=17825792;
+
+--connect(con1, localhost, root,,)
+CREATE TABLE t1 (t1_fld1 TEXT) ENGINE=InnoDB;
+CREATE TABLE t2 (t2_fld1 MEDIUMTEXT) ENGINE=InnoDB;
+CREATE TABLE t3 (t3_fld1 LONGTEXT) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES (REPEAT('a',300));
+INSERT INTO t2 VALUES (REPEAT('b',65680));
+INSERT INTO t3 VALUES (REPEAT('c',16777300));
+
+SELECT LENGTH(t1_fld1) FROM t1;
+SELECT LENGTH(t2_fld1) FROM t2;
+SELECT LENGTH(t3_fld1) FROM t3;
+
+--echo # With strict mode
+SET SQL_MODE='STRICT_ALL_TABLES';
+
+--error ER_DATA_TOO_LONG
+ALTER TABLE t1 CHANGE `t1_fld1` `my_t1_fld1` TINYTEXT;
+--error ER_DATA_TOO_LONG
+ALTER TABLE t2 CHANGE `t2_fld1` `my_t2_fld1` TEXT;
+--error ER_DATA_TOO_LONG
+ALTER TABLE t3 CHANGE `t3_fld1` `my_t3_fld1` MEDIUMTEXT;
+
+--echo # With non-strict mode
+SET SQL_MODE='';
+
+ALTER TABLE t1 CHANGE `t1_fld1` `my_t1_fld1` TINYTEXT;
+ALTER TABLE t2 CHANGE `t2_fld1` `my_t2_fld1` TEXT;
+ALTER TABLE t3 CHANGE `t3_fld1` `my_t3_fld1` MEDIUMTEXT;
+
+SELECT LENGTH(my_t1_fld1) FROM t1;
+SELECT LENGTH(my_t2_fld1) FROM t2;
+SELECT LENGTH(my_t3_fld1) FROM t3;
+
+# Cleanup
+--disconnect con1
+--source include/wait_until_disconnected.inc
+
+--connection default
+DROP TABLE t1, t2, t3;
+
+SET SQL_MODE=default;
+SET GLOBAL max_allowed_packet=default;
+
+
+--echo #
+--echo # Testing wl#11605: Alter table with character set conversion as
+--echo # inplace operation, Step 1, NO INDEX
+--echo #
+
+SET NAMES UTF8MB4;
+--echo # VARCHAR(512): SWE7 -> BINARY
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET SWE7);
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # VARCHAR(512): ASCII -> BINARY
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET ASCII);
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # VARCHAR(512): UTF8MB4 -> BINARY
+--echo # Not allowed because 512 binary chars cannot hold all 512 char
+--echo # utf8mb4 strings
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET UTF8MB4);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5));
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET BINARY,
+ALGORITHM = INPLACE;
+
+--echo # VARCHAR(512) CHARSET UTF8MB4 -> VARCHAR(2048) CHARSET BINARY:
+--echo # Converting to BINARY and increasing the VARCHAR size accordingly is ok
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(2048) CHARSET BINARY,
+ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # Conversions requiring COPY algorithm
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET ASCII);
+INSERT INTO t1 VALUES ('a string');
+
+--echo # VARCHAR(512): ASCII -> SWE7
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET SWE7, ALGORITHM = INPLACE;
+
+--echo # VARCHAR(512): ASCII -> UCS2
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET UCS2, ALGORITHM = INPLACE;
+
+--echo # VARCHAR(512): ASCII -> UTF8MB4
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET UTF8MB4,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # VARCHAR(512): UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 VARCHAR(512) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 VARCHAR(512) CHARSET UTF8MB4,
+ALGORITHM = INPLACE;
+--echo # Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # CHAR(1): UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 CHAR(1) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (0xc3a6), (0xc3b8);
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(1) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--echo # CHAR(31): UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 CHAR(31) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(31) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+--echo # Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # Crossing the boundary of 256 bytes usage, cannot be INPLACE.
+--echo # 85*3 -> 85*4 and 64*3 -> 64*4
+CREATE TABLE t1(c1 CHAR(85) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(85) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+DROP TABLE t1;
+CREATE TABLE t1(c1 CHAR(64) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(64) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # Increase in column size above 256 bytes should be inplace.
+--echo # 86*3 -> 86*4
+CREATE TABLE t1(c1 CHAR(86) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(86) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # Increase in column size within 256 bytes should be inplace.
+--echo # 63*3 -> 63*4
+CREATE TABLE t1(c1 CHAR(63) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 CHAR(63) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # TINYTEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 TINYTEXT CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 TINYTEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+--echo # Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # TEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 TEXT CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 TEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+--echo # Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # MEDIUMTEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 MEDIUMTEXT CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 MEDIUMTEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+--echo # Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # LONGTEXT: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 LONGTEXT CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT(0xc3a6, 0xc3b8, 0xc3a5, "text"));
+ALTER TABLE t1 MODIFY COLUMN c1 LONGTEXT CHARSET UTF8MB4, ALGORITHM = INPLACE;
+--echo # Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # ENUM: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET UTF8MB3);
+INSERT INTO t1 VALUES ('a');
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c', 0xf0909080) CHARSET UTF8MB4,
+ALGORITHM = INPLACE;
+--echo # Insert chars that only can be represented in utf8mb4
+INSERT INTO t1 VALUES (0xf0909080);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+
+--echo # ENUM: UTF8MB3 -> UTF8MB4: Inplace rejected, new value not at the end
+CREATE TABLE t1(c1 ENUM(0xc3a6,0xc3b8,0xc3a5) CHARSET UTF8MB3);
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM(0xc3a6,0xf0909080,0xc3b8,0xc3a5)
+CHARSET UTF8MB4, ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # ENUM: ASCII -> BINARY
+CREATE TABLE t1(c1 ENUM('a', 'b','c') CHARSET ASCII);
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # ENUM: SWE7 -> BINARY
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET SWE7);
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # ENUM: UTF8MB3 -> BINARY
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET UTF8MB3);
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # ENUM: UTF8MB4 -> BINARY
+CREATE TABLE t1(c1 ENUM('a','b','c') CHARSET UTF8MB4);
+ALTER TABLE t1 MODIFY COLUMN c1 ENUM('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+
+--echo # SET: UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 SET('b',0xc3a6,0xc3b8,0xc3a5) CHARSET UTF8MB3);
+INSERT INTO t1 VALUES (CONCAT('b,', 0xc3a6));
+ALTER TABLE t1 MODIFY COLUMN c1 SET('b',0xc3a6,0xc3b8,0xc3a5,0xf0909080)
+CHARSET UTF8MB4, ALGORITHM = INPLACE;
+--echo # Insert set value which can only be represented in utf8mb4
+INSERT INTO t1 VALUES (CONCAT('b,', 0xf0909080, ',', 0xc3b8));
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # SET: UTF8MB3 -> UTF8MB4: Inplace rejected, new value not at the end
+CREATE TABLE t1(c1 SET(0xc3a6,0xc3b8,0xc3a5) CHARSET UTF8MB3);
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c1 SET(0xc3a6,0xf0909080,0xc3b8,0xc3a5)
+CHARSET UTF8MB4, ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # SET: ASCII -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET ASCII);
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # SET: SWE7 -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET SWE7);
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # SET: UTF8MB3 -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET UTF8MB3);
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # SET: UTF8MB4 -> BINARY
+CREATE TABLE t1(c1 SET('a','b','c') CHARSET UTF8MB4);
+ALTER TABLE t1 MODIFY COLUMN c1 SET('a','b','c') CHARSET BINARY,
+ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # SET operations
+CREATE TABLE t1 (a SET('a1','a2'));
+INSERT INTO t1 VALUES ('a1'),('a2');
+
+--echo # No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a3'), ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES ('a2,a3');
+SELECT a FROM t1;
+
+--echo # Copy: Modify and add new to the end
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','xx','a5'), ALGORITHM = INPLACE;
+
+--echo # Copy: Remove from the end
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2'), ALGORITHM = INPLACE;
+
+--echo # Copy: Add new member in the middle
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a0','a3'), ALGORITHM = INPLACE;
+
+--echo # No copy: Add new to the end
+ALTER TABLE t1 MODIFY COLUMN a SET('a1','a2','a3','a4'), ALGORITHM = INPLACE;
+INSERT INTO t1 VALUES ('a3,a4');
+SELECT a FROM t1;
+
+--echo # Numerical increase (pack length), but adding to the end
+--echo # It should be possible to do this inplace, but leads to crash in
+--echo # DML on altered table.
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN a
+SET('a1','a2','a3','a4','a5','a6','a7','a8','a9','a10'), ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+
+--echo # Change charset for Instantly added column
+--echo # UTF8MB3 -> UTF8MB4
+CREATE TABLE t1(c1 int, c2 CHAR(1) CHARSET ASCII);
+INSERT INTO t1 VALUES(1,'a');
+ALTER TABLE t1 ADD COLUMN c3 VARCHAR(1) CHARSET UTF8MB3 DEFAULT 'b', ALGORITHM = INSTANT;
+SELECT * FROM t1;
+ALTER TABLE t1 MODIFY COLUMN c3 VARCHAR(1) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+
+--echo # Change charset of columns used in virtual column
+--echo # UTF8MB3 -> UTF8MB4
+
+CREATE TABLE t1(c1 int,
+                c2 VARCHAR(1) CHARSET UTF8MB3,
+                c3 VARCHAR(1) CHARSET UTF8MB3,
+                c4 VARCHAR(2) GENERATED ALWAYS AS (CONCAT(c2,c3)) virtual);
+INSERT INTO t1(c1,c2,c3) VALUES(1,'a','b');
+SELECT * FROM t1;
+ALTER TABLE t1
+  MODIFY COLUMN c2 VARCHAR(1) CHARSET UTF8MB4,
+  MODIFY COLUMN c3 VARCHAR(1) CHARSET UTF8MB4, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+
+--echo # There are few negative scenarios
+--echo # char length cannot be changed during inplace
+CREATE TABLE t1(c CHAR(1) CHARSET ASCII);
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c CHAR(4) CHARSET BINARY, ALGORITHM = INPLACE;
+ALTER TABLE t1 MODIFY COLUMN c CHAR(1) CHARSET BINARY, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+
+--echo # Charset cannot be changed inplace for indexed columns
+CREATE TABLE t1(c VARCHAR(1) CHARSET ASCII UNIQUE KEY);
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET BINARY, ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # Collation cannot be changed inplace for indexed columns even
+--echo # if the character set stays the same (see bug#30386119).
+CREATE TABLE t1(c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci PRIMARY KEY);
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ALGORITHM = INPLACE;
+--echo # Using the copy algorithm works.
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ALGORITHM = COPY;
+DROP TABLE t1;
+
+--echo # Collation cannot be changed inplace for non-indexed columns if an index
+--echo # on the column is added in the same statement.
+CREATE TABLE t1(c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci);
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD UNIQUE INDEX(c), ALGORITHM = INPLACE;
+--echo # Using the copy algorithm works.
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD UNIQUE INDEX(c), ALGORITHM = COPY;
+DROP TABLE t1;
+
+--echo # Add a composite index using a prefix key part.
+CREATE TABLE t1(i INT, c VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci);
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD INDEX idx(i, c(5)), ALGORITHM = INPLACE;
+--echo # Using the copy algorithm works.
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(10) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, ADD INDEX idx(i, c(5)), ALGORITHM = COPY;
+DROP TABLE t1;
+
+--echo # Collation can be changed inplace for indexed columns if the index is dropped
+--echo # in the same statement.
+CREATE TABLE t1(c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci, UNIQUE INDEX idx(c));
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(1) CHARSET utf8mb4 COLLATE utf8mb4_0900_as_ci, DROP INDEX idx, ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+--echo # No change (charset or otherwise) which makes
+--echo # Field::max_display_length exceed 255, can be done inplace
+CREATE TABLE t1(c VARCHAR(1) CHARSET ASCII);
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(256) CHARSET BINARY, ALGORITHM = INPLACE;
+ALTER TABLE t1 MODIFY COLUMN c VARCHAR(255) CHARSET BINARY, ALGORITHM = INPLACE;
+DROP TABLE t1;
+
+
+--echo # table level charset change
+CREATE TABLE t1(c VARCHAR(1)) CHARSET ASCII;
+INSERT INTO t1 VALUES('a');
+SELECT * FROM t1;
+ALTER TABLE t1 CONVERT TO CHARSET BINARY, ALGORITHM = INPLACE;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+SET NAMES default;
+
+--echo #
+--echo # Bug #29501324	ADD VIRTUAL FIRST + ADD COLUMN CAUSES ASSERTION FAILURE.
+--echo #
+
+CREATE TABLE t1 (b INT);
+--echo # The below ALTER TABLE causes assertion failure without the fix.
+ALTER TABLE t1 ADD gcol INT AS (b + 1) VIRTUAL FIRST, ADD COLUMN a INT;
+DROP TABLE t1;
+
+# Add test suppressions on node_2
+#
+# Some of the above tests check for negatives scenarios and expect the queries
+# to fail.  But since, the ALTER TABLE is replicated as TOI, it would result in
+# the same error on the other node as well.  So, there would be errors in the
+# error log and we need to suppress the errors.
+
+--connection node_2
+--echo [connection node_2]
+CALL mtr.add_suppression("Specified key was too long");
+CALL mtr.add_suppression("Cannot change column type INPLACE. Try ALGORITHM=COPY.");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.");
+CALL mtr.add_suppression("Incorrect prefix key; the used key part isn't a string");
+CALL mtr.add_suppression("Incorrect datetime value: '0000-00-00' for column");
+CALL mtr.add_suppression("LOCK=NONE is not supported for this operation. Try LOCK=SHARED");
+CALL mtr.add_suppression("LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.");
+CALL mtr.add_suppression("Storage engine 'MEMORY' does not support system tables");
+CALL mtr.add_suppression("Table 't1' already exists");
+CALL mtr.add_suppression("Can't DROP 'PRIMARY'; check that column/key exists");
+CALL mtr.add_suppression("Unknown column 'no_such_col' in 'order clause'");
+CALL mtr.add_suppression("Incorrect datetime value: '0000-00-00 00:00:00' for column");
+CALL mtr.add_suppression("Can't DROP 'no_such_key'; check that column/key exists");
+CALL mtr.add_suppression("Unknown table 'test.t1'");
+CALL mtr.add_suppression("Incorrect date value: '0000-00-00' for column");
+CALL mtr.add_suppression("Table 't\\+2' already exists");
+CALL mtr.add_suppression("LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE");
+CALL mtr.add_suppression("Storage engine 'CSV' does not support system tables");
+CALL mtr.add_suppression("Storage engine 'InnoDB' does not support system tables.");
+CALL mtr.add_suppression("Storage engine 'MRG_MYISAM' does not support system tables");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported. Reason: InnoDB presently supports one FULLTEXT index creation at a time. Try ALGORITHM=COPY");
+CALL mtr.add_suppression("Incorrect index name 'primary'");
+CALL mtr.add_suppression("Invalid use of NULL value");
+CALL mtr.add_suppression("Data too long for column .* at row 1");
+CALL mtr.add_suppression("Key .* doesn't exist in table 't1'");
+CALL mtr.add_suppression("Duplicate key name '.*' on query");
+CALL mtr.add_suppression("Event 1 Query apply failed: 1");
+CALL mtr.add_suppression("Incorrect usage of ALGORITHM=INSTANT and LOCK=NONE/SHARED/EXCLUSIVE");
+CALL mtr.add_suppression("ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.");
+CALL mtr.add_suppression("Incorrect usage of DEFAULT and generated column");
+CALL mtr.add_suppression("Column 'd' cannot be null");
+CALL mtr.add_suppression("Incorrect column name 'nnnnnnnnnn.*");
+CALL mtr.add_suppression("Unknown column '.*' in 't1'");
+CALL mtr.add_suppression("Can't DROP '.*'; check that column/key exists");
+CALL mtr.add_suppression("Duplicate column name .* on query");
+CALL mtr.add_suppression("spatial indexes can't be primary or unique indexes.");
+CALL mtr.add_suppression("Spatial index on virtual generated column' is not supported for generated columns");
+CALL mtr.add_suppression("Column 'c' has a generated column dependency");
+
+--connection node_1
+--echo [connection node_1]
+CALL mtr.add_suppression("While running PXC node in cluster mode it will skip binlogging of non-replicating DDL statement");
+
+# Cleanup
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_alter_table_mdl.cnf
+++ b/mysql-test/suite/galera/t/galera_alter_table_mdl.cnf
@@ -1,0 +1,7 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+log_slave_updates
+
+[mysqld.2]
+log_slave_updates

--- a/mysql-test/suite/galera/t/galera_alter_table_mdl.test
+++ b/mysql-test/suite/galera/t/galera_alter_table_mdl.test
@@ -1,0 +1,228 @@
+#
+# Test ALTER TABLE hang due to Apply Monitor and MDL hang
+#
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/have_log_bin.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+# Clear the binlogs before starting the test
+RESET MASTER;
+
+# Don't make threads wait
+--let $wsrep_sync_wait_saved = `SELECT @@GLOBAL.wsrep_sync_wait`
+SET GLOBAL wsrep_sync_wait = 0;
+
+# Create auxiliary connections on node1
+--connect(node_1_1, 127.0.0.1, root, , test, $NODE_MYPORT_1)
+--connect(node_1_2, 127.0.0.1, root, , test, $NODE_MYPORT_1)
+
+--connection node_1
+CREATE TABLE t1 (a INTEGER PRIMARY KEY);
+
+--echo # --------------------------------
+--echo # Test 1: Execute ALTER TABLE on node2 (Remote)
+--echo # --------------------------------
+
+--connection node_1
+--let $debug_point = halt_alter_table_after_lock_downgrade
+--source include/add_debug_point.inc
+
+# Execute ALTER TABLE from node2
+--connection node_2
+ALTER TABLE t1 ENGINE = InnoDB;
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR alter_table_inplace_after_downgrade';
+
+--connection node_1_2
+--send INSERT INTO test.t1 VALUES(10)
+
+--connection node_1_1
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT State = "Waiting for table metadata lock" FROM information_schema.processlist WHERE info = "INSERT INTO test.t1 VALUES(10)";
+--source include/wait_condition.inc
+
+# Assert that INSERT query is waiting for the metadata lock
+--let $state= `SELECT State FROM information_schema.processlist WHERE info = "INSERT INTO test.t1 VALUES(10)"`
+--let $assert_text= INSERT query should be waiting for the metadata lock.
+--let $assert_cond= "$state" = "Waiting for table metadata lock"
+--source include/assert.inc
+
+SET DEBUG_SYNC = 'now SIGNAL continue_inplace_alter';
+SET DEBUG_SYNC = 'RESET';
+
+--connection node_1_2
+--reap
+
+SELECT * FROM t1;
+
+# Assert that INSERT query commits after the ALTER query
+--let $limit= 2,10
+--let $event_sequence= Anonymous_Gtid # Query/.*CREATE TABLE.* # Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid
+--source include/assert_binlog_events.inc
+
+--echo # --------------------------------
+--echo # Test 2: Execute ALTER TABLE on node1 (Local)
+--echo # --------------------------------
+
+# Clear the binlogs before starting the next test
+RESET MASTER;
+
+# Execute ALTER TABLE from node1
+--connection node_1
+--send ALTER TABLE t1 ENGINE = InnoDB;
+
+--connection node_1_1
+SET DEBUG_SYNC = 'now WAIT_FOR alter_table_inplace_after_downgrade';
+
+--connection node_1_2
+--send INSERT INTO test.t1 VALUES(11)
+
+--connection node_1_1
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT State = "Waiting for table metadata lock" FROM information_schema.processlist WHERE info = "INSERT INTO test.t1 VALUES(11)";
+--source include/wait_condition.inc
+
+# Assert that INSERT query is waiting for the metadata lock
+--let $state= `SELECT State FROM information_schema.processlist WHERE info = "INSERT INTO test.t1 VALUES(11)"`
+--let $assert_text= INSERT query should be waiting for the metadata lock.
+--let $assert_cond= "$state" = "Waiting for table metadata lock"
+--source include/assert.inc
+
+SET DEBUG_SYNC = 'now SIGNAL continue_inplace_alter';
+SET DEBUG_SYNC = 'RESET';
+
+--connection node_1
+--reap
+
+--connection node_1_2
+--reap
+
+SELECT * FROM t1;
+
+# Assert that INSERT query commits after the ALTER query
+--let $limit= 2,10
+--let $event_sequence= Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid
+--source include/assert_binlog_events.inc
+
+--echo # --------------------------------
+--echo # Test 3: Testing with wsrep_OSU_method = "RSU"
+--echo # --------------------------------
+
+# Clear the binlogs before starting the next test
+RESET MASTER;
+
+--connection node_1
+SET SESSION wsrep_OSU_method = "RSU";
+--send ALTER TABLE t1 ENGINE = InnoDB;
+
+--connection node_1_1
+SET DEBUG_SYNC = 'now WAIT_FOR alter_table_inplace_after_downgrade';
+
+# Galera debug point is already set
+--connection node_1_2
+--send INSERT INTO test.t1 VALUES(12)
+
+--connection node_1_1
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT State = "Waiting for table metadata lock" FROM information_schema.processlist WHERE info = "INSERT INTO test.t1 VALUES(12)";
+--source include/wait_condition.inc
+
+# Assert that INSERT query is waiting for the metadata lock
+--let $state= `SELECT State FROM information_schema.processlist WHERE info = "INSERT INTO test.t1 VALUES(12)"`
+--let $assert_text= INSERT query should be waiting for the metadata lock.
+--let $assert_cond= "$state" = "Waiting for table metadata lock"
+--source include/assert.inc
+
+SET DEBUG_SYNC = 'now SIGNAL continue_inplace_alter';
+SET DEBUG_SYNC = 'RESET';
+
+--connection node_1
+--reap
+
+--connection node_1_2
+--reap
+
+SELECT * FROM t1;
+
+# Reset the wsrep_OSU_method
+--connection node_1
+SET SESSION wsrep_OSU_method = DEFAULT;
+
+# Assert that INSERT query commits after the ALTER query
+--let $limit= 2,10
+--let $event_sequence= Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid
+--source include/assert_binlog_events.inc
+
+# Reset the debug point before further testing.
+--source include/remove_debug_point.inc
+
+--echo # --------------------------------
+--echo # Test 4: Testing with ALGORITHM and LOCK syntax.
+--echo # --------------------------------
+
+--enable_info
+ALTER TABLE t1 ADD COLUMN b INTEGER;
+ALTER TABLE t1 ADD INDEX i1(b), LOCK= DEFAULT;
+
+--echo # In the below tests, ALTER TABLE with LOCK=NONE is not supported for the
+--echo # reason that it needs SHARED LOCK during the execution on the query.
+
+# Tests for default algorithm
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ADD INDEX i2(b), LOCK= NONE;
+ALTER TABLE t1 ADD INDEX i2(b), LOCK= SHARED;
+ALTER TABLE t1 ADD INDEX i3(b), LOCK= EXCLUSIVE;
+
+# Tests inplace add index
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM=INPLACE, LOCK= NONE;
+ALTER TABLE t1 ADD INDEX i4(b), ALGORITHM=INPLACE, LOCK= SHARED;
+ALTER TABLE t1 ADD INDEX i5(b), ALGORITHM=INPLACE, LOCK= EXCLUSIVE;
+
+# Tests forced inplace algorithm for changing the engine (LOCK=NONE is not supported)
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 ENGINE=InnoDB, ALGORITHM= INPLACE, LOCK= NONE;
+ALTER TABLE t1 ENGINE=InnoDB, ALGORITHM= INPLACE, LOCK= SHARED;
+ALTER TABLE t1 ENGINE=InnoDB, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+
+# Tests for inplace rename column (LOCK=NONE is not supported)
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 CHANGE COLUMN b c INT, ALGORITHM= INPLACE, LOCK= NONE;
+ALTER TABLE t1 CHANGE COLUMN b c INT, ALGORITHM= INPLACE, LOCK= SHARED;
+ALTER TABLE t1 CHANGE COLUMN c b INT, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+
+SHOW CREATE TABLE t1;
+
+# Tests for inplace drop index (LOCK=NONE is not supported)
+ALTER TABLE t1 DROP INDEX i2, ALGORITHM= INPLACE, LOCK= DEFAULT;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 DROP INDEX i3, ALGORITHM= INPLACE, LOCK= NONE;
+ALTER TABLE t1 DROP INDEX i4, ALGORITHM= INPLACE, LOCK= SHARED;
+ALTER TABLE t1 DROP INDEX i5, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+
+# Tests for inplace rename table (needs Exclusive lock)
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= NONE;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= SHARED;
+ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
+ALTER TABLE t2 RENAME TO t1, ALGORITHM= INPLACE, LOCK= DEFAULT;
+
+--disable_info
+--connection node_2
+CALL mtr.add_suppression("LOCK=NONE is not supported for this operation. Try LOCK=SHARED.");
+CALL mtr.add_suppression("LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.");
+CALL mtr.add_suppression("LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.");
+CALL mtr.add_suppression("Event 1 Query apply failed: 1");
+
+# Cleanup
+--disconnect node_1_1
+--disconnect node_1_2
+--connection node_1
+--eval SET GLOBAL wsrep_sync_wait = $wsrep_sync_wait_saved;
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3418
https://jira.percona.com/browse/PXC-2382

Problem
-------
Cluster node can hang when there is a concurrent read-write load on the table
and there is a parallel inplace ALTER TABLE is happening on the table.

Analysis
--------
The deadlock can be seen even on a single node cluster with

- An Inplace ALTER TABLE query in one session.
- A DML on same table in from another session.

1. In general, as per PXC protocol, DDL in TOI/RSU is a blocking operation.
   This means when DDL is active no other transaction is allowed to make
   progress.

2. When DDL starts, it will block upcoming transactions from committing till
   it is completed. If these transactions are valid (non-conflicting) then
   generally these transactions will end up waiting for commit and this would
   cause flow-control to kick-in.

3. If a conflicting DML is executed on the same machine, in most cases, MDL locks
   can protect it from concurrent execution. But, in case of an inplace ALTER,
   the query doesn't need EXCLUSIVE MDL lock for complete tenure. So, DMLs can
   take SHARED_WRITE metadata lock on the same table and can even update the
   rows. However, if the DML is conflicting, it shall fail during the
   certification stage thereby causing a local cert failure. 

4. These transactions then enter into a wait state inside the local_monitor in
   Galera untill its turn. In this case, it can proceed only after ALTER TABLE
   exits the local monitor.

futex_wait_cancelable,__pthread_cond_wait_common,__pthread_cond_wait,
gu::Lock::wait,galera::Monitor::enter,galera::ReplicatorSMM::cert,
galera::ReplicatorSMM::cert_and_catch,galera::ReplicatorSMM::certify,
galera_certify,wsrep::wsrep_provider_v26::certify(wsrep_provider_v26.cpp:778),
wsrep::transaction::certify_commit(transaction.cpp:1380),
wsrep::transaction::before_prepare(transaction.cpp:311),
wsrep::client_state::before_prepare(client_state.hpp:421),
wsrep_before_prepare(wsrep_trans_observer.h:241),ha_prepare_low(handler.cc:2491),
MYSQL_BIN_LOG::prepare(binlog.cc:8401),ha_commit_trans(handler.cc:1817),
trans_commit_stmt(transaction.cc:546),mysql_execute_command(sql_parse.cc:5683),
mysql_parse(sql_parse.cc:6391),wsrep_mysql_parse(sql_parse.cc:7662),
dispatch_command(sql_parse.cc:2128),do_command(sql_parse.cc:1436),

5. In the meanwhile, if the inplace ALTER TABLE tries to upgrade the lock to
   EXCLUSIVE during its execution, the acquisition fails (due to the above
   transactions holding the SHARED MDLs) and thus ALTER query waits until it
   gets the required LOCK on the table.

Stack trace (pt-pmp):

futex_abstimed_wait_cancelable,__pthread_cond_wait_common,
__pthread_cond_timedwait,native_cond_timedwait(thr_cond.h:100),
my_cond_timedwait(thr_cond.h:149),inline_mysql_cond_timedwait(mysql_cond.h:217),
MDL_wait::timed_wait(mdl.cc:1880),MDL_context::acquire_lock(mdl.cc:3631),
MDL_context::upgrade_shared_lock(mdl.cc:3896),wait_while_table_is_used(sql_base.cc:2480),
mysql_inplace_alter_table,mysql_alter_table(sql_table.cc:17083),
Sql_cmd_alter_table::execute(sql_alter.cc:608),mysql_execute_command(sql_parse.cc:5476),
mysql_parse(sql_parse.cc:6391),wsrep_mysql_parse(sql_parse.cc:7662),
dispatch_command(sql_parse.cc:2128),do_command(sql_parse.cc:1436),

In simple, this is a 2 way dead lock where-in 

- The client threads wait for their turn (can happen only when ALTER TABLE
  finishes its execution).

- The alter table query is trying to upgrade to an exclusive MDL lock on the
  target table and is waiting for all the users of the table to release the
  MDL.

Solution
--------
Make all the inplace alter table to take the MDL for the whole duration.

Observed behavioral changes post fix:

All the DMLs now will now wait for the metadata lock on the table if there is
an ongoing inplace ALTER TABLE on the same table. With this change we wouldn't
be deviating much away from the existing behavior as we are already blocking
the DMLs during the execution of a DDL. As a result, the conflicting DMLs will
now wait instead of the erroring out with deadlock error.


Note to reviewers
---------
1. In 8.0, Deadlock happens only when the ALTER TABLE is executing in RSU and doesn't happen with TOI. In case of TOI, the DML fails the certification process, rolls back the statement and will wait inside the commit_order_enter when it tries to relase the commit_order.

```
futex_wait_cancelable,__pthread_cond_wait_common,__pthread_cond_wait,gu::Lock::wait,galera::Monitor::enter,galera::ReplicatorSMM::commit_order_enter_local,galera_commit_order_enter,wsrep::wsrep_provider_v26::commit_order_enter(wsrep_provider_v26.cpp:812),wsrep::transaction::release_commit_order(transaction.cpp:680),wsrep::transaction::after_statement(transaction.cpp:783),wsrep::client_state::after_statement(client_state.cpp:245),wsrep_after_statement(wsrep_trans_observer.h:452),wsrep_mysql_parse(sql_parse.cc:7686),dispatch_command(sql_parse.cc:2128),do_command(sql_parse.cc:1436),handle_connection(connection_handler_per_thread.cc:312),pfs_spawn_thread(pfs.cc:2855),start_thread,clone
```