### PR TITLE
PXC-3508 : SST with OpenSSL 1.1.1 and encrypt=2,3 fails with "E SSL_C…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -442,6 +442,20 @@ get_transfer()
             if check_for_version "$SOCAT_VERSION" "1.7.3"; then
                 donor_extra=',commonname=""'
             fi
+
+            # PXC-3508 : If 'ssl_dhparams' option has been set, then always add it
+            # to the socat command (both donor and joiner)
+            if [[ $encrypt -eq 2 || $encrypt -eq 3 ]]; then
+                if [[ -n $ssl_dhparams ]]; then
+                    if [[ ! $donor_extra =~ dhparam= ]]; then
+                        donor_extra+=",dhparam=$ssl_dhparams"
+                    fi
+                    if [[ ! $joiner_extra =~ dhparam= ]]; then
+                        joiner_extra+=",dhparam=$ssl_dhparams"
+                    fi
+                fi
+            fi
+
         fi
 
         # prepend a comma if it's not already there
@@ -481,7 +495,7 @@ get_transfer()
                 tcmd="socat -u openssl-listen:${TSST_PORT},reuseaddr,cert=${tcert},key=${tkey},verify=0${joiner_extra}${sockopt} stdio"
             else
                 wsrep_log_info "Encrypting with CERT: $tcert, KEY: $tkey"
-                tcmd="socat -u stdio openssl-connect:${REMOTEIP}:${TSST_PORT},cert=${tcert},key=${tkey},verify=0${sockopt}"
+                tcmd="socat -u stdio openssl-connect:${REMOTEIP}:${TSST_PORT},cert=${tcert},key=${tkey},verify=0${donor_extra}${sockopt}"
             fi
         elif [[ $encrypt -eq 4 ]]; then
             wsrep_log_info "Using openssl based encryption with socat: with key, crt, and ca"


### PR DESCRIPTION
…TX_set_tmp_dh" from socat

Issue
Using OpenSSL fixed a bug with the way it used/generated dhparams.  This means that
certificates generated using an older version of OpenSSL would now fail if
used with OpenSSL 1.1.1.

Solution
Explicitly set the dhparam option with socat to workaround the use of the
old certs.