### PR TITLE
PXC-3655: [MTR] The test `all_persisted_variables.test` fails on Jenkins

### DIFF
--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -46,7 +46,7 @@ include/assert.inc [Expect 500+ variables in the table. Due to open Bugs, we are
 
 # Test SET PERSIST
 
-include/assert.inc [Expect 501 persisted variables in the table.]
+include/assert.inc [Expect 499 persisted variables in the table.]
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -54,9 +54,9 @@ include/assert.inc [Expect 501 persisted variables in the table.]
 ************************************************************
 # restart
 
-include/assert.inc [Expect 501 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 501 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 501 persisted variables with matching peristed and global values.]
+include/assert.inc [Expect 499 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 499 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 499 persisted variables with matching peristed and global values.]
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -43,7 +43,7 @@ call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* Changing innodb_extend_and_i
 call mtr.add_suppression("Failed to initialize TLS for channel: mysql_main");
 
 let $total_global_vars=`SELECT COUNT(*) FROM performance_schema.global_variables where variable_name NOT LIKE 'ndb_%'`;
-let $total_persistent_vars=501;
+let $total_persistent_vars=499;
 
 --echo ***************************************************************
 --echo * 0. Verify that variables present in performance_schema.global


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3655

Problem:
The variables `wsrep_provider` and `wsrep_notify_cmd` were made read
only by PXC-3592, and now they cannot be set using `SET [PERSIST]`
command and are no more considered as persisted variables. This causes
the test `all_persisted_variables.test` to fail with assertion when it
got 499 persistable variables instead of 501.

Solution:
Re-recorded the testcase.