### PR TITLE
fix config file location for Ubuntu/Debian

### DIFF
--- a/doc/source/howtos/garbd_howto.rst
+++ b/doc/source/howtos/garbd_howto.rst
@@ -47,7 +47,7 @@ Configuration
 =============
 
 To configure *Galera Arbitrator* on *Ubuntu/Debian* you need to edit the
-:file:`/etc/default/garbd` file. On *CentOS/RHEL* configuration can be found in
+:file:`/etc/default/garb` file. On *CentOS/RHEL* configuration can be found in
 :file:`/etc/sysconfig/garb` file.
 
 Configuration file should look like this after installation:


### PR DESCRIPTION
Looking at `/usr/bin/garb-systemd` the config file on Ubuntu/Debian system is expected at `/etc/default/garb`.