### PR TITLE
PXC-3547: Fix SSL test failures

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -812,6 +812,7 @@
 #include "sql/sql_udf.h"
 #include "sql/ssl_acceptor_context_iterator.h"
 #include "sql/ssl_acceptor_context_operator.h"
+#include "sql/ssl_acceptor_context_status.h"
 #include "sql/ssl_init_callback.h"
 #include "sql/sys_vars.h"         // fixup_enforce_gtid_consistency_...
 #include "sql/sys_vars_shared.h"  // intern_find_sys_var
@@ -10229,6 +10230,95 @@ static int show_table_definitions(THD *, SHOW_VAR *var, char *buff) {
   return 0;
 }
 
+/*
+   Functions relying on SSL
+   Note: In the show_ssl_* functions, we need to check if we have a
+         valid vio-object since this isn't always true, specifically
+         when session_status or global_status is requested from
+         inside an Event.
+ */
+static int show_ssl_get_version(THD *thd, SHOW_VAR *var, char *) {
+  SSL_handle ssl = thd->get_ssl();
+  var->type = SHOW_CHAR;
+  if (ssl)
+    var->value = const_cast<char *>(SSL_get_version(ssl));
+  else
+    var->value = const_cast<char *>("");
+  return 0;
+}
+
+static int show_ssl_session_reused(THD *thd, SHOW_VAR *var, char *buff) {
+  SSL_handle ssl = thd->get_ssl();
+  var->type = SHOW_LONG;
+  var->value = buff;
+  if (ssl)
+    *((long *)buff) = (long)SSL_session_reused(ssl);
+  else
+    *((long *)buff) = 0;
+  return 0;
+}
+
+static int show_ssl_get_default_timeout(THD *thd, SHOW_VAR *var, char *buff) {
+  SSL_handle ssl = thd->get_ssl();
+  var->type = SHOW_LONG;
+  var->value = buff;
+  if (ssl)
+    *((long *)buff) = (long)SSL_get_default_timeout(ssl);
+  else
+    *((long *)buff) = 0;
+  return 0;
+}
+
+static int show_ssl_get_verify_mode(THD *thd, SHOW_VAR *var, char *buff) {
+  SSL_handle ssl = thd->get_ssl();
+  var->type = SHOW_LONG;
+  var->value = buff;
+  if (ssl)
+    *((long *)buff) = (long)SSL_get_verify_mode(ssl);
+  else
+    *((long *)buff) = 0;
+  return 0;
+}
+
+static int show_ssl_get_verify_depth(THD *thd, SHOW_VAR *var, char *buff) {
+  SSL_handle ssl = thd->get_ssl();
+  var->type = SHOW_LONG;
+  var->value = buff;
+  if (ssl)
+    *((long *)buff) = (long)SSL_get_verify_depth(ssl);
+  else
+    *((long *)buff) = 0;
+  return 0;
+}
+
+static int show_ssl_get_cipher(THD *thd, SHOW_VAR *var, char *) {
+  SSL_handle ssl = thd->get_ssl();
+  var->type = SHOW_CHAR;
+  if (ssl)
+    var->value = const_cast<char *>(SSL_get_cipher(ssl));
+  else
+    var->value = const_cast<char *>("");
+  return 0;
+}
+
+static int show_ssl_get_cipher_list(THD *thd, SHOW_VAR *var, char *buff) {
+  SSL_handle ssl = thd->get_ssl();
+  var->type = SHOW_CHAR;
+  var->value = buff;
+  if (ssl) {
+    int i;
+    const char *p;
+    char *end = buff + SHOW_VAR_FUNC_BUFF_SIZE;
+    for (i = 0; (p = SSL_get_cipher_list(ssl, i)) && buff < end; i++) {
+      buff = my_stpnmov(buff, p, end - buff - 1);
+      *buff++ = ':';
+    }
+    if (i) buff--;
+  }
+  *buff = 0;
+  return 0;
+}
+
 #ifdef HAVE_POOL_OF_THREADS
 static int show_threadpool_idle_threads(THD *thd MY_ATTRIBUTE((unused)),
                                         SHOW_VAR *var, char *buff) {
@@ -10532,6 +10622,94 @@ SHOW_VAR status_vars[] = {
      SHOW_LONGLONG_STATUS, SHOW_SCOPE_ALL},
     {"Sort_scan", (char *)offsetof(System_status_var, filesort_scan_count),
      SHOW_LONGLONG_STATUS, SHOW_SCOPE_ALL},
+    {"Ssl_accept_renegotiates",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_accept_renegotiate,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Ssl_accepts", (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_accept,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Ssl_callback_cache_hits",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_cb_hits, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_cipher", (char *)&show_ssl_get_cipher, SHOW_FUNC, SHOW_SCOPE_ALL},
+    {"Ssl_cipher_list", (char *)&show_ssl_get_cipher_list, SHOW_FUNC,
+     SHOW_SCOPE_ALL},
+    {"Ssl_client_connects",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_connect, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_connect_renegotiates",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_connect_renegotiate,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Ssl_ctx_verify_depth",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_get_verify_depth, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_ctx_verify_mode",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_get_verify_mode, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_default_timeout", (char *)&show_ssl_get_default_timeout, SHOW_FUNC,
+     SHOW_SCOPE_ALL},
+    {"Ssl_finished_accepts",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_accept_good, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_finished_connects",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_connect_good, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_session_cache_hits",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_hits, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_session_cache_misses",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_misses, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_session_cache_mode",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_get_session_cache_mode,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Ssl_session_cache_overflows",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_cache_full, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_session_cache_size",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_get_cache_size,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Ssl_session_cache_timeouts",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_timeouts, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_sessions_reused", (char *)&show_ssl_session_reused, SHOW_FUNC,
+     SHOW_SCOPE_ALL},
+    {"Ssl_used_session_cache_entries",
+     (char *)&Ssl_mysql_main_status::show_ssl_ctx_sess_number, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Ssl_verify_depth", (char *)&show_ssl_get_verify_depth, SHOW_FUNC,
+     SHOW_SCOPE_ALL},
+    {"Ssl_verify_mode", (char *)&show_ssl_get_verify_mode, SHOW_FUNC,
+     SHOW_SCOPE_ALL},
+    {"Ssl_version", (char *)&show_ssl_get_version, SHOW_FUNC, SHOW_SCOPE_ALL},
+    {"Ssl_server_not_before",
+     (char *)&Ssl_mysql_main_status::show_ssl_get_server_not_before, SHOW_FUNC,
+     SHOW_SCOPE_ALL},
+    {"Ssl_server_not_after",
+     (char *)&Ssl_mysql_main_status::show_ssl_get_server_not_after, SHOW_FUNC,
+     SHOW_SCOPE_ALL},
+    {"Current_tls_ca", (char *)&Ssl_mysql_main_status::show_ssl_get_ssl_ca,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Current_tls_capath",
+     (char *)&Ssl_mysql_main_status::show_ssl_get_ssl_capath, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Current_tls_cert", (char *)&Ssl_mysql_main_status::show_ssl_get_ssl_cert,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Current_tls_key", (char *)&Ssl_mysql_main_status::show_ssl_get_ssl_key,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Current_tls_version",
+     (char *)&Ssl_mysql_main_status::show_ssl_get_tls_version, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Current_tls_cipher",
+     (char *)&Ssl_mysql_main_status::show_ssl_get_ssl_cipher, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Current_tls_ciphersuites",
+     (char *)&Ssl_mysql_main_status::show_ssl_get_tls_ciphersuites, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
+    {"Current_tls_crl", (char *)&Ssl_mysql_main_status::show_ssl_get_ssl_crl,
+     SHOW_FUNC, SHOW_SCOPE_GLOBAL},
+    {"Current_tls_crlpath",
+     (char *)&Ssl_mysql_main_status::show_ssl_get_ssl_crlpath, SHOW_FUNC,
+     SHOW_SCOPE_GLOBAL},
     {"Rsa_public_key", (char *)&show_rsa_public_key, SHOW_FUNC,
      SHOW_SCOPE_GLOBAL},
     {"Table_locks_immediate", (char *)&locks_immediate, SHOW_LONG,


### PR DESCRIPTION
Issue: ssl related MTR tests were failing because of missing ssl status
variables. These variables were likely missed during a PS->PXC merge.

Fix: re added these variables based on the PS source.