### PR TITLE
Fixed PXC-3644 ([MTR] Tests fail during IST)

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -888,7 +888,7 @@ cleanup_joiner()
         wsrep_log_debug "Cleaning up fifo file $progress"
         rm $progress
     fi
-    if [[ -n "${JOINER_SST_DIR}" && -z "$WSREP_LOG_DEBUG" ]]; then
+    if [[ -n "${JOINER_SST_DIR:-}" && -z "$WSREP_LOG_DEBUG" ]]; then
       [[ -d "${JOINER_SST_DIR}" ]] && rm -rf "${JOINER_SST_DIR}" || true
     fi
     if [[ -n "${tmpdirbase}" ]]; then


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3644

Problem:
This is a regression of 31323d496631ce93bb6d5c88ec71c05bdd74d3d7
SST / IST Script rans with set -u, which will abort the exection if
unbound variable is set. As part of previous fix, we were wrongly
testing if ${JOINER_SST_DIR} was set as part of cleanup.

Fix:
Adjusted test of ${JOINER_SST_DIR} to not halt the execution.