### PR TITLE
PXC-3589 5.7.32 breaks LOCK=NONE usage (5.7)

### DIFF
--- a/doc/source/limitation.rst
+++ b/doc/source/limitation.rst
@@ -74,3 +74,11 @@ The following limitations apply to |PXC|:
 
      Galera Documentation: Tables without Primary Keys
         http://galeracluster.com/documentation-webpages/limitations.html#tables-without-primary-keys
+
+* As of version 5.7.32-13.47, an INPLACE `ALTER TABLE <https://dev.mysql.com/doc/refman/5.7/en/alter-table.html>`__  query takes an internal shared lock on the table during the execution of the query. The ``LOCK=NONE`` clause is no longer allowed for all of the INPLACE ALTER TABLE queries due to this change.
+
+  This change addresses a deadlock, which could cause a cluster node to hang in the following scenario:
+
+  * An INPLACE ``ALTER TABLE`` query in one session or being applied as Total Order Isolation (TOI) 
+
+  * A DML on the same table from another session


### PR DESCRIPTION
 Changes to be committed:
	modified:   source/limitation.rst