### PR TITLE
PXC-3654: MTR runs take more time due to re-execution of tests with [ENV] configuration

### DIFF
--- a/mysql-test/lib/mtr_cases.pm
+++ b/mysql-test/lib/mtr_cases.pm
@@ -724,6 +724,12 @@ sub create_test_combinations($$) {
   my @new_cases;
 
   foreach my $comb (@{$combinations}) {
+
+# ---- wsrep
+    # ENV is used in My::Config::ENV to store the environment so is not a true combination
+    next if ($comb->{'name'} eq 'ENV');
+# ---- wsrep
+
     # Skip this combination if the values it provides already are set
     # in master_opt or slave_opt.
     if (My::Options::is_set($test->{master_opt}, $comb->{comb_opt}) ||
@@ -909,10 +915,6 @@ sub collect_one_suite($$$$) {
       mtr_report(" - Adding combinations for $suite");
 
       foreach my $test (@cases) {
-# ---- wsrep
-	# ENV is used in My::Config::ENV to store the environment so is not a true combination
-	next if ( $test->{'name'} eq 'ENV' );
-# ---- wsrep
         next if ($test->{'skip'} or defined $test->{'combination'});
         push(@new_cases, create_test_combinations($test, \@combinations));
       }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3654

Problem
-------
binlog* and rpl* test suites take more time to complete.

Analysis
--------
In order to support galera testing, PXC's MTR added a new section/group
named 'ENV' (My::Config::ENV) for processing of cnf files.

However, after merging PS-8.0.16 to PXC, MTR started considering the ENV
group as a new test combination and caused rpl* and binlog* to
additionally run with the 'ENV' combination, thereby making the tests to
execute one more time resulting in the increase of overall time required
to complete the suite.

Solution
--------
Avoid running tests with [ENV] combination, like how it happens in lower
versions.

Note
----
Test output without the patch:
```------------------------------------------------------------------------------
[ 20%] rpl.percona_bug_ps3885 'mix'              [ pass ]    695
[ 40%] rpl.percona_bug_ps3885 'row'              [ pass ]    704
[ 60%] rpl.percona_bug_ps3885 'stmt'             [ pass ]    712
[ 80%] rpl.percona_bug_ps3885 'ENV'              [ pass ]    742
[100%] shutdown_report                           [ pass ]

```
Test output with the patch:
```
------------------------------------------------------------------------------
[ 25%] rpl.percona_bug_ps3885 'mix'              [ pass ]    767
[ 50%] rpl.percona_bug_ps3885 'row'              [ pass ]    719
[ 75%] rpl.percona_bug_ps3885 'stmt'             [ pass ]    686
[100%] shutdown_report                           [ pass ]       
------------------------------------------------------------------------------
```
Below is the comparision of time taken with and without patch
```
MTR options: --mem --parallel=auto --force --retry=0
+-------------+------------------------+
|  Test Suite |      Time Taken(s)     |
|             +-------------+----------+
|             | Without Fix | With Fix |
+-------------+-------------+----------+
|    binlog   |     318     |    269   |
+-------------+-------------+----------+
| binlog_gtid |     145     |    118   |
+-------------+-------------+----------+
|   rpl_gtid  |     538     |    379   |
+-------------+-------------+----------+
|  rpl_nogtid |     860     |    551   |
+-------------+-------------+----------+
```