### PR TITLE
PXC-3548 [MTR] Tests fail because of Incorrect datetime value: '0000-00-00 00:00:00' for column 'Timestamp'

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -282,6 +282,15 @@ galera.MW-284 : BUG#0000 test is incompatible with native mysql8.0 server slave 
 galera.galera_fk_lock_parent_update_child : BUG#0 Few cases have timing issues(PXC-3431) and few are invalid after PXC-3501
 galera.galera_toi_ddl_fk_insert : BUG#0 CODERSHIP qa#39 test fails sporadically (PXC-3431)
 
+# Bugs failing due to PXC-3548
+main.system_tables_myisam                           : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
+binlog.binlog_stm_unsafe_read_acl_tables_in_dml_ddl : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
+main.system_tables_myisam_lctn_1                    : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
+main.mysql_upgrade_grant                            : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
+main.ps_sys_upgrade                                 : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
+sysschema.mysqldump                                 : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
+main.transactional_acl_tables                       : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
+main.schema_read_only_cs                            : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
 
 # encryption
 # Probably we should use upstream version of encryption tests for PXC


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3548

Problem
-------
The following tests are failing with error: Incorrect datetime value:
'0000-00-00 00:00:00' for column 'Timestamp'

1. main.system_tables_myisam
2. binlog.binlog_stm_unsafe_read_acl_tables_in_dml_ddl
3. main.system_tables_myisam_lctn_1
4. main.mysql_upgrade_grant
5. main.ps_sys_upgrade
6. sysschema.mysqldump
7. main.transactional_acl_tables
8. main.schema_read_only_cs

Analysis
--------
1. Due to PS-6837 / Bug#98495, the `Timestamp` field of the `mysql.tables_priv`
   table is set to NULL timestamp for all GRANT/REVOKE queries.

2. During server startup, the role `mysql.pxc.sst.role` is created and
   is given access to `PERCONA_SCHEMA`.`xtrabackup_history` table.

3. Since the role `mysql.pxc.sst.role` is created using GRANT query, due
   to PS-6837 / Bug#98495, the timestamp will have NULL value.

4. The tests execute
   `CREATE TABLE <table_name> AS SELECT * FROM mysql.tables_priv;`

   Since the column `Timestamp `is defined as

     `timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`

   the CREATE TABLE query fails with an error

     `Incorrect datetime value: '0000-00-00 00:00:00' for column 'Timestamp'`

when it tries to insert the row having `mysql.pxc.sst.role` to the new
table.

Solution
--------
Disable the failing tests until [PS-6837](https://jira.percona.com/browse/PS-6837) / [Bug#98495](https://bugs.mysql.com/bug.php?id=98495) is fixed.