### PR TITLE
PXC-3640: Update server code to match wsrep-lib changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "wsrep-lib"]
 	path = wsrep-lib
 	url = https://github.com/percona/wsrep-lib.git
-        branch = percona-4.x-8.0
+  branch = percona-4.x-8.0
 [submodule "extra/coredumper"]
 	path = extra/coredumper
 	url = https://github.com/Percona-Lab/coredumper.git

--- a/mysql-test/suite/galera_3nodes/r/inconsistency_shutdown.result
+++ b/mysql-test/suite/galera_3nodes/r/inconsistency_shutdown.result
@@ -153,8 +153,3 @@ Timeout in wait_condition.inc for SELECT 1 FROM performance_schema.GLOBAL_STATUS
 SET SESSION wsrep_on=OFF;
 # restart
 DROP TABLE t1;
-CALL mtr.add_suppression('Slave SQL: Could not execute Update_rows event on table test.t1; Can\'t find record in \'t1\', Error_code: 1032; handler error HA_ERR_KEY_NOT_FOUND; the event\'s master log FIRST, end_log_pos 0, Error_code: MY-001032');
-CALL mtr.add_suppression('Update_rows apply failed: 120, seqno');
-CALL mtr.add_suppression('Inconsistency detected: Inconsistent by consensus on');
-CALL mtr.add_suppression('last left .* greater than drain seqno');
-CALL mtr.add_suppression("WSREP: Failed to apply write set: ");

--- a/mysql-test/suite/galera_3nodes/t/inconsistency_shutdown.test
+++ b/mysql-test/suite/galera_3nodes/t/inconsistency_shutdown.test
@@ -183,11 +183,13 @@ SET SESSION wsrep_on=OFF;
 
 DROP TABLE t1;
 
+--disable_query_log
 CALL mtr.add_suppression('Slave SQL: Could not execute Update_rows event on table test.t1; Can\'t find record in \'t1\', Error_code: 1032; handler error HA_ERR_KEY_NOT_FOUND; the event\'s master log FIRST, end_log_pos 0, Error_code: MY-001032');
 CALL mtr.add_suppression('Update_rows apply failed: 120, seqno');
 CALL mtr.add_suppression('Inconsistency detected: Inconsistent by consensus on');
 CALL mtr.add_suppression('last left .* greater than drain seqno');
-CALL mtr.add_suppression("WSREP: Failed to apply write set: ");
+CALL mtr.add_suppression("Failed to apply write set: ");
+--enable_query_log
 
 # Restore original auto_increment_offset values.
 --source ../../galera/include/auto_increment_offset_restore.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -12461,13 +12461,13 @@ bool wsrep_stmt_rollback_is_safe(THD *thd) {
     if (thd->wsrep_sr().fragments_certified() > 0 &&
         (cache_mngr->trx_cache.get_prev_position() == MY_OFF_T_UNDEF ||
          cache_mngr->trx_cache.get_prev_position() <
-             thd->wsrep_sr().bytes_certified())) {
+             thd->wsrep_sr().log_position())) {
       WSREP_DEBUG(
           "statement rollback is not safe for streaming replication"
           " pre-stmt_pos: %llu, frag repl pos: %zu\n"
           "Thread: %u, SQL: %s",
           cache_mngr->trx_cache.get_prev_position(),
-          thd->wsrep_sr().bytes_certified(), thd->thread_id(),
+          thd->wsrep_sr().log_position(), thd->thread_id(),
           thd->query().str);
       ret = false;
     }

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -135,7 +135,7 @@ static int wsrep_write_cache_inc(THD *const thd,
   unsigned char *read_pos = NULL;
   my_off_t read_len = 0;
 
-  if (cache->begin(&read_pos, &read_len, thd->wsrep_sr().bytes_certified())) {
+  if (cache->begin(&read_pos, &read_len, thd->wsrep_sr().log_position())) {
     WSREP_ERROR("Failed to initialize io-cache");
     DBUG_RETURN(ER_ERROR_ON_WRITE);
   }

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -144,7 +144,7 @@ void Wsrep_client_service::cleanup_transaction() {
 }
 
 int Wsrep_client_service::prepare_fragment_for_replication(
-    wsrep::mutable_buffer &buffer) {
+    wsrep::mutable_buffer &buffer, size_t& log_position) {
   assert(m_thd == current_thd);
   THD *thd = m_thd;
   DBUG_ENTER("Wsrep_client_service::prepare_fragment_for_replication");
@@ -162,7 +162,7 @@ int Wsrep_client_service::prepare_fragment_for_replication(
   unsigned char *read_pos = NULL;
   my_off_t read_len = 0;
 
-  if (cache->begin(&read_pos, &read_len, thd->wsrep_sr().bytes_certified())) {
+  if (cache->begin(&read_pos, &read_len, thd->wsrep_sr().log_position())) {
     DBUG_RETURN(1);
   }
 
@@ -186,6 +186,7 @@ int Wsrep_client_service::prepare_fragment_for_replication(
     }
   }
   assert(total_length == buffer.size());
+  log_position = cache->length();
 cleanup:
   if (cache->truncate(saved_pos)) {
     WSREP_WARN("Failed to reinitialize IO cache");
@@ -257,6 +258,16 @@ void Wsrep_client_service::will_replay() {
   mysql_mutex_unlock(&LOCK_wsrep_replaying);
 }
 
+void Wsrep_client_service::signal_replayed()
+{
+  assert(m_thd == current_thd);
+  mysql_mutex_lock(&LOCK_wsrep_replaying);
+  --wsrep_replaying;
+  assert(wsrep_replaying >= 0);
+  mysql_cond_broadcast(&COND_wsrep_replaying);
+  mysql_mutex_unlock(&LOCK_wsrep_replaying);
+}
+
 enum wsrep::provider::status Wsrep_client_service::replay() {
   assert(m_thd == current_thd);
   DBUG_ENTER("Wsrep_client_service::replay");
@@ -284,11 +295,13 @@ enum wsrep::provider::status Wsrep_client_service::replay() {
 
   delete replayer_thd;
 
-  mysql_mutex_lock(&LOCK_wsrep_replaying);
-  --wsrep_replaying;
-  mysql_cond_broadcast(&COND_wsrep_replaying);
-  mysql_mutex_unlock(&LOCK_wsrep_replaying);
   DBUG_RETURN(ret);
+}
+
+enum wsrep::provider::status Wsrep_client_service::replay_unordered()
+{
+  assert(0);
+  return wsrep::provider::error_not_implemented;
 }
 
 void Wsrep_client_service::wait_for_replayers(
@@ -307,6 +320,12 @@ void Wsrep_client_service::wait_for_replayers(
   }
   mysql_mutex_unlock(&LOCK_wsrep_replaying);
   lock.lock();
+}
+
+enum wsrep::provider::status Wsrep_client_service::commit_by_xid()
+{
+  assert(0);
+  return wsrep::provider::error_not_implemented;
 }
 
 void Wsrep_client_service::debug_sync(const char *sync_point

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -35,22 +35,33 @@ class Wsrep_client_service : public wsrep::client_service {
  public:
   Wsrep_client_service(THD *, Wsrep_client_state &);
 
-  bool interrupted(wsrep::unique_lock<wsrep::mutex> &) const;
-  void reset_globals();
-  void store_globals();
-  int prepare_data_for_replication();
-  void cleanup_transaction();
-  bool statement_allowed_for_streaming() const;
-  size_t bytes_generated() const;
-  int prepare_fragment_for_replication(wsrep::mutable_buffer &);
-  int remove_fragments(wsrep::unique_lock<wsrep::mutex> &lock);
-  void emergency_shutdown() { throw wsrep::not_implemented_error(); }
-  void will_replay();
-  enum wsrep::provider::status replay();
-  void wait_for_replayers(wsrep::unique_lock<wsrep::mutex> &);
-  void debug_sync(const char *);
-  void debug_crash(const char *);
-  int bf_rollback();
+  bool interrupted(wsrep::unique_lock<wsrep::mutex> &) const override;
+  void reset_globals() override;
+  void store_globals() override;
+  int prepare_data_for_replication() override;
+  void cleanup_transaction() override;
+  bool statement_allowed_for_streaming() const override;
+  size_t bytes_generated() const override;
+  int prepare_fragment_for_replication(wsrep::mutable_buffer &, size_t& log_position) override;
+  int remove_fragments(wsrep::unique_lock<wsrep::mutex> &lock) override;
+  void emergency_shutdown()  override{ throw wsrep::not_implemented_error(); }
+  void will_replay() override;
+  void signal_replayed() override;
+  enum wsrep::provider::status replay_unordered() override;
+  enum wsrep::provider::status replay() override;
+  void wait_for_replayers(wsrep::unique_lock<wsrep::mutex> &) override;
+  enum wsrep::provider::status commit_by_xid() override;
+  bool is_explicit_xa() override
+  {
+    return false;
+  }
+  bool is_xa_rollback() override
+  {
+    return false;
+  }
+  void debug_sync(const char *) override;
+  void debug_crash(const char *) override;
+  int bf_rollback() override;
 
  private:
   friend class Wsrep_server_service;

--- a/sql/wsrep_condition_variable.h
+++ b/sql/wsrep_condition_variable.h
@@ -29,7 +29,7 @@ class Wsrep_condition_variable : public wsrep::condition_variable {
   void notify_all() { mysql_cond_broadcast(&m_cond); }
 
   void wait(wsrep::unique_lock<wsrep::mutex> &lock) {
-    mysql_mutex_t *mutex = static_cast<mysql_mutex_t *>(lock.mutex().native());
+    mysql_mutex_t *mutex = static_cast<mysql_mutex_t *>(lock.mutex()->native());
     mysql_cond_wait(&m_cond, mutex);
   }
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -598,7 +598,7 @@ void wsrep_pfs_instr_cb(wsrep_pfs_instr_type_t type, wsrep_pfs_instr_ops_t ops,
 }
 #endif /* HAVE_PSI_INTERFACE */
 
-static void wsrep_log_cb(wsrep::log::level level, const char *msg) {
+static void wsrep_log_cb(wsrep::log::level level, const char*, const char *msg) {
   switch (level) {
     case wsrep::log::info:
       WSREP_GALERA_LOG(INFORMATION_LEVEL, msg);
@@ -2141,8 +2141,7 @@ static int wsrep_TOI_begin(THD *thd, const char *db_, const char *table_,
 
   wsrep::client_state &cs(thd->wsrep_cs());
   int ret = cs.enter_toi_local(
-      key_array, wsrep::const_buffer(buff.ptr, buff.len),
-      wsrep::provider::flag::start_transaction | wsrep::provider::flag::commit);
+      key_array, wsrep::const_buffer(buff.ptr, buff.len));
 
   if (ret) {
     assert(cs.current_error());

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -155,6 +155,9 @@ void Wsrep_server_service::bootstrap() {
 void Wsrep_server_service::log_message(enum wsrep::log::level level,
                                        const char *message) {
   switch (level) {
+    case wsrep::log::unknown:
+      WSREP_DEBUG("unknown: %s", message);
+      break;
     case wsrep::log::debug:
       // sql_print_information("debug: %s", message);
       WSREP_DEBUG("debug: %s", message);
@@ -311,6 +314,24 @@ wsrep::view Wsrep_server_service::get_view(wsrep::client_service &c,
 
 wsrep::gtid Wsrep_server_service::get_position(wsrep::client_service &) {
   return wsrep_get_SE_checkpoint();
+}
+
+void Wsrep_server_service::set_position(wsrep::client_service& c WSREP_UNUSED,
+                                        const wsrep::gtid& gtid)
+{
+  Wsrep_client_service& cs WSREP_UNUSED (static_cast<Wsrep_client_service&>(c));
+  assert(cs.m_client_state.transaction().state()
+              == wsrep::transaction::s_aborted);
+ // Wait until all prior committers have finished.
+  wsrep::gtid wait_for(gtid.id(),
+                       wsrep::seqno(gtid.seqno().get() - 1));
+  if (auto err = Wsrep_server_state::instance().provider()
+      .wait_for_gtid(wait_for, std::numeric_limits<int>::max()))
+  {
+    WSREP_WARN("Wait for gtid returned error %d while waiting for "
+               "prior transactions to commit before setting position", err);
+  }
+  wsrep_set_SE_checkpoint(gtid);
 }
 
 void Wsrep_server_service::log_state_change(

--- a/sql/wsrep_server_service.h
+++ b/sql/wsrep_server_service.h
@@ -29,48 +29,49 @@ class Wsrep_server_service : public wsrep::server_service {
   Wsrep_server_service(Wsrep_server_state &server_state)
       : m_server_state(server_state) {}
 
-  wsrep::storage_service *storage_service(wsrep::client_service &);
+  wsrep::storage_service *storage_service(wsrep::client_service &) override;
 
-  wsrep::storage_service *storage_service(wsrep::high_priority_service &);
+  wsrep::storage_service *storage_service(wsrep::high_priority_service &) override;
 
-  void release_storage_service(wsrep::storage_service *);
-
-  wsrep::high_priority_service *streaming_applier_service(
-      wsrep::client_service &);
+  void release_storage_service(wsrep::storage_service *) override;
 
   wsrep::high_priority_service *streaming_applier_service(
-      wsrep::high_priority_service &);
+      wsrep::client_service &) override;
 
-  void release_high_priority_service(wsrep::high_priority_service *);
+  wsrep::high_priority_service *streaming_applier_service(
+      wsrep::high_priority_service &) override;
 
-  void background_rollback(wsrep::client_state &);
+  void release_high_priority_service(wsrep::high_priority_service *) override;
 
-  void bootstrap();
-  void log_message(enum wsrep::log::level, const char *);
+  void background_rollback(wsrep::client_state &) override;
 
-  void log_dummy_write_set(wsrep::client_state &, const wsrep::ws_meta &) {
+  void bootstrap() override;
+  void log_message(enum wsrep::log::level, const char *) override;
+
+  void log_dummy_write_set(wsrep::client_state &, const wsrep::ws_meta &) override {
     throw wsrep::not_implemented_error();
   }
 
-  void log_view(wsrep::high_priority_service *, const wsrep::view &);
+  void log_view(wsrep::high_priority_service *, const wsrep::view &) override;
 
-  void recover_streaming_appliers(wsrep::client_service &);
-  void recover_streaming_appliers(wsrep::high_priority_service &);
-  wsrep::view get_view(wsrep::client_service &, const wsrep::id &own_id);
+  void recover_streaming_appliers(wsrep::client_service &) override;
+  void recover_streaming_appliers(wsrep::high_priority_service &) override;
+  wsrep::view get_view(wsrep::client_service &, const wsrep::id &own_id) override;
 
-  wsrep::gtid get_position(wsrep::client_service &);
+  wsrep::gtid get_position(wsrep::client_service &) override;
+  void set_position(wsrep::client_service&, const wsrep::gtid&) override;
 
   void log_state_change(enum wsrep::server_state::state,
-                        enum wsrep::server_state::state);
+                        enum wsrep::server_state::state) override;
 
-  bool sst_before_init() const;
+  bool sst_before_init() const override;
 
-  std::string sst_request();
-  int start_sst(const std::string &, const wsrep::gtid &, bool);
+  std::string sst_request() override;
+  int start_sst(const std::string &, const wsrep::gtid &, bool) override;
 
-  int wait_committing_transactions(int);
+  int wait_committing_transactions(int) override;
 
-  void debug_sync(const char *);
+  void debug_sync(const char *) override;
 
  private:
   Wsrep_server_state &m_server_state;

--- a/sql/wsrep_storage_service.cc
+++ b/sql/wsrep_storage_service.cc
@@ -94,7 +94,8 @@ void Wsrep_storage_service::adopt_transaction(
 int Wsrep_storage_service::append_fragment(const wsrep::id &server_id,
                                            wsrep::transaction_id transaction_id,
                                            int flags,
-                                           const wsrep::const_buffer &data) {
+                                           const wsrep::const_buffer &data,
+                                           const wsrep::xid& xid WSREP_UNUSED) {
   DBUG_ENTER("Wsrep_storage_service::append_fragment");
   assert(m_thd == current_thd);
   DBUG_PRINT("info", ("Wsrep_storage_service::append_fragment(%u, %p)",

--- a/sql/wsrep_storage_service.h
+++ b/sql/wsrep_storage_service.h
@@ -25,17 +25,17 @@ class Wsrep_storage_service : public wsrep::storage_service,
                               public wsrep::high_priority_context {
  public:
   Wsrep_storage_service(THD *);
-  ~Wsrep_storage_service();
-  int start_transaction(const wsrep::ws_handle &);
-  void adopt_transaction(const wsrep::transaction &);
+  ~Wsrep_storage_service() override;
+  int start_transaction(const wsrep::ws_handle &) override;
+  void adopt_transaction(const wsrep::transaction &) override;
   int append_fragment(const wsrep::id &, wsrep::transaction_id, int flags,
-                      const wsrep::const_buffer &);
-  int update_fragment_meta(const wsrep::ws_meta &);
-  int remove_fragments();
-  int commit(const wsrep::ws_handle &, const wsrep::ws_meta &);
-  int rollback(const wsrep::ws_handle &, const wsrep::ws_meta &);
-  void store_globals();
-  void reset_globals();
+                      const wsrep::const_buffer &, wsrep::xid const& xid) override;
+  int update_fragment_meta(const wsrep::ws_meta &) override;
+  int remove_fragments() override;
+  int commit(const wsrep::ws_handle &, const wsrep::ws_meta &) override;
+  int rollback(const wsrep::ws_handle &, const wsrep::ws_meta &) override;
+  void store_globals() override;
+  void reset_globals() override;
 
  private:
   friend class Wsrep_server_service;

--- a/storage/perfschema/unittest/pfs_account-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_account-oom-t.cc
@@ -34,6 +34,7 @@
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/pfs_user.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
 

--- a/storage/perfschema/unittest/pfs_host-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_host-oom-t.cc
@@ -31,6 +31,7 @@
 #include "storage/perfschema/pfs_instr.h"
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
 

--- a/storage/perfschema/unittest/pfs_instr-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_instr-oom-t.cc
@@ -36,6 +36,7 @@
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/pfs_user.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
 

--- a/storage/perfschema/unittest/pfs_instr-t.cc
+++ b/storage/perfschema/unittest/pfs_instr-t.cc
@@ -30,6 +30,7 @@
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "unittest/mytap/tap.h"
 
 static void test_no_instruments() {

--- a/storage/perfschema/unittest/pfs_instr_class-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_instr_class-oom-t.cc
@@ -30,6 +30,7 @@
 #include "storage/perfschema/pfs_instr.h"
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
 

--- a/storage/perfschema/unittest/pfs_instr_class-t.cc
+++ b/storage/perfschema/unittest/pfs_instr_class-t.cc
@@ -27,6 +27,7 @@
 #include "storage/perfschema/pfs_instr.h"
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "unittest/mytap/tap.h"
 
 static void test_no_registration() {

--- a/storage/perfschema/unittest/pfs_misc-t.cc
+++ b/storage/perfschema/unittest/pfs_misc-t.cc
@@ -29,6 +29,7 @@
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "unittest/mytap/tap.h"
 
 static void test_digest_length_overflow() {

--- a/storage/perfschema/unittest/pfs_server_stubs.cc
+++ b/storage/perfschema/unittest/pfs_server_stubs.cc
@@ -69,3 +69,4 @@ int log_message(int, ...) {
 bool acl_is_utility_user(const char *, const char *, const char *) {
   return false;
 }
+

--- a/storage/perfschema/unittest/pfs_user-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_user-oom-t.cc
@@ -31,6 +31,7 @@
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/pfs_user.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
 

--- a/storage/perfschema/unittest/stub_pfs_defaults.h
+++ b/storage/perfschema/unittest/stub_pfs_defaults.h
@@ -22,5 +22,14 @@
 
 #include "storage/perfschema/pfs.h"
 #include "storage/perfschema/pfs_defaults.h"
+#include "wsrep-lib/wsrep-API/v26/wsrep_api.h"
 
 void install_default_setup(PSI_thread_bootstrap *) {}
+
+void wsrep_sst_cancel(bool) { }
+
+void wsrep_pfs_instr_cb(wsrep_pfs_instr_type_t, wsrep_pfs_instr_ops_t,
+                        wsrep_pfs_instr_tag_t, void **, void **,
+                        const void *) {}
+
+


### PR DESCRIPTION
* bytes_certified is called log_position from now
* prepare_fragment_for_replication also has a log_position output
  parameter
* changed replay API. Updated related methods to match codership
  behavior.
* XA commit stubs (not implemented, only assertions)
* added override where methods are overridden
* changed NBO api stubs (not implemented in this commit)

Also:
* dev-helper builds galera with psi=1
* dev-helper uses pxb 8.0.23
* fixed an error in wsrep_sst_xtrabackup related to an uninitailized
  variable
*