### PR TITLE
PXC-3645: Deadlock during ongoing transaction and RSU

### DIFF
--- a/mysql-test/suite/galera/r/galera_rsu_simple.result
+++ b/mysql-test/suite/galera/r/galera_rsu_simple.result
@@ -19,3 +19,12 @@ SELECT COUNT(*) = 2 FROM t1;
 COUNT(*) = 2
 1
 DROP TABLE t1;
+CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT, k INT);
+INSERT INTO t1(k) VALUES (1),(2),(3),(101),(102),(103);
+BEGIN;
+UPDATE t1 SET k=k+1 WHERE id<100;
+SET wsrep_OSU_method = RSU;
+ALTER TABLE t1 ADD KEY(k);
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_rsu_simple.result
+++ b/mysql-test/suite/galera/r/galera_rsu_simple.result
@@ -28,3 +28,14 @@ ALTER TABLE t1 ADD KEY(k);
 COMMIT;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE t1;
+CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT, k INT);
+INSERT INTO t1(k) VALUES (1),(2),(3),(101),(102),(103);
+SET SESSION wsrep_on = OFF;
+BEGIN;
+UPDATE t1 SET k=k+1 WHERE id<100;
+SET wsrep_OSU_method = RSU;
+ALTER TABLE t1 ADD KEY(k);
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET SESSION wsrep_on = ON;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_rsu_simple.test
+++ b/mysql-test/suite/galera/t/galera_rsu_simple.test
@@ -46,7 +46,7 @@ UPDATE t1 SET k=k+1 WHERE id<100;
 
 --connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --connection node_1a
-SET wsrep_OSU_method = RSU; 
+SET wsrep_OSU_method = RSU;
 ALTER TABLE t1 ADD KEY(k);
 
 --connection node_1
@@ -54,6 +54,29 @@ ALTER TABLE t1 ADD KEY(k);
 COMMIT;
 
 DROP TABLE t1;
+
+
+###
+### RSU BF-ing local transaction within non-wsrep session (5.7 behavior)
+###
+--connection node_1
+CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT, k INT);
+INSERT INTO t1(k) VALUES (1),(2),(3),(101),(102),(103);
+SET SESSION wsrep_on = OFF;
+BEGIN;
+UPDATE t1 SET k=k+1 WHERE id<100;
+
+--connection node_1a
+SET wsrep_OSU_method = RSU;
+ALTER TABLE t1 ADD KEY(k);
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+SET SESSION wsrep_on = ON;
+DROP TABLE t1;
+
 
 --disconnect node_1a
 --source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_rsu_simple.test
+++ b/mysql-test/suite/galera/t/galera_rsu_simple.test
@@ -4,6 +4,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_debug_sync.inc
+--source include/count_sessions.inc
 
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
 
@@ -33,6 +34,29 @@ SELECT COUNT(*) = 2 FROM t1;
 
 DROP TABLE t1;
 
+
+###
+### RSU BF-ing local transaction (5.7 behavior)
+###
+--connection node_1
+CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT, k INT);
+INSERT INTO t1(k) VALUES (1),(2),(3),(101),(102),(103);
+BEGIN;
+UPDATE t1 SET k=k+1 WHERE id<100;
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+SET wsrep_OSU_method = RSU; 
+ALTER TABLE t1 ADD KEY(k);
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+DROP TABLE t1;
+
+--disconnect node_1a
+--source include/wait_until_count_sessions.inc
 
 ###
 ### RSU with parallely active commit connection

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8680,8 +8680,9 @@ void handler::unlock_shared_ha_data() {
 
 int ha_wsrep_abort_transaction(THD *bf_thd, THD *victim_thd, bool signal) {
   DBUG_ENTER("ha_wsrep_abort_transaction");
-  if (!WSREP(bf_thd) && !(bf_thd->variables.wsrep_OSU_method == WSREP_OSU_RSU &&
-                          wsrep_thd_is_toi(bf_thd))) {
+
+  // do not abort if wsrep_on==0 and this BF thread is not RSU
+  if (!WSREP(bf_thd) && !wsrep_thd_is_in_rsu(bf_thd)) {
     DBUG_RETURN(0);
   }
 

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8681,8 +8681,9 @@ void handler::unlock_shared_ha_data() {
 int ha_wsrep_abort_transaction(THD *bf_thd, THD *victim_thd, bool signal) {
   DBUG_ENTER("ha_wsrep_abort_transaction");
 
-  // do not abort if wsrep_on==0 and this BF thread is not RSU
-  if (!WSREP(bf_thd) && !wsrep_thd_is_in_rsu(bf_thd)) {
+  // Proceed with abort only if wsrep_on=1 or THD in in RSU
+  bool do_abort = WSREP(bf_thd) || wsrep_thd_is_in_rsu(bf_thd);
+  if (!do_abort) {
     DBUG_RETURN(0);
   }
 

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -97,10 +97,11 @@ extern "C" bool wsrep_thd_is_in_rsu(const THD *thd) {
 
 extern "C" bool wsrep_thd_is_BF(const THD *thd, bool sync) {
   bool status = false;
-  if (thd && (WSREP(thd) || wsrep_thd_is_in_rsu(thd)) ) {
+  if (thd && (WSREP(thd) || wsrep_thd_is_in_rsu(thd))) {
     if (sync)
       mysql_mutex_lock(const_cast<mysql_mutex_t *>(&thd->LOCK_wsrep_thd));
-    status = (wsrep_thd_is_applying(thd) || wsrep_thd_is_toi(thd) || wsrep_thd_is_in_rsu(thd));
+    status = (wsrep_thd_is_applying(thd) || wsrep_thd_is_toi(thd) ||
+              wsrep_thd_is_in_rsu(thd));
     if (sync)
       mysql_mutex_unlock(const_cast<mysql_mutex_t *>(&thd->LOCK_wsrep_thd));
   }

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -97,10 +97,10 @@ extern "C" bool wsrep_thd_is_in_rsu(const THD *thd) {
 
 extern "C" bool wsrep_thd_is_BF(const THD *thd, bool sync) {
   bool status = false;
-  if (thd && WSREP(thd)) {
+  if (thd && (WSREP(thd) || wsrep_thd_is_in_rsu(thd)) ) {
     if (sync)
       mysql_mutex_lock(const_cast<mysql_mutex_t *>(&thd->LOCK_wsrep_thd));
-    status = (wsrep_thd_is_applying(thd) || wsrep_thd_is_toi(thd));
+    status = (wsrep_thd_is_applying(thd) || wsrep_thd_is_toi(thd) || wsrep_thd_is_in_rsu(thd));
     if (sync)
       mysql_mutex_unlock(const_cast<mysql_mutex_t *>(&thd->LOCK_wsrep_thd));
   }

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2379,7 +2379,8 @@ bool wsrep_handle_mdl_conflict(const MDL_context *requestor_ctx,
 
   mysql_mutex_lock(&request_thd->LOCK_wsrep_thd);
 
-  if (wsrep_thd_is_toi(request_thd) || wsrep_thd_is_applying(request_thd)) {
+  if (wsrep_thd_is_toi(request_thd) || wsrep_thd_is_in_rsu(request_thd) ||
+      wsrep_thd_is_applying(request_thd)) {
     mysql_mutex_unlock(&request_thd->LOCK_wsrep_thd);
 
     WSREP_MDL_LOG(DEBUG, "---------- MDL conflict --------", schema, schema_len,

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -328,10 +328,20 @@ void wsrep_fire_rollbacker(THD *thd) {
 int wsrep_abort_thd(const THD *bf_thd, THD *victim_thd, bool signal) {
   DBUG_ENTER("wsrep_abort_thd");
   mysql_mutex_lock(&victim_thd->LOCK_wsrep_thd);
-  if ((WSREP(bf_thd) ||
-       ((WSREP_ON || bf_thd->variables.wsrep_OSU_method == WSREP_OSU_RSU) &&
-        wsrep_thd_is_toi(bf_thd))) &&
-      victim_thd && !wsrep_thd_is_aborting(victim_thd)) {
+
+  // TOI => wsrep_on=1
+  // RSU => wsrep_on=0
+  // The transaction will be aborted if:
+  // (
+  //   1. BF-ing thread has wsrep_on=1
+  //   OR
+  //   2. wsrep is globally enabled and we are in RSU
+  // )
+  // AND
+  // 3. victim thread is not aborting or already aborted
+  if (  (WSREP(bf_thd) ||
+        (WSREP_ON && wsrep_thd_is_in_rsu(bf_thd)))
+      &&  victim_thd && !wsrep_thd_is_aborting(victim_thd) ) {
     WSREP_DEBUG("wsrep_abort_thd, by: %llu, victim: %llu",
                 (bf_thd) ? (long long)bf_thd->real_id : 0,
                 (long long)victim_thd->real_id);

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -339,9 +339,8 @@ int wsrep_abort_thd(const THD *bf_thd, THD *victim_thd, bool signal) {
   // )
   // AND
   // 3. victim thread is not aborting or already aborted
-  if (  (WSREP(bf_thd) ||
-        (WSREP_ON && wsrep_thd_is_in_rsu(bf_thd)))
-      &&  victim_thd && !wsrep_thd_is_aborting(victim_thd) ) {
+  if ((WSREP(bf_thd) || (WSREP_ON && wsrep_thd_is_in_rsu(bf_thd))) &&
+      victim_thd && !wsrep_thd_is_aborting(victim_thd)) {
     WSREP_DEBUG("wsrep_abort_thd, by: %llu, victim: %llu",
                 (bf_thd) ? (long long)bf_thd->real_id : 0,
                 (long long)victim_thd->real_id);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3645

Problem:
1. session_1 has pending write transaction
2. session_2 performs RSU which conflicts with transaction from
session_1
3. session_1 commits
4. both sessions are blocked

Cause:
1. session_1: holds MDL lock
2. session_2: RSU is started, which causes Galera desync and then pause.
Pause causes entering into LocalOrder lock with seqno N
3. session_2: stops on MDL lock which is held by session_1
4. session_1: commits. It tries to replicate, however session_2 keeps
LocalOrder lock

In 5.7 when we called wsrep_to_isolation_begin(), regardless of TOI
or RSU we set thd->wsrep_exec_mode= TOTAL_ORDER. Then when session 2
detects deadlock, abort action is done if
thd->wsrep_exec_mode= TOTAL_ORDER. So we perform abort for both TOI
and RSU.

In 8.0 we don't have wsrep_exec_mode (we have thd->wsrep_cs().mode()
instead).
wsrep::client_state::m_toi and wsrep::client_state::m_rsu were
introduced. We set them accordingly in wsrep_to_isolation_begin().
The logic that used to check for thd->wsrep_exec_mode in 5.7 was
refactored to check wsrep_thd_is_toi(), which returns true only in case
of wsrep::client_state::m_toi.
It looks like it was some mechanical refactoring, and
wsrep::client_state::m_rsu was simply omitted.

Solution:
Bring back the behavior from 5.7