### PR TITLE
[8.0] PXC-3226: Results from CHECK TABLE from PXC server is causing the client libraries to crash

### DIFF
--- a/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
+++ b/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
@@ -1,0 +1,57 @@
+#
+# 1. Create a table on node_1.
+[node_1a]
+CREATE TABLE t1(i INT PRIMARY KEY);
+#
+# 2. Execute CHECK TABLE query on node_1 and halt the query in
+#    ha_innobase::check() function.
+SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
+CHECK TABLE t1;;
+[node_1b]
+SET DEBUG_SYNC="now WAIT_FOR reached";
+#
+# 3. Execute an ALTER TABLE query on node_2 and wait for it to be
+#    replicated to node_1.
+[node_2]
+ALTER TABLE t1 ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+SET DEBUG_SYNC="now SIGNAL continue";
+SET DEBUG_SYNC="RESET";
+#
+# 4. ALTER TABLE, being replicated as TOI, aborts the CHECK TABLE
+#    query. Verify that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+#
+# 5. Cleanup
+DROP TABLE t1;
+#
+# 1. Create a table on node_1.
+[node_1a]
+CREATE TABLE t1(i INT PRIMARY KEY)
+PARTITION BY RANGE (i)
+(
+PARTITION p0 VALUES LESS THAN (2),
+PARTITION p1 VALUES LESS THAN (4)
+);
+#
+# 2. Execute CHECK TABLE query on node_1 and halt the query in
+#    ha_innobase::check() function.
+SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
+CHECK TABLE t1;;
+[node_1b]
+SET DEBUG_SYNC="now WAIT_FOR reached";
+#
+# 3. Execute an ALTER TABLE query on node_2 and wait for it to be
+#    replicated to node_1.
+[node_2]
+ALTER TABLE t1 ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+SET DEBUG_SYNC="now SIGNAL continue";
+SET DEBUG_SYNC="RESET";
+#
+# 4. ALTER TABLE, being replicated as TOI, aborts the CHECK TABLE
+#    query. Verify that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+#
+# 5. Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
+++ b/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
@@ -1,0 +1,94 @@
+# ==== Purpose ====
+#
+# This test verifies that the no retries are performed when CHECK TABLE query
+# gets BF-aborted by a TOI running on the same table.
+#
+# ==== Implementation ====
+#
+# 1. Create a table on node_1.
+# 2. Execute CHECK TABLE query on node_1 and halt the query in
+#    ha_innobase::check() function.
+# 3. Execute an ALTER TABLE query on node_2 and wait for it to be replicated to
+#    node_1.
+# 4. ALTER TABLE, being replicated as TOI, aborts the CHECK TABLE query. Verify
+#    that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
+# 5. Repeat steps 1-4 with partitioned table.
+# 6. Cleanup
+#
+# ==== References ====
+#
+# PXC-3226: Results from CHECK, ANALYZE from PXC server is causing the client
+#           libraries to crash
+
+--source include/have_debug_sync.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+# Create auxiliary connections
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+--let $i = 0
+while ($i < 2) {
+
+  --echo #
+  --echo # 1. Create a table on node_1.
+  --echo [node_1a]
+  --connection node_1a
+  if ($i == 0) {
+    CREATE TABLE t1(i INT PRIMARY KEY);
+  }
+  if ($i == 1) {
+    CREATE TABLE t1(i INT PRIMARY KEY)
+    PARTITION BY RANGE (i)
+    (
+      PARTITION p0 VALUES LESS THAN (2),
+      PARTITION p1 VALUES LESS THAN (4)
+    );
+  }
+
+  --echo #
+  --echo # 2. Execute CHECK TABLE query on node_1 and halt the query in
+  --echo #    ha_innobase::check() function.
+  SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
+  --send CHECK TABLE t1;
+
+  --echo [node_1b]
+  --connection node_1b
+  SET DEBUG_SYNC="now WAIT_FOR reached";
+
+  --echo #
+  --echo # 3. Execute an ALTER TABLE query on node_2 and wait for it to be
+  --echo #    replicated to node_1.
+  --echo [node_2]
+  --connection node_2
+  ALTER TABLE t1 ENGINE=InnoDB;
+  INSERT INTO t1 VALUES (1);
+
+  --connection node_1
+  --let $wait_condition = SELECT COUNT(*) = 1 FROM t1
+  --source include/wait_condition.inc
+
+  # Clear the DEBUG_SYNC variable.
+  SET DEBUG_SYNC="now SIGNAL continue";
+  SET DEBUG_SYNC="RESET";
+
+  --echo #
+  --echo # 4. ALTER TABLE, being replicated as TOI, aborts the CHECK TABLE
+  --echo #    query. Verify that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
+  --connection node_1a
+  --error ER_LOCK_DEADLOCK
+  --reap
+
+  --echo #
+  --echo # 5. Cleanup
+  DROP TABLE t1;
+  --inc $i
+}
+
+# Disconnect auxiliary connections
+--disconnect node_1a
+--disconnect node_1b
+
+--connection node_1
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7835,6 +7835,39 @@ static uint kill_one_thread(THD *thd, my_thread_id id, bool only_kill_query)
 }
 
 #ifdef WITH_WSREP
+static bool wsrep_should_retry_in_autocommit(enum_sql_command &sql_command)
+{
+  /*
+    We are here could mean that the query resulted in a cluster-wide
+    conflict and had to be aborted. While it happened, it is possible that
+    the client may have already received partial data from server and may
+    have been waiting for the OK/EOF packet (usually sent by
+    THD::send_statement_status() in dispatch_command()) to report it to the
+    user.
+
+    When retry is performed in such a case, the server shall start sending
+    result and field metadata once again and this would cause the client
+    program to receive unexpected metadata information in place of an
+    OK/EOF packet and thus causes the client to error out with Malformed
+    packet error.
+
+    So, we avoid retries for such queries that return result set to client,
+    but cannot be run in TOI and can be killed by a TOI.
+
+    As of now, we only do this check for CHECK TABLE and SELECT, and if the
+    same symptom is found for other commands, then please add it to the
+    below list.
+  */
+  switch (sql_command)
+  {
+    case SQLCOM_CHECK:
+    case SQLCOM_SELECT:
+      return false;
+    default:
+      return true;
+  }
+}
+
 static void wsrep_mysql_parse(THD *thd, const char *rawbuf, uint length,
                               Parser_state *parser_state, bool update_userstat)
 {
@@ -7937,8 +7970,8 @@ static void wsrep_mysql_parse(THD *thd, const char *rawbuf, uint length,
 
         mysql_reset_thd_for_next_command(thd);
         thd->killed= THD::NOT_KILLED;
-        if (is_autocommit                           &&
-            thd->lex->sql_command != SQLCOM_SELECT  &&
+        if (is_autocommit &&
+            wsrep_should_retry_in_autocommit(thd->lex->sql_command) &&
            (thd->wsrep_retry_counter < thd->variables.wsrep_retry_autocommit))
         {
           WSREP_DEBUG("Retrying auto-commit query (on abort): %s", WSREP_QUERY(thd));

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17601,6 +17601,9 @@ ha_innobase::check(
 
 	DBUG_ENTER("ha_innobase::check");
 	DBUG_ASSERT(thd == ha_thd());
+#ifdef WITH_WSREP
+	DEBUG_SYNC(thd, "ha_innobase_check");
+#endif /* WITH_WSREP */
 	ut_a(m_prebuilt->trx->magic_n == TRX_MAGIC_N);
 	ut_a(m_prebuilt->trx == thd_to_trx(thd));
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3226

Problem
-------
PXC node can send malformed packets to client and can cause client to fail with
asserion

  `!check_buffer || (vio_pending(net->vio) <= 1)' in net_clear().

Background
----------
For any query that sends result set to the client, the server does the following
things as per classic protocol.

1. Result metadata specifying the number of fields in the result set
   i.e, `protocol->start_result_metadata()`.
2. The field metadata specifying the types of fields in the result set
   i.e, `protocol->send_field_metadata()` followed by
   `protocol->end_result_metadata()`.
3. Actual row data (any data sent between `protocol->start_row()` and
   `protocol->end_row()`
4. An OK/EOF packet indicating the end of result set.
   `protocol->send_eof()` / `protocol->send_ok()` usually called from
   `THD::send_statement_status()` in the end of `dispatch_command()`

Analysis
--------
When the server is running in autocommit mode and when it is executing a query
that sends some result set to client programs and it was BF aborted by TOI or
high priority transactions, the `wsrep_retry_autocommit` mechanism comes into
effect and the server retries the autocommit query withouy returning the error
to the client.

However, when the server is retrying the query, it is possible that the client
program may have already received partial result from server and may have been
already waiting for the OK/EOF packet to report it to the user (i.e, Steps 1-3
are over and waiting for the step 4 to happen).

In such a scenario, when a retry is performed, the server shall start executing
from Step-1 to Step-4 and if the query execution is successful, it sends OK/EOF
packet in the end to indicate that the query is complete. But on the client
side, this causes the client program to receive unexepected result metadata in
place of an OK/EOF packet and thus causes the client to error out with Malformed
packet error.

Note:
This issue was mostly seen with CHECK TABLE query when it's execution was
interrupted by a TOI. However, this issue is not seen with commands that run
in TOI. So, we can infer that this can happen on all queries that return result,
cannot run in TOI and can be killed by a PXC.

Fix
---
Disable wsrep_retry_autocommit mechanism for CHECK TABLE and instead report
ER_DEADLOCK_ERROR.

Note: As of now, we only disable it for CHECK TABLE and if the problem exists for
other commands, we can add them later.

Note to Reviewers
---
1. The additional code changes in `storage/innobase/handler/ha_innodb.cc` are a side-effect of running clang-format-10.