### PR TITLE
PXC-2668 : Update SST code to use roles

### DIFF
--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -1270,12 +1270,12 @@ INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'lo
 
 # These are the values for
 #  GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *.* TO 'mysql.pxc.sst.role'@localhost;
-#  GRANT CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history TO 'mysql.pxc.sst.role'@localhost;
+#  GRANT ALTER, CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT SELECT ON performance_schema.* TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT CREATE ON PERCONA_SCHEMA.* to 'mysql.pxc.sst.role'@localhost;
 INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.sst.role','N','N','N','N','N','N','Y','N','Y','N','N','N','N','N','N','Y','N','Y','N','N','Y','N','N','N','N','N','N','N','N','','','','',0,0,0,0,'caching_sha2_password','','Y',CURRENT_TIMESTAMP,NULL,'Y','N','N',NULL,NULL,NULL,NULL);
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'BACKUP_ADMIN', 'N');
-INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Select,Insert,Create', '');
+INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Alter,Select,Insert,Create', '');
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'performance_schema', 'mysql.pxc.sst.role','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N');
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N');
 

--- a/scripts/mysql_system_users.sql
+++ b/scripts/mysql_system_users.sql
@@ -84,7 +84,7 @@ CREATE ROLE 'mysql.pxc.sst.role'@localhost;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql.pxc.sst.role'@localhost;
 GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *.*
  TO 'mysql.pxc.sst.role'@localhost;
-GRANT CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history
+GRANT ALTER, CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history
  TO 'mysql.pxc.sst.role'@localhost;
 -- For some reason this is also needed, although the docs say BACKUP_ADMIN is enough
 GRANT SELECT ON performance_schema.* TO 'mysql.pxc.sst.role'@localhost;

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1125,34 +1125,8 @@ static int wsrep_create_sst_user(bool initialize_thread, const char *password) {
     "CREATE USER 'mysql.pxc.sst.user'@localhost "
     " IDENTIFIED BY '%s' ACCOUNT LOCK;",
     "CREATE USER mysql.pxc.sst.user IDENTIFIED WITH * BY * ACCOUNT LOCK",
-  /*
-    This is the code that uses the mysql.pxc.sst.role
-    However there is a bug in 8.0.15 where the "GRANT CREATE ON DBNAME.*" when
-    used in a role, does not allow the user with the role to create a database.
-    So we have to explicitly grant the privileges.
-  */
-#if 0
     "GRANT 'mysql.pxc.sst.role'@localhost TO 'mysql.pxc.sst.user'@localhost;", nullptr,
     "SET DEFAULT ROLE 'mysql.pxc.sst.role'@localhost to 'mysql.pxc.sst.user'@localhost;", nullptr,
-#else
-    /*
-      Explicit privileges needed to run XtraBackup.  This is only used due
-      to the bug in 8.0.15 described above.
-    */
-    "GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, "
-    "SUPER ON *.* TO 'mysql.pxc.sst.user'@localhost;",
-    nullptr,
-    "GRANT CREATE, INSERT, SELECT ON PERCONA_SCHEMA.xtrabackup_history TO "
-    "'mysql.pxc.sst.user'@localhost;",
-    nullptr,
-    "GRANT SELECT ON performance_schema.* TO 'mysql.pxc.sst.user'@localhost;",
-    nullptr,
-    "GRANT CREATE USER ON *.* to 'mysql.pxc.sst.user'@localhost;",
-    nullptr,
-    "GRANT CREATE ON PERCONA_SCHEMA.* to 'mysql.pxc.sst.user'@localhost;",
-    nullptr,
-#endif
-
     "ALTER USER 'mysql.pxc.sst.user'@localhost ACCOUNT UNLOCK;",
     nullptr,
     nullptr,


### PR DESCRIPTION
Issue
Due to problems with the initial 8.0 release, the mysql.pxc.sst.role
was not used.

Solution
The mysql.pxc.sst.user now uses the mysql.pxc.sst.role
Also added the ALTER privilege for the xtrabackup history table
(due to a change in pxb 8.0.25)