### PR TITLE
Bug#32045681: Heap-use-after-free in triggers Item_splocal::this_item() [release branch]

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -1609,17 +1609,9 @@ bool Item::is_blob_field() const {
 *****************************************************************************/
 
 Item_sp_variable::Item_sp_variable(const Name_string sp_var_name)
-    : m_thd(nullptr),
-      m_name(sp_var_name)
-#ifndef DBUG_OFF
-      ,
-      m_sp(nullptr)
-#endif
-{
-}
+    : m_name(sp_var_name) {}
 
-bool Item_sp_variable::fix_fields(THD *thd, Item **) {
-  m_thd = thd; /* NOTE: this must be set before any this_xxx() */
+bool Item_sp_variable::fix_fields(THD *, Item **) {
   Item *it = this_item();
 
   DBUG_ASSERT(it->fixed);
@@ -1735,19 +1727,19 @@ Item_splocal::Item_splocal(const Name_string sp_var_name, uint sp_var_idx,
 }
 
 Item *Item_splocal::this_item() {
-  DBUG_ASSERT(m_sp == m_thd->sp_runtime_ctx->sp);
+  assert(m_sp == current_thd->sp_runtime_ctx->sp);
 
-  return m_thd->sp_runtime_ctx->get_item(m_var_idx);
+  return current_thd->sp_runtime_ctx->get_item(m_var_idx);
 }
 
 const Item *Item_splocal::this_item() const {
-  DBUG_ASSERT(m_sp == m_thd->sp_runtime_ctx->sp);
+  assert(m_sp == current_thd->sp_runtime_ctx->sp);
 
-  return m_thd->sp_runtime_ctx->get_item(m_var_idx);
+  return current_thd->sp_runtime_ctx->get_item(m_var_idx);
 }
 
 Item **Item_splocal::this_item_addr(THD *thd, Item **) {
-  DBUG_ASSERT(m_sp == thd->sp_runtime_ctx->sp);
+  assert(m_sp == thd->sp_runtime_ctx->sp);
 
   return thd->sp_runtime_ctx->get_item_addr(m_var_idx);
 }
@@ -1779,19 +1771,19 @@ Item_case_expr::Item_case_expr(uint case_expr_id)
       m_case_expr_id(case_expr_id) {}
 
 Item *Item_case_expr::this_item() {
-  DBUG_ASSERT(m_sp == m_thd->sp_runtime_ctx->sp);
+  assert(m_sp == current_thd->sp_runtime_ctx->sp);
 
-  return m_thd->sp_runtime_ctx->get_case_expr(m_case_expr_id);
+  return current_thd->sp_runtime_ctx->get_case_expr(m_case_expr_id);
 }
 
 const Item *Item_case_expr::this_item() const {
-  DBUG_ASSERT(m_sp == m_thd->sp_runtime_ctx->sp);
+  assert(m_sp == current_thd->sp_runtime_ctx->sp);
 
-  return m_thd->sp_runtime_ctx->get_case_expr(m_case_expr_id);
+  return current_thd->sp_runtime_ctx->get_case_expr(m_case_expr_id);
 }
 
 Item **Item_case_expr::this_item_addr(THD *thd, Item **) {
-  DBUG_ASSERT(m_sp == thd->sp_runtime_ctx->sp);
+  assert(m_sp == thd->sp_runtime_ctx->sp);
 
   return thd->sp_runtime_ctx->get_case_expr_addr(m_case_expr_id);
 }

--- a/sql/item.h
+++ b/sql/item.h
@@ -3377,13 +3377,6 @@ class Item_basic_constant : public Item {
 *****************************************************************************/
 
 class Item_sp_variable : public Item {
- protected:
-  /*
-    THD, which is stored in fix_fields() and is used in this_item() to avoid
-    current_thd use.
-  */
-  THD *m_thd;
-
  public:
   Name_string m_name;
 
@@ -3393,7 +3386,7 @@ class Item_sp_variable : public Item {
     Routine to which this Item_splocal belongs. Used for checking if correct
     runtime context is used for variable handling.
   */
-  sp_head *m_sp;
+  sp_head *m_sp{nullptr};
 #endif
 
  public:

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -3446,8 +3446,8 @@ bool Item_func_internal_update_time::resolve_type(THD *thd) {
   return false;
 }
 
-bool Item_func_internal_update_time::get_date(
-    MYSQL_TIME *ltime, my_time_flags_t fuzzy_date MY_ATTRIBUTE((unused))) {
+bool Item_func_internal_update_time::get_date(MYSQL_TIME *ltime,
+                                              my_time_flags_t) {
   DBUG_TRACE;
 
   String schema_name;
@@ -3525,8 +3525,8 @@ bool Item_func_internal_check_time::resolve_type(THD *thd) {
   return false;
 }
 
-bool Item_func_internal_check_time::get_date(
-    MYSQL_TIME *ltime, my_time_flags_t fuzzy_date MY_ATTRIBUTE((unused))) {
+bool Item_func_internal_check_time::get_date(MYSQL_TIME *ltime,
+                                             my_time_flags_t) {
   DBUG_TRACE;
 
   String schema_name;

--- a/sql/item_timefunc.h
+++ b/sql/item_timefunc.h
@@ -1733,8 +1733,6 @@ class Item_func_last_day final : public Item_date_func {
 };
 
 class Item_func_internal_update_time final : public Item_datetime_func {
-  THD *thd;
-
  public:
   Item_func_internal_update_time(const POS &pos, PT_item_list *list)
       : Item_datetime_func(pos, list) {}
@@ -1745,8 +1743,6 @@ class Item_func_internal_update_time final : public Item_datetime_func {
 };
 
 class Item_func_internal_check_time final : public Item_datetime_func {
-  THD *thd;
-
  public:
   Item_func_internal_check_time(const POS &pos, PT_item_list *list)
       : Item_datetime_func(pos, list) {}


### PR DESCRIPTION
This problem requires several subsequent sessions to use the same
trigger procedure, containing a local variable. Since Items are
prepared only on first installment in the server, and the m_thd member
of Item_splocal is initialized only on preparation, on second use
m_thd is different from the current THD and a failure is provoked.

There are at least two ways to fix this problem. One is to assign
m_thd when binding the procedure to the new session. However, the
solution may be considered vulnerable and we may risk ending with
the same problem. The strategy chosen here is to remove the m_thd
member and use current_thd instead. The existing code warns about it,
however accessing current_thd as a thread-local variable is
sufficiently fast now, and the same principle is used several other
places in the server. Still, passing a THD as context argument would
be even better, but is far too intrusive for a bugfix.

Reviewed by: Dmitry Lenev <Dmitry.Lenev@oracle.com>