### PR TITLE
PXC-3643: [MTR] Tests fail with keyring warnings in error log

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -389,6 +389,12 @@ INSERT INTO global_suppressions VALUES
  ("Clone removing all user data for provisioning: Finished"),
  ("\\[Warning\\] .*Non innodb table: .* is not cloned and is empty."),
 
+ /*
+   Warnings/errors seen when server is loaded with keyring plugin without
+   enabling pxc_encrypt_cluster_traffic.
+ */
+ ("You have enabled keyring plugin. SST encryption is mandatory."),
+
  ("THE_LAST_SUPPRESSION");
 
 

--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
@@ -1,4 +1,3 @@
-CALL mtr.add_suppression("You have enabled keyring plugin. SST encryption is mandatory.");
 include/assert_grep.inc [Keyring plugin requires SST encryption]
 SELECT 1;
 1

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
@@ -7,8 +7,6 @@
 
 --source include/big_test.inc
 --source include/galera_cluster.inc
-CALL mtr.add_suppression("You have enabled keyring plugin. SST encryption is mandatory.");
-
 
 --disable_query_log
 --connection node_1

--- a/mysql-test/suite/sys_vars/r/binlog_encryption.result
+++ b/mysql-test/suite/sys_vars/r/binlog_encryption.result
@@ -1,4 +1,3 @@
-CALL mtr.add_suppression("You have enabled keyring plugin. SST encryption is mandatory.");
 SELECT COUNT(@@GLOBAL.binlog_encryption);
 COUNT(@@GLOBAL.binlog_encryption)
 1

--- a/mysql-test/suite/sys_vars/t/binlog_encryption.test
+++ b/mysql-test/suite/sys_vars/t/binlog_encryption.test
@@ -13,7 +13,6 @@
 #
 # Reference: WL#10957
 ###############################################################################
-CALL mtr.add_suppression("You have enabled keyring plugin. SST encryption is mandatory.");
 
 # Save initial value
 --let $saved_binlog_encryption= `SELECT @@global.binlog_encryption`


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3643

Background:
After PXC-3092, we log a warning to notify customer when keyring
is enabled but pxc_encrypt_cluster_traffic is disabled.

Fix: Add the keyring warning to the global suppression list.