### PR TITLE
PXC-3464: Data is not propagated with SET SESSION sql_log_bin = 0

### DIFF
--- a/mysql-test/include/mtr_check.sql
+++ b/mysql-test/include/mtr_check.sql
@@ -203,11 +203,11 @@ BEGIN
   -- We do not use DROP USER IF EXISTS because some tests are using
   -- --skip-grant-tables.
   COMMIT;
-  SET SESSION sql_log_bin = OFF;
+  SET SESSION wsrep_on = OFF;
   DELETE FROM mysql.user WHERE user = 'mysql.pxc.sst.user';
   DELETE FROM mysql.global_grants WHERE user = 'mysql.pxc.sst.user';
   COMMIT;
-  SET SESSION sql_log_bin = ON;
+  SET SESSION wsrep_on = ON;
 
   -- Checksum system tables to make sure they have been properly
   -- restored after test.

--- a/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
@@ -34,6 +34,7 @@ call mtr.add_suppression("Ignoring error 'Unknown table 'test.t1'' on query");
 call mtr.add_suppression("Query apply failed");
 call mtr.add_suppression("Inconsistency detected");
 drop table t1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
 Killing server ...
 Starting mysqld
 # restart

--- a/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
+++ b/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
@@ -11,24 +11,18 @@ INSERT INTO t1 VALUES (2);
 SELECT @@global.gtid_executed;
 @@global.gtid_executed
 
-CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
-call mtr.add_suppression("Ignoring error 'Unknown table 'test.t2'' on query");
-CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t3'' on query");
-call mtr.add_suppression("Ignoring error 'Unknown table 'test.t3'' on query");
-CALL mtr.add_suppression("Slave SQL: Error 'Compression dictionary 'numbers' does not exist'");
-call mtr.add_suppression("Ignoring error 'Compression dictionary 'numbers' does not exist'");
-call mtr.add_suppression("Query apply failed.*");
-SELECT COUNT(*) = 1 FROM t1;
-COUNT(*) = 1
+SELECT COUNT(*) = 2 FROM t1;
+COUNT(*) = 2
 1
-SELECT COUNT(*) = 0 FROM t1 WHERE f1 = 1;
-COUNT(*) = 0
+SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 1;
+COUNT(*) = 1
 1
 SHOW TABLES;
 Tables_in_test
 t1
-SHOW CREATE USER 'demo'@'localhost';
-ERROR HY000: Operation SHOW CREATE USER failed for 'demo'@'localhost'
+t2
+t3
+include/assert.inc [demo@localhost user should be replicated to node_2]
 DROP TABLE t1;
 SET SESSION sql_log_bin = 0;
 DROP TABLE t2;
@@ -36,31 +30,32 @@ DROP TABLE t3;
 DROP COMPRESSION_DICTIONARY numbers;
 DROP USER 'demo'@'localhost';
 SET SESSION sql_log_bin = 1;
-use test;
-create table t (i int, primary key pk(i)) engine=innodb;
-insert into t values (1);
-set sql_log_bin=0;
-alter table t add column j int;
-optimize table t;
+USE test;
+CREATE TABLE t (i INT, PRIMARY KEY pk(i)) ENGINE=InnoDB;
+INSERT INTO t VALUES (1);
+SET sql_log_bin=0;
+ALTER TABLE t ADD COLUMN j int;
+OPTIMIZE TABLE t;
 Table	Op	Msg_type	Msg_text
 test.t	optimize	note	Table does not support optimize, doing recreate + analyze instead
 test.t	optimize	status	OK
-analyze table t;
+ANALYZE TABLE t;
 Table	Op	Msg_type	Msg_text
 test.t	analyze	status	OK
-repair table t;
+REPAIR TABLE t;
 Table	Op	Msg_type	Msg_text
 test.t	repair	note	The storage engine for the table doesn't support repair
-set sql_log_bin=1;
-set sql_log_bin=0;
-insert into t values (2, 2);
-set sql_log_bin=1;
-select * from t;
+SET sql_log_bin=1;
+SET sql_log_bin=0;
+INSERT INTO t VALUES (2, 2);
+SET sql_log_bin=1;
+SELECT * FROM t;
 i	j
 1	NULL
 2	2
-use test;
-select * from t;
-i
-1
-drop table t;
+USE test;
+SELECT * FROM t;
+i	j
+1	NULL
+2	2
+DROP TABLE t;

--- a/mysql-test/suite/galera/r/session_logbin_off.result
+++ b/mysql-test/suite/galera/r/session_logbin_off.result
@@ -1,0 +1,26 @@
+include/assert.inc [node_1 binlog should be enabled]
+SHOW VARIABLES LIKE 'sql_log_bin';
+Variable_name	Value
+sql_log_bin	ON
+SHOW VARIABLES LIKE 'log_bin';
+Variable_name	Value
+log_bin	ON
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+SET SESSION sql_log_bin = OFF;
+INSERT INTO t1 VALUES (1);
+DELETE FROM t1;
+# restart:--skip-log-bin
+include/assert.inc [node_2 log_bin should be OFF]
+include/assert.inc [node_2 sql_log_bin should be ON]
+SHOW VARIABLES LIKE 'sql_log_bin';
+Variable_name	Value
+sql_log_bin	ON
+SHOW VARIABLES LIKE 'log_bin';
+Variable_name	Value
+log_bin	OFF
+INSERT INTO t1 VALUES (0);
+SET SESSION sql_log_bin = OFF;
+INSERT INTO t1 VALUES (1);
+DELETE FROM t1;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_bf_abort_get_lock.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_get_lock.test
@@ -78,10 +78,22 @@ call mtr.add_suppression("Query apply failed");
 call mtr.add_suppression("Inconsistency detected");
 drop table t1;
 
-# Rejoin node #2
+# Kill and start node #2
+# Enable the node_1 to continue running during the split-brain situation that
+# occurs when the node_2 is killed
+--let $wsrep_provider_options_orig = `SELECT @@wsrep_provider_options`
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+
 --connection node_2
 --source include/kill_galera.inc
 --sleep 1
 --echo Starting mysqld
 --source include/start_mysqld.inc
+
+--connection node_1
+--disable_query_log
+--eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_orig';
+--enable_query_log
+
+
 

--- a/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
+++ b/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
@@ -1,6 +1,6 @@
 #
-# Test SET SESSION sql_log_bin = 0 . We expect that unlogged updates will not be replicated
-# to the slave and that there will be no assertions in the process.
+# Test SET SESSION sql_log_bin = 0 . We expect that even with this settings
+# replication across PXC nodes will take place.
 #
 
 --source include/galera_cluster.inc
@@ -27,22 +27,17 @@ INSERT INTO t1 VALUES (2);
 SELECT @@global.gtid_executed;
 
 --connection node_2
-CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
-call mtr.add_suppression("Ignoring error 'Unknown table 'test.t2'' on query");
-CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t3'' on query");
-call mtr.add_suppression("Ignoring error 'Unknown table 'test.t3'' on query");
-CALL mtr.add_suppression("Slave SQL: Error 'Compression dictionary 'numbers' does not exist'");
-call mtr.add_suppression("Ignoring error 'Compression dictionary 'numbers' does not exist'");
-call mtr.add_suppression("Query apply failed.*");
-
-SELECT COUNT(*) = 1 FROM t1;
-SELECT COUNT(*) = 0 FROM t1 WHERE f1 = 1;
+SELECT COUNT(*) = 2 FROM t1;
+SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 1;
 SHOW TABLES;
 
---error ER_CANNOT_USER
-SHOW CREATE USER 'demo'@'localhost';
+# avoid SHOW CREATE USER as it will show hashed password with will do mess with
+# results file
+--let $assert_text = demo@localhost user should be replicated to node_2
+--let $assert_cond = COUNT(*) = 1 FROM mysql.user WHERE User="demo" AND host="localhost"
+--source include/assert.inc
 
---connection node_1
+--connection node_2
 DROP TABLE t1;
 SET SESSION sql_log_bin = 0;
 DROP TABLE t2;
@@ -53,27 +48,25 @@ SET SESSION sql_log_bin = 1;
 
 #-------------------------------------------------------------------------------
 #
-# Setting sql_log_bin = 0 use to block DML replication but allow DDL replication
-# After fixing PXC#841 we ensure that sql_log_bin also blocks DDL replication
-# PXC#915 is regression caused during implementation of PXC#841.
+# Setting sql_log_bin = 0 should not block DDL/MDL across PXC cluser (PXC-3464)
 #
 
 --connection node_1
-use test;
-create table t (i int, primary key pk(i)) engine=innodb;
-insert into t values (1);
-set sql_log_bin=0;
-alter table t add column j int;
-optimize table t;
-analyze table t;
-repair table t;
-set sql_log_bin=1;
-set sql_log_bin=0;
-insert into t values (2, 2);
-set sql_log_bin=1;
-select * from t;
+USE test;
+CREATE TABLE t (i INT, PRIMARY KEY pk(i)) ENGINE=InnoDB;
+INSERT INTO t VALUES (1);
+SET sql_log_bin=0;
+ALTER TABLE t ADD COLUMN j int;
+OPTIMIZE TABLE t;
+ANALYZE TABLE t;
+REPAIR TABLE t;
+SET sql_log_bin=1;
+SET sql_log_bin=0;
+INSERT INTO t VALUES (2, 2);
+SET sql_log_bin=1;
+SELECT * FROM t;
 
 --connection node_2
-use test;
-select * from t;
-drop table t;
+USE test;
+SELECT * FROM t;
+DROP TABLE t;

--- a/mysql-test/suite/galera/t/session_logbin_off.test
+++ b/mysql-test/suite/galera/t/session_logbin_off.test
@@ -1,0 +1,72 @@
+--source include/galera_cluster.inc
+
+--connection node_1
+--let $assert_text = node_1 binlog should be enabled
+--let $sql_log_bin = query_get_value(SHOW VARIABLES LIKE 'sql_log_bin', Value, 1)
+--let $assert_cond = "$sql_log_bin" = "ON"
+--source include/assert.inc
+
+SHOW VARIABLES LIKE 'sql_log_bin';
+SHOW VARIABLES LIKE 'log_bin';
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+
+SET SESSION sql_log_bin = OFF;
+
+INSERT INTO t1 VALUES (1);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t1
+--source include/wait_condition.inc
+
+--connection node_1
+DELETE FROM t1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM t1
+--source include/wait_condition.inc
+
+#
+# Now the same, but with --skip-log-bin. Let's use node_2 for this
+#
+--connection node_2
+--let $restart_parameters = "restart:--skip-log-bin"
+--source include/restart_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--let $assert_text = node_2 log_bin should be OFF
+--let $log_bin = query_get_value(SHOW VARIABLES LIKE 'log_bin', Value, 1)
+--let $assert_cond = "$log_bin" = "OFF"
+--source include/assert.inc
+
+--let $assert_text = node_2 sql_log_bin should be ON
+--let $sql_log_bin = query_get_value(SHOW VARIABLES LIKE 'sql_log_bin', Value, 1)
+--let $assert_cond = "$sql_log_bin" = "ON"
+--source include/assert.inc
+
+SHOW VARIABLES LIKE 'sql_log_bin';
+SHOW VARIABLES LIKE 'log_bin';
+
+INSERT INTO t1 VALUES (0);
+
+SET SESSION sql_log_bin = OFF;
+
+INSERT INTO t1 VALUES (1);
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t1
+--source include/wait_condition.inc
+
+--connection node_2
+DELETE FROM t1;
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 0 FROM t1
+--source include/wait_condition.inc
+
+
+# cleanup
+DROP TABLE t1;

--- a/sql/dd/impl/transaction_impl.cc
+++ b/sql/dd/impl/transaction_impl.cc
@@ -164,6 +164,9 @@ Update_dictionary_tables_ctx::Update_dictionary_tables_ctx(THD *thd)
   // Disable bin logging
   m_saved_options = m_thd->variables.option_bits;
   m_thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  m_thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   // Set bit to indicate that the thread is updating the data dictionary tables.
   m_thd->variables.option_bits |= OPTION_DD_UPDATE_CONTEXT;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -969,6 +969,9 @@ bool Log_to_csv_event_handler::log_general(
 
   ulonglong save_thd_options = thd->variables.option_bits;
   thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   TABLE_LIST table_list(MYSQL_SCHEMA_NAME.str, MYSQL_SCHEMA_NAME.length,
                         GENERAL_LOG_NAME.str, GENERAL_LOG_NAME.length,

--- a/sql/query_options.h
+++ b/sql/query_options.h
@@ -129,4 +129,12 @@
 */
 #define OPTION_NO_SUBQUERY_DURING_OPTIMIZATION (1ULL << 39)  // intern
 
+#ifdef WITH_WSREP
+/**
+  If this flag is set it means that the server internally disabled binloggin
+  with the intention to pause hold the replication.
+*/
+#define OPTION_BIN_LOG_INTERNAL_OFF (1ULL << 40)  // disable binlog, intern
+#endif
+
 #endif /* QUERY_OPTIONS_INCLUDED */

--- a/sql/rpl_gtid_persist.cc
+++ b/sql/rpl_gtid_persist.cc
@@ -155,6 +155,9 @@ bool Gtid_table_access_context::init(THD **thd, TABLE **table, bool is_write) {
     /* Disable binlog temporarily */
     m_tmp_disable_binlog__save_options = (*thd)->variables.option_bits;
     (*thd)->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+    (*thd)->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
   }
 
   if (!(*thd)->get_transaction()->xid_state()->has_state(XID_STATE::XA_NOTR)) {

--- a/sql/rpl_info_table.cc
+++ b/sql/rpl_info_table.cc
@@ -120,6 +120,9 @@ int Rpl_info_table::do_init_info(enum_find_method method, uint instance) {
   saved_mode = thd->variables.sql_mode;
   ulonglong saved_options = thd->variables.option_bits;
   thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   /*
     Opens and locks the rpl_info table before accessing it.
@@ -186,6 +189,9 @@ int Rpl_info_table::do_flush_info(const bool force) {
   saved_mode = thd->variables.sql_mode;
   ulonglong saved_options = thd->variables.option_bits;
   thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
   thd->is_operating_substatement_implicitly = true;
 
   /*
@@ -286,6 +292,9 @@ int Rpl_info_table::do_clean_info() {
   saved_mode = thd->variables.sql_mode;
   ulonglong saved_options = thd->variables.option_bits;
   thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   /*
     Opens and locks the rpl_info table before accessing it.
@@ -354,6 +363,9 @@ int Rpl_info_table::do_reset_info(uint nparam, const char *param_schema,
   saved_mode = thd->variables.sql_mode;
   ulonglong saved_options = thd->variables.option_bits;
   thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   /*
     Opens and locks the rpl_info table before accessing it.
@@ -764,6 +776,9 @@ bool Rpl_info_table::do_update_is_transactional() {
   saved_mode = thd->variables.sql_mode;
   ulonglong saved_options = thd->variables.option_bits;
   thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   /*
     Opens and locks the rpl_info table before accessing it.

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -2727,6 +2727,9 @@ bool sp_head::execute_function(THD *thd, Item **argp, uint argcount,
     mysql_bin_log.start_union_events(thd, q + 1);
     binlog_save_options = thd->variables.option_bits;
     thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+    thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
   }
 
   opt_trace_disable_if_no_stored_proc_func_access(thd, this);

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -692,7 +692,11 @@ bool Sql_cmd_discard_import_tablespace::execute(THD *thd) {
       thd->variables.wsrep_saved_binlog_state =
           System_variables::wsrep_binlog_state_t::WSREP_BINLOG_DISABLED;
     }
+    thd->variables.wsrep_saved_binlog_internal_off_state =
+        thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF;
+
     thd->variables.option_bits &= ~OPTION_BIN_LOG;
+    thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
   }
 #endif /* WITH_WSREP */
 

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -238,6 +238,9 @@ THD::Attachable_trx::Attachable_trx(THD *thd, Attachable_trx *prev_trx)
   // the binary log allows skipping some code related to figuring out what
   // log format should be used.
   m_thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   // Possible parent's involvement to multi-statement transaction is masked
 
@@ -2339,6 +2342,9 @@ void THD::reset_sub_statement_state(Sub_statement_state *backup,
   if ((!lex->requires_prelocking() || is_update_query(lex->sql_command)) &&
       !is_current_stmt_binlog_format_row()) {
     variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+    variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
   }
 
   if ((backup->option_bits & OPTION_BIN_LOG) &&

--- a/sql/sql_thd_internal_api.cc
+++ b/sql/sql_thd_internal_api.cc
@@ -219,7 +219,7 @@ int thd_non_transactional_update(const THD *thd) {
 int thd_binlog_format(const THD *thd) {
 #ifdef WITH_WSREP
   if (((WSREP(thd) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()) &&
-      (thd->variables.option_bits & OPTION_BIN_LOG))
+      !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF))
     return (int)thd->variables.binlog_format;
 #else
   if (mysql_bin_log.is_open() && (thd->variables.option_bits & OPTION_BIN_LOG))

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -486,6 +486,8 @@ struct System_variables {
     WSREP_BINLOG_ENABLED,
     WSREP_BINLOG_DISABLED
   } wsrep_saved_binlog_state;
+
+  bool wsrep_saved_binlog_internal_off_state;
 #endif /* WITH_WSREP */
 
   /**

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -130,6 +130,12 @@ void Wsrep_client_service::cleanup_transaction() {
     } else {
       m_thd->variables.option_bits &= ~OPTION_BIN_LOG;
     }
+    if (m_thd->variables.wsrep_saved_binlog_internal_off_state) {
+      m_thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+    } else {
+      m_thd->variables.option_bits &= ~OPTION_BIN_LOG_INTERNAL_OFF;
+    }
+    m_thd->variables.wsrep_saved_binlog_internal_off_state = false;
 
     m_thd->variables.wsrep_saved_binlog_state =
         System_variables::wsrep_binlog_state_t::WSREP_BINLOG_NOTSET;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1834,9 +1834,6 @@ static int wsrep_drop_table_query(THD *thd, uchar **buf, size_t *buf_len) {
  */
 static bool wsrep_can_run_in_toi(THD *thd, const char *db, const char *table,
                                  const TABLE_LIST *table_list) {
-  /* Only if binlog is enabled and user can try to set sql_log_bin=0. */
-  if (mysql_bin_log.is_open() && !(thd->variables.option_bits & OPTION_BIN_LOG))
-    return false;
 
   /* compression dictionary is not table object that has temporary qualifier
   attached to it. Neither it is dependent on other object that needs

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -109,6 +109,7 @@ class binlog_off {
         m_option_bits(thd->variables.option_bits),
         m_sql_log_bin(thd->variables.sql_log_bin) {
     thd->variables.option_bits &= ~OPTION_BIN_LOG;
+    thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
     thd->variables.sql_log_bin = 0;
   }
   ~binlog_off() {

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -654,6 +654,7 @@ static void *sst_joiner_thread(void *a) {
     /* No binlogging */
     thd->variables.sql_log_bin = 0;
     thd->variables.option_bits &= ~OPTION_BIN_LOG;
+    thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
     /* No general log */
     thd->variables.option_bits |= OPTION_LOG_OFF;
     /* Read committed isolation to avoid gap locking */

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -942,6 +942,7 @@ thd::thd(bool won) : init(), ptr(new THD) {
     wsrep_assign_from_threadvars(ptr);
     wsrep_store_threadvars(ptr);
     ptr->variables.option_bits &= ~OPTION_BIN_LOG;  // disable binlog
+    ptr->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
     ptr->variables.wsrep_on = won;
     ptr->m_security_ctx->set_master_access(~(ulong)0);
     lex_start(ptr);

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -134,8 +134,11 @@ bool wsrep_on_update(sys_var *, THD *thd, enum_var_type) {
       thd->variables.wsrep_saved_binlog_state =
           System_variables::wsrep_binlog_state_t::WSREP_BINLOG_DISABLED;
     }
+    thd->variables.wsrep_saved_binlog_internal_off_state =
+        thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF;
 
     thd->variables.option_bits &= ~OPTION_BIN_LOG;
+    thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
 
   } else if (thd->variables.wsrep_on &&
              thd->variables.wsrep_saved_binlog_state !=
@@ -152,6 +155,13 @@ bool wsrep_on_update(sys_var *, THD *thd, enum_var_type) {
                System_variables::wsrep_binlog_state_t::WSREP_BINLOG_DISABLED) {
       thd->variables.option_bits &= ~OPTION_BIN_LOG;
     }
+    if (thd->variables.wsrep_saved_binlog_internal_off_state) {
+      thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+    } else {
+      thd->variables.option_bits &= ~OPTION_BIN_LOG_INTERNAL_OFF;
+    }
+    thd->variables.wsrep_saved_binlog_internal_off_state = false;
+
     thd->variables.wsrep_saved_binlog_state =
         System_variables::wsrep_binlog_state_t::WSREP_BINLOG_NOTSET;
   }

--- a/storage/innobase/clone/clone0repl.cc
+++ b/storage/innobase/clone/clone0repl.cc
@@ -501,6 +501,10 @@ void Clone_persist_gtid::periodic_write() {
 
   m_thread_id = thd_get_thread_id(thd);
 
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
+
   /* Allow GTID to be persisted on read only server. */
   thd->set_skip_readonly_check();
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -20370,20 +20370,22 @@ int ha_innobase::external_lock(THD *thd, /*!< in: handle to the user thread */
 
     if (!skip) {
 #ifdef WITH_WSREP
-      if (!wsrep_on(thd) || wsrep_thd_is_local(m_user_thd)) {
+      bool sql_log_bin_on = thd->variables.option_bits & OPTION_BIN_LOG;
+      if (sql_log_bin_on &&
+          (!wsrep_on(thd) || wsrep_thd_is_local(m_user_thd))) {
         my_error(ER_BINLOG_STMT_MODE_AND_ROW_ENGINE, MYF(0),
                  " InnoDB is limited to row-logging when"
                  " transaction isolation level is"
                  " READ COMMITTED or READ UNCOMMITTED.");
+        return HA_ERR_LOGGING_IMPOSSIBLE;
       }
 #else
       my_error(ER_BINLOG_STMT_MODE_AND_ROW_ENGINE, MYF(0),
                " InnoDB is limited to row-logging when"
                " transaction isolation level is"
                " READ COMMITTED or READ UNCOMMITTED.");
-#endif /* WITH_WSREP */
-
       return HA_ERR_LOGGING_IMPOSSIBLE;
+#endif /* WITH_WSREP */
     }
   }
 

--- a/storage/ndb/plugin/ndb_local_connection.cc
+++ b/storage/ndb/plugin/ndb_local_connection.cc
@@ -137,6 +137,9 @@ bool Ndb_local_connection::execute_query_iso(MYSQL_LEX_STRING sql_text,
   ulonglong save_thd_options = m_thd->variables.option_bits;
   assert(sizeof(save_thd_options) == sizeof(m_thd->variables.option_bits));
   m_thd->variables.option_bits &= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   /*
     Increment query_id, the query_id is used when generating


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3464

Problem:
When sql_log_bin session variable is set to OFF, queries are not
replicated across PXC cluster nodes

Cause:
PXC flow decides if particular statement needs to be replicated basing
on inter alia sql_log_bin value.

Solution:
All statements are replicated. However we are still blocking replication
if it was blocked internally by the server (auxiliary
OPTION_BIN_LOG_INTERNAL_OFF flag introduced)