### PR TITLE
[5.7] PXC-3501: Replication issues with foreign key deletes after PXC-5.7.31 upgrade

### DIFF
--- a/mysql-test/suite/galera/r/galera_fk_delete.result
+++ b/mysql-test/suite/galera/r/galera_fk_delete.result
@@ -1,0 +1,18 @@
+# [connection node_1]
+CREATE TABLE t1 (
+id int primary key
+);
+CREATE TABLE t2 (
+id int primary key,
+f_id int, FOREIGN KEY(f_id) REFERENCES t1(id)
+);
+INSERT INTO t1 SELECT 1;
+# [connection node_2]
+include/assert.inc [node2 has parallel applier threads configured]
+# [connection node_1]
+# [connection node_2]
+include/assert.inc [t2 on node_2 has 2000 rows]
+# [connection node_1]
+DELETE FROM t2;
+DELETE FROM t1;
+DROP TABLE t2,t1;

--- a/mysql-test/suite/galera/t/disabled.def
+++ b/mysql-test/suite/galera/t/disabled.def
@@ -23,3 +23,5 @@ pxc_encrypt_rest_gt_vault : Vault server availability is unreliable
 pxc_encrypt_rest_fpt_vault : Vault server availability is unreliable
 #galera_var_wsrep_recover : Issue#330 2018-05-16 CODERSHIP https://github.com/codership/mysql-wsrep/issues/330
 #mysql-wsrep#216 : GCF-1021 0000-00-00 CODERSHIP 5.7 Regression: obfuscated passwords not consistent in error logs
+galera_fk_lock_parent_update_child : 2021-01-04 Disabled by Percona as few cases fail due to timing issue (PXC-3431) and few are invalid after PXC-3501
+galera_toi_ddl_fk_insert : qa#39 2021-01-04 CODERSHIP galera_toi_ddl_fk_insert fails sporadically / PXC-3431

--- a/mysql-test/suite/galera/t/galera_fk_delete.cnf
+++ b/mysql-test/suite/galera/t/galera_fk_delete.cnf
@@ -1,0 +1,4 @@
+!include ../my.cnf
+
+[mysqld.2]
+wsrep-slave-threads=4

--- a/mysql-test/suite/galera/t/galera_fk_delete.test
+++ b/mysql-test/suite/galera/t/galera_fk_delete.test
@@ -1,0 +1,69 @@
+#
+# This test verifies that, in a foreign key relationship, child table DELETE
+# followed by parent table DELETE are not parallelized and are handled
+# sequentially by the applier threads when wsrep_slave_threads > 1.
+#
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+
+# Create two tables with FK relationship.
+--echo # [connection node_1]
+CREATE TABLE t1 (
+  id int primary key
+);
+
+CREATE TABLE t2 (
+  id int primary key,
+  f_id int, FOREIGN KEY(f_id) REFERENCES t1(id)
+);
+
+INSERT INTO t1 SELECT 1;
+
+# Ensure that node_2 is configured with wsrep_slave_threads > 1.
+--echo # [connection node_2]
+--connection node_2
+--let $assert_text = node2 has parallel applier threads configured
+--let $assert_cond = [SELECT @@GLOBAL.wsrep_slave_threads > 1] = 1
+--source include/assert.inc
+
+# Insert 2000 rows on node_1.
+--echo # [connection node_1]
+--connection node_1
+--disable_query_log
+--let $count=2000
+while($count)
+{
+  --eval INSERT INTO t2 VALUES ($count, 1);
+  --dec $count
+}
+--enable_query_log
+
+# Verify that all rows have been applied.
+--echo # [connection node_2]
+--connection node_2
+--let $assert_text = t2 on node_2 has 2000 rows
+--let $assert_cond = [SELECT COUNT(*) = 2000 FROM t2] = 1
+--source include/assert.inc
+
+# This is the main part of the test.
+#
+# Here we try delete rows from both the tables. If foreign key dependencies
+# are not included in the writesets, then the below DELETE statements would
+# allow parent table DELETE to be executed in parallel with the child table
+# DELETE when wsrep-slave-threads > 1, thus making the wsrep applier thread
+# to error out with HA_ERR_ROW_IS_REFERENCED when it tries to delete the
+# parent row while some of the rows in the child table are still referring
+# to the same row.
+#
+# If foreign key dependencies are written to the writesets, then
+# depends_seqno of the parent table delete would point to the global seqno
+# of the child table delete and it ensures that we don't parallelize these
+# statements on other nodes.
+
+--echo # [connection node_1]
+--connection node_1
+DELETE FROM t2;
+DELETE FROM t1;
+
+# Cleanup.
+DROP TABLE t2,t1;

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -420,8 +420,10 @@ wsrep_row_upd_check_foreign_constraints(
 		NOT break the constraint. */
 
 		if (foreign->foreign_index == index
-		    && row_upd_changes_first_fields_binary(
-		        entry, index, node->update, foreign->n_fields)) {
+		    && (node->is_delete
+			|| row_upd_changes_first_fields_binary(
+				entry, index, node->update,
+				foreign->n_fields))) {
 
 			if (foreign->referenced_table == NULL) {
 				foreign->referenced_table = 


### PR DESCRIPTION
PXC-3487: HA_ERR_ROW_IS_REFERENCED - FK constraint fail, node consistency compromised - after PXC updates only

https://jira.percona.com/browse/PXC-3501
https://jira.percona.com/browse/PXC-3487

This is a regression from PXC-3352(https://jira.percona.com/browse/PXC-3352).

Background
==========
Earlier, in a FK relationship, if the parent table's referenced rows are
locked, the DELTE operation on child table from another session tried to lock
the parent row and used to wait till the parent row is unlocked.

As part of fix for PXC-3352, we made the server to behave in same way as of the
PS-5.7 by removing the check for DELETE queries, as we couldn't find a real
case where the DELETE query would need the parent row to be locked.

Problem
=======
The fix for PXC-3352 didn't consider that removing the condition for the DELETE
queries could make the writeset keys to not include the row dependecies between
the child and the parent tables.

Let us consider the below example.

1. CREATE TABLE t1 (id int primary key);
2. CREATE TABLE t2 (id int primary key , f_id int DEFAULT NULL, FOREIGN KEY(f_id)  REFERENCES t1 (id));
3. INSERT INTO t1 SELECT 1;
4. INSERT INTO t2 VALUES (1,1),(2,1),(3,1),(4,1)
5. DELETE FROM t2; -- Child Table
6. DELETE FROM t1; -- Parent Table

Here are the writesets generated while executing the 5th query (DELETE on child
table).
~~~
WRITESETS BEFORE PXC-3352:
Keys appended in `wsrep_prepare_key_for_innodb()`

---------------------------------------------------------------------
   KEY_PART0(db_name) KEY_PART1(table_name) KAY_PART2(row data)
---------------------------------------------------------------------
1. key[0].ptr:"test"  key[1].ptr:"t1"       key[2].ptr: 0 1 0 0 0 <- FK
2. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 1 0 0 0
3. key[0].ptr:"test"  key[1].ptr:"t1"       key[2].ptr: 0 1 0 0 0 <- FK
4. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 2 0 0 0
5. key[0].ptr:"test"  key[1].ptr:"t1"       key[2].ptr: 0 1 0 0 0 <- FK
6. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 3 0 0 0
7. key[0].ptr:"test"  key[1].ptr:"t1"       key[2].ptr: 0 1 0 0 0 <- FK
8. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 4 0 0 0

WRITESETS AFTER PXC-3352:
Keys appended in `wsrep_prepare_key_for_innodb()`
---------------------------------------------------------------------
   KEY_PART0(db_name) KEY_PART1(table_name) KAY_PART2(row data)
---------------------------------------------------------------------
1. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 1 0 0 0
2. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 2 0 0 0
3. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 3 0 0 0
4. key[0].ptr:"test"  key[1].ptr:"t2"       key[2].ptr: 0 4 0 0 0
~~~
After the fix for PXC-3352, for DELETE queries on child tables, the server
replicated writesets without the reference to the parent table row. As a
result, parallel applying (wsrep-slave-threads > 1) on other nodes allowed
parent table DELETE to be executed in parallel with the child table DELETE,
thus making the wsrep applier thread to error out with below error.

    Slave SQL: Could not execute Delete_rows event on table test.t1; Cannot
    delete or update a parent row: a foreign key constraint fails (`test`.`t2`,
    CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`f_id`) REFERENCES `t1` (`id`)),
    Error_code: 1451; handler error HA_ERR_ROW_IS_REFERENCED;

Solution
======
1. The fix for the PXC-3352 has been partially reverted, and for the
   above said reasons, we now lock parent referenced row for the DELETE
   queries in order to write the dependency information to the writeset.
2. The tests galera.galera_fk_lock_parent_update_child and
   galera.galera_toi_ddl_fk_insert have been disabled.

Testing Done
----
Jenkins: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/94/testReport/
Failing testcases:
1. galera.galera_sst_xtrabackup-v2_keyring - Fails due to PXC-3508
2. galera.galera_sst_xtrabackup-v2_encrypt_with_key - Fails due to PXC-3508 

Note to reviewers
---
This is not a GCA based commit.