### PR TITLE
PXC-3449: Galera fails after MDL BF-BF conflict

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf.result
@@ -1,0 +1,72 @@
+SET SESSION wsrep_sync_wait = 0;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
+INSERT INTO p1 VALUES (1,1);
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, f2 CHAR(30), fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1, 'INITIAL VALUE', 1);
+INSERT INTO c1 VALUES (2, 'INITIAL VALUE', 1);
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+ALTER TABLE p1 ADD f1 INT;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET AUTOCOMMIT = ON;
+START TRANSACTION;
+UPDATE c1 SET f2 = 'changed from node 1' WHERE pk = 1;
+SELECT * FROM c1 WHERE pk = 2 FOR UPDATE;
+pk	f2	fk
+2	INITIAL VALUE	1
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+UPDATE c1 SET f2 = 'changed from node 2' WHERE pk = 2;
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
+COMMIT;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,abort_trx_end';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET SESSION wsrep_on = 0;
+Timeout in wait_condition.inc for SELECT 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_debug_sync_waiters' AND VARIABLE_VALUE = 'abort_trx_end apply_monitor_master_enter_sync commit_monitor_master_enter_sync'
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=abort_trx_end';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+include/assert.inc [node_2 changes should be replicated]
+node_1:
+SELECT * FROM c1;
+pk	f2	fk
+1	INITIAL VALUE	1
+2	changed from node 2	1
+SELECT * FROM p1;
+pk	f2	f1
+1	1	NULL
+SHOW CREATE TABLE p1;
+Table	Create Table
+p1	CREATE TABLE `p1` (
+  `pk` int NOT NULL,
+  `f2` int DEFAULT NULL,
+  `f1` int DEFAULT NULL,
+  PRIMARY KEY (`pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+node_2:
+SELECT * FROM c1;
+pk	f2	fk
+1	INITIAL VALUE	1
+2	changed from node 2	1
+SELECT * FROM p1;
+pk	f2	f1
+1	1	NULL
+SHOW CREATE TABLE p1;
+Table	Create Table
+p1	CREATE TABLE `p1` (
+  `pk` int NOT NULL,
+  `f2` int DEFAULT NULL,
+  `f1` int DEFAULT NULL,
+  PRIMARY KEY (`pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE c1;
+DROP TABLE p1;

--- a/mysql-test/suite/galera/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf.result
@@ -10,7 +10,6 @@ SET SESSION wsrep_sync_wait=0;
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
 SET GLOBAL wsrep_provider_options = 'dbug=';
-SET AUTOCOMMIT = ON;
 START TRANSACTION;
 UPDATE c1 SET f2 = 'changed from node 1' WHERE pk = 1;
 SELECT * FROM c1 WHERE pk = 2 FOR UPDATE;

--- a/mysql-test/suite/galera/r/galera_bf_bf_optimistic_pa.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf_optimistic_pa.result
@@ -16,8 +16,14 @@ SELECT * FROM c1 WHERE pk = 2 FOR UPDATE;
 pk	f2	fk
 2	INITIAL VALUE	1
 SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+UPDATE c1 SET f2 = 'changed from node 2' WHERE pk = 2;
 SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
 COMMIT;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
 SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
 SET GLOBAL wsrep_provider_options = 'dbug=';
@@ -25,5 +31,38 @@ SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+include/assert.inc [node_2 changes should be replicated]
+node_1:
+SELECT * FROM c1;
+pk	f2	fk
+1	INITIAL VALUE	1
+2	changed from node 2	1
+SELECT * FROM p1;
+pk	f2	f1
+1	1	NULL
+SHOW CREATE TABLE p1;
+Table	Create Table
+p1	CREATE TABLE `p1` (
+  `pk` int NOT NULL,
+  `f2` int DEFAULT NULL,
+  `f1` int DEFAULT NULL,
+  PRIMARY KEY (`pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+node_2:
+SELECT * FROM c1;
+pk	f2	fk
+1	INITIAL VALUE	1
+2	changed from node 2	1
+SELECT * FROM p1;
+pk	f2	f1
+1	1	NULL
+SHOW CREATE TABLE p1;
+Table	Create Table
+p1	CREATE TABLE `p1` (
+  `pk` int NOT NULL,
+  `f2` int DEFAULT NULL,
+  `f1` int DEFAULT NULL,
+  PRIMARY KEY (`pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 DROP TABLE c1;
 DROP TABLE p1;

--- a/mysql-test/suite/galera/r/galera_ddl_fk_conflict.result
+++ b/mysql-test/suite/galera/r/galera_ddl_fk_conflict.result
@@ -77,9 +77,9 @@ EXPECT_2
 2
 ######################################################################
 #
-# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate,
 #              but fails in certification for earlier DDL on child table
-#              which is child to both FK parents 
+#              which is child to both FK parents
 #
 ######################################################################
 BEGIN;
@@ -238,9 +238,9 @@ EXPECT_2
 2
 ######################################################################
 #
-# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate,
 #              but fails in certification for earlier DDL on child table
-#              which is child to both FK parents 
+#              which is child to both FK parents
 #
 ######################################################################
 BEGIN;
@@ -392,9 +392,9 @@ EXPECT_2
 2
 ######################################################################
 #
-# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate,
 #              but fails in certification for earlier DDL on child table
-#              which is child to both FK parents 
+#              which is child to both FK parents
 #
 ######################################################################
 BEGIN;
@@ -502,9 +502,9 @@ EXPECT_2
 2
 ######################################################################
 #
-# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate,
 #              but fails in certification for earlier DDL on child table
-#              which is child to both FK parents 
+#              which is child to both FK parents
 #
 ######################################################################
 BEGIN;

--- a/mysql-test/suite/galera/r/galera_ddl_fk_conflict.result
+++ b/mysql-test/suite/galera/r/galera_ddl_fk_conflict.result
@@ -1,0 +1,543 @@
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_sync_wait=0;
+######################################################################
+# Test for OPTIMIZE 
+######################################################################
+######################################################################
+#
+# Scenario #1: DML working on FK parent table BF aborted by DDL
+#              over child table
+#
+######################################################################
+SET SESSION wsrep_sync_wait=0;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p2 VALUES (1, 'INITIAL VALUE');
+INSERT INTO p2 VALUES (2, 'INITIAL VALUE');
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+CREATE TABLE c2 (pk INTEGER PRIMARY KEY, fk1 INTEGER, fk2 INTEGER, FOREIGN KEY (fk1) REFERENCES p1(pk), FOREIGN KEY (fk2) REFERENCES p2(pk));
+INSERT INTO c2 VALUES (1,1,1), (2,1,2);
+SET AUTOCOMMIT=ON;
+START TRANSACTION;
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+SET SESSION wsrep_sync_wait=0;
+OPTIMIZE TABLE c1 ;
+Table	Op	Msg_type	Msg_text
+test.c1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.c1	optimize	status	OK
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #2: DML working on FK parent table tries to replicate, but
+#              fails in certification for earlier DDL on child table
+#
+######################################################################
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+OPTIMIZE TABLE c1 ;
+Table	Op	Msg_type	Msg_text
+test.c1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.c1	optimize	status	OK
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+#              but fails in certification for earlier DDL on child table
+#              which is child to both FK parents 
+#
+######################################################################
+BEGIN;
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+OPTIMIZE TABLE c2 ;
+Table	Op	Msg_type	Msg_text
+test.c2	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.c2	optimize	status	OK
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+UPDATE p2 SET f2 = 'TO DEADLOCK' WHERE pk = 2;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+DROP TABLE c1, c2;
+DROP TABLE p1, p2;
+######################################################################
+# Test for OPTIMIZE 
+######################################################################
+SET SESSION wsrep_sync_wait=0;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+######################################################################
+#
+# Scenario #4: DML working on FK parent table tries to replicate, but
+#              fails in certification for earlier DDL on child table
+#              and another temporary table. TMP table should be skipped
+#              but FK child table should be replicated with proper keys
+#
+######################################################################
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+CREATE TEMPORARY TABLE tmp (i int);
+OPTIMIZE TABLE c1, tmp ;
+Table	Op	Msg_type	Msg_text
+test.c1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.c1	optimize	status	OK
+test.tmp	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.tmp	optimize	status	OK
+DROP TABLE tmp;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+DROP TABLE c1;
+DROP TABLE p1;
+######################################################################
+# Test for REPAIR 
+######################################################################
+######################################################################
+#
+# Scenario #1: DML working on FK parent table BF aborted by DDL
+#              over child table
+#
+######################################################################
+SET SESSION wsrep_sync_wait=0;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p2 VALUES (1, 'INITIAL VALUE');
+INSERT INTO p2 VALUES (2, 'INITIAL VALUE');
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+CREATE TABLE c2 (pk INTEGER PRIMARY KEY, fk1 INTEGER, fk2 INTEGER, FOREIGN KEY (fk1) REFERENCES p1(pk), FOREIGN KEY (fk2) REFERENCES p2(pk));
+INSERT INTO c2 VALUES (1,1,1), (2,1,2);
+SET AUTOCOMMIT=ON;
+START TRANSACTION;
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+SET SESSION wsrep_sync_wait=0;
+REPAIR TABLE c1 ;
+Table	Op	Msg_type	Msg_text
+test.c1	repair	note	The storage engine for the table doesn't support repair
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #2: DML working on FK parent table tries to replicate, but
+#              fails in certification for earlier DDL on child table
+#
+######################################################################
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+REPAIR TABLE c1 ;
+Table	Op	Msg_type	Msg_text
+test.c1	repair	note	The storage engine for the table doesn't support repair
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+#              but fails in certification for earlier DDL on child table
+#              which is child to both FK parents 
+#
+######################################################################
+BEGIN;
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+REPAIR TABLE c2 ;
+Table	Op	Msg_type	Msg_text
+test.c2	repair	note	The storage engine for the table doesn't support repair
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+UPDATE p2 SET f2 = 'TO DEADLOCK' WHERE pk = 2;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+DROP TABLE c1, c2;
+DROP TABLE p1, p2;
+######################################################################
+# Test for REPAIR 
+######################################################################
+SET SESSION wsrep_sync_wait=0;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+######################################################################
+#
+# Scenario #4: DML working on FK parent table tries to replicate, but
+#              fails in certification for earlier DDL on child table
+#              and another temporary table. TMP table should be skipped
+#              but FK child table should be replicated with proper keys
+#
+######################################################################
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+CREATE TEMPORARY TABLE tmp (i int);
+REPAIR TABLE c1, tmp ;
+Table	Op	Msg_type	Msg_text
+test.c1	repair	note	The storage engine for the table doesn't support repair
+test.tmp	repair	note	The storage engine for the table doesn't support repair
+DROP TABLE tmp;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+DROP TABLE c1;
+DROP TABLE p1;
+######################################################################
+# Test for ALTER ENGINE=INNODB
+######################################################################
+######################################################################
+#
+# Scenario #1: DML working on FK parent table BF aborted by DDL
+#              over child table
+#
+######################################################################
+SET SESSION wsrep_sync_wait=0;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p2 VALUES (1, 'INITIAL VALUE');
+INSERT INTO p2 VALUES (2, 'INITIAL VALUE');
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+CREATE TABLE c2 (pk INTEGER PRIMARY KEY, fk1 INTEGER, fk2 INTEGER, FOREIGN KEY (fk1) REFERENCES p1(pk), FOREIGN KEY (fk2) REFERENCES p2(pk));
+INSERT INTO c2 VALUES (1,1,1), (2,1,2);
+SET AUTOCOMMIT=ON;
+START TRANSACTION;
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+SET SESSION wsrep_sync_wait=0;
+ALTER TABLE c1 ENGINE=INNODB;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #2: DML working on FK parent table tries to replicate, but
+#              fails in certification for earlier DDL on child table
+#
+######################################################################
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+ALTER TABLE c1 ENGINE=INNODB;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+#              but fails in certification for earlier DDL on child table
+#              which is child to both FK parents 
+#
+######################################################################
+BEGIN;
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+ALTER TABLE c2 ENGINE=INNODB;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+UPDATE p2 SET f2 = 'TO DEADLOCK' WHERE pk = 2;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+DROP TABLE c1, c2;
+DROP TABLE p1, p2;
+######################################################################
+# Test for TRUNCATE 
+######################################################################
+######################################################################
+#
+# Scenario #1: DML working on FK parent table BF aborted by DDL
+#              over child table
+#
+######################################################################
+SET SESSION wsrep_sync_wait=0;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p2 VALUES (1, 'INITIAL VALUE');
+INSERT INTO p2 VALUES (2, 'INITIAL VALUE');
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+CREATE TABLE c2 (pk INTEGER PRIMARY KEY, fk1 INTEGER, fk2 INTEGER, FOREIGN KEY (fk1) REFERENCES p1(pk), FOREIGN KEY (fk2) REFERENCES p2(pk));
+INSERT INTO c2 VALUES (1,1,1), (2,1,2);
+SET AUTOCOMMIT=ON;
+START TRANSACTION;
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+SET SESSION wsrep_sync_wait=0;
+TRUNCATE TABLE c1 ;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #2: DML working on FK parent table tries to replicate, but
+#              fails in certification for earlier DDL on child table
+#
+######################################################################
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+TRUNCATE TABLE c1 ;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+######################################################################
+#
+# Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+#              but fails in certification for earlier DDL on child table
+#              which is child to both FK parents 
+#
+######################################################################
+BEGIN;
+BEGIN;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+TRUNCATE TABLE c2 ;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+COMMIT;
+UPDATE p2 SET f2 = 'TO DEADLOCK' WHERE pk = 2;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT 'I deadlocked';
+I deadlocked
+I deadlocked
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+EXPECT_2
+2
+DROP TABLE c1, c2;
+DROP TABLE p1, p2;

--- a/mysql-test/suite/galera/r/galera_flush_local.result
+++ b/mysql-test/suite/galera/r/galera_flush_local.result
@@ -3,6 +3,7 @@ Table	Op	Msg_type	Msg_text
 test.t0	optimize	Warning	Truncated incorrect sort_buffer_size value: '0'
 test.t0	optimize	Warning	Truncated incorrect myisam_repair_threads value: '0'
 test.t0	optimize	Error	Table 'test.t0' doesn't exist
+test.t0	optimize	Error	Table 'test.t0' doesn't exist
 test.t0	optimize	status	Operation failed
 DROP TABLE IF EXISTS t1, t2, x1, x2;
 CREATE TABLE t1 (f1 INTEGER);

--- a/mysql-test/suite/galera/r/pxc_non_existent_tables.result
+++ b/mysql-test/suite/galera/r/pxc_non_existent_tables.result
@@ -11,6 +11,7 @@ test.nonexestint2	analyze	status	Operation failed
 OPTIMIZE TABLE nonexstent1;
 Table	Op	Msg_type	Msg_text
 test.nonexstent1	optimize	Error	Table 'test.nonexstent1' doesn't exist
+test.nonexstent1	optimize	Error	Table 'test.nonexstent1' doesn't exist
 test.nonexstent1	optimize	status	Operation failed
 INSERT INTO t1 VALUES (1);
 ANALYZE TABLE t1, nonexistent3;

--- a/mysql-test/suite/galera/t/galera_bf_bf.cnf
+++ b/mysql-test/suite/galera/t/galera_bf_bf.cnf
@@ -1,0 +1,2 @@
+!include suite/galera/galera_2nodes.cnf
+!include suite/galera/galera_optimistic_pa.cnf

--- a/mysql-test/suite/galera/t/galera_bf_bf.cnf
+++ b/mysql-test/suite/galera/t/galera_bf_bf.cnf
@@ -1,2 +1,0 @@
-!include suite/galera/galera_2nodes.cnf
-!include suite/galera/galera_optimistic_pa.cnf

--- a/mysql-test/suite/galera/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf.test
@@ -8,8 +8,9 @@
 # with ALTER TABLE certification keys.
 #
 
---source include/galera_cluster.inc
 --source include/have_debug_sync.inc
+--source suite/galera/include/galera_have_debug_sync.inc
+--source include/galera_cluster.inc
 --source include/count_sessions.inc
 
 --connect node_1_toi, 127.0.0.1, root, , test, $NODE_MYPORT_1
@@ -37,7 +38,6 @@ SET SESSION wsrep_sync_wait=0;
 ######################################################################
 
 --connection node_1
-SET AUTOCOMMIT = ON;
 START TRANSACTION;
 
 UPDATE c1 SET f2 = 'changed from node 1' WHERE pk = 1;

--- a/mysql-test/suite/galera/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf.test
@@ -1,0 +1,119 @@
+#
+# Test that ALTER TABLE on parent table is properly ordered with simultaneous
+# transactions that perform DML on child table.
+#
+# node_2's UPDATE should be ordered after ALTER TABLE, as from point of view of
+# node_2 it is executed after ALTER TABLE
+# node_1's UPDATE should fail certification as its certification keys conflict
+# with ALTER TABLE certification keys.
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--connect node_1_toi, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1_toi
+SET SESSION wsrep_sync_wait = 0;
+
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
+INSERT INTO p1 VALUES (1,1);
+
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, f2 CHAR(30), fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1, 'INITIAL VALUE', 1);
+INSERT INTO c1 VALUES (2, 'INITIAL VALUE', 1);
+
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+
+--send ALTER TABLE p1 ADD f1 INT
+
+--connection node_1
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+######################################################################
+
+--connection node_1
+SET AUTOCOMMIT = ON;
+START TRANSACTION;
+
+UPDATE c1 SET f2 = 'changed from node 1' WHERE pk = 1;
+SELECT * FROM c1 WHERE pk = 2 FOR UPDATE;
+
+# Block the applier on node #1 and issue a conflicting update on node #2
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+SET SESSION wsrep_sync_wait = 0;
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_2
+UPDATE c1 SET f2 = 'changed from node 2' WHERE pk = 2;
+
+--connection node_1a
+# Block the commit, send the COMMIT and wait until it gets blocked
+
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+--send COMMIT
+
+--connection node_1a
+--let $galera_sync_point = apply_monitor_master_enter_sync apply_monitor_slave_enter_sync commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Let the conflicting UPDATE proceed and wait until it hits abort_trx_end.
+# The victim transaction still sits in commit_monitor_master_sync_point.
+
+--let $galera_sync_point = abort_trx_end
+--source include/galera_set_sync_point.inc
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--let $galera_sync_point = abort_trx_end apply_monitor_master_enter_sync commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+
+# Let the transactions proceed
+--source include/galera_clear_sync_point.inc
+--let $galera_sync_point = abort_trx_end
+--source include/galera_signal_sync_point.inc
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Commit succeeds
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+--connection node_1_toi
+--reap
+# wait for replication thd to do its job
+--let $assert_text = node_2 changes should be replicated
+--let $assert_cond = [SELECT COUNT(*) FROM c1 WHERE pk = 2 AND f2 = "changed from node 2"] = 1
+--source include/assert.inc
+
+--echo node_1:
+SELECT * FROM c1;
+SELECT * FROM p1;
+SHOW CREATE TABLE p1;
+
+--connection node_2
+--echo node_2:
+SELECT * FROM c1;
+SELECT * FROM p1;
+SHOW CREATE TABLE p1;
+
+DROP TABLE c1;
+DROP TABLE p1;
+
+--disconnect node_1_toi
+--disconnect node_1a
+--source include/wait_until_count_sessions.inc
+

--- a/mysql-test/suite/galera/t/galera_bf_bf_optimistic_pa.cnf
+++ b/mysql-test/suite/galera/t/galera_bf_bf_optimistic_pa.cnf
@@ -1,0 +1,2 @@
+!include suite/galera/galera_2nodes.cnf
+!include suite/galera/galera_optimistic_pa.cnf

--- a/mysql-test/suite/galera/t/galera_bf_bf_optimistic_pa.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf_optimistic_pa.test
@@ -2,12 +2,12 @@
 # Test that ALTER TABLE on parent table is properly ordered with simultaneous
 # transactions that perform DML on child table.
 #
-# UPDATE should fail certification as its certification keys conflict
+# node_2's UPDATE should be ordered after ALTER TABLE, as from point of view of
+# node_2 it is executed after ALTER TABLE
+# node_1's UPDATE should fail certification as its certification keys conflict
 # with ALTER TABLE certification keys.
 #
-# Without the fix, UPDATE is certified, then aborted by already replicated TOI
-# transaction which causes its replay. When replaying it conflicts with TOI
-# causing BF-BF conflict.
+# Without the fix, it triggers BF-BF conflict between TOI and wsrep applier.
 #
 
 --source include/have_debug_sync.inc
@@ -41,14 +41,22 @@ SET SESSION wsrep_sync_wait=0;
 
 --connection node_1
 START TRANSACTION;
+
 UPDATE c1 SET f2 = 'changed from node 1' WHERE pk = 1;
 SELECT * FROM c1 WHERE pk = 2 FOR UPDATE;
 
+# Block the applier on node #1 and issue a conflicting update on node #2
 --connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
---connection node_1a
 SET SESSION wsrep_sync_wait = 0;
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
 
+--connection node_2
+UPDATE c1 SET f2 = 'changed from node 2' WHERE pk = 2;
+
+--connection node_1a
 # Block the commit, send the COMMIT and wait until it gets blocked
+
 --let $galera_sync_point = commit_monitor_master_enter_sync
 --source include/galera_set_sync_point.inc
 
@@ -56,13 +64,23 @@ SET SESSION wsrep_sync_wait = 0;
 --send COMMIT
 
 --connection node_1a
---let $galera_sync_point = apply_monitor_master_enter_sync commit_monitor_master_enter_sync
+--let $galera_sync_point = apply_monitor_master_enter_sync apply_monitor_slave_enter_sync commit_monitor_master_enter_sync
 --source include/galera_wait_sync_point.inc
 --source include/galera_clear_sync_point.inc
 
+# Let the conflicting UPDATE proceed and wait until it hits abort_trx_end.
+# The victim transaction still sits in commit_monitor_master_sync_point.
+
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--let $galera_sync_point = apply_monitor_master_enter_sync commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+
 # Let the transactions proceed
+--source include/galera_clear_sync_point.inc
 --let $galera_sync_point = commit_monitor_master_enter_sync
 --source include/galera_signal_sync_point.inc
+
 --let $galera_sync_point = apply_monitor_master_enter_sync
 --source include/galera_signal_sync_point.inc
 --source include/galera_clear_sync_point.inc
@@ -70,14 +88,28 @@ SET SESSION wsrep_sync_wait = 0;
 --connection node_1
 --error ER_LOCK_DEADLOCK
 --reap
+
 --connection node_1_toi
 --reap
+# wait for replication thd to do its job
+--let $assert_text = node_2 changes should be replicated
+--let $assert_cond = [SELECT COUNT(*) FROM c1 WHERE pk = 2 AND f2 = "changed from node 2"] = 1
+--source include/assert.inc
+
+--echo node_1:
+SELECT * FROM c1;
+SELECT * FROM p1;
+SHOW CREATE TABLE p1;
+
+--connection node_2
+--echo node_2:
+SELECT * FROM c1;
+SELECT * FROM p1;
+SHOW CREATE TABLE p1;
 
 DROP TABLE c1;
 DROP TABLE p1;
 
 --disconnect node_1_toi
 --disconnect node_1a
---connection node_1
-
 --source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_ddl_fk_conflict.inc
+++ b/mysql-test/suite/galera/t/galera_ddl_fk_conflict.inc
@@ -1,0 +1,192 @@
+#
+# Test for MDL BF-BF lock conflict
+# There are some DDL statements, which take extensive MDL lock for
+# a table referenced by foreign key constraint from the actual affetec table.
+# This extensive MDL lock may cause MDL BF-BF confclict situations, if the
+# FK parent table is not listed as certification key in the replication write set.
+# i.e. if replication allows such DDL to apply in parallel with regular DML operating
+# on the FK parent table.
+#
+# This test has two scenarios, where DML modifies FK parent table in node 1,
+# and offending DDL for FK child table is sent from node 2.
+#
+# param: $table_admin_command
+#        DDL table command to test, script will build full SQL statement:
+#        $table_admin_command TABLE c;
+#
+# param: $table_admin_command_end
+#        Optional additional SQL syntax to end the SQL statement, if any
+#        $table_admin_command TABLE c $table_admin_command_end;
+#
+# scenario 1, can be used to test if a DDL statement causes such MDL locking vulnerability.
+# call this test script with some table DDL command in $table_admin_command
+# if scenario 1 passes (especially COMMIT does fail for ER_LOCK_DEADLOCK),
+# then this particular DDL is vulnerable. scenraio 2 should fail for this DDL
+# unless code has not been fixed to append parent table certification keys for it.
+#
+
+--echo ######################################################################
+--echo # Test for $table_admin_command $table_admin_command_end
+--echo ######################################################################
+
+
+--echo ######################################################################
+--echo #
+--echo # Scenario #1: DML working on FK parent table BF aborted by DDL
+--echo #              over child table
+--echo #
+--echo ######################################################################
+
+--connection node_1
+SET SESSION wsrep_sync_wait=0;
+
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+
+
+CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p2 VALUES (1, 'INITIAL VALUE');
+INSERT INTO p2 VALUES (2, 'INITIAL VALUE');
+
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+
+CREATE TABLE c2 (pk INTEGER PRIMARY KEY, fk1 INTEGER, fk2 INTEGER, FOREIGN KEY (fk1) REFERENCES p1(pk), FOREIGN KEY (fk2) REFERENCES p2(pk));
+INSERT INTO c2 VALUES (1,1,1), (2,1,2);
+
+--connection node_1
+SET AUTOCOMMIT=ON;
+START TRANSACTION;
+
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+
+--connection node_2
+SET SESSION wsrep_sync_wait=0;
+# wait for tables to be created in node 2 and all rows inserted as well
+--let $wait_condition = SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' and TABLE_NAME LIKE 'c%'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 2  FROM c2
+--source include/wait_condition.inc
+
+# replicate the DDL to be tested
+--eval $table_admin_command TABLE c1 $table_admin_command_end
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+
+--connection node_2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+
+--echo ######################################################################
+--echo #
+--echo # Scenario #2: DML working on FK parent table tries to replicate, but
+--echo #              fails in certification for earlier DDL on child table
+--echo #
+--echo ######################################################################
+
+--connection node_1
+BEGIN;
+
+# Block the applier on node #1 and issue DDL on node 2
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_2
+--eval $table_admin_command TABLE c1 $table_admin_command_end
+
+--connection node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+--let $expected_cert_failures = `SELECT VARIABLE_VALUE+1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'`
+
+--connection node_1
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+--send COMMIT
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_cert_failures FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'
+--source include/wait_condition.inc
+
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+SELECT 'I deadlocked';
+
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+
+--connection node_2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+
+
+--echo ######################################################################
+--echo #
+--echo # Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+--echo #              but fails in certification for earlier DDL on child table
+--echo #              which is child to both FK parents 
+--echo #
+--echo ######################################################################
+
+--connection node_1
+BEGIN;
+
+--connection node_1b
+BEGIN;
+
+--connection node_1a
+# Block the applier on node #1 and issue DDL on node 2
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_2
+--eval $table_admin_command TABLE c2 $table_admin_command_end
+
+--connection node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+--let $expected_cert_failures = `SELECT VARIABLE_VALUE+2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'`
+
+--connection node_1
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+--send COMMIT
+
+--connection node_1b
+UPDATE p2 SET f2 = 'TO DEADLOCK' WHERE pk = 2;
+--send COMMIT
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_cert_failures FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'
+--source include/wait_condition.inc
+
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+SELECT 'I deadlocked';
+
+--connection node_1b
+--error ER_LOCK_DEADLOCK
+--reap
+SELECT 'I deadlocked';
+
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+
+--connection node_2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
+
+DROP TABLE c1, c2;
+DROP TABLE p1, p2;

--- a/mysql-test/suite/galera/t/galera_ddl_fk_conflict.inc
+++ b/mysql-test/suite/galera/t/galera_ddl_fk_conflict.inc
@@ -1,8 +1,8 @@
 #
 # Test for MDL BF-BF lock conflict
 # There are some DDL statements, which take extensive MDL lock for
-# a table referenced by foreign key constraint from the actual affetec table.
-# This extensive MDL lock may cause MDL BF-BF confclict situations, if the
+# a table referenced by foreign key constraint from the actual affected table.
+# This extensive MDL lock may cause MDL BF-BF conflict situations, if the
 # FK parent table is not listed as certification key in the replication write set.
 # i.e. if replication allows such DDL to apply in parallel with regular DML operating
 # on the FK parent table.
@@ -21,7 +21,7 @@
 # scenario 1, can be used to test if a DDL statement causes such MDL locking vulnerability.
 # call this test script with some table DDL command in $table_admin_command
 # if scenario 1 passes (especially COMMIT does fail for ER_LOCK_DEADLOCK),
-# then this particular DDL is vulnerable. scenraio 2 should fail for this DDL
+# then this particular DDL is vulnerable. scenario 2 should fail for this DDL
 # unless code has not been fixed to append parent table certification keys for it.
 #
 

--- a/mysql-test/suite/galera/t/galera_ddl_fk_conflict.inc
+++ b/mysql-test/suite/galera/t/galera_ddl_fk_conflict.inc
@@ -131,9 +131,9 @@ SELECT COUNT(*) AS EXPECT_2 FROM p2 WHERE f2 = 'INITIAL VALUE';
 
 --echo ######################################################################
 --echo #
---echo # Scenario #3: 2 DMLs working on two FK parent tables try to replicate, 
+--echo # Scenario #3: 2 DMLs working on two FK parent tables try to replicate,
 --echo #              but fails in certification for earlier DDL on child table
---echo #              which is child to both FK parents 
+--echo #              which is child to both FK parents
 --echo #
 --echo ######################################################################
 

--- a/mysql-test/suite/galera/t/galera_ddl_fk_conflict.test
+++ b/mysql-test/suite/galera/t/galera_ddl_fk_conflict.test
@@ -29,7 +29,7 @@ SET SESSION wsrep_sync_wait=0;
 --source galera_ddl_fk_conflict.inc
 
 --let $table_admin_command = TRUNCATE
---let $table_admin_command_end = 
+--let $table_admin_command_end =
 --source galera_ddl_fk_conflict.inc
 
 # CHECK and ANALYZE are not affected

--- a/mysql-test/suite/galera/t/galera_ddl_fk_conflict.test
+++ b/mysql-test/suite/galera/t/galera_ddl_fk_conflict.test
@@ -1,0 +1,36 @@
+#
+# MDL BF-BF lock conflict
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source suite/galera/include/galera_have_debug_sync.inc
+
+# sync point controlling session
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+SET SESSION wsrep_sync_wait=0;
+
+# secondary conflicting DML victim session
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1b
+SET SESSION wsrep_sync_wait=0;
+
+--let $table_admin_command = OPTIMIZE
+--source galera_ddl_fk_conflict.inc
+--source galera_ddl_fk_conflict_with_tmp.inc
+
+--let $table_admin_command = REPAIR
+--source galera_ddl_fk_conflict.inc
+--source galera_ddl_fk_conflict_with_tmp.inc
+
+--let $table_admin_command = ALTER
+--let $table_admin_command_end = ENGINE=INNODB
+--source galera_ddl_fk_conflict.inc
+
+--let $table_admin_command = TRUNCATE
+--let $table_admin_command_end = 
+--source galera_ddl_fk_conflict.inc
+
+# CHECK and ANALYZE are not affected
+

--- a/mysql-test/suite/galera/t/galera_ddl_fk_conflict.test
+++ b/mysql-test/suite/galera/t/galera_ddl_fk_conflict.test
@@ -2,9 +2,9 @@
 # MDL BF-BF lock conflict
 #
 
---source include/galera_cluster.inc
 --source include/have_debug_sync.inc
 --source suite/galera/include/galera_have_debug_sync.inc
+--source include/galera_cluster.inc
 
 # sync point controlling session
 --connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1

--- a/mysql-test/suite/galera/t/galera_ddl_fk_conflict_with_tmp.inc
+++ b/mysql-test/suite/galera/t/galera_ddl_fk_conflict_with_tmp.inc
@@ -1,0 +1,69 @@
+--echo ######################################################################
+--echo # Test for $table_admin_command $table_admin_command_end
+--echo ######################################################################
+
+
+--connection node_1
+SET SESSION wsrep_sync_wait=0;
+
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
+INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
+
+
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO c1 VALUES (1,1);
+
+--echo ######################################################################
+--echo #
+--echo # Scenario #4: DML working on FK parent table tries to replicate, but
+--echo #              fails in certification for earlier DDL on child table
+--echo #              and another temporary table. TMP table should be skipped
+--echo #              but FK child table should be replicated with proper keys
+--echo #
+--echo ######################################################################
+
+--connection node_1
+BEGIN;
+
+# Block the applier on node #1 and issue DDL on node 2
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_2
+# wait for tables to be created in node 2 and all rows inserted as well
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 'c1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1  FROM c1
+--source include/wait_condition.inc
+CREATE TEMPORARY TABLE tmp (i int);
+--eval $table_admin_command TABLE c1, tmp $table_admin_command_end
+DROP TABLE tmp;
+
+--connection node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+--let $expected_cert_failures = `SELECT VARIABLE_VALUE+1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'`
+
+--connection node_1
+UPDATE p1 SET f2 = 'TO DEADLOCK' WHERE pk = 1;
+--send COMMIT
+
+--connection node_1a
+--let $wait_condition = SELECT VARIABLE_VALUE = $expected_cert_failures FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_cert_failures'
+--source include/wait_condition.inc
+
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+SELECT 'I deadlocked';
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+
+--connection node_2
+SELECT COUNT(*) AS EXPECT_1 FROM p1 WHERE f2 = 'INITIAL VALUE';
+
+DROP TABLE c1;
+DROP TABLE p1;

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -5125,7 +5125,7 @@ MDL_ticket *MDL_ticket_store::materialized_front(int di) {
 #ifdef WITH_WSREP
 void MDL_ticket::wsrep_report(bool debug) {
   if (debug) {
-    WSREP_DEBUG(
+    WSREP_INFO(
         "MDL ticket: type: %s, space: %s, db: %s, name: %s",
         (get_type() == MDL_INTENTION_EXCLUSIVE)
             ? "intention exclusive"

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -538,7 +538,7 @@ static Check_result check_for_upgrade(THD *thd, dd::String_type &sname,
 /*
    OPTIMIZE, REPAIR and ALTER may take MDL locks not only for the affected
    table, but also for the table referenced by foreign key constraint.
-   ALTER additionally may take MTL lock of the tables that are referencing
+   ALTER additionally may take MDL lock of the tables that are referencing
    altered table.
    This wsrep_toi_replication() function handles TOI replication for OPTIMIZE
    and REPAIR so that certification keys for potential FK parent tables are

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -558,7 +558,6 @@ static bool wsrep_toi_replication(THD *thd, TABLE_LIST *tables) {
       return false;
   }
 
-  close_thread_tables(thd);
   wsrep::key_array keys;
 
   wsrep_append_fk_parent_table(thd, tables, &keys);

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4792,7 +4792,7 @@ int mysql_execute_command(THD *thd, bool first_level) {
       /* FLUSH LOGS OR FLUSH BINARY LOGS are not replicated.
       Check git-hash#8aa97efd935a for more details. */
 
-      /* REFRESH_TABLES is taken care inside reload_acl_and_cache */
+      /* REFRESH_TABLES is taken care inside handle_reload_request */
       if (lex->type &
           (REFRESH_GRANT | REFRESH_HOSTS | REFRESH_STATUS |
            REFRESH_USER_RESOURCES | REFRESH_ERROR_LOG | REFRESH_SLOW_LOG |
@@ -4815,9 +4815,9 @@ int mysql_execute_command(THD *thd, bool first_level) {
         if ((lex->type & REFRESH_TABLES) &&
             !(lex->type & (REFRESH_FOR_EXPORT | REFRESH_READ_LOCK))) {
           /*
-            This is done after reload_acl_and_cache is because
+            This is done after handle_reload_request is because
             LOCK TABLES is not replicated in galera, the upgrade of which
-            is checked in reload_acl_and_cache.
+            is checked in handle_reload_request.
             Hence, done after/if we are able to upgrade locks.
           */
           if (first_table) {

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -129,7 +129,7 @@ extern uint sql_command_flags[];
 extern const LEX_CSTRING command_name[];
 
 #ifdef WITH_WSREP
-#include <service_wsrep.h>
+#include "service_wsrep.h"
 
 #define WSREP_TO_ISOLATION_BEGIN_IF(db_, table_, table_list_)                 \
   if (WSREP(thd) && thd->wsrep_cs().state() != wsrep::client_state::s_none && \
@@ -163,8 +163,8 @@ extern const LEX_CSTRING command_name[];
                                            fk_tables)                         \
   if (WSREP(thd) && thd->wsrep_cs().state() != wsrep::client_state::s_none && \
       !thd->lex->no_write_to_binlog &&                                        \
-      wsrep_to_isolation_begin(thd, db_, table_, table_list_, nullptr, NULL,  \
-                               fk_tables))
+      wsrep_to_isolation_begin(thd, db_, table_, table_list_, nullptr,        \
+                               nullptr, fk_tables))
 
 #define WSREP_SYNC_WAIT(thd_, before_)                                    \
   {                                                                       \

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -129,16 +129,22 @@ extern uint sql_command_flags[];
 extern const LEX_CSTRING command_name[];
 
 #ifdef WITH_WSREP
+#include <service_wsrep.h>
 
-// #define WSREP_MYSQL_DB (char *)"mysql"
+#define WSREP_TO_ISOLATION_BEGIN_IF(db_, table_, table_list_)                 \
+  if (WSREP(thd) && thd->wsrep_cs().state() != wsrep::client_state::s_none && \
+      wsrep_to_isolation_begin(thd, db_, table_, table_list_))
+
 #define WSREP_TO_ISOLATION_BEGIN(db_, table_, table_list_)                   \
   if (WSREP(thd) && wsrep_to_isolation_begin(thd, db_, table_, table_list_)) \
     goto error;
 
-#define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_) \
-  if (WSREP(thd) && wsrep_thd_is_local(thd) &&                                \
-      wsrep_to_isolation_begin(thd, db_, table_, table_list_, alter_info_))   \
-    goto error;
+#define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_, \
+                                       fk_tables_)                            \
+  if (WSREP(thd) && thd->wsrep_cs().state() != wsrep::client_state::s_none && \
+      wsrep_thd_is_local(thd) &&                                              \
+      wsrep_to_isolation_begin(thd, db_, table_, table_list_, nullptr,        \
+                               alter_info_, fk_tables_))
 
 #define WSREP_TO_ISOLATION_END                                                 \
   if ((WSREP(thd) && wsrep_thd_is_local_toi(thd)) || wsrep_thd_is_in_rsu(thd)) \
@@ -147,10 +153,18 @@ extern const LEX_CSTRING command_name[];
 /* Checks if lex->no_write_to_binlog is set for statements that use
   LOCAL or NO_WRITE_TO_BINLOG
 */
-#define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_) \
-  if (WSREP(thd) && !thd->lex->no_write_to_binlog &&              \
-      wsrep_to_isolation_begin(thd, db_, table_, table_list_))    \
-    goto error;
+#define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_)             \
+  if (WSREP(thd) && thd->wsrep_cs().state() != wsrep::client_state::s_none && \
+      !thd->lex->no_write_to_binlog &&                                        \
+      wsrep_to_isolation_begin(thd, db_, table_, table_list_))                \
+    goto wsrep_error_label;
+
+#define WSREP_TO_ISOLATION_BEGIN_FK_TABLES(db_, table_, table_list_,          \
+                                           fk_tables)                         \
+  if (WSREP(thd) && thd->wsrep_cs().state() != wsrep::client_state::s_none && \
+      !thd->lex->no_write_to_binlog &&                                        \
+      wsrep_to_isolation_begin(thd, db_, table_, table_list_, nullptr, NULL,  \
+                               fk_tables))
 
 #define WSREP_SYNC_WAIT(thd_, before_)                                    \
   {                                                                       \
@@ -160,6 +174,8 @@ extern const LEX_CSTRING command_name[];
 #else
 
 #define WSREP_TO_ISOLATION_BEGIN(db_, table_, table_list_)
+#define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_)
+#define WSREP_TO_ISOLATION_BEGIN_FK_TABLES(db_, table_, table_list_, fk_tables_)
 #define WSREP_TO_ISOLATION_END
 #define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_)
 #define WSREP_SYNC_WAIT(thd_, before_)

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -617,7 +617,7 @@ bool Sql_cmd_alter_table_truncate_partition::execute(THD *thd) {
   if (check_one_table_access(thd, DROP_ACL, first_table)) return true;
 
 #ifdef WITH_WSREP
-  TABLE *find_temporary_table(THD * thd, const TABLE_LIST *tl);
+  extern TABLE *find_temporary_table(THD * thd, const TABLE_LIST *tl);
 
   if (WSREP(thd) &&
       (!thd->is_current_stmt_binlog_format_row() ||

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1668,18 +1668,15 @@ wsrep::key_array wsrep_prepare_keys_for_toi(const char *db, const char *table,
 static bool collect_fk_children(const dd::Table *table_def,
                                 wsrep::key_array *keys) {
   for (const dd::Foreign_key_parent *fk : table_def->foreign_key_parents()) {
-    WSREP_INFO("(c) appended fkey %s", fk->child_table_name().c_str());
-
     keys->push_back(wsrep_prepare_key_for_toi(fk->child_schema_name().c_str(),
                                               fk->child_table_name().c_str(),
                                               wsrep::key::shared));
   }
-
   return false;
 }
 
 void wsrep_append_child_tables(THD *thd, TABLE_LIST *tables,
-                                     wsrep::key_array *keys) {
+                               wsrep::key_array *keys) {
   if (!WSREP(thd) || !WSREP_CLIENT(thd)) return;
   TABLE_LIST *table;
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -17,6 +17,8 @@
 #include "mysql/plugin.h"
 #include "mysqld.h"
 #include "rpl_slave.h"
+#include "sql/dd/cache/dictionary_client.h"  // dd::cache::Dictionary_client
+#include "sql/dd/types/table.h"
 #include "sql/key_spec.h"
 #include "sql/sql_alter.h"
 #include "sql/sql_lex.h"
@@ -1628,7 +1630,8 @@ wsrep::key_array wsrep_prepare_keys_for_alter_add_fk(const char *child_table_db,
 wsrep::key_array wsrep_prepare_keys_for_toi(const char *db, const char *table,
                                             const TABLE_LIST *table_list,
                                             dd::Tablespace_table_ref_vec *trefs,
-                                            Alter_info *alter_info) {
+                                            Alter_info *alter_info,
+                                            wsrep::key_array *fk_tables) {
   wsrep::key_array ret;
   if (db || table) {
     ret.push_back(wsrep_prepare_key_for_toi(db, table, wsrep::key::exclusive));
@@ -1653,7 +1656,98 @@ wsrep::key_array wsrep_prepare_keys_for_toi(const char *db, const char *table,
                                               wsrep::key::exclusive));
     }
   }
+  if (fk_tables && !fk_tables->empty()) {
+    ret.insert(ret.end(), fk_tables->begin(), fk_tables->end());
+  }
   return ret;
+}
+
+/*
+ * Collect wsrep keys corresponding to tables that are referencing given table
+ */
+static bool collect_fk_children(const dd::Table *table_def,
+                                wsrep::key_array *keys) {
+  for (const dd::Foreign_key_parent *fk : table_def->foreign_key_parents()) {
+    WSREP_INFO("(c) appended fkey %s", fk->child_table_name().c_str());
+
+    keys->push_back(wsrep_prepare_key_for_toi(fk->child_schema_name().c_str(),
+                                              fk->child_table_name().c_str(),
+                                              wsrep::key::shared));
+  }
+
+  return false;
+}
+
+void wsrep_append_child_tables(THD *thd, TABLE_LIST *tables,
+                                     wsrep::key_array *keys) {
+  if (!WSREP(thd) || !WSREP_CLIENT(thd)) return;
+  TABLE_LIST *table;
+
+  thd->mdl_context.release_transactional_locks();
+  MDL_savepoint mdl_savepoint = thd->mdl_context.mdl_savepoint();
+
+  uint counter;
+  if (open_temporary_tables(thd, tables) ||
+      open_tables(thd, &tables, &counter,
+                  MYSQL_OPEN_FORCE_SHARED_HIGH_PRIO_MDL)) {
+    WSREP_DEBUG("unable to open table for FK checks for %s", thd->query().str);
+  }
+
+  for (table = tables; table; table = table->next_local) {
+    if (!is_temporary_table(table) && table->table) {
+      const dd::Table *table_obj = nullptr;
+      dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
+      if (thd->dd_client()->acquire(
+              dd::String_type(table->table->s->db.str),
+              dd::String_type(table->table->s->table_name.str), &table_obj)) {
+        assert(0);
+      }
+      collect_fk_children(table_obj, keys);
+    }
+  }
+
+  /* close the table and release MDL locks */
+  close_thread_tables(thd);
+  thd->mdl_context.rollback_to_savepoint(mdl_savepoint);
+  for (table = tables; table; table = table->next_local) {
+    table->table = NULL;
+    table->mdl_request.ticket = NULL;
+  }
+}
+
+void wsrep_append_fk_parent_table(THD *thd, TABLE_LIST *tables,
+                                  wsrep::key_array *keys) {
+  if (!WSREP(thd) || !WSREP_CLIENT(thd)) return;
+  TABLE_LIST *table;
+
+  thd->mdl_context.release_transactional_locks();
+  MDL_savepoint mdl_savepoint = thd->mdl_context.mdl_savepoint();
+
+  uint counter;
+  if (open_temporary_tables(thd, tables) ||
+      open_tables(thd, &tables, &counter,
+                  MYSQL_OPEN_FORCE_SHARED_HIGH_PRIO_MDL)) {
+    WSREP_DEBUG("unable to open table for FK checks for %s", thd->query().str);
+  }
+  for (table = tables; table; table = table->next_local) {
+    if (!is_temporary_table(table) && table->table) {
+      for (TABLE_SHARE_FOREIGN_KEY_INFO *fk = table->table->s->foreign_key;
+           fk < table->table->s->foreign_key + table->table->s->foreign_keys;
+           ++fk) {
+        WSREP_INFO("(p) appended fkey %s", fk->referenced_table_name.str);
+        keys->push_back(wsrep_prepare_key_for_toi(fk->referenced_table_db.str,
+                                                  fk->referenced_table_name.str,
+                                                  wsrep::key::shared));
+      }
+    }
+  }
+  /* close the table and release MDL locks */
+  close_thread_tables(thd);
+  thd->mdl_context.rollback_to_savepoint(mdl_savepoint);
+  for (table = tables; table; table = table->next_local) {
+    table->table = NULL;
+    table->mdl_request.ticket = NULL;
+  }
 }
 
 /*
@@ -1987,7 +2081,8 @@ static void free_gtid_event_buf(THD *thd) {
 static int wsrep_TOI_begin(THD *thd, const char *db_, const char *table_,
                            const TABLE_LIST *table_list,
                            dd::Tablespace_table_ref_vec *trefs,
-                           Alter_info *alter_info) {
+                           Alter_info *alter_info,
+                           wsrep::key_array *fk_tables) {
   uchar *buf(0);
   size_t buf_len(0);
   int buf_err;
@@ -2056,8 +2151,8 @@ static int wsrep_TOI_begin(THD *thd, const char *db_, const char *table_,
 
   struct wsrep_buf buff = {buf, buf_len};
 
-  wsrep::key_array key_array =
-      wsrep_prepare_keys_for_toi(db_, table_, table_list, trefs, alter_info);
+  wsrep::key_array key_array = wsrep_prepare_keys_for_toi(
+      db_, table_, table_list, trefs, alter_info, fk_tables);
 
   THD_STAGE_INFO(thd, stage_wsrep_preparing_for_TO_isolation);
   snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
@@ -2192,7 +2287,8 @@ static void wsrep_RSU_end(THD *thd) {
 int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
                              const TABLE_LIST *table_list,
                              dd::Tablespace_table_ref_vec *trefs,
-                             Alter_info *alter_info) {
+                             Alter_info *alter_info,
+                             wsrep::key_array *fk_tables) {
   /*
     No isolation for applier or replaying threads.
    */
@@ -2274,7 +2370,8 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
   if (thd->variables.wsrep_on && wsrep_thd_is_local(thd)) {
     switch (thd->variables.wsrep_OSU_method) {
       case WSREP_OSU_TOI:
-        ret = wsrep_TOI_begin(thd, db_, table_, table_list, trefs, alter_info);
+        ret = wsrep_TOI_begin(thd, db_, table_, table_list, trefs, alter_info,
+                              fk_tables);
         break;
       case WSREP_OSU_RSU:
         ret = wsrep_RSU_begin(thd, db_, table_);

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -239,7 +239,7 @@ extern void wsrep_prepend_PATH(const char *path);
 void wsrep_append_fk_parent_table(THD *thd, TABLE_LIST *table,
                                   wsrep::key_array *keys);
 void wsrep_append_child_tables(THD *thd, TABLE_LIST *tables,
-                                     wsrep::key_array *keys);
+                               wsrep::key_array *keys);
 
 /* some inline functions are defined in wsrep_mysqld_inl.h */
 

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -236,6 +236,11 @@ extern enum wsrep::provider::status wsrep_sync_wait_upto_gtid(
 extern void wsrep_last_committed_id(wsrep_gtid_t *gtid);
 extern int wsrep_check_opts(int argc, char *const *argv);
 extern void wsrep_prepend_PATH(const char *path);
+void wsrep_append_fk_parent_table(THD *thd, TABLE_LIST *table,
+                                  wsrep::key_array *keys);
+void wsrep_append_child_tables(THD *thd, TABLE_LIST *tables,
+                                     wsrep::key_array *keys);
+
 /* some inline functions are defined in wsrep_mysqld_inl.h */
 
 /* Provide a wrapper of the WSREP_ON macro for plugins to use */
@@ -427,7 +432,8 @@ class Alter_info;
 int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
                              const TABLE_LIST *table_list,
                              dd::Tablespace_table_ref_vec *trefs = NULL,
-                             Alter_info *alter_info = NULL);
+                             Alter_info *alter_info = NULL,
+                             wsrep::key_array *fk_tables = NULL);
 bool wsrep_thd_is_in_to_isolation(THD *thd, bool flock);
 void wsrep_to_isolation_end(THD *thd);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3449

Problem:
When ALTER TABLE (TOI) is executed in user session, sometimes it happens
that it conflicts (MDL) with high priority transaction, which causes
BF-BF abort and server termination.

Cause:
1. Let's assume we have 2 tables p1 (parent) and c1 (child). Child
having foreign key referencing p1.
2. TOI done on p1 gets replicated, but doesn't enter ApplyMonitor,
so its local execution does not start yet
3. At the same time node 2 executes and replicates DML on c1
4. Replicated DML is executed by replication thread on node 2 (high
priority).
It gets MDL locks on c1
5. ALTER TABLE (TOI) continues. It gets MDL locks on c1 as well

Solution:
Similar issue was reported to MariaDB and fixed under MDEV-21577.
The same fix was also applied to MySQL patch from Codership. The fix
assumes that DDL is locking only parent tables. ALTER TABLE however,
locks child tables as well.

1. MDEV-21577 patch has been applied (code changes + MTR test)
2. Child tables added as certification keys when ALTER TABLE is executed
(code changes + MTR test)