### PR TITLE
PXC-3549: Fix high priority transactions

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -273,10 +273,6 @@ binlog.binlog_xa_prepared_disconnect : BUG#0 Issue#330 2018-05-16 CODERSHIP mw-3
 
 # Galera 4.5 / 8.0.21 related
 galera.galera_mysqlpump : BUG#0 Wasn't working properly even before inconsistency voting 
-galera.high_prio_trx_1 : BUG#0 Failing after 8.0.21 merge. Also fails in codership sources
-galera.high_prio_trx_2 : BUG#0 Failing after 8.0.21 merge. Also fails in codership sources
-galera.high_prio_trx_3 : BUG#0 Failing after 8.0.21 merge. Also fails in codership sources
-galera.galera_high_prio_trx_fk : BUG#0 Failing after 8.0.21 merge. Also fails in codership sources
 galera.galera-index-online-fk : BUG#0 fk_40 triggers inconsistency voting, as it uses a debug_sync on node1
 galera.MW-284 : BUG#0000 test is incompatible with native mysql8.0 server slave behavior (upstream)
 galera.galera_fk_lock_parent_update_child : BUG#0 Few cases have timing issues(PXC-3431) and few are invalid after PXC-3501

--- a/mysql-test/suite/group_replication/r/gr_high_prio_trx.result
+++ b/mysql-test/suite/group_replication/r/gr_high_prio_trx.result
@@ -17,6 +17,7 @@ UPDATE t1 SET c1=99 WHERE c1=0;
 UPDATE t1 SET c1=1 WHERE c1=0;
 [connection server2]
 SET DEBUG_SYNC='now SIGNAL waiting1';
+SET DEBUG_SYNC='RESET';
 [connection sigcon]
 [connection sigcon]
 COMMIT;

--- a/mysql-test/suite/group_replication/r/gr_primary_key_conflict_xa.result
+++ b/mysql-test/suite/group_replication/r/gr_primary_key_conflict_xa.result
@@ -88,6 +88,7 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
 SET @@GLOBAL.DEBUG= @debug_save;
+SET DEBUG_SYNC='RESET';
 
 ########################################################################
 # 5. It will execute without error as the conflicting transactions have

--- a/mysql-test/suite/group_replication/t/gr_high_prio_trx.test
+++ b/mysql-test/suite/group_replication/t/gr_high_prio_trx.test
@@ -74,6 +74,8 @@ UPDATE t1 SET c1=1 WHERE c1=0;
 # was aborted
 SET DEBUG_SYNC='now SIGNAL waiting1';
 
+SET DEBUG_SYNC='RESET';
+
 ####### SIGCON #######
 --echo [connection sigcon]
 --let $rpl_connection_name= sigcon

--- a/mysql-test/suite/group_replication/t/gr_primary_key_conflict_xa.test
+++ b/mysql-test/suite/group_replication/t/gr_primary_key_conflict_xa.test
@@ -144,7 +144,7 @@ XA END 'trx2';
 --echo # group_replication_before_message_broadcast debug sync point.
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
---let $wait_condition=SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'debug sync point: now'
+--let $wait_condition=SELECT COUNT(*)=0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'debug sync'
 --source include/wait_condition.inc
 
 --echo
@@ -164,6 +164,7 @@ INSERT INTO t1 VALUES (3);
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
 SET @@GLOBAL.DEBUG= @debug_save;
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ########################################################################

--- a/mysql-test/suite/rpl/r/rpl_high_prio_trx_slave.result
+++ b/mysql-test/suite/rpl/r/rpl_high_prio_trx_slave.result
@@ -25,6 +25,7 @@ SET DEBUG_SYNC='now SIGNAL waiting1';
 [connection sigcon]
 COMMIT;
 ERROR HY000: Got error 149 - 'Lock deadlock; Retry transaction' during COMMIT
+SET DEBUG_SYNC='RESET';
 include/sync_slave_sql_with_master.inc
 include/assert.inc ['There is a 1 in t1']
 include/assert.inc ['There is no 0 in t1']

--- a/mysql-test/suite/rpl/t/rpl_high_prio_trx_slave.test
+++ b/mysql-test/suite/rpl/t/rpl_high_prio_trx_slave.test
@@ -72,6 +72,10 @@ SET DEBUG_SYNC='now SIGNAL waiting1';
 --error ER_ERROR_DURING_COMMIT
 COMMIT;
 
+# With PXC, it is possible that we killed the query before we signaled waiting1
+# this cleans the debug sync point up
+SET DEBUG_SYNC='RESET';
+
 --disconnect sigcon
 
 ####### SLAVE #######

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -185,7 +185,13 @@ extern "C" bool wsrep_thd_skip_locking(const THD *thd) {
 }
 
 extern "C" bool wsrep_thd_order_before(const THD *left, const THD *right) {
-  if (wsrep_thd_trx_seqno(left) < wsrep_thd_trx_seqno(right)) {
+  if (!WSREP(left) && !WSREP(right)) {
+    // we do not care about non wsrep threads, keep original behavior
+    return true;
+  }
+  if (left && right &&
+      wsrep_thd_trx_seqno(left) > 0 &&
+      wsrep_thd_trx_seqno(left) < wsrep_thd_trx_seqno(right)) {
     WSREP_DEBUG("BF conflict, order: %lld %lld\n",
                 (long long)wsrep_thd_trx_seqno(left),
                 (long long)wsrep_thd_trx_seqno(right));

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -1349,9 +1349,7 @@ static void lock_mark_trx_for_rollback(hit_list_t &hit_list, trx_id_t hp_trx_id,
   flag will be cleared if the transaction is rolled back
   synchronously before we get a chance to do it. */
 
-#ifndef WITH_WSREP
   trx->in_innodb |= TRX_FORCE_ROLLBACK | TRX_FORCE_ROLLBACK_ASYNC;
-#endif /* WITH_WSREP */
 
   bool cas;
   os_thread_id_t thread_id = os_thread_get_curr_id();

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -3708,13 +3708,6 @@ void trx_kill_blocking(trx_t *trx) {
       trx_mutex_enter(victim_trx);
     }
 
-#ifdef WITH_WSREP
-    victim_trx->in_innodb &= ~TRX_FORCE_ROLLBACK_ASYNC;
-    victim_trx->in_innodb &= ~TRX_FORCE_ROLLBACK;
-    trx_mutex_exit(victim_trx);
-    continue;
-#endif
-
     /* Compare the version to check if the transaction has
     already finished */
     if (victim_trx->version != version) {


### PR DESCRIPTION
Issue: pxc (and upstream mysql-wsrep) changed the bf abort logic in
8.0.22, and as part of this, also high priority abort. These changes
also didn't depend on the wsrep_on variable, and were effective always
when PXC was built with WITH_WSREP (always).

These changes were incompatible with innodb (GR) high priority
transaction, and caused related tests to fail.

Fix: rolled back some of the changes, which are also not required for
galera bf abort to function.