### PR TITLE
PXC-3555 - [MTR] Fix failing tests

### DIFF
--- a/mysql-test/suite/auth_sec/r/early_plugin_load.result
+++ b/mysql-test/suite/auth_sec/r/early_plugin_load.result
@@ -3,7 +3,7 @@
 SELECT PLUGIN_NAME, PLUGIN_STATUS, LOAD_OPTION FROM INFORMATION_SCHEMA.PLUGINS
 WHERE PLUGIN_NAME LIKE 'keyring_file';
 PLUGIN_NAME	PLUGIN_STATUS	LOAD_OPTION
-keyring_file	ACTIVE	FORCE
+keyring_file	ACTIVE	ON
 SHOW VARIABLES LIKE 'keyring_file';
 Variable_name	Value
 # 3. Try uninstalling keyring_file plugin


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3555

Post-push fix: Re-recorded the test `auth_sec.early_plugin_load` since
we changed the logic (commit: 8c523c32) to force-initialize the keyring
plugin only when wsrep_provider is loaded.

Note:
Before the fix, the test failed with result content mismatch
```
CURRENT_TEST: auth_sec.early_plugin_load
--- /home/venki/work/pxc/mysql-test/suite/auth_sec/r/early_plugin_load.result	2021-05-10 14:02:38.095584991 +0300
+++ /home/venki/work/pxc/bld/mysql-test/var/log/early_plugin_load.reject	2021-05-10 14:03:05.632511940 +0300
@@ -3,7 +3,7 @@
 SELECT PLUGIN_NAME, PLUGIN_STATUS, LOAD_OPTION FROM INFORMATION_SCHEMA.PLUGINS
 WHERE PLUGIN_NAME LIKE 'keyring_file';
 PLUGIN_NAME	PLUGIN_STATUS	LOAD_OPTION
-keyring_file	ACTIVE	FORCE
+keyring_file	ACTIVE	ON
 SHOW VARIABLES LIKE 'keyring_file';
 Variable_name	Value
 # 3. Try uninstalling keyring_file plugin

mysqltest: Result length mismatch
```