### PR TITLE
PXC-3509: Do not try to create SSL files when --help is specified

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6428,7 +6428,8 @@ static int init_server_components() {
   if (wsrep_init_server()) unireg_abort(MYSQLD_ABORT_EXIT);
 
   if (!wsrep_recovery) {
-    if (pxc_encrypt_cluster_traffic && !opt_initialize) {
+    if (pxc_encrypt_cluster_traffic && !opt_initialize &&
+        !is_help_or_validate_option()) {
       bool bootstrap = (wsrep_new_cluster ||
                         (strcmp(wsrep_cluster_address, "gcomm://") == 0));
       if (TLS_channel::singleton_init(&mysql_main, mysql_main_channel,


### PR DESCRIPTION
Issue: the server tries to create ssl files even when the --help option
is specified, but in this case, the working directory isn't changed to
the datadir.

This results in:
1. the server creating SSL certificates in an incorrect location (at the
  current working directory when executing mysqld --help)
2. if the current user has no write permission to the current working
  directory, startup will fail with permission denied errors.

Fix: only initialize wsrep ssl if the help option isn't specified