### PR TITLE
PXC Stability: Fixed PXC-3446, PXC-3552 and PXC-3553

### DIFF
--- a/mysql-test/t/mysqlpump_extended.test
+++ b/mysql-test/t/mysqlpump_extended.test
@@ -249,7 +249,7 @@ DROP DATABASE db1_extended;
 
 CREATE USER u1@localhost IDENTIFIED BY 'abc';
 CREATE USER u2;
---exec $MYSQL_PUMP --users --exclude-users=root,mysql.sys,mysql.session,mysql.infoschema --exclude-databases=mysql,mtr > $MYSQLTEST_VARDIR/tmp/db1_extended.sql
+--exec $MYSQL_PUMP --users --exclude-users=root,mysql.sys,mysql.session,mysql.infoschema,mysql.pxc.sst.role,mysql.pxc.internal.session --exclude-databases=mysql,mtr > $MYSQLTEST_VARDIR/tmp/db1_extended.sql
 DROP USER u1@localhost,u2;
 --exec $MYSQL < $MYSQLTEST_VARDIR/tmp/db1_extended.sql
 --remove_file $MYSQLTEST_VARDIR/tmp/db1_extended.sql
@@ -286,7 +286,7 @@ CREATE USER u2;
 CREATE USER u3@120.0.0.1;
 GRANT SELECT ON mysql.user to u3@120.0.0.1;
 
---exec $MYSQL_PUMP --exclude-databases=mysql,mtr --exclude-users=u2,u1@120.0.0.1,root,mysql.sys,mysql.session,mysql.infoschema > $MYSQLTEST_VARDIR/tmp/db1_extended.sql
+--exec $MYSQL_PUMP --exclude-databases=mysql,mtr --exclude-users=u2,u1@120.0.0.1,root,mysql.sys,mysql.session,mysql.infoschema,mysql.pxc.sst.role,mysql.pxc.internal.session > $MYSQLTEST_VARDIR/tmp/db1_extended.sql
 DROP USER u1@localhost,u3@120.0.0.1,u1@120.0.0.1,u2;
 --exec $MYSQL < $MYSQLTEST_VARDIR/tmp/db1_extended.sql
 --remove_file $MYSQLTEST_VARDIR/tmp/db1_extended.sql
@@ -298,7 +298,7 @@ DROP USER u1@localhost,u3@120.0.0.1;
 --echo # test add-drop-user
 
 CREATE USER u1@localhost IDENTIFIED BY 'abc';
---exec $MYSQL_PUMP --exclude-databases=mysql,mtr --exclude-users=root,mysql.sys,mysql.session,mysql.infoschema --add-drop-user > $MYSQLTEST_VARDIR/tmp/db1_extended.sql
+--exec $MYSQL_PUMP --exclude-databases=mysql,mtr --exclude-users=root,mysql.sys,mysql.session,mysql.infoschema,mysql.pxc.sst.role,mysql.pxc.internal.session --add-drop-user > $MYSQLTEST_VARDIR/tmp/db1_extended.sql
 DROP USER u1@localhost;
 # if restore reports error it means db1_extended.sql has DROP USER stmt
 --error 1

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9861,6 +9861,7 @@ err:
     to NULL.
   */
   delete thd;
+  delete static_cast<Wsrep_thd_args*>(arg);
 
   my_thread_end();
 #if OPENSSL_VERSION_NUMBER < 0x10100000L

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7721,7 +7721,7 @@ static Sys_var_charptr Sys_wsrep_data_home_dir(
 
 static Sys_var_charptr Sys_wsrep_cluster_name(
     "wsrep_cluster_name", "Name for the cluster",
-    READ_ONLY GLOBAL_VAR(wsrep_cluster_name), CMD_LINE(REQUIRED_ARG),
+    PREALLOCATED READ_ONLY GLOBAL_VAR(wsrep_cluster_name), CMD_LINE(REQUIRED_ARG),
     IN_FS_CHARSET, DEFAULT(WSREP_CLUSTER_NAME), NO_MUTEX_GUARD, NOT_IN_BINLOG,
     ON_CHECK(wsrep_cluster_name_check), ON_UPDATE(wsrep_cluster_name_update));
 


### PR DESCRIPTION
1. PXC-3446 - Memory leak during server shutdown
    
    https://jira.percona.com/browse/PXC-3446
    
    Problem: Almost every MTR test exposed the following memory leaks when
    run in cluster mode.
    
    1. Memory leak in rollbacker thread arguments.
    
    ==111465== 16 bytes in 1 blocks are definitely lost in loss record 2 of 4
    ==111465==    at 0x89ECC83: operator new(unsigned long)
    ==111465==    by 0x389DC9A: wsrep_create_rollbacker() (wsrep_thd.cc:309)
    ==111465==    by 0x3874FBE: wsrep_init_startup(bool) (wsrep_mysqld.cc:1125)
    ==111465==    by 0x34010C5: init_server_components() (mysqld.cc:6199)
    ==111465==    by 0x340715B: mysqld_main(int, char**) (mysqld.cc:7689)
    ==111465==    by 0x31A9919: main (main.cc:25)
    
    2. Memory leak in `wsrep_cluster_name` server variable.
    
    ==111465== 49 bytes in 1 blocks are definitely lost in loss record 4 of 4
    ==111465==    at 0x89EC723: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==111465==    by 0x4A8EAA7: my_raw_malloc(unsigned long, int) (my_malloc.cc:199)
    ==111465==    by 0x4A8E6F0: my_malloc(unsigned int, unsigned long, int) (my_malloc.cc:81)
    ==111465==    by 0x4A8EC74: my_strdup(unsigned int, char const*, int) (my_malloc.cc:296)
    ==111465==    by 0x38A4DE8: wsrep_init_vars() (wsrep_var.cc:51)
    ==111465==    by 0x340D3B1: mysql_init_variables() (mysqld.cc:10643)
    ==111465==    by 0x33FAA5A: init_common_variables() (mysqld.cc:4891)
    ==111465==    by 0x34063E9: mysqld_main(int, char**) (mysqld.cc:7504)
    ==111465==    by 0x31A9919: main (main.cc:25)
    
    Fix: The above memory leaks have been fixed.
-----
2. PXC-3552 - [MTR] Fix main.mysqld--validate-config test (server abort)   
    https://jira.percona.com/browse/PXC-3552
    
    Fixed issues:
    1. When --validate-config option is specified and the datadir is not
       specified, mysqld was trying to change directory and was erroring out
       with 'No such file or directory'. As part of the fix, we skip the
       operation if either --help or --validate-option is specified
    
    2. Server logged PXC warnings even when --help/--validate-config option
       was specified. This is fixed now.
    
    3. Specifying --validate-config created binlog index files. This is
       fixed now.
-----
3. PXC-3553 - [MTR] Fix main.mysqlpump_extended test
    https://jira.percona.com/browse/PXC-3553
    
    Modified the test case to add the PXC users `mysql.pxc.sst.role` and
    `mysql.pxc.internal.session` to the `--exclude-users` mysqlpump option
    to exclude these users while taking the backup.

Testing Done
----------
1. Jenkins: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/160/testReport/ [In Progress]

Note to reviewers
------
The extra changes in `sql/mysqld.cc` are side-effects of running clang-format-10.