### PR TITLE
Fixed PXC-3596 (Node stuck in aborting SST) - 8.0

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_failure.result
+++ b/mysql-test/suite/galera/r/galera_sst_failure.result
@@ -6,5 +6,10 @@ include/assert.inc [node_1 should be in SYNC state after serving SST to node_2]
 SET GLOBAL debug = "+d,wsrep_sst_donate_cb_fails";
 include/assert.inc [node_1 should go back to SYNC state]
 SET GLOBAL debug = "-d,wsrep_sst_donate_cb_fails";
+SET GLOBAL debug = "+d,wsrep_sst_donor_skip";
+include/assert_grep.inc [Checking node_2 error was due to stale SST]
+include/assert.inc [node_1 should go back to SYNC state]
+include/assert.inc [Cluster should stay as Primary]
+SET GLOBAL debug = "-d,wsrep_sst_donor_skip";
 cleanup
 # restart

--- a/mysql-test/suite/galera/t/galera_sst_failure.test
+++ b/mysql-test/suite/galera/t/galera_sst_failure.test
@@ -42,6 +42,55 @@ SET GLOBAL debug = "+d,wsrep_sst_donate_cb_fails";
 # cleanup
 SET GLOBAL debug = "-d,wsrep_sst_donate_cb_fails";
 
+# Setup node1 to skip sending backup on next SST
+SET GLOBAL debug = "+d,wsrep_sst_donor_skip";
+
+# Restart node 2 forcing SST
+--connection node_2
+
+# Remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# Adjust SST timeout
+--exec cp $MYSQLTEST_VARDIR/my.cnf $MYSQLTEST_VARDIR/my_sst.cnf
+append_file $MYSQLTEST_VARDIR/my_sst.cnf;
+[sst]
+sst-idle-timeout=20
+EOF
+
+# Start node_2
+--let $error_log= $MYSQLTEST_VARDIR/tmp/test_error_log.err
+--let $mysqld2=$MYSQLD --defaults-group-suffix=.2 --defaults-file=$MYSQLTEST_VARDIR/my_sst.cnf --wsrep-provider-options='base_port=$NODE_GALERAPORT_2' --console > $error_log 2>&1
+--error 134
+--exec $mysqld2
+
+--connection node_1
+
+# Check node_2 error was due to stale SST
+--let $assert_text= Checking node_2 error was due to stale SST
+--let $assert_file= $MYSQLTEST_VARDIR/tmp/test_error_log.err
+--let $assert_select= Killing SST \([0-9]*\) with SIGKILL after stalling for [0-9]* seconds
+--let $assert_only_after=CURRENT_TEST: galera.galera_sst_failure2
+--let $assert_count=1
+--source include/assert_grep.inc
+
+# node_1 should go back to SYNC state
+--let $assert_text=node_1 should go back to SYNC state
+--let $wsrep_local_state_comment = query_get_value(SHOW STATUS LIKE 'wsrep_local_state_comment', Value, 1)
+--let $assert_cond= "$wsrep_local_state_comment" = "Synced"
+--source include/assert.inc
+
+# cluster should stay as Primary
+--let $assert_text=Cluster should stay as Primary
+--let $wsrep_local_state_comment = query_get_value(SHOW STATUS LIKE 'wsrep_cluster_status', Value, 1)
+--let $assert_cond= "$wsrep_local_state_comment" = "Primary"
+--source include/assert.inc
+
+# cleanup
+SET GLOBAL debug = "-d,wsrep_sst_donor_skip";
+
 --connection node_2
 --echo cleanup
+--remove_file $error_log
+--remove_file $MYSQLTEST_VARDIR/my_sst.cnf
 --source include/start_mysqld.inc

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -27,6 +27,7 @@ WSREP_SST_OPT_PLUGINDIR=""
 WSREP_SST_OPT_USER=""
 WSREP_SST_OPT_PSWD=""
 WSREP_SST_OPT_VERSION=""
+WSREP_SST_OPT_DEBUG=""
 
 WSREP_LOG_DEBUG=""
 
@@ -127,6 +128,10 @@ case "$1" in
         ;;
     '--binlog')
         WSREP_SST_OPT_BINLOG="$2"
+        shift
+        ;;
+    '--debug')
+        WSREP_SST_OPT_DEBUG="$2"
         shift
         ;;
     *) # must be command

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -56,6 +56,7 @@ extern const char wsrep_defaults_group_suffix[];
 #define WSREP_SST_OPT_PARENT "--parent"
 #define WSREP_SST_OPT_BINLOG "--binlog"
 #define WSREP_SST_OPT_VERSION "--mysqld-version"
+#define WSREP_SST_OPT_DEBUG "--debug"
 
 // mysqldump-specific options
 #define WSREP_SST_OPT_HOST "--host"
@@ -1440,6 +1441,10 @@ static int sst_donate_other(const char *method, const char *addr,
       wsrep_defaults_group_suffix, MYSQL_SERVER_VERSION MYSQL_SERVER_SUFFIX_DEF,
       binlog_opt, binlog_opt_val, uuid_oss.str().c_str(), gtid.seqno().get(),
       bypass ? " " WSREP_SST_OPT_BYPASS : "");
+  DBUG_EXECUTE_IF("wsrep_sst_donor_skip", {
+    ret = snprintf(cmd_str() + strlen(cmd_str()), cmd_len - strlen(cmd_str()),
+                   WSREP_SST_OPT_DEBUG " '%s'", "wsrep_sst_donor_skip");
+  });
   my_free(binlog_opt_val);
 
   if (ret < 0 || ret >= cmd_len) {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3596

Problem:
SST xtrabackup process happens with an unlimited timeout on joiner side.
In case the donor crash or has a network issue it can trigger two issues
on joiner:
1) If the connection has already been establish to socat/nc, we will
relay on TCP layer to close the connection, this can vary depending on
the nature of the network issue and OS/Kernel configuration.
2) Socat will start to listen on the SST port and will block until a new
connection is established. If donor leaves the cluster after joiner has
started to listen but before the connection has been established, joiner
socat will hang forever.

Solution:
Implement a timeout function that will use the size of .sst directory
as metric to validate if we are suffering a stall on SST. In case of
data size has not moved since the last 5 seconds, we enter stall mode.
In stall mode we keep checking the size every second, until we reach
sst-timeout seconds (default to 120 seconds). When timeout is reached,
SST is aborted on joiner side.

Also fixed an issue at cleanup_joiner code where if the sst temp dir
were created at datadir, it wouldn't be cleaned up after sst has
failed.

(cherry picked from commit 616a3b5364672f7f1ddca74b706e4d21fc3373e9)