### PR TITLE
PXC-3475 (wsrep_ready = OFF regression after cluster init)

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -296,7 +296,7 @@ wsrep_recover_position() {
 
   eval_log_error "$mysqld_cmd --wsrep_recover $wr_options"
 
-  local rp="$(grep 'WSREP: Recovered position:' $wr_logfile)"
+  local rp="$(grep '\[WSREP\] Recovered position:' $wr_logfile)"
   if [ -z "$rp" ]; then
     local skipped="$(grep WSREP $wr_logfile | grep 'skipping position recovery')"
     if [ -z "$skipped" ]; then
@@ -306,7 +306,7 @@ wsrep_recover_position() {
       log_notice "WSREP: Position recovery skipped"
     fi
   else
-    local start_pos="$(echo $rp | sed 's/.*WSREP\:\ Recovered\ position://' \
+    local start_pos="$(echo $rp | sed 's/.*WSREP\]\ Recovered\ position://' \
         | sed 's/^[ \t]*//')"
     log_notice "WSREP: Recovered position $start_pos"
     wsrep_start_position_opt="--wsrep_start_position=$start_pos"


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3475

Problem:
Calling mysqld_safe after a full cluster crasg, fail to retrieve proper
recovery point. mysqld_safe was then calling mysqld passing an empty
wsrep-start-position, which makes pc.recover functionality to not work.

Fix:
Adjust mysqld_safe script to properly parse 8.0 log style.