### PR TITLE
PXC-3502: Crash while listing indexes

### DIFF
--- a/mysql-test/suite/galera/r/pxc_table_indexes.result
+++ b/mysql-test/suite/galera/r/pxc_table_indexes.result
@@ -1,0 +1,7 @@
+include/assert.inc [node_1 binlog should be disabled]
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, UNIQUE KEY bkey (b));
+SHOW INDEXES FROM t1;
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t1	0	PRIMARY	1	a	A	0	NULL	NULL		BTREE			YES	NULL
+t1	0	bkey	1	b	A	0	NULL	NULL	YES	BTREE			YES	NULL
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_table_indexes-master.opt
+++ b/mysql-test/suite/galera/t/pxc_table_indexes-master.opt
@@ -1,0 +1,1 @@
+--skip-log-bin

--- a/mysql-test/suite/galera/t/pxc_table_indexes.test
+++ b/mysql-test/suite/galera/t/pxc_table_indexes.test
@@ -1,0 +1,14 @@
+# Test SHOW INDEXES statement when binlog is disabled
+
+--source include/galera_cluster.inc
+
+--connection node_1
+--let $assert_text=node_1 binlog should be disabled
+--let $log_bin = query_get_value(SHOW VARIABLES LIKE 'log_bin', Value, 1)
+--let $assert_cond= "$log_bin" = "OFF"
+--source include/assert.inc
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, UNIQUE KEY bkey (b));
+SHOW INDEXES FROM t1;
+
+DROP TABLE t1;

--- a/sql/sql_thd_internal_api.cc
+++ b/sql/sql_thd_internal_api.cc
@@ -218,9 +218,8 @@ int thd_non_transactional_update(const THD *thd) {
 
 int thd_binlog_format(const THD *thd) {
 #ifdef WITH_WSREP
-  if ((WSREP(thd) && wsrep_emulate_bin_log) ||
-      ((mysql_bin_log.is_open()) &&
-       (thd->variables.option_bits & OPTION_BIN_LOG)))
+  if (((WSREP(thd) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()) &&
+      (thd->variables.option_bits & OPTION_BIN_LOG))
     return (int)thd->variables.binlog_format;
 #else
   if (mysql_bin_log.is_open() && (thd->variables.option_bits & OPTION_BIN_LOG))


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3502

Problem:
For tables having more than one index, listing indexes causes server
crash.

Cause:
Wsrep commit hooks are called because of wrong condition in function
thd_binlog_format(). They are called even if binlog is disabled.
The problem is caused by wrong initial merge from 5.7 branch.

Solution:
Fixed condition in thd_binlog_format() function.