### PR TITLE
PXC-3522: [8.0] Add ability to build tarball with Debug binaries

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -100,6 +100,7 @@ do
         shift
         CMAKE_BUILD_TYPE='Debug'
         BUILD_COMMENT="debug."
+        TARBALL_SUFFIX="-debug"
         DEBUG_EXTRA="-DDEBUG_EXTNAME=ON"
         SCONS_ARGS+=' debug=0'
         ;;
@@ -262,7 +263,7 @@ TOKUDB_BACKUP_VERSION="${MYSQL_VERSION}${MYSQL_VERSION_EXTRA}"
 
 RELEASE_TAG=''
 PRODUCT_NAME="Percona-XtraDB-Cluster_$MYSQL_VERSION$MYSQL_VERSION_EXTRA"
-PRODUCT_FULL_NAME="${PRODUCT_NAME}.${TAG}_${BUILD_COMMENT}$(uname -s)${DIST_NAME:-}.$MACHINE_SPECS${GLIBC_VER:-}"
+PRODUCT_FULL_NAME="${PRODUCT_NAME}.${TAG}_$(uname -s)${DIST_NAME:-}.$MACHINE_SPECS${GLIBC_VER:-}${TARBALL_SUFFIX:-}"
 
 #
 # This corresponds to GIT revision when the build/package is created.

--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -696,11 +696,13 @@ fi
     link
 
     # MIN TARBALL
-    cd "$TARGETDIR/usr/local/minimal/$PRODUCT_FULL_NAME-minimal"
-    rm -rf mysql-test 2> /dev/null
-    rm -rf percona-xtradb-cluster-tests 2> /dev/null
-    find . -type f -exec file '{}' \; | grep ': ELF ' | cut -d':' -f1 | xargs strip --strip-unneeded
-    link
+    if [[ $CMAKE_BUILD_TYPE != "Debug" ]]; then
+        cd "$TARGETDIR/usr/local/minimal/$PRODUCT_FULL_NAME-minimal"
+        rm -rf mysql-test 2> /dev/null
+        rm -rf percona-xtradb-cluster-tests 2> /dev/null
+        find . -type f -exec file '{}' \; | grep ': ELF ' | cut -d':' -f1 | xargs strip --strip-unneeded
+        link
+    fi
 )
 
 # Package the archive
@@ -710,10 +712,12 @@ fi
     find $PRODUCT_FULL -type f -name 'COPYING.AGPLv3' -delete
     $TAR --owner=0 --group=0 -czf "$TARGETDIR/$PRODUCT_FULL_NAME.tar.gz" $PRODUCT_FULL_NAME
 
-    cd "$TARGETDIR/usr/local/minimal/"
-    # PS-4854 Percona Server for MySQL tarball without AGPLv3 dependency/license
-    find $PRODUCT_FULL -type f -name 'COPYING.AGPLv3' -delete
-    $TAR --owner=0 --group=0 -czf "$TARGETDIR/$PRODUCT_FULL_NAME-minimal.tar.gz" $PRODUCT_FULL_NAME-minimal
+    if [[ $CMAKE_BUILD_TYPE != "Debug" ]]; then
+        cd "$TARGETDIR/usr/local/minimal/"
+        # PS-4854 Percona Server for MySQL tarball without AGPLv3 dependency/license
+        find $PRODUCT_FULL -type f -name 'COPYING.AGPLv3' -delete
+        $TAR --owner=0 --group=0 -czf "$TARGETDIR/$PRODUCT_FULL_NAME-minimal.tar.gz" $PRODUCT_FULL_NAME-minimal
+    fi
 ) || exit 1
 
 if [[ $KEEP_BUILD -eq 0 ]]

--- a/build-ps/pxc_builder.sh
+++ b/build-ps/pxc_builder.sh
@@ -208,6 +208,7 @@ get_sources(){
     # add git submodules because make dist uses git archive which doesn't include them
     rsync -av ${WORKDIR}/percona-xtradb-cluster/percona-xtradb-cluster-galera/ ${PXCDIR}/percona-xtradb-cluster-galera --exclude .git
     rsync -av ${WORKDIR}/percona-xtradb-cluster/wsrep-lib/ ${PXCDIR}/wsrep-lib --exclude .git
+    rsync -av ${WORKDIR}/percona-xtradb-cluster/extra/coredumper/ ${PXCDIR}/extra/coredumper --exclude .git
 
     sed -i 's:ROUTER_RUNTIMEDIR:/var/run/mysqlrouter/:g' ${PXCDIR}/packaging/rpm-common/*
     cd ${PXCDIR}/packaging/rpm-common || exit

--- a/build-ps/pxc_builder.sh
+++ b/build-ps/pxc_builder.sh
@@ -21,6 +21,7 @@ Usage: $0 [OPTIONS]
         --rpm_release       RPM version( default = 1)
         --deb_release       DEB version( default = 1)
         --bin_release       BIN version( default = 1)
+        --debug             Build debug tarball
         --help) usage ;;
 Example $0 --builddir=/tmp/PXC80 --get_sources=1 --build_src_rpm=1 --build_rpm=1
 EOF
@@ -57,6 +58,7 @@ parse_arguments() {
             --deb_release=*) DEB_RELEASE="$val" ;;
             --bin_release=*) BIN_RELEASE="$val" ;;
             --no_clone=*) NO_CLONE="$val" ;;
+            --debug=*) DEBUG="$val" ;;
             --help) usage ;;      
             *)
               if test -n "$pick_args"
@@ -834,7 +836,11 @@ build_tarball(){
     if [ -f /etc/redhat-release ]; then
         sed -i 's:cmake ../../:/usr/bin/cmake3 ../../:g' ./build-ps/build-binary.sh
     fi
-    bash -x ./build-ps/build-binary.sh --with-jemalloc=jemalloc/ -t $BIN_RELEASE $BUILD_ROOT
+    if [[ ${DEBUG} == 1 ]]; then
+        bash -x ./build-ps/build-binary.sh --debug --with-jemalloc=jemalloc/ -t $BIN_RELEASE $BUILD_ROOT
+    else
+        bash -x ./build-ps/build-binary.sh --with-jemalloc=jemalloc/ -t $BIN_RELEASE $BUILD_ROOT
+    fi
     mkdir -p ${WORKDIR}/tarball
     mkdir -p ${CURDIR}/tarball
     cp  $BUILD_NUMBER/*.tar.gz ${WORKDIR}/tarball
@@ -862,6 +868,7 @@ INSTALL=0
 RPM_RELEASE=1
 DEB_RELEASE=1
 BIN_RELEASE=1
+DEBUG=0
 REVISION=0
 BRANCH="8.0"
 MECAB_INSTALL_DIR="${WORKDIR}/mecab-install"


### PR DESCRIPTION
Builds: https://rel.cd.percona.com/job/percona-xtradb-cluster-80-bintar-debug/label_exp=min-centos-7-x64/3/
Tests: https://rel.cd.percona.com/job/percona-xtradb-cluster-80-bintar-test/66/