### PR TITLE
PXC-3506 build changes for pxc-8.0.21

### DIFF
--- a/build-ps/debian/percona-xtradb-cluster-common.install
+++ b/build-ps/debian/percona-xtradb-cluster-common.install
@@ -1,3 +1,6 @@
 # configuration files
 debian/extra/conf.d  etc/mysql/
 debian/extra/my.cnf.fallback etc/mysql/
+#coredumper
+usr/include/coredumper/coredumper.h
+usr/lib/libcoredumper.a

--- a/build-ps/debian/percona-xtradb-cluster-mysql-router.install
+++ b/build-ps/debian/percona-xtradb-cluster-mysql-router.install
@@ -36,7 +36,7 @@ usr/lib/mysqlrouter/plugin/rest_router.so
 usr/lib/mysqlrouter/plugin/rest_routing.so
 usr/lib/mysqlrouter/plugin/rest_metadata_cache.so
 # private shared libraries
-usr/lib/mysqlrouter/private/libprotobuf-lite.so.3.6.1
+usr/lib/mysqlrouter/private/libprotobuf-lite.so.*
 usr/lib/mysqlrouter/private/libmysqlharness.so.1
 usr/lib/mysqlrouter/private/libmysqlrouter.so.1
 usr/lib/mysqlrouter/private/libmysqlrouter_http.so.1

--- a/build-ps/debian/percona-xtradb-cluster-server.install
+++ b/build-ps/debian/percona-xtradb-cluster-server.install
@@ -56,5 +56,5 @@ libgalera_smm.so usr/lib/galera4
 lib/systemd/system/mysql.service
 lib/systemd/system/mysql@.service
 #private shared libs
-usr/lib/mysql/private/libprotobuf-lite.so.3.6.1
-usr/lib/mysql/private/libprotobuf.so.3.6.1
+usr/lib/mysql/private/libprotobuf-lite.so.*
+usr/lib/mysql/private/libprotobuf.so.*

--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -75,7 +75,7 @@ Prefix: %{_sysconfdir}
 
 #Placeholder should be replaced on preparation stage
 %if %{undefined galera_version}
- %define galera_version 4.3 
+ %define galera_version 4.5
 %endif
 
 %if %{undefined galera_revision}
@@ -654,14 +654,14 @@ mkdir debug
   # Attempt to remove any optimisation flags from the debug build
   CFLAGS=`echo " ${CFLAGS} " | \
             sed -e 's/ -O[0-9]* / /' \
-                -e 's/-Wp,-D_FORTIFY_SOURCE=2/ /' \
+                -e 's/-Wp,-D_FORTIFY_SOURCE=2/ -Wno-missing-field-initializers -Wno-error /' \
                 -e 's/ -unroll2 / /' \
                 -e 's/ -ip / /' \
                 -e 's/^ //' \
                 -e 's/ $//'`
   CXXFLAGS=`echo " ${CXXFLAGS} " | \
               sed -e 's/ -O[0-9]* / /' \
-                  -e 's/-Wp,-D_FORTIFY_SOURCE=2/ /' \
+                  -e 's/-Wp,-D_FORTIFY_SOURCE=2/ -Wno-missing-field-initializers -Wno-error /' \
                   -e 's/ -unroll2 / /' \
                   -e 's/ -ip / /' \
                   -e 's/^ //' \
@@ -875,6 +875,8 @@ install -m 644 "%{malloc_lib_source}" \
 rm -f $RBR%{_mandir}/man1/make_win_bin_dist.1*
 rm -f $RBR%{_bindir}/ps_tokudb_admin
 rm -f $RBR%{_bindir}/ps-admin
+rm -rf $RBR/usr/cmake/coredumper-relwithdebinfo.cmake
+rm -rf $RBR/usr/cmake/coredumper.cmake
 
 %if 0%{?systemd}
   rm -rf $RBR%{_sysconfdir}/init.d/mysql
@@ -916,8 +918,6 @@ install -m 644 $MBD/%{galera_src_dir}/asio/LICENSE_1_0.txt    \
     $RBR%{galera_docs}/LICENSE.asio
 install -m 644 $MBD/%{galera_src_dir}/www.evanjones.ca/LICENSE \
     $RBR%{galera_docs}/LICENSE.crc32c
-install -m 644 $MBD/%{galera_src_dir}/chromium/LICENSE       \
-    $RBR%{galera_docs}/LICENSE.chromium
 
 install -d $RBR%{galera_docs2}
 install -m 644 $MBD/%{galera_src_dir}/COPYING                     \
@@ -1472,8 +1472,8 @@ fi
 %attr(755, root, root) %{_sbindir}/mysqld
 %attr(755, root, root) %{_sbindir}/mysqld-debug
 %dir %{_libdir}/mysql/private
-%attr(755, root, root) %{_libdir}/mysql/private/libprotobuf-lite.so.3.6.1
-%attr(755, root, root) %{_libdir}/mysql/private/libprotobuf.so.3.6.1
+%attr(755, root, root) %{_libdir}/mysql/private/libprotobuf-lite.so.*
+%attr(755, root, root) %{_libdir}/mysql/private/libprotobuf.so.*
 %if 0%{?systemd} == 0
 %attr(755, root, root) %{_sbindir}/rcmysql
 %endif
@@ -1521,7 +1521,6 @@ fi
 %doc %attr(0644,root,root) %{galera_docs}/README-MySQL
 %doc %attr(0644,root,root) %{galera_docs}/LICENSE.asio
 %doc %attr(0644,root,root) %{galera_docs}/LICENSE.crc32c
-%doc %attr(0644,root,root) %{galera_docs}/LICENSE.chromium
 %config(noreplace) %{_sysconfdir}/my.cnf
 %dir %{_sysconfdir}/my.cnf.d
 
@@ -1570,6 +1569,9 @@ fi
 %{_sysconfdir}/ld.so.conf.d/percona-xtradb-cluster-shared-%{version}-%{_arch}.conf
 # Shared libraries (omit for architectures that don't support them)
 %{_libdir}/mysql/libperconaserver*.so*
+#coredumper
+%attr(755, root, root) %{_includedir}/coredumper/coredumper.h
+%attr(755, root, root) /usr/lib/libcoredumper.a
 
 # ----------------------------------------------------------------------------
 %files -n percona-xtradb-cluster-garbd

--- a/build-ps/pxc_builder.sh
+++ b/build-ps/pxc_builder.sh
@@ -206,6 +206,7 @@ get_sources(){
     # add git submodules because make dist uses git archive which doesn't include them
     rsync -av ${WORKDIR}/percona-xtradb-cluster/percona-xtradb-cluster-galera/ ${PXCDIR}/percona-xtradb-cluster-galera --exclude .git
     rsync -av ${WORKDIR}/percona-xtradb-cluster/wsrep-lib/ ${PXCDIR}/wsrep-lib --exclude .git
+    rsync -av ${WORKDIR}/percona-xtradb-cluster/extra/coredumper/ ${PXCDIR}/extra/coredumper --exclude .git
 
     sed -i 's:ROUTER_RUNTIMEDIR:/var/run/mysqlrouter/:g' ${PXCDIR}/packaging/rpm-common/*
     cd ${PXCDIR}/packaging/rpm-common || exit
@@ -341,8 +342,8 @@ install_deps() {
         apt-get -y install libtool libnuma-dev scons libboost-dev libboost-program-options-dev check
         apt-get -y install doxygen doxygen-gui graphviz rsync libcurl4-openssl-dev
         apt-get -y install libcurl4-openssl-dev libre2-dev pkg-config libtirpc-dev libev-dev
-        apt-get -y install --download-only percona-xtrabackup-24=2.4.20-1.${DIST}
-        apt-get -y install --download-only percona-xtrabackup-80=8.0.13-1.${DIST}
+        apt-get -y install --download-only percona-xtrabackup-24=2.4.21-1.${DIST}
+        apt-get -y install --download-only percona-xtrabackup-80=8.0.14-1.${DIST}
     fi
     return;
 }
@@ -777,7 +778,7 @@ build_tarball(){
     if [ -f /etc/redhat-release ]; then
         mkdir pxb-2.4
         pushd pxb-2.4
-        yumdownloader percona-xtrabackup-24-2.4.20
+        yumdownloader percona-xtrabackup-24-2.4.21
         rpm2cpio *.rpm | cpio --extract --make-directories --verbose
         mv usr/bin ./
         mv usr/lib* ./
@@ -790,7 +791,7 @@ build_tarball(){
 
         mkdir pxb-8.0
         pushd pxb-8.0
-        yumdownloader percona-xtrabackup-80-8.0.13
+        yumdownloader percona-xtrabackup-80-8.0.14
         rpm2cpio *.rpm | cpio --extract --make-directories --verbose
         mv usr/bin ./
         mv usr/lib64 ./


### PR DESCRIPTION
1. Add coredumper to packages,
2. Fix libprotobuf packaging
3. Update pxb versions
4. Remove galera chromium files from packages
5. Bump galera_version to 4.5 in rpm spec