### PR TITLE
PXC-2913: Fix MDL locks assertion when wsrep provider is unloaded

### DIFF
--- a/mysql-test/suite/galera/r/galera_lock_table.result
+++ b/mysql-test/suite/galera/r/galera_lock_table.result
@@ -38,3 +38,28 @@ use mysql;
 select count(*) from wsrep_cluster;
 count(*)
 1
+SET GLOBAL wsrep_provider='none';
+include/assert.inc [No backup locks expected]
+LOCK TABLES FOR BACKUP;
+include/assert.inc [One backup lock expected]
+BEGIN;
+SET GLOBAL log_bin='wrong value';
+ERROR HY000: Variable 'log_bin' is a read only variable
+SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE='BACKUP TABLES';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+include/assert.inc [One backup lock expected]
+UNLOCK TABLES;
+include/assert.inc [No backup locks expected]
+ROLLBACK;
+include/assert.inc [No backup locks expected]
+LOCK INSTANCE FOR BACKUP;
+include/assert.inc [One backup lock expected]
+BEGIN;
+SET GLOBAL log_bin='wrong value';
+ERROR HY000: Variable 'log_bin' is a read only variable
+SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE='BACKUP LOCK';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+include/assert.inc [One backup lock expected]
+UNLOCK INSTANCE;
+include/assert.inc [No backup locks expected]
+ROLLBACK;

--- a/mysql-test/suite/galera/t/galera_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_lock_table.test
@@ -66,3 +66,83 @@ show create table wsrep_cluster;
 #
 use mysql;
 select count(*) from wsrep_cluster;
+
+#
+# Test scenario:
+# 1) unload wsrep_provider
+# 2) lock tables/instance for backup
+# 3) start transaction
+# 4) execute statement that causes WSREP transaction rollback, but does not
+#    involve any storage engine
+# 5) check that backup lock is still present
+#
+
+--let $no_backup_locks_txt = No backup locks expected
+--let $backup_locks_txt = One backup lock expected
+
+--connection node_2
+--let $wsrep_provider_orig = `SELECT @@wsrep_provider`
+--let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
+
+SET GLOBAL wsrep_provider='none';
+
+
+--let $assert_text = $no_backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP TABLES"] = 0
+--source include/assert.inc
+LOCK TABLES FOR BACKUP;
+--let $assert_text = $backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP TABLES"] = 1
+--source include/assert.inc
+BEGIN;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET GLOBAL log_bin='wrong value';
+--error ER_LOCK_DEADLOCK
+SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE='BACKUP TABLES';
+
+--let $assert_text = $backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP TABLES"] = 1
+--source include/assert.inc
+UNLOCK TABLES;
+--let $assert_text = $no_backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP TABLES"] = 0
+--source include/assert.inc
+
+# MySQL transaction is still ongoing, only WSREP transaction was aborted.
+# Finish it before reloading wsrep provider.
+ROLLBACK;
+
+
+--let $assert_text = $no_backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP LOCK"] = 0
+--source include/assert.inc
+LOCK INSTANCE FOR BACKUP;
+--let $assert_text = $backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP LOCK"] = 1
+--source include/assert.inc
+BEGIN;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET GLOBAL log_bin='wrong value';
+--error ER_LOCK_DEADLOCK
+SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE='BACKUP LOCK';
+
+--let $assert_text = $backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP LOCK"] = 1
+--source include/assert.inc
+UNLOCK INSTANCE;
+--let $assert_text = $no_backup_locks_txt
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.metadata_locks WHERE OBJECT_TYPE="BACKUP LOCK"] = 0
+--source include/assert.inc
+
+# MySQL transaction is still ongoing, only WSREP transaction was aborted.
+# Finish it before reloading wsrep provider.
+ROLLBACK;
+
+# Cleanup
+--disable_query_log
+--eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
+--eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
+--enable_query_log
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1389,7 +1389,9 @@ bool do_command(THD *thd) {
   if (wsrep_before_command(thd)) {
     thd->store_globals();
     WSREP_LOG_THD(thd, "enter found BF aborted");
-    DBUG_ASSERT(!thd->mdl_context.has_locks());
+    /* We don't expect stmt/transactional locks. Explicit locks are allowed */
+    DBUG_ASSERT(!thd->mdl_context.has_stmt_locks());
+    DBUG_ASSERT(!thd->mdl_context.has_transactional_locks());
     DBUG_ASSERT(!thd->get_stmt_da()->is_set());
     /* We let COM_QUIT and COM_STMT_CLOSE to execute even if wsrep aborted. */
     if (command != COM_STMT_CLOSE && command != COM_QUIT) {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-2913

Problem:
This problem is visible only for debug builds and the case when wsrep
provider is not loaded (SET GLOBAL wsrep_provider = 'none')

1. Backup lock is taken
2. Transaction is started. This causes wsrep transaction object to be
created
3. Without involving any storage engine execute statement that causes
error. This causes wsrep transaction object transition to 'aborted'
state
4. Because wsrep provider is not loaded, wsrep_after_statement() is not
called and wsrep transaction id is not cleared
5. Execute next statement. wsrep_before_command() is executed and it
detects aborted transaction which causes MDL locks check (problematic
assert). However backup locks are allowed at this point.

Cause:
Wrong assert condition.

Solution:
Assert condition disallowing any MDL locks changed to the one
disallowing stmt/transactional locks. Explicit locks are allowed.

Note:
We still have the effect of the failure of the statement next to the one
causing wsrep transaction rollback. It fails with ER_LOCK_DEADLOCK. This
is caused by explained above detection of aborted transaction in
wsrep_before_command(). As this is the corner case and is the same as we
already have in release build, I decided not to change it. It would need
bigger logic rework, which seems not to be necessary for now.