### PR TITLE
PXC-3679 disable SNI for socat 1.7.4.0 (5.7)

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -635,6 +635,10 @@ get_transfer()
             if check_for_version "$SOCAT_VERSION" "1.7.3"; then
                 donor_extra=',commonname=""'
             fi
+            # disable SNI if socat supports it
+            if check_for_version "$SOCAT_VERSION" "1.7.4"; then
+                donor_extra+=',no-sni=1'
+            fi
 
             # PXC-3508 : If 'ssl_dhparams' option has been set, then always add it
             # to the socat command (both donor and joiner)


### PR DESCRIPTION
* starting from '1.7.4.0' SNI is enabled by default,
  if socat >= '1.7.4.0' is used we neeed to disable SNI