### PR TITLE
PXC-3559: Fix unstable galera_sr.GCF-1043B test

### DIFF
--- a/mysql-test/suite/galera/r/kill_empty_transaction.result
+++ b/mysql-test/suite/galera/r/kill_empty_transaction.result
@@ -1,0 +1,12 @@
+#node_1
+CREATE TABLE test_table (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 CHAR(255)) ENGINE=InnoDB;
+#node_2
+SET @@GLOBAL.debug = "+d,pause_commit_after_update_single_table";
+UPDATE test_table SET f2 = 'y' WHERE f1 = 1 OR f1 = 2;;
+#node_2a
+SET DEBUG_SYNC = "now WAIT_FOR update_commit_waiting";
+SET @@GLOBAL.debug = "-d,pause_commit_after_update_single_table";
+#node_1
+INSERT INTO test_table VALUES (1,'y'),(2,'x');
+SET DEBUG_SYNC = "RESET";
+DROP table test_table;

--- a/mysql-test/suite/galera/t/kill_empty_transaction.test
+++ b/mysql-test/suite/galera/t/kill_empty_transaction.test
@@ -1,0 +1,45 @@
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+--connection node_1
+--echo #node_1
+CREATE TABLE test_table (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 CHAR(255)) ENGINE=InnoDB;
+
+--connection node_2
+--echo #node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE 'test/test_table';
+--source include/wait_condition.inc
+
+SET @@GLOBAL.debug = "+d,pause_commit_after_update_single_table";
+
+--send UPDATE test_table SET f2 = 'y' WHERE f1 = 1 OR f1 = 2;
+
+--connection node_2a
+--echo #node_2a
+SET DEBUG_SYNC = "now WAIT_FOR update_commit_waiting";
+# do not pause next time when retry autocommit takes place
+SET @@GLOBAL.debug = "-d,pause_commit_after_update_single_table";
+
+--connection node_1
+--echo #node_1
+INSERT INTO test_table VALUES (1,'y'),(2,'x');
+
+# We do not need to signal innobase_commit_low_begin point to continue, as the
+# thread waiting on it was BF killed, and threads waiting on debug sync points
+# were already continued automatically. 
+
+--connection node_2
+--reap
+
+
+# cleanup
+--connection node_2
+SET DEBUG_SYNC = "RESET";
+
+--disconnect node_2a
+
+--connection node_1
+DROP table test_table;
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -1126,6 +1126,13 @@ bool Sql_cmd_update::update_single_table(THD *thd) {
 
   DBUG_ASSERT(CountHiddenFields(*update_value_list) == 0);
 
+  DBUG_EXECUTE_IF("pause_commit_after_update_single_table", {
+    const char act[] =
+        "innobase_commit_low_begin "
+        "SIGNAL update_commit_waiting WAIT_FOR continue";
+    DBUG_ASSERT(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));
+  };);
+
   // Following test is disabled, as we get RQG errors that are hard to debug
   // DBUG_ASSERT((error >= 0) == thd->is_error());
   return error >= 0 || thd->is_error();


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3559

Problem:
Assertion is triggered when empty local transaction is BF aborted by
replicated transaction (originally reproduced by galera_sr.GCF-1043B
test ran in parallel)

Cause:
We removed check for TRX_FORCE_ROLLBACK_DISABLE from 'if' condition in
lock_make_trx_hit_list(), so now HP transaction can BF other transaction
even if the flag is set.
It is OK in general case if local transaction is not empty (so it is
replicated and certified). If it conflicts with HP transaction it will
not be certified (so will be discarded), and if it was certified, there
is no possibility for other transaction to BF it because that other
transaction should fail certification.
If local transaction is the empty transaction, it is not replicated
and certified as it does not generate any writestes. So it follows the
normal transaction path. But empty transaction can get some locks.
If at the same time there is replicated transaction attempting to get
the same locks, it can BF local transaction at any stage, even if local
transaction is commiting. (note that it can happen only for empty local
transaction)

Solution:
Allow trx_commit_for_mysql() to return DB_FORCED_ABORT.