### PR TITLE
PXC-3554: Fixed handling multiple servers specified in bind-address

### DIFF
--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -286,7 +286,8 @@ extern wsrep_seqno_t wsrep_locked_seqno;
 
 #define WSREP_ERROR(fmt, ...)                                         \
   do {                                                                \
-    if (!Wsrep_server_state::instance().is_initialized_unprotected()) \
+    if (Wsrep_server_state::has_instance() &&                         \
+        !Wsrep_server_state::instance().is_initialized_unprotected()) \
       pxc_force_flush_error_message = true;                           \
     WSREP_LOG(ERROR_LEVEL, fmt, ##__VA_ARGS__)                        \
   } while (0);

--- a/sql/wsrep_utils.h
+++ b/sql/wsrep_utils.h
@@ -18,6 +18,8 @@
 
 #include "wsrep_priv.h"
 
+void wsrep_get_single_address(const char *const addr, char *buf,
+                              size_t buf_len);
 unsigned int wsrep_check_ip(const char *addr, bool *is_ipv6);
 size_t wsrep_guess_ip(char *buf, size_t buf_len);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3554

1. WSREP_ERROR macro fixed. Added missing check for Wsrep_server_state
instance before using it.

2. MySQL >= 8.0.13 allows multiple IPs to be specified as 'bind-address'
parameter value. This parameter is used by wsrep part to guess node
address, however implementation assumed a single IP value. Implementation
was fixed to choose the first IP in case