### PR TITLE
Fixed PXC-3596 (Node stuck in aborting SST)

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_failure.result
+++ b/mysql-test/suite/galera/r/galera_sst_failure.result
@@ -4,5 +4,10 @@ include/assert.inc [node_1 should be in SYNC state after serving SST to node_2]
 SET GLOBAL debug = "+d,wsrep_sst_donate_cb_fails";
 include/assert.inc [node_1 should go back to SYNC state]
 SET GLOBAL debug = "-d,wsrep_sst_donate_cb_fails";
+SET GLOBAL debug = "+d,wsrep_sst_donor_skip";
+include/assert_grep.inc [Checking node_2 error was due to stale SST]
+include/assert.inc [node_1 should go back to SYNC state]
+include/assert.inc [Cluster should stay as Primary]
+SET GLOBAL debug = "-d,wsrep_sst_donor_skip";
 cleanup
 # restart

--- a/mysql-test/suite/galera/t/galera_sst_failure.test
+++ b/mysql-test/suite/galera/t/galera_sst_failure.test
@@ -40,6 +40,55 @@ SET GLOBAL debug = "+d,wsrep_sst_donate_cb_fails";
 # cleanup
 SET GLOBAL debug = "-d,wsrep_sst_donate_cb_fails";
 
+# Setup node1 to skip sending backup on next SST
+SET GLOBAL debug = "+d,wsrep_sst_donor_skip";
+
+# Restart node 2 forcing SST
+--connection node_2
+
+# Remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# Adjust SST timeout
+--exec cp $MYSQLTEST_VARDIR/my.cnf $MYSQLTEST_VARDIR/my_sst.cnf
+append_file $MYSQLTEST_VARDIR/my_sst.cnf;
+[sst]
+sst-idle-timeout=20
+EOF
+
+# Start node_2
+--let $error_log= $MYSQLTEST_VARDIR/tmp/test_error_log.err
+--let $mysqld2=$MYSQLD --defaults-group-suffix=.2 --defaults-file=$MYSQLTEST_VARDIR/my_sst.cnf --wsrep-provider-options='base_port=$NODE_GALERAPORT_2' --console > $error_log 2>&1
+--error 1
+--exec $mysqld2
+
+--connection node_1
+
+# Check node_2 error was due to stale SST
+--let $assert_text= Checking node_2 error was due to stale SST
+--let $assert_file= $MYSQLTEST_VARDIR/tmp/test_error_log.err
+--let $assert_select= Killing SST \([0-9]*\) with SIGKILL after stalling for [0-9]* seconds
+--let $assert_only_after=CURRENT_TEST: galera.galera_sst_failure2
+--let $assert_count=1
+--source include/assert_grep.inc
+
+# node_1 should go back to SYNC state
+--let $assert_text=node_1 should go back to SYNC state
+--let $wsrep_local_state_comment = query_get_value(SHOW STATUS LIKE 'wsrep_local_state_comment', Value, 1)
+--let $assert_cond= "$wsrep_local_state_comment" = "Synced"
+--source include/assert.inc
+
+# cluster should stay as Primary
+--let $assert_text=Cluster should stay as Primary
+--let $wsrep_local_state_comment = query_get_value(SHOW STATUS LIKE 'wsrep_cluster_status', Value, 1)
+--let $assert_cond= "$wsrep_local_state_comment" = "Primary"
+--source include/assert.inc
+
+# cleanup
+SET GLOBAL debug = "-d,wsrep_sst_donor_skip";
+
 --connection node_2
 --echo cleanup
+--remove_file $error_log
+--remove_file $MYSQLTEST_VARDIR/my_sst.cnf
 --source include/start_mysqld.inc

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -26,6 +26,7 @@ WSREP_SST_OPT_AUTH=${WSREP_SST_OPT_AUTH:-}
 WSREP_SST_OPT_USER=${WSREP_SST_OPT_USER:-}
 WSREP_SST_OPT_PSWD=${WSREP_SST_OPT_PSWD:-}
 WSREP_SST_OPT_VERSION=""
+WSREP_SST_OPT_DEBUG=""
 
 WSREP_LOG_DEBUG=""
 
@@ -108,6 +109,10 @@ case "$1" in
         ;;
     '--binlog')
         WSREP_SST_OPT_BINLOG="$2"
+        shift
+        ;;
+    '--debug')
+        WSREP_SST_OPT_DEBUG="$2"
         shift
         ;;
     *) # must be command

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -282,6 +282,51 @@ interruptable_timeout() {
     echo ${piperesult[@]}
 }
 
+# Monitor progress of SST and kill the process if stalled.
+monitor_sst_progress() {
+  local tmpsstdir=$1
+  shift
+  local pid=$1
+  shift
+  local timeout=$1
+  shift
+  local current_timeout=0
+  local previous_size=0
+  sleep=5
+  if [[ ${timeout} -eq 0 ]]; then
+    return;
+  fi
+
+  while true; do
+    kill -0 $pid 2> /dev/null
+    if [[ $? -ne 0 ]]; then
+      break;
+    fi
+    if [[ ! -d ${tmpsstdir} ]]; then
+      break;
+    fi
+
+    current_size=$(du --max-depth=1 ${tmpsstdir} | tail -n 1 | awk '{print $1}')
+    if [[ ${current_size} -eq  ${previous_size} ]]; then
+      current_timeout=$((current_timeout + 1))
+      sleep=1
+    else
+      # Reset timeout and set sleep back to 5 seconds.
+      current_timeout=0
+      sleep=5
+      previous_size=${current_size}
+    fi
+
+    if [[ ${current_timeout} -eq  ${timeout} ]]; then
+      wsrep_log_error "Killing SST ($pid) with SIGKILL after stalling for ${current_timeout} seconds"
+      pkill -SIGKILL -P ${pid} 2> /dev/null
+      break;
+    fi
+
+    sleep ${sleep};
+  done
+}
+
 #
 # Configures the commands for encrypt=1
 # Sets up the parameters (algo/keys) for XB-based encryption
@@ -1808,7 +1853,14 @@ then
         fi
 
         set +e
-        timeit "${stagemsg}-SST" "$INNOBACKUP | $tcmd; RC=( "\${PIPESTATUS[@]}" )"
+        # With wsrep_sst_donor_skip we never send the backup
+        if [ "$WSREP_SST_OPT_DEBUG" = "wsrep_sst_donor_skip" ]
+        then
+          RC=0
+        else
+          timeit "${stagemsg}-SST" "$INNOBACKUP | $tcmd; RC=( "\${PIPESTATUS[@]}" )"
+        fi
+
         set -e
 
         if [ ${RC[0]} -ne 0 ]; then
@@ -1863,6 +1915,7 @@ then
     ib_home_dir=$(parse_cnf mysqld innodb-data-home-dir "")
     ib_log_dir=$(parse_cnf mysqld innodb-log-group-home-dir "")
     ib_undo_dir=$(parse_cnf mysqld innodb-undo-directory "")
+    ssttimeout=$(parse_cnf sst sst-idle-timeout 120)
 
     stagemsg="Joiner-Recv"
 
@@ -2010,7 +2063,10 @@ then
                      fi
 
                      XB_DONOR_KEYRING_FILE_PATH="${KEYRING_FILE_DIR}/${XB_DONOR_KEYRING_FILE}"
-                     recv_data_from_donor_to_joiner "${KEYRING_FILE_DIR}" "${stagemsg}-keyring" 0 2
+                     recv_data_from_donor_to_joiner "${KEYRING_FILE_DIR}" "${stagemsg}-keyring" 0 2 &
+                     jpid=$!
+                     monitor_sst_progress "${KEYRING_FILE_DIR}" $jpid $ssttimeout &
+                     wait $jpid
                      keyringapplyopt=" --keyring-file-data=$XB_DONOR_KEYRING_FILE_PATH "
                      wsrep_log_info "donor keyring received at: '${XB_DONOR_KEYRING_FILE_PATH}'"
                  else
@@ -2107,6 +2163,7 @@ then
 
         XB_GTID_INFO_FILE_PATH="${DATA}/${XB_GTID_INFO_FILE}"
         wsrep_log_info "............Waiting for SST streaming to complete!"
+        monitor_sst_progress "${JOINER_SST_DIR}" $jpid $ssttimeout &
         wait $jpid
 
         get_proc

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -116,6 +116,7 @@ extern const char wsrep_defaults_group_suffix[];
 #define WSREP_SST_OPT_PARENT   "--parent"
 #define WSREP_SST_OPT_BINLOG   "--binlog"
 #define WSREP_SST_OPT_VERSION  "--mysqld-version"
+#define WSREP_SST_OPT_DEBUG    "--debug"
 
 // mysqldump-specific options
 #define WSREP_SST_OPT_USER     "--user"
@@ -1439,6 +1440,10 @@ static int sst_donate_other (const char*   method,
                  binlog_opt, binlog_opt_val,
                  uuid, (long long) seqno,
                  bypass ? " " WSREP_SST_OPT_BYPASS : "");
+  DBUG_EXECUTE_IF("wsrep_sst_donor_skip", {
+    ret= snprintf(cmd_str() + strlen(cmd_str()), cmd_len - strlen(cmd_str()),
+                  WSREP_SST_OPT_DEBUG " '%s'", "wsrep_sst_donor_skip");
+  });
   my_free(binlog_opt_val);
 
   if (ret < 0 || ret >= cmd_len)


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3596

Problem:
SST xtrabackup process happens with an unlimited timeout on joiner side.
In case the donor crash or has a network issue it can trigger two issues
on joiner:
1) If the connection has already been establish to socat/nc, we will
relay on TCP layer to close the connection, this can vary depending on
the nature of the network issue and OS/Kernel configuration.
2) Socat will start to listen on the SST port and will block until a new
connection is established. If donor leaves the cluster after joiner has
started to listen but before the connection has been established, joiner
socat will hang forever.

Solution:
Implement a timeout function that will use the size of .sst directory
as metric to validate if we are suffering a stall on SST. In case of
data size has not moved since the last 5 seconds, we enter stall mode.
In stall mode we keep checking the size every second, until we reach
sst-timeout seconds (default to 120 seconds). When timeout is reached,
SST is aborted on joiner side.