### PR TITLE
PXC-3592: Make wsrep_provider and wsrep_notify_cmd read only

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_ist_gcache_rollover.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_ist_gcache_rollover.result
@@ -1,9 +1,9 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
 INSERT INTO t1 VALUES (01), (02), (03), (04), (05);
 Unloading wsrep provider ...
-SET GLOBAL wsrep_provider = 'none';
+SET GLOBAL wsrep_cluster_address='';
 Unloading wsrep provider ...
-SET GLOBAL wsrep_provider = 'none';
+SET GLOBAL wsrep_cluster_address='';
 INSERT INTO t1 VALUES (11), (12), (13), (14), (15);
 INSERT INTO t1 VALUES (21), (22), (23), (24), (25);
 SET GLOBAL wsrep_provider_options = 'dbug=d,ist_sender_send_after_get_buffers';

--- a/mysql-test/suite/galera_3nodes/t/galera_ist_gcache_rollover.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_ist_gcache_rollover.test
@@ -44,7 +44,6 @@ INSERT INTO t1 VALUES (21), (22), (23), (24), (25);
 # ... and restart providers to force IST
 --connection node_2
 --disable_query_log
---eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
 --eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
 --enable_query_log
 
@@ -53,7 +52,6 @@ INSERT INTO t1 VALUES (31), (32), (33), (34), (35);
 
 --connection node_3
 --disable_query_log
---eval SET GLOBAL wsrep_provider = '$wsrep_provider_orig';
 --eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
 --enable_query_log
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3592

Post-merge fix: Fixed the failing `galera_3nodes.galera_ist_gcache_rollover` test case.

**NOTE**
Before the fix, the test failed with 
```
[  3%] galera_3nodes.galera_ist_gcache_rollover w3 [ retry-fail ]
        Test ended at 2021-03-05 14:24:23

CURRENT_TEST: galera_3nodes.galera_ist_gcache_rollover
mysqltest: At line 47: query 'SET GLOBAL wsrep_provider = '$wsrep_provider_orig';' failed: 1238: Variable 'wsrep_provider' is a read only variable

The result from queries just before the failure was:
CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
INSERT INTO t1 VALUES (01), (02), (03), (04), (05);
Unloading wsrep provider ...
SET GLOBAL wsrep_cluster_address='';
Unloading wsrep provider ...
SET GLOBAL wsrep_cluster_address='';
INSERT INTO t1 VALUES (11), (12), (13), (14), (15);
INSERT INTO t1 VALUES (21), (22), (23), (24), (25);
SET GLOBAL wsrep_provider_options = 'dbug=d,ist_sender_send_after_get_buffers';
safe_process[25943]: Child process: 25944, exit: 1

 - the logfile can be found in '/tmp/results/PXC/mysql-test/var/log/galera_3nodes.galera_ist_gcache_rollover/galera_ist_gcache_rollover.log'

Test galera_3nodes.galera_ist_gcache_rollover has failed 2 times, no more retries!
```
Test result after fix.
```
TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 13000..13009
[ 50%] galera_3nodes.galera_ist_gcache_rollover [ pass ]  13863
[100%] shutdown_report                          [ pass ]       
--------------------------------------------------------------------------
The servers were restarted 0 times
Spent 13.863 of 76 seconds executing testcases

Completed: All 2 tests were successful.
```