### PR TITLE
PXC-3565: PXC is more than 60% slower than PS

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6627,6 +6627,11 @@ int mysqld_main(int argc, char **argv)
 #endif
   }
 
+#ifdef WITH_WSREP
+  // Initialize wsrep_provider_set before anything else wsrep related
+  wsrep_provider_set = wsrep_provider != NULL && strcmp(wsrep_provider, WSREP_NONE) != 0;
+#endif
+
   /* 
    The subsequent calls may take a long time : e.g. innodb log read.
    Thus set the long running service control manager timeout
@@ -6639,6 +6644,7 @@ int mysqld_main(int argc, char **argv)
     unireg_abort(1);
 
 #ifdef WITH_WSREP /* WSREP AFTER SE */
+
   if (wsrep_recovery)
   {
     select_thread_in_use= 0;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -512,6 +512,7 @@ int wsrep_init()
   {
     // enable normal operation in case no provider is specified
     wsrep_ready_set(TRUE);
+    wsrep_provider_set = false;
     global_system_variables.wsrep_on = 0;
     wsrep_init_args args;
     args.logger_cb = wsrep_log_cb;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -213,10 +213,11 @@ extern "C" bool wsrep_is_wsrep_on(void);
 /* Other global variables */
 extern wsrep_seqno_t wsrep_locked_seqno;
 
-#define WSREP_ON                         \
-  ((global_system_variables.wsrep_on) && \
-   wsrep_provider                     && \
-   strcmp(wsrep_provider, WSREP_NONE))
+extern bool wsrep_provider_set;
+
+#define WSREP_ON                          \
+  ((global_system_variables.wsrep_on) &&  \
+   wsrep_provider_set)
 
 /* use xxxxxx_NNULL macros when thd pointer is guaranteed to be non-null to
  * avoid compiler warnings (GCC 6 and later) */

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -28,6 +28,7 @@
 #include <cstdlib>
 
 const  char* wsrep_provider         = 0;
+bool         wsrep_provider_set     = false;
 const  char* wsrep_provider_options = 0;
 const  char* wsrep_cluster_address  = 0;
 const  char* wsrep_cluster_name     = 0;
@@ -40,6 +41,7 @@ ulong   wsrep_reject_queries;
 int wsrep_init_vars()
 {
   wsrep_provider        = my_strdup(WSREP_NONE, MYF(MY_WME));
+  wsrep_provider_set    = false;
   wsrep_provider_options= my_strdup("", MYF(MY_WME));
   wsrep_cluster_address = my_strdup("", MYF(MY_WME));
   wsrep_cluster_name    = my_strdup(WSREP_CLUSTER_NAME, MYF(MY_WME));
@@ -376,6 +378,8 @@ bool wsrep_provider_update (sys_var *self, THD* thd, enum_var_type type)
   }
   free(tmp);
 
+  wsrep_provider_set = (wsrep_provider != NULL) && strcmp(wsrep_provider, WSREP_NONE) != 0;
+
   // we sure don't want to use old address with new provider
   wsrep_cluster_address_init(NULL);
   wsrep_provider_options_init(NULL);
@@ -401,6 +405,7 @@ void wsrep_provider_init (const char* value)
 
   if (wsrep_provider) my_free((void *)wsrep_provider);
   wsrep_provider = my_strdup(value, MYF(0));
+  wsrep_provider_set = (wsrep_provider != NULL) && strcmp(wsrep_provider, WSREP_NONE) != 0;
 }
 
 bool wsrep_provider_options_check (sys_var *self, THD* thd, set_var* var)


### PR DESCRIPTION
Issue: on longer running queries we can measure that PXC with wsrep
loaded is 60% slower than PXC without the wsrep library or PS.

Fix: After analyzing perf and callgrind results it is clear that
this is caused by the WSREP_ON macro, which is used two times for each
select. This macro had a strlen call in it, which was executed two times
for each row.

To fix the performance issue this commit refactors the WSREP_ON macro:
instead of directly using strlen it introduces the wsrep_provider_set
global boolean variable, which is recalculated when wsrep_provider
changes.