### PR TITLE
PXC-3464: Data is not propagated with SET SESSION sql_log_bin = 0

### DIFF
--- a/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
+++ b/mysql-test/suite/galera/r/galera_sql_log_bin_zero.result
@@ -8,45 +8,45 @@ INSERT INTO t1 VALUES (2);
 SELECT @@global.gtid_executed;
 @@global.gtid_executed
 
-CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
-SELECT COUNT(*) = 1 FROM t1;
-COUNT(*) = 1
+SELECT COUNT(*) = 2 FROM t1;
+COUNT(*) = 2
 1
-SELECT COUNT(*) = 0 FROM t1 WHERE f1 = 1;
-COUNT(*) = 0
+SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 1;
+COUNT(*) = 1
 1
 SHOW TABLES;
 Tables_in_test
 t1
+t2
 DROP USER 'demo'@'localhost';
-ERROR HY000: Operation DROP USER failed for 'demo'@'localhost'
 DROP TABLE t1;
 DROP TABLE t2;
-use test;
-create table t (i int, primary key pk(i)) engine=innodb;
-insert into t values (1);
-set sql_log_bin=0;
-alter table t add column j int;
-optimize table t;
+USE test;
+CREATE TABLE t (i INT, PRIMARY KEY pk(i)) ENGINE=InnoDB;
+INSERT INTO t VALUES (1);
+SET sql_log_bin=0;
+ALTER TABLE t ADD COLUMN j int;
+OPTIMIZE TABLE t;
 Table	Op	Msg_type	Msg_text
 test.t	optimize	note	Table does not support optimize, doing recreate + analyze instead
 test.t	optimize	status	OK
-analyze table t;
+ANALYZE TABLE t;
 Table	Op	Msg_type	Msg_text
 test.t	analyze	status	OK
-repair table t;
+REPAIR TABLE t;
 Table	Op	Msg_type	Msg_text
 test.t	repair	note	The storage engine for the table doesn't support repair
-set sql_log_bin=1;
-set sql_log_bin=0;
-insert into t values (2, 2);
-set sql_log_bin=1;
-select * from t;
+SET sql_log_bin=1;
+SET sql_log_bin=0;
+INSERT INTO t VALUES (2, 2);
+SET sql_log_bin=1;
+SELECT * FROM t;
 i	j
 1	NULL
 2	2
-use test;
-select * from t;
-i
-1
-drop table t;
+USE test;
+SELECT * FROM t;
+i	j
+1	NULL
+2	2
+DROP TABLE t;

--- a/mysql-test/suite/galera/r/session_logbin_off.result
+++ b/mysql-test/suite/galera/r/session_logbin_off.result
@@ -1,0 +1,30 @@
+include/assert.inc [node_1 binlog should be enabled]
+SHOW VARIABLES LIKE 'sql_log_bin';
+Variable_name	Value
+sql_log_bin	ON
+SHOW VARIABLES LIKE 'log_bin';
+Variable_name	Value
+log_bin	ON
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+SET SESSION sql_log_bin = OFF;
+INSERT INTO t1 VALUES (1);
+include/assert.inc [node_2 t1 should have two rows]
+DELETE FROM t1;
+include/assert.inc [node_2 t1 should have zero rows]
+# restart:--skip-log-bin
+include/assert.inc [node_2 log_bin should be OFF]
+include/assert.inc [node_2 sql_log_bin should be ON]
+SHOW VARIABLES LIKE 'sql_log_bin';
+Variable_name	Value
+sql_log_bin	ON
+SHOW VARIABLES LIKE 'log_bin';
+Variable_name	Value
+log_bin	OFF
+INSERT INTO t1 VALUES (0);
+SET SESSION sql_log_bin = OFF;
+INSERT INTO t1 VALUES (1);
+include/assert.inc [node_1 t1 should have two rows]
+DELETE FROM t1;
+include/assert.inc [node_1 t1 should have zero rows]
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/session_logbin_off.result
+++ b/mysql-test/suite/galera/r/session_logbin_off.result
@@ -9,9 +9,7 @@ CREATE TABLE t1 (a INT PRIMARY KEY);
 INSERT INTO t1 VALUES (0);
 SET SESSION sql_log_bin = OFF;
 INSERT INTO t1 VALUES (1);
-include/assert.inc [node_2 t1 should have two rows]
 DELETE FROM t1;
-include/assert.inc [node_2 t1 should have zero rows]
 # restart:--skip-log-bin
 include/assert.inc [node_2 log_bin should be OFF]
 include/assert.inc [node_2 sql_log_bin should be ON]
@@ -24,7 +22,5 @@ log_bin	OFF
 INSERT INTO t1 VALUES (0);
 SET SESSION sql_log_bin = OFF;
 INSERT INTO t1 VALUES (1);
-include/assert.inc [node_1 t1 should have two rows]
 DELETE FROM t1;
-include/assert.inc [node_1 t1 should have zero rows]
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
+++ b/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
@@ -1,6 +1,6 @@
 #
 # Test SET SESSION sql_log_bin = 0 . We expect that even with this settings
-# repliation across PXC nodes will take place.
+# replication across PXC nodes will take place.
 #
 
 --source include/galera_cluster.inc

--- a/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
+++ b/mysql-test/suite/galera/t/galera_sql_log_bin_zero.test
@@ -1,6 +1,6 @@
 #
-# Test SET SESSION sql_log_bin = 0 . We expect that unlogged updates will not be replicated
-# to the slave and that there will be no assertions in the process.
+# Test SET SESSION sql_log_bin = 0 . We expect that even with this settings
+# repliation across PXC nodes will take place.
 #
 
 --source include/galera_cluster.inc
@@ -23,11 +23,9 @@ INSERT INTO t1 VALUES (2);
 SELECT @@global.gtid_executed;
 
 --connection node_2
-CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t2'' on query");
-SELECT COUNT(*) = 1 FROM t1;
-SELECT COUNT(*) = 0 FROM t1 WHERE f1 = 1;
+SELECT COUNT(*) = 2 FROM t1;
+SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 1;
 SHOW TABLES;
---error ER_CANNOT_USER
 DROP USER 'demo'@'localhost';
 
 --connection node_1
@@ -37,27 +35,26 @@ DROP TABLE t2;
 
 #-------------------------------------------------------------------------------
 #
-# Setting sql_log_bin = 0 use to block DML replication but allow DDL replication
-# After fixing PXC#841 we ensure that sql_log_bin also blocks DDL replication
-# PXC#915 is regression caused during implementation of PXC#841.
+# Setting sql_log_bin = 0 should not block DDL/MDL across PXC cluser (PXC-3464)
 #
 
 --connection node_1
-use test;
-create table t (i int, primary key pk(i)) engine=innodb;
-insert into t values (1);
-set sql_log_bin=0;
-alter table t add column j int;
-optimize table t;
-analyze table t;
-repair table t;
-set sql_log_bin=1;
-set sql_log_bin=0;
-insert into t values (2, 2);
-set sql_log_bin=1;
-select * from t;
+USE test;
+CREATE TABLE t (i INT, PRIMARY KEY pk(i)) ENGINE=InnoDB;
+INSERT INTO t VALUES (1);
+SET sql_log_bin=0;
+ALTER TABLE t ADD COLUMN j int;
+OPTIMIZE TABLE t;
+ANALYZE TABLE t;
+REPAIR TABLE t;
+SET sql_log_bin=1;
+SET sql_log_bin=0;
+INSERT INTO t VALUES (2, 2);
+SET sql_log_bin=1;
+SELECT * FROM t;
 
 --connection node_2
-use test;
-select * from t;
-drop table t;
+USE test;
+SELECT * FROM t;
+DROP TABLE t;
+

--- a/mysql-test/suite/galera/t/session_logbin_off.test
+++ b/mysql-test/suite/galera/t/session_logbin_off.test
@@ -17,17 +17,15 @@ SET SESSION sql_log_bin = OFF;
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
---let $assert_text = node_2 t1 should have two rows
---let $assert_cond = [SELECT COUNT(*) FROM t1] = 2
---source include/assert.inc
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t1
+--source include/wait_condition.inc
 
 --connection node_1
 DELETE FROM t1;
 
 --connection node_2
---let $assert_text = node_2 t1 should have zero rows
---let $assert_cond = [SELECT COUNT(*) FROM t1] = 0
---source include/assert.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM t1
+--source include/wait_condition.inc
 
 #
 # Now the same, but with --skip-log-bin. Let's use node_2 for this
@@ -59,17 +57,15 @@ SET SESSION sql_log_bin = OFF;
 INSERT INTO t1 VALUES (1);
 
 --connection node_1
---let $assert_text = node_1 t1 should have two rows
---let $assert_cond = [SELECT COUNT(*) FROM t1] = 2
---source include/assert.inc
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t1
+--source include/wait_condition.inc
 
 --connection node_2
 DELETE FROM t1;
 
 --connection node_1
---let $assert_text = node_1 t1 should have zero rows
---let $assert_cond = [SELECT COUNT(*) FROM t1] = 0
---source include/assert.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM t1
+--source include/wait_condition.inc
 
 
 # cleanup

--- a/mysql-test/suite/galera/t/session_logbin_off.test
+++ b/mysql-test/suite/galera/t/session_logbin_off.test
@@ -1,0 +1,76 @@
+--source include/galera_cluster.inc
+
+--connection node_1
+--let $assert_text = node_1 binlog should be enabled
+--let $sql_log_bin = query_get_value(SHOW VARIABLES LIKE 'sql_log_bin', Value, 1)
+--let $assert_cond = "$sql_log_bin" = "ON"
+--source include/assert.inc
+
+SHOW VARIABLES LIKE 'sql_log_bin';
+SHOW VARIABLES LIKE 'log_bin';
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+
+SET SESSION sql_log_bin = OFF;
+
+INSERT INTO t1 VALUES (1);
+
+--connection node_2
+--let $assert_text = node_2 t1 should have two rows
+--let $assert_cond = [SELECT COUNT(*) FROM t1] = 2
+--source include/assert.inc
+
+--connection node_1
+DELETE FROM t1;
+
+--connection node_2
+--let $assert_text = node_2 t1 should have zero rows
+--let $assert_cond = [SELECT COUNT(*) FROM t1] = 0
+--source include/assert.inc
+
+#
+# Now the same, but with --skip-log-bin. Let's use node_2 for this
+#
+--connection node_2
+--let $restart_parameters = "restart:--skip-log-bin"
+--source include/restart_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--let $assert_text = node_2 log_bin should be OFF
+--let $log_bin = query_get_value(SHOW VARIABLES LIKE 'log_bin', Value, 1)
+--let $assert_cond = "$log_bin" = "OFF"
+--source include/assert.inc
+
+--let $assert_text = node_2 sql_log_bin should be ON
+--let $sql_log_bin = query_get_value(SHOW VARIABLES LIKE 'sql_log_bin', Value, 1)
+--let $assert_cond = "$sql_log_bin" = "ON"
+--source include/assert.inc
+
+SHOW VARIABLES LIKE 'sql_log_bin';
+SHOW VARIABLES LIKE 'log_bin';
+
+INSERT INTO t1 VALUES (0);
+
+SET SESSION sql_log_bin = OFF;
+
+INSERT INTO t1 VALUES (1);
+
+--connection node_1
+--let $assert_text = node_1 t1 should have two rows
+--let $assert_cond = [SELECT COUNT(*) FROM t1] = 2
+--source include/assert.inc
+
+--connection node_2
+DELETE FROM t1;
+
+--connection node_1
+--let $assert_text = node_1 t1 should have zero rows
+--let $assert_cond = [SELECT COUNT(*) FROM t1] = 0
+--source include/assert.inc
+
+
+# cleanup
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8454,6 +8454,13 @@ static bool check_table_binlog_row_based(THD *thd, TABLE *table)
               table->s->cached_row_logging_check == 1);
 
 #ifdef WITH_WSREP
+ /*
+    In addition to above conditions, PXC allows replication if:
+    1. Binlogging was not disabled internally by the server with the
+       explicit intention to not replicate (OPTION_BIN_LOG_INTERNAL_OFF flag)
+    2a. We are in binlog emulation mode and current thread is not applier thread
+    2b. PXC replication for current is enabled (wsrep_on == true)
+  */
   return (thd->is_current_stmt_binlog_format_row() &&
           table->s->cached_row_logging_check &&
           !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF) &&
@@ -8463,7 +8470,6 @@ static bool check_table_binlog_row_based(THD *thd, TABLE *table)
               &&
               mysql_bin_log.is_open()))));
 #else
-
   return (thd->is_current_stmt_binlog_format_row() &&
           table->s->cached_row_logging_check &&
           (thd->variables.option_bits & OPTION_BIN_LOG) &&

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -1092,6 +1092,9 @@ bool Log_to_csv_event_handler::log_general(THD *thd, ulonglong event_utime,
 
   ulonglong save_thd_options= thd->variables.option_bits;
   thd->variables.option_bits&= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  thd->variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   TABLE_LIST table_list;
   table_list.init_one_table(MYSQL_SCHEMA_NAME.str, MYSQL_SCHEMA_NAME.length,

--- a/sql/ndb_local_connection.cc
+++ b/sql/ndb_local_connection.cc
@@ -170,6 +170,9 @@ Ndb_local_connection::execute_query_iso(MYSQL_LEX_STRING sql_text,
   ulonglong save_thd_options= m_thd->variables.option_bits;
   assert(sizeof(save_thd_options) == sizeof(m_thd->variables.option_bits));
   m_thd->variables.option_bits&= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  m_thd->variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
 
   bool result = execute_query(sql_text,
                               ignore_mysql_errors,

--- a/sql/query_options.h
+++ b/sql/query_options.h
@@ -120,4 +120,8 @@
 */
 #define OPTION_ALLOW_BATCH              (1ULL << 36) // THD, intern (slave)
 
+#ifdef WITH_WSREP
+#define OPTION_BIN_LOG_INTERNAL_OFF          (1ULL << 37) // disable binlog, intern
+#endif
+
 #endif  /* QUERY_OPTIONS_INCLUDED */

--- a/sql/rpl_gtid_persist.cc
+++ b/sql/rpl_gtid_persist.cc
@@ -186,6 +186,9 @@ bool Gtid_table_access_context::init(THD **thd, TABLE **table, bool is_write)
     /* Disable binlog temporarily */
     m_tmp_disable_binlog__save_options= (*thd)->variables.option_bits;
     (*thd)->variables.option_bits&= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+    (*thd)->variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
   }
 
   if (!(*thd)->get_transaction()->xid_state()->has_state(XID_STATE::XA_NOTR))

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -4324,8 +4324,16 @@ void set_slave_thread_options(THD* thd)
   ulonglong options= thd->variables.option_bits | OPTION_BIG_SELECTS;
   if (opt_log_slave_updates)
     options|= OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+  else
+  {
+    options&= ~OPTION_BIN_LOG;
+    options|= OPTION_BIN_LOG_INTERNAL_OFF;
+  }
+#else
   else
     options&= ~OPTION_BIN_LOG;
+#endif
   thd->variables.option_bits= options;
   thd->variables.completion_type= 0;
 

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -1318,6 +1318,9 @@ bool sp_head::execute_function(THD *thd, Item **argp, uint argcount,
     mysql_bin_log.start_union_events(thd, q + 1);
     binlog_save_options= thd->variables.option_bits;
     thd->variables.option_bits&= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+    thd->variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
   }
 
   opt_trace_disable_if_no_stored_proc_func_access(thd, this);

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4550,7 +4550,7 @@ extern "C" int thd_binlog_format(const MYSQL_THD thd)
 {
 #ifdef WITH_WSREP
   if (((WSREP(thd) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()) &&
-      (thd->variables.option_bits & OPTION_BIN_LOG))
+      !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF))
 #else
   if (mysql_bin_log.is_open() && (thd->variables.option_bits & OPTION_BIN_LOG))
 #endif
@@ -4779,6 +4779,9 @@ void THD::reset_sub_statement_state(Sub_statement_state *backup,
       !is_current_stmt_binlog_format_row())
   {
     variables.option_bits&= ~OPTION_BIN_LOG;
+#ifdef WITH_WSREP
+    variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF;
+#endif
   }
 
   if ((backup->option_bits & OPTION_BIN_LOG) &&

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5503,9 +5503,19 @@ my_eof(THD *thd)
   }
 }
 
-#define tmp_disable_binlog(A)                                           \
+#ifdef WITH_WSREP
+#define tmp_disable_binlog(A)                                              \
+  {ulonglong tmp_disable_binlog__save_options= (A)->variables.option_bits; \
+  (A)->variables.option_bits&= ~OPTION_BIN_LOG;                            \
+  (A)->variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF
+
+#else
+
+#define tmp_disable_binlog(A)                                              \
   {ulonglong tmp_disable_binlog__save_options= (A)->variables.option_bits; \
   (A)->variables.option_bits&= ~OPTION_BIN_LOG
+
+#endif
 
 #define reenable_binlog(A)   (A)->variables.option_bits= tmp_disable_binlog__save_options;}
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1924,10 +1924,6 @@ static int wsrep_drop_table_query(THD* thd, uchar** buf, size_t* buf_len)
 static bool wsrep_can_run_in_toi(THD *thd, const char *db, const char *table,
                                  const TABLE_LIST *table_list)
 {
-  /* Only if binlog is enabled and user can try to set sql_log_bin=0. */
-  if (mysql_bin_log.is_open() && !(thd->variables.option_bits & OPTION_BIN_LOG))
-    return false;
-
   /* compression dictionary is not table object that has temporary qualifier
   attached to it. Neither it is dependent on other object that needs
   validation. */

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -814,6 +814,7 @@ thd::thd (my_bool won) : init(), ptr(new THD)
     ptr->thread_stack= (char*) &ptr;
     ptr->store_globals();
     ptr->variables.option_bits&= ~OPTION_BIN_LOG; // disable binlog
+    ptr->variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF;
     ptr->variables.wsrep_on = won;
     ptr->m_security_ctx->set_master_access(~(ulong)0);
     lex_start(ptr);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3464

Problem:
When sql_log_bin session variable is set to OFF, queries are not
replicated across PXC cluster nodes

Cause:
PXC flow decides if particular statement needs to be replicated basing
on inter alia sql_log_bin value.

Solution:
All statements are replicated. However we are still blocking replication
if it was blocked internally by the server (auxiliary
OPTION_BIN_LOG_INTERNAL_OFF flag introduced)

This work is not based on GCA commit, because currently GCA is too old
and does not contain all necessary changes (code and MTR suite fixes)