### PR TITLE
PostFix PXC-3585: Galera logs are not showing new lines

### DIFF
--- a/sql/server_component/log_sink_trad.cc
+++ b/sql/server_component/log_sink_trad.cc
@@ -204,6 +204,8 @@ int log_sink_trad(void *instance MY_ATTRIBUTE((unused)), log_line *ll) {
           /* Provider may want to log multiline messages so skip the newline
            * sanitation below. */
           if (5 == subsys_len && !strcmp(subsys, "WSREP")) break;
+          if (9 == subsys_len && !strcmp(subsys, "WSREP-SST")) break;
+          if (6 == subsys_len && !strcmp(subsys, "Galera")) break;
 #endif /* WITH_WSREP */
           /*
             If the message contains a newline, copy the message and


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3585

Issue: Orginal fix missed two log subsystem
Fix: Added WSREP-SST and Galera group to skip removing new lines.