### PR TITLE
PXC-3026: Fix most of WITH_WSREP issues in the 5.7 branch

### DIFF
--- a/check_src/check_file.sh
+++ b/check_src/check_file.sh
@@ -1,0 +1,50 @@
+# Compares a single PS/PXC source file
+# The script will print out an error and a diff if there is any difference
+# after removing the PXC specific code, not counting whitespace and empty lines
+# The script also allows whitelisting expected differences, such as different
+# product names (Percona Server vs Percona Xtradb Cluster)
+
+# Usage: bash check_src/check_file.sh <file_name> <PS 5.6 source directory>
+# The script should be run from the root directory of the PXC source
+# The PS source should be the currently merged PS tag
+
+# Extending/changing the whitelist:
+# The whitelist directory contains files in a single directory (without
+# subdirectories), each file whitelist a single real source file, with the
+# same name.
+# The whitelist file contains the lines starting with > or < of the expected
+# diff: only the change without the actual line/offset numbers, to prevent
+# unrelated changes from breaking the whitelisted change.
+if [ ! -s $2/$1 ] ; then
+  exit 0
+fi
+F=`mktemp`
+gawk -f check_src/rem.awk $1 > $F
+
+D=`mktemp`
+D2=`mktemp`
+diff -wB $F $2/$1 > $D
+
+if [ -s $D ] ; then
+  WHITELIST_NAME=check_src/whitelist/${1##*/}
+  if [ -f $WHITELIST_NAME ] ; then
+    D3=`mktemp`
+    cat $D | grep "^[<>].*" > $D3
+    diff -wB $WHITELIST_NAME $D3 > $D2
+    rm $D3
+    if [ ! -s $D2 ] ; then
+      echo -n "" > $D
+    fi
+  fi
+fi
+
+if [ -s $D ] ; then
+  echo "============"
+  echo "Error: $1"
+  echo "============"
+  cat $D
+fi
+
+rm $F
+rm $D
+rm $D2

--- a/check_src/rem.awk
+++ b/check_src/rem.awk
@@ -1,0 +1,74 @@
+# AWK script to remove PXC specific code from source files
+# Based on common PXC specific ifdefs/macros
+BEGIN {
+	# We are currently checking a WITH_WSREP ifdef line
+	with_wsrep = 0
+	# We encountered an if(n)def WITH_WSREP block before,
+	# and it's scope, or the scope of its else clause is still open
+	had_wsrep = 0
+	# How many ifdefs we have nested?
+	# Used to ensure that we find the correct else/endif
+	nest_level = 0
+	# We encountered an ifndef WITH_WSREP, or the else clause of
+	# the ifdef version
+	ifndef_wsrep = 0
+}
+
+{
+	skip_this = 0
+	if ($0 ~ /WSREP_TO_ISOLATION_BEGIN/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /WSREP_TO_ISOLATION_END/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /WSREP_SYNC_WAIT/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /WAIT_ALLOW_WRITES/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /#if/) {
+		if ($0 ~ /WITH_WSREP/ || $0 ~ /WITH_INNODB_DISALLOW_WRITES/) {
+			if ($0 ~ /ifndef/) {
+				had_wsrep = 1
+				ifndef_wsrep = 1
+				nest_level = 0
+				skip_this = 1
+			} else {
+				with_wsrep = 1
+				had_wsrep = 1
+				nest_level = 0
+			}
+		} else if (had_wsrep == 1) {
+			nest_level = nest_level + 1
+		}
+	}
+	if ($0 ~ /#else/ && (with_wsrep == 1 || ifndef_wsrep == 1) && nest_level == 0) {
+		if (ifndef_wsrep == 1) {
+			with_wsrep = 1
+			ifndef_wsrep = 0
+		} else {
+			with_wsrep = 0
+		}
+		skip_this = 1
+	}
+	if ($0 ~ /#endif/ && nest_level == 0) {
+		if (had_wsrep == 1) {
+			skip_this = 1
+		}
+		had_wsrep = 0
+		with_wsrep = 0
+		ifndef_wsrep = 0
+	}
+	if ($0 ~ /#endif/ && nest_level != 0) {
+		nest_level = nest_level - 1
+	}
+	if (with_wsrep == 0 && skip_this == 0) {
+		print $0
+	}
+}

--- a/check_src/run.sh
+++ b/check_src/run.sh
@@ -1,0 +1,9 @@
+# Compares every source file between PS/PXC for differences without the if WITH_WSREP
+# blocks.
+# Usage:  bash check_src/run.sh <PS_DIRECTORY>
+PS_56_LOCATION=$1
+find . -type f -name '*.h' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+find . -type f -name '*.cc' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+find . -type f -name '*.c' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+find . -type f -name '*.ic' -exec bash check_src/check_file.sh '{}' $PS_56_LOCATION \;
+

--- a/check_src/whitelist/lock0lock.cc
+++ b/check_src/whitelist/lock0lock.cc
@@ -1,0 +1,6 @@
+< @param[in] add_to_hash	If the lock should be added to the hash table
+< @param[in,out] c_lock	conflicting lock
+< @param[in,out] thr	query thread handler */
+> @param[in] add_to_hash	If the lock should be added to the hash table */
+< @param[in,out] c_lock		conflicting lock
+< @param[in,out] thr		query thread handler

--- a/check_src/whitelist/lock0priv.h
+++ b/check_src/whitelist/lock0priv.h
@@ -1,0 +1,6 @@
+<       @param[in,out] c_lock           conflicting lock
+<       @param[in,out] thr              query thread handler
+<       @param[in] add_to_hash  If the lock should be added to the hash table
+<       @param[in,out] c_lock   conflicting lock
+<       @param[in,out] thr      query thread handler */
+>       @param[in] add_to_hash  If the lock should be added to the hash table */

--- a/check_src/whitelist/log.h
+++ b/check_src/whitelist/log.h
@@ -1,0 +1,1 @@
+< #define WSREP_BINLOG_FORMAT(my_format) my_format

--- a/check_src/whitelist/my_thread.h
+++ b/check_src/whitelist/my_thread.h
@@ -1,0 +1,4 @@
+> #if defined(__sparc) && (defined(__SUNPRO_CC) || defined(__SUNPRO_C))
+> #define STACK_MULTIPLIER 2UL
+> #else
+> #endif

--- a/check_src/whitelist/mysql.cc
+++ b/check_src/whitelist/mysql.cc
@@ -1,0 +1,2 @@
+<          "Percona XtraDB Cluster manual: http://www.percona.com/doc/percona-xtradb-cluster/5.7/\n"
+>            "Percona Server manual: http://www.percona.com/doc/percona-server/%d.%d\n"

--- a/check_src/whitelist/signal_handler.cc
+++ b/check_src/whitelist/signal_handler.cc
@@ -1,0 +1,8 @@
+<     "Please help us make Percona XtraDB Cluster better by reporting any\n"
+<     "bugs at https://jira.percona.com/projects/PXC/issues\n\n");
+>     "Please help us make Percona Server better by reporting any\n"
+>     "bugs at https://bugs.percona.com/\n\n");
+<     "You may download the Percona XtraDB Cluster operations manual by visiting\n"
+<     "http://www.percona.com/software/percona-xtradb-cluster/. You may find information\n"
+>     "You may download the Percona Server operations manual by visiting\n"
+>     "http://www.percona.com/software/percona-server/. You may find information\n"

--- a/check_src/whitelist/sql_class.h
+++ b/check_src/whitelist/sql_class.h
@@ -1,0 +1,3 @@
+< #define WSREP_BINLOG_FORMAT(my_format) my_format
+<
+< #define CF_SKIP_WSREP_CHECK     0

--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -1047,8 +1047,12 @@ static int execute_commands(MYSQL *mysql,int argc, char **argv)
     }
     case ADMIN_PASSWORD:
     {
+#ifdef WITH_WSREP
       const int buff_len=128;
       char buff[buff_len];
+#else
+      char buff[128];
+#endif /* WITH_WSREP */
       time_t start_time;
       char *typed_password= NULL, *verified= NULL, *tmp= NULL;
       bool log_off= true, err= false;

--- a/include/my_sqlcommand.h
+++ b/include/my_sqlcommand.h
@@ -190,11 +190,13 @@ enum enum_sql_command {
   SQLCOM_CREATE_COMPRESSION_DICTIONARY,
   SQLCOM_DROP_COMPRESSION_DICTIONARY,
 
+#ifdef WITH_WSREP
   /*
     Also for PXC, if the command is replicated to other nodes as a
     DDL (no-writeset replication), add a testcase to
     galera_wsrep_ddl_access_checking.test
   */
+#endif /* WITH_WSREP */
   /* This should be the last !!! */
   SQLCOM_END
 };

--- a/include/my_thread.h
+++ b/include/my_thread.h
@@ -42,10 +42,9 @@
 /*
   MySQL can survive with 32K, but some glibc libraries require > 128K stack
   To resolve hostnames. Also recursive stored procedures needs stack.
-
-  ASAN requires more stack space.
 */
-#if defined(HAVE_ASAN)
+#if defined(WITH_WSREP) && defined(HAVE_ASAN)
+/* ASAN requires more stack space. */
 #define STACK_MULTIPLIER 8UL
 #elif defined(__sparc) && (defined(__SUNPRO_CC) || defined(__SUNPRO_C))
 #define STACK_MULTIPLIER 2UL

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -85,7 +85,6 @@ public:
       @retval true The queue was empty before this operation.
       @retval false The queue was non-empty before this operation.
     */
-    /** Append a linked list of threads to the queue */
 #ifdef WITH_WSREP
     bool append(THD *first, bool interim_commit=false);
 #else

--- a/sql/conn_handler/connection_handler_per_thread.cc
+++ b/sql/conn_handler/connection_handler_per_thread.cc
@@ -353,13 +353,15 @@ extern "C" void *handle_connection(void *arg)
 #endif /* WITH_WSREP */
 
     delete thd;
+#ifdef WITH_WSREP
     thd= NULL;
+#endif /* WITH_WSREP */
 
     if (abort_loop) // Server is shutting down so end the pthread.
       break;
 
-    channel_info= NULL;
 #ifdef WITH_WSREP
+    channel_info= NULL;
     if (wsrep_applier_thread)
       break;
 #endif /* WITH_WSREP */

--- a/sql/conn_handler/socket_connection.cc
+++ b/sql/conn_handler/socket_connection.cc
@@ -544,8 +544,8 @@ public:
     (void) mysql_sock_set_nonblocking(listener_socket);
 #endif
 
-// TODO: PXC....is this needed ?
 #if defined(WITH_WSREP) && defined(HAVE_FCNTL) && defined(FD_CLOEXEC)
+// TODO: PXC....is this needed ?
   (void) fcntl(mysql_socket_getfd(listener_socket), F_SETFD, FD_CLOEXEC);
 #endif /* WITH_WSREP */
 
@@ -965,8 +965,8 @@ Channel_info* Mysqld_socket_listener::listen_for_connection_event()
     return NULL;
   }
 
-// TODO: PXC .... is this needed ?
 #if defined(WITH_WSREP) && defined(HAVE_FCNTL) && defined(FD_CLOEXEC)
+// TODO: PXC .... is this needed ?
     (void) fcntl(mysql_socket_getfd(connect_sock), F_SETFD, FD_CLOEXEC);
 #endif /* WITH_WSREP */
 

--- a/sql/event_data_objects.cc
+++ b/sql/event_data_objects.cc
@@ -40,7 +40,9 @@
 
 #include "mysql/psi/mysql_sp.h"
 
+#ifdef WITH_WSREP
 #include "wsrep_thd.h"
+#endif
 
 /**
   @addtogroup Event_Scheduler

--- a/sql/event_scheduler.cc
+++ b/sql/event_scheduler.cc
@@ -31,7 +31,9 @@
 #include "mysqld_thd_manager.h"      // Global_THD_manager
 #include "sql_error.h"               // Sql_condition
 #include "sql_class.h"               // THD
+#ifdef WITH_WSREP
 #include "debug_sync.h"
+#endif /* WITH_WSREP */
 
 /**
   @addtogroup Event_Scheduler
@@ -381,9 +383,9 @@ Event_worker_thread::run(THD *thd, Event_queue_element_for_exec *event)
                           job_data.definer.str,
                           job_data.dbname.str, job_data.name.str);
 
+#ifdef WITH_WSREP
   DEBUG_SYNC(thd, "event_worker_thread_end");
 
-#ifdef WITH_WSREP
   if (WSREP(thd))
   {
     mysql_mutex_lock(&thd->LOCK_wsrep_thd);

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1461,13 +1461,15 @@ void trans_register_ha(THD *thd, bool all, handlerton *ht_arg,
 */
 #ifdef HAVE_PSI_TRANSACTION_INTERFACE
   if (thd->m_transaction_psi == NULL &&
-      ht_arg->db_type != DB_TYPE_BINLOG
 #ifdef WITH_WSREP
+      ht_arg->db_type != DB_TYPE_BINLOG
       /* Do not register transactions for WSREP engine registration should be
       done by the base transactional storage engine (InnoDB). */
       && ht_arg->db_type != DB_TYPE_WSREP
-#endif /* WITH_WSREP */
      )
+#else
+      ht_arg->db_type != DB_TYPE_BINLOG)
+#endif /* WITH_WSREP */
   {
     const XID *xid= trn_ctx->xid_state()->get_xid();
     my_bool autocommit= !thd->in_multi_stmt_transaction_mode();
@@ -1511,7 +1513,9 @@ int ha_prepare(THD *thd)
 
     while (ha_info)
     {
+#ifdef WITH_WSREP
       int err;
+#endif /* WITH_WSREP */
       handlerton *ht= ha_info->ht();
       assert(!thd->status_var_aggregated);
       thd->status_var.ha_prepare_count++;
@@ -1521,7 +1525,11 @@ int ha_prepare(THD *thd)
           ha_rollback_trans(thd, true);
           DBUG_RETURN(1);
         });
+#ifdef WITH_WSREP
         if ((err= ht->prepare(ht, thd, true)))
+#else
+        if (ht->prepare(ht, thd, true))
+#endif /* WITH_WSREP */
         {
 #ifdef WITH_WSREP
           if (WSREP(thd) && ht->db_type == DB_TYPE_WSREP)
@@ -1974,8 +1982,8 @@ int ha_commit_low(THD *thd, bool all, bool run_after_commit)
   Ha_trx_info *ha_info= trn_ctx->ha_trx_info(trx_scope), *ha_info_next;
 
   DBUG_ENTER("ha_commit_low");
-#if 0
 #ifdef WITH_WSREP
+#if 0
   if (WSREP(thd))
   {
     snprintf (thd->wsrep_info, sizeof(thd->wsrep_info),
@@ -1983,8 +1991,8 @@ int ha_commit_low(THD *thd, bool all, bool run_after_commit)
               (long long)wsrep_thd_trx_seqno(thd));
     thd_proc_info(thd, thd->wsrep_info);
   }
-#endif /* WITH_WSREP */
 #endif
+#endif /* WITH_WSREP */
 
   if (ha_info)
   {

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -422,7 +422,9 @@ enum legacy_db_type
   DB_TYPE_MARIA,
   /** Performance schema engine. */
   DB_TYPE_PERFORMANCE_SCHEMA,
+#ifdef WITH_WSREP
   DB_TYPE_WSREP,
+#endif /* WITH_WSREP */
   DB_TYPE_TOKUDB=41,
   DB_TYPE_ROCKSDB=42,
   DB_TYPE_FIRST_DYNAMIC=43,

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -1138,11 +1138,17 @@ volatile int32 Global_read_lock::m_active_requests;
   @retval True   Failure, thread was killed.
 */
 
+#ifdef WITH_WSREP
 bool Global_read_lock::lock_global_read_lock(THD *thd, bool *own_lock)
+#else
+bool Global_read_lock::lock_global_read_lock(THD *thd)
+#endif /* WITH_WSREP */
 {
   DBUG_ENTER("lock_global_read_lock");
 
+#ifdef WITH_WSREP
   *own_lock= FALSE;
+#endif /* WITH_WSREP */
 
   if (!m_state)
   {
@@ -1177,7 +1183,9 @@ bool Global_read_lock::lock_global_read_lock(THD *thd, bool *own_lock)
     m_mdl_global_shared_lock= mdl_request.ticket;
     m_state= GRL_ACQUIRED;
 
+#ifdef WITH_WSREP
     *own_lock= TRUE;
+#endif /* WITH_WSREP */
   }
   /*
     We DON'T set global_read_lock_blocks_commit now, it will be set after

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -11468,10 +11468,12 @@ int Rows_log_event::do_apply_event(Relay_log_info const *rli)
         RPL_TABLE_LIST *ptr= static_cast<RPL_TABLE_LIST*>(table_list_ptr);
         assert(ptr->m_tabledef_valid);
         TABLE *conv_table;
+#ifdef WITH_WSREP
         /*
           Use special mem_root 'Log_event::m_event_mem_root' while doing
           compatiblity check (i.e., while creating temporary table)
          */
+#endif /* WITH_WSREP */
         if (!ptr->m_tabledef.compatible_with(thd, const_cast<Relay_log_info*>(rli),
                                              ptr->table, &conv_table))
         {

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -2721,7 +2721,7 @@ MDL_lock::can_grant_lock(enum_mdl_type type_arg,
                         wsrep_thd_query(requestor_ctx->wsrep_get_thd()));
             can_grant = true;
       }
-#ifdef WITH_WSREP_TODO
+#ifdef WSREP_TODO
       /* victim unobstrusive lock holder is hard to find.
          Skipping here to allow high priority thread to continue,
          it will have earlier seqno and victims will die at certification stage
@@ -2739,7 +2739,7 @@ MDL_lock::can_grant_lock(enum_mdl_type type_arg,
                      );
         }
       }
-#endif /* WITH_WSREP_TODO */
+#endif /* WSREP_TODO */
       else if (WSREP(requestor_ctx->wsrep_get_thd()))
       {
         WSREP_DEBUG("Granting MDL to applier/TOI action processor over unobstrusive locks");

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4834,9 +4834,9 @@ a file name for --log-bin-index option", opt_binlog_index_name);
       opt_bin_logname=my_strdup(key_memory_opt_bin_logname,
                                 buf, MYF(0));
     }
-  }
 
 #ifdef WITH_WSREP /* WSREP BEFORE SE */
+  }
     /*
       Wsrep initialization must happen at this point, because:
       - opt_bin_logname must be known when starting replication
@@ -4943,8 +4943,6 @@ a file name for --log-bin-index option", opt_binlog_index_name);
     }
   }
 #else
-  if (opt_bin_log)
-  {
     /*
       Skip opening the index file if we start with --help. This is necessary
       to avoid creating the file in an otherwise empty datadir, which will
@@ -5021,12 +5019,12 @@ a file name for --log-bin-index option", opt_binlog_index_name);
     sql_print_warning("ignore-builtin-innodb is ignored "
                       "and will be removed in future releases.");
 
-#ifndef WITH_WSREP
+#ifdef WITH_WSREP
   /* Leave the original location if wsrep is not involved otherwise
   we do this before initializing WSREP as wsrep needs access to
   gtid_mode which and for accessing gtid_mode gtid_sid_locks has to be
   initialized which is done by this function. */
-
+#else
   if (gtid_server_init())
   {
     sql_print_error("Failed to initialize GTID structures.");
@@ -5464,9 +5462,9 @@ extern "C" void *handle_shutdown(void *arg)
     my_thread_end();
     my_thread_exit(0);
   }
+#ifdef WITH_WSREP
 #if 0
 // TODO not sure why need to re-init on shutdown.
-#ifdef WITH_WSREP
   mysql_mutex_init(key_LOCK_wsrep_ready,
                    &LOCK_wsrep_ready, MY_MUTEX_INIT_FAST);
   mysql_cond_init(key_COND_wsrep_ready, &COND_wsrep_ready);
@@ -10775,9 +10773,8 @@ static PSI_thread_info all_server_threads[]=
   { &key_thread_one_connection, "one_connection", 0},
   { &key_thread_signal_hand, "signal_handler", PSI_FLAG_GLOBAL},
   { &key_thread_compress_gtid_table, "compress_gtid_table", PSI_FLAG_GLOBAL},
-  { &key_thread_parser_service, "parser_service", PSI_FLAG_GLOBAL}
+  { &key_thread_parser_service, "parser_service", PSI_FLAG_GLOBAL},
 #ifdef WITH_WSREP
-  ,
   { &key_THREAD_wsrep_sst_joiner, "THREAD_wsrep_sst_joiner", 0},
   { &key_THREAD_wsrep_sst_donor, "THREAD_wsrep_sst_donor", 0},
   { &key_THREAD_wsrep_applier, "THREAD_wsrep_applier", 0},

--- a/sql/rpl_gtid_state.cc
+++ b/sql/rpl_gtid_state.cc
@@ -27,7 +27,10 @@
 #include "sql_class.h"             // THD
 #include "debug_sync.h"            // DEBUG_SYNC
 #include "binlog.h"
+
+#ifdef WITH_WSREP
 #include "rpl_group_replication.h" // is_group_replication_plugin_loaded()
+#endif /* WITH_WSREP */
 
 #include <vector>
 

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -878,12 +878,14 @@ public:
   void cleanup_after_session()
   {
     if (deferred_events)
+#ifdef WITH_WSREP
     {
+#endif /* WITH_WSREP */
       delete deferred_events;
 #ifdef WITH_WSREP
       deferred_events= NULL;
-#endif /* WITH_WSREP */
     }
+#endif /* WITH_WSREP */
   };
    
   /**

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -8099,7 +8099,6 @@ wsrep_restart_point:
       wsrep_restart_slave_activated= TRUE;
     }
   }
-#endif /* WITH_WSREP */
 
 /*
   Note: the order of the broadcast and unlock calls below (first broadcast, then unlock)
@@ -8109,6 +8108,7 @@ wsrep_restart_point:
   mysql_cond_broadcast(&rli->stop_cond);
   DBUG_EXECUTE_IF("simulate_slave_delay_at_terminate_bug38694", sleep(5););
   mysql_mutex_unlock(&rli->run_lock);  // tell the world we are done
+#endif /* WITH_WSREP */
 
   DBUG_LEAVE;                            // Must match DBUG_ENTER()
   my_thread_end();

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -74,11 +74,11 @@ extern "C" void handle_fatal_signal(int sig)
 
   segfaulted = 1;
 
+#ifdef WITH_WSREP
 /*
   The wsrep subsystem has their its own actions
   which need be performed before exiting:
 */
-#ifdef WITH_WSREP
   wsrep_handle_fatal_signal(sig);
 #endif /* WITH_WSREP */
 

--- a/sql/sp_instr.cc
+++ b/sql/sp_instr.cc
@@ -39,7 +39,9 @@
 #include "binlog.h"
 #include "item_cmpfunc.h" // Item_func_eq
 #include "debug_sync.h"   // DEBUG_SYNC
+#ifdef WITH_WSREP
 #include "sql_audit.h"
+#endif /* WITH_WSREP */
 
 #include <algorithm>
 #include <functional>

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1992,7 +1992,6 @@ void THD::init(void)
   wsrep_skip_SE_checkpoint = false;
   wsrep_skip_wsrep_hton   = false;
 #endif /* WITH_WSREP */
-  status_var_aggregated= false;
   binlog_row_event_extra_data= 0;
 
   if (variables.sql_log_bin)
@@ -4552,10 +4551,11 @@ extern "C" int thd_binlog_format(const MYSQL_THD thd)
 #ifdef WITH_WSREP
   if (((WSREP(thd) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()) &&
       !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF))
+    return (int) WSREP_BINLOG_FORMAT(thd->variables.binlog_format);
 #else
   if (mysql_bin_log.is_open() && (thd->variables.option_bits & OPTION_BIN_LOG))
-#endif
-    return (int) WSREP_BINLOG_FORMAT(thd->variables.binlog_format);
+    return (int) thd->variables.binlog_format;
+#endif /* WITH_WSREP */
   else
     return BINLOG_FORMAT_UNSPEC;
 }

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -1587,9 +1587,11 @@ void close_connection(THD *thd, uint sql_errno,
   if (MYSQL_CONNECTION_DONE_ENABLED())
   {
     sleep(0); /* Workaround to avoid tailcall optimisation */
+#ifdef WITH_WSREP
     mysql_mutex_lock(&thd->LOCK_wsrep_thd);
     wsrep_thd_set_query_state(thd, QUERY_EXITING);
     mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
+#endif /* WITH_WSREP */
   }
 
   if (generate_event)

--- a/sql/sql_join_buffer.h
+++ b/sql/sql_join_buffer.h
@@ -361,9 +361,7 @@ protected:
   { 
     assert(end_pos >= buff);
     assert(buff_size >= ulong(end_pos - buff));
-    return static_cast<ulong>(
-      std::max<long>(buff_size - (end_pos - buff) - aux_buff_size, 0L)
-    );
+    return ulong(buff_size - (end_pos - buff) - aux_buff_size);
   }
 
   /* Shall skip record from the join buffer if its match flag is on */
@@ -836,9 +834,7 @@ protected:
     assert(last_key_entry >= end_pos);
     assert(buff_size >= aux_buff_size);
     assert(ulong(last_key_entry - end_pos) >= aux_buff_size);
-    return static_cast<ulong>(
-      std::max<long>(last_key_entry - end_pos - aux_buff_size, 0L)
-    );
+    return ulong(last_key_entry - end_pos - aux_buff_size);
   }
 
   /* 

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -80,9 +80,11 @@
 using std::max;
 using std::min;
 
+#ifdef WITH_WSREP
 #if !defined(MYSQL_MAX_VARIABLE_VALUE_LEN)
 #define MYSQL_MAX_VARIABLE_VALUE_LEN 1024
 #endif // !defined(MYSQL_MAX_VARIABLE_VALUE_LEN)
+#endif /* WITH_WSREP */
 #define STR_OR_NIL(S) ((S) ? (S) : "<nil>")
 
 enum enum_i_s_events_fields
@@ -9580,8 +9582,12 @@ ST_FIELD_INFO variables_fields_info[]=
 {
   {"VARIABLE_NAME", 64, MYSQL_TYPE_STRING, 0, 0, "Variable_name",
    SKIP_OPEN_TABLE},
+#ifdef WITH_WSREP
   {"VARIABLE_VALUE", MYSQL_MAX_VARIABLE_VALUE_LEN, MYSQL_TYPE_STRING, 0, 1,
    "Value", SKIP_OPEN_TABLE},
+#else
+  {"VARIABLE_VALUE", 1024, MYSQL_TYPE_STRING, 0, 1, "Value", SKIP_OPEN_TABLE},
+#endif /* WITH_WSREP */
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, SKIP_OPEN_TABLE}
 };
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1357,6 +1357,7 @@ static Sys_var_mybool Sys_binlog_rows_query(
        SESSION_VAR(binlog_rows_query_log_events),
        CMD_LINE(OPT_ARG), DEFAULT(FALSE));
 
+#ifdef WITH_WSREP
 static bool binlog_order_commits_check(sys_var *self, THD *thd, set_var *var)
 {
   if (WSREP(thd))
@@ -1370,14 +1371,19 @@ static bool binlog_order_commits_check(sys_var *self, THD *thd, set_var *var)
   }
   return false;
 }
+#endif /* WITH_WSREP */
 
 static Sys_var_mybool Sys_binlog_order_commits(
        "binlog_order_commits",
        "Issue internal commit calls in the same order as transactions are"
        " written to the binary log. Default is to order commits.",
        GLOBAL_VAR(opt_binlog_order_commits),
+#ifdef WITH_WSREP
        CMD_LINE(OPT_ARG), DEFAULT(TRUE), NO_MUTEX_GUARD,
        NOT_IN_BINLOG, ON_CHECK(binlog_order_commits_check), ON_UPDATE(0));
+#else
+       CMD_LINE(OPT_ARG), DEFAULT(TRUE));
+#endif /* WITH_WSREP */
 
 static Sys_var_ulong Sys_bulk_insert_buff_size(
        "bulk_insert_buffer_size", "Size of tree cache used in bulk "
@@ -3334,7 +3340,9 @@ static bool check_require_secure_transport(sys_var *self, THD *thd, set_var *var
 static bool fix_read_only(sys_var *self, THD *thd, enum_var_type type)
 {
   bool result= true;
+#ifdef WITH_WSREP
   bool own_lock= false;
+#endif /* WITH_WSREP */
 
   my_bool new_read_only= read_only; // make a copy before releasing a mutex
   DBUG_ENTER("sys_var_opt_readonly::update");
@@ -3385,7 +3393,11 @@ static bool fix_read_only(sys_var *self, THD *thd, enum_var_type type)
   read_only= opt_readonly;
   mysql_mutex_unlock(&LOCK_global_system_variables);
 
+#ifdef WITH_WSREP
   if (thd->global_read_lock.lock_global_read_lock(thd, &own_lock))
+#else
+  if (thd->global_read_lock.lock_global_read_lock(thd))
+#endif /* WITH_WSREP */
     goto end_with_mutex_unlock;
 
   if ((result= thd->global_read_lock.make_global_read_lock_block_commit(thd)))
@@ -3398,10 +3410,14 @@ static bool fix_read_only(sys_var *self, THD *thd, enum_var_type type)
 
  end_with_read_lock:
   /* Release the lock */
+#ifdef WITH_WSREP
   if (own_lock)
   {
+#endif /* WITH_WSREP */
     thd->global_read_lock.unlock_global_read_lock(thd);
+#ifdef WITH_WSREP
   }
+#endif /* WITH_WSREP */
  end_with_mutex_unlock:
   mysql_mutex_lock(&LOCK_global_system_variables);
  end:
@@ -3411,7 +3427,9 @@ static bool fix_read_only(sys_var *self, THD *thd, enum_var_type type)
 
 static bool fix_super_read_only(sys_var *self, THD *thd, enum_var_type type)
 {
+#ifdef WITH_WSREP
   bool own_lock= false;
+#endif /* WITH_WSREP */
   DBUG_ENTER("sys_var_opt_super_readonly::update");
 
   /* return if no changes: */
@@ -3450,7 +3468,11 @@ static bool fix_super_read_only(sys_var *self, THD *thd, enum_var_type type)
   super_read_only = opt_super_readonly;
   mysql_mutex_unlock(&LOCK_global_system_variables);
 
+#ifdef WITH_WSREP
   if (thd->global_read_lock.lock_global_read_lock(thd, &own_lock))
+#else
+  if (thd->global_read_lock.lock_global_read_lock(thd))
+#endif /* WITH_WSREP */
     goto end_with_mutex_unlock;
 
   if ((result = thd->global_read_lock.make_global_read_lock_block_commit(thd)))
@@ -3460,7 +3482,9 @@ static bool fix_super_read_only(sys_var *self, THD *thd, enum_var_type type)
 
   end_with_read_lock:
     /* Release the lock */
+#ifdef WITH_WSREP
     if (own_lock)
+#endif /* WITH_WSREP */
       thd->global_read_lock.unlock_global_read_lock(thd);
   end_with_mutex_unlock:
     mysql_mutex_lock(&LOCK_global_system_variables);
@@ -6199,7 +6223,11 @@ static Sys_var_uint Sys_sync_binlog_period(
        " every #th write to the file. Use 0 to disable synchronous"
        " flushing",
        GLOBAL_VAR(sync_binlog_period), CMD_LINE(REQUIRED_ARG),
+#ifdef WITH_WSREP
        VALID_RANGE(0, UINT_MAX), DEFAULT(0), BLOCK_SIZE(1));
+#else
+       VALID_RANGE(0, UINT_MAX), DEFAULT(1), BLOCK_SIZE(1));
+#endif /* WITH_WSREP */
 
 static Sys_var_uint Sys_sync_masterinfo_period(
        "sync_master_info", "Synchronously flush master info to disk "

--- a/sql/table.h
+++ b/sql/table.h
@@ -2216,6 +2216,7 @@ struct TABLE_LIST
     return view != NULL ? view_name.str : table_name;
   }
 
+#ifdef WITH_WSREP
   /**
      @brief Returns the table alias that this TABLE_LIST represents.
      This is needed to get the real name of the temporary table as the normal
@@ -2225,6 +2226,7 @@ struct TABLE_LIST
      @details The unqualified table alias
    */
   const char *get_table_alias() const { return alias; }
+#endif /* WITH_WSREP */
 
   int fetch_number_of_rows();
   bool update_derived_keys(Field*, Item**, uint);

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1806,7 +1806,11 @@ static void print_pool_blocked_message(bool max_threads_reached)
     if (max_threads_reached)
       sql_print_error(MAX_THREADS_REACHED_MSG);
     else
+#ifdef WITH_WSREP
       sql_print_error(CREATE_THREAD_ERROR_MSG, my_errno());
+#else
+      sql_print_error(CREATE_THREAD_ERROR_MSG, my_errno);
+#endif /* WITH_WSREP */
 
     if (now > pool_block_start)
     {

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -813,12 +813,14 @@ bool trans_rollback_to_savepoint(THD *thd, LEX_STRING name)
 
   thd->get_transaction()->m_savepoints= sv;
 
+#ifdef WITH_WSREP
   /*
     Release metadata locks that were acquired during this savepoint unit
     unless binlogging is on. Releasing locks with binlogging on can break
     replication as it allows other connections to drop these tables before
     rollback to savepoint is written to the binlog.
   */
+#endif /* WITH_WSREP */
   if (!res && mdl_can_safely_rollback_to_savepoint)
     thd->mdl_context.rollback_to_savepoint(sv->mdl_savepoint);
 

--- a/storage/blackhole/ha_blackhole.cc
+++ b/storage/blackhole/ha_blackhole.cc
@@ -38,7 +38,11 @@ static inline bool is_slave_applier(const THD &thd)
 static inline bool pretend_for_slave(const THD &thd)
 {
   return is_slave_applier(thd) &&
+#ifdef WITH_WSREP
     ((thd.rli_slave && thd.rli_slave->rows_query_ev) || thd.query().str == NULL);
+#else
+    (thd.rli_slave->rows_query_ev|| thd.query().str == NULL);
+#endif
 }
 
 

--- a/storage/heap/hp_test2.c
+++ b/storage/heap/hp_test2.c
@@ -81,6 +81,7 @@ int main(int argc, char *argv[])
   hp_create_info.min_records= (ulong) recant/2;
   hp_create_info.columns= 4;
   hp_create_info.columndef= columndef;
+  hp_create_info.fixed_key_fieldnr= 4;
   hp_create_info.fixed_data_size= 39;
 
   write_count=update=opt_delete=0;

--- a/storage/innobase/include/lock0priv.h
+++ b/storage/innobase/include/lock0priv.h
@@ -751,8 +751,6 @@ public:
 	@param[in, out] wait_for	The lock that the the joining
 					transaction is waiting for
 	@param[in] prdt			Predicate [optional]
-	@param[in,out] c_lock		conflicting lock
-	@param[in,out] thr		query thread handler
 	@return DB_LOCK_WAIT, DB_DEADLOCK, or DB_QUE_THR_SUSPENDED, or
 		DB_SUCCESS_LOCKED_REC; DB_SUCCESS_LOCKED_REC means that
 		there was a deadlock, but another transaction was chosen
@@ -884,12 +882,12 @@ private:
 	@param[in] add_to_hash	If the lock should be added to the hash table
 	@param[in,out] c_lock	conflicting lock
 	@param[in,out] thr	query thread handler */
-	void lock_add(lock_t* lock, bool add_to_hash
 #ifdef WITH_WSREP
-		,lock_t* const	c_lock,
-		que_thr_t*	thr
+	void lock_add(lock_t* lock, bool add_to_hash, lock_t* const	c_lock,
+                que_thr_t* thr);
+#else
+	 void lock_add(lock_t* lock, bool add_to_hash);
 #endif /* WITH_WSREP */
-		     );
 
 	/**
 	Check and resolve any deadlocks

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -1115,7 +1115,7 @@ public:
 	}
 
 	/** @return true if the page write should not be encrypted */
-	MY_NODISCARD bool is_encryption_disabled() const
+	bool is_encryption_disabled() const MY_NODISCARD
 	{
 		return((m_type & NO_ENCRYPTION) != 0);
 	}

--- a/storage/innobase/include/trx0sys.h
+++ b/storage/innobase/include/trx0sys.h
@@ -311,6 +311,7 @@ trx_sys_read_wsrep_checkpoint(
         XID* xid); /*!< out: WSREP XID */
 #endif /* WITH_WSREP */
 
+/*===================================*/
 /*****************************************************************//**
 Initializes the tablespace tag system. */
 void

--- a/storage/innobase/include/trx0sys.ic
+++ b/storage/innobase/include/trx0sys.ic
@@ -428,9 +428,9 @@ trx_id_t
 trx_sys_get_new_trx_id()
 /*====================*/
 {
-#ifndef WITH_WSREP
+#ifdef WITH_WSREP
 	/* wsrep_fake_trx_id  violates this assert */
- 	// ut_ad(mutex_own(&trx_sys->mutex));
+#else
 	ut_ad(trx_sys_mutex_own());
 #endif /* !WITH_WSREP */
 

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -604,12 +604,11 @@ Check if the transaction is being referenced. */
 
 UNIV_INLINE
 const trx_t*
-trx_arbitrate(const trx_t*	requestor,
-	      const trx_t*	holder
-#ifdef WITH_WSREP
-	      ,my_bool		sync = FALSE 
+#ifndef WITH_WSREP
+trx_arbitrate(const trx_t* requestor, const trx_t*	holder);
+#else
+trx_arbitrate(const trx_t* requestor, const trx_t*	holder, my_bool sync = FALSE);
 #endif /* WITH_WSREP */
-	     );
 
 /**
 @param[in] trx		Transaction to check

--- a/storage/innobase/include/trx0trx.ic
+++ b/storage/innobase/include/trx0trx.ic
@@ -357,12 +357,14 @@ trx_is_high_priority(const trx_t* trx)
 @return the transaction that will be rolled back, null don't care */
 UNIV_INLINE
 const trx_t*
-trx_arbitrate(const trx_t*	requestor,
-	      const trx_t*	holder
 #ifdef WITH_WSREP
-	      ,my_bool		sync
-#endif /* WITH_WSREP */
+trx_arbitrate(const trx_t*	requestor,
+	      const trx_t*	holder,
+	      my_bool		sync
 	     )
+#else
+trx_arbitrate(const trx_t*	requestor, const trx_t*	holder)
+#endif /* WITH_WSREP */
 {
 	ut_ad(!trx_is_autocommit_non_locking(holder));
 	ut_ad(!trx_is_autocommit_non_locking(requestor));

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -1351,7 +1351,7 @@ lock_rec_other_has_conflicting(
                         }
 #else
 		if (lock_rec_has_to_wait(trx, mode, lock, is_supremum)) {
-#endif /* WITH_WSREP */
+#endif
 			return(lock);
 		}
 	}
@@ -1411,7 +1411,8 @@ lock_sec_rec_some_has_impl(
 	return(trx);
 }
 
-#if defined(UNIV_DEBUG) && !defined(WITH_WSREP)
+#ifndef WITH_WSREP
+#ifdef UNIV_DEBUG
 /*********************************************************************//**
 Checks if some transaction, other than given trx_id, has an explicit
 lock on the given rec, in the given precise_mode.
@@ -1460,7 +1461,8 @@ lock_rec_other_trx_holds_expl(
 
 	return(holds);
 }
-#endif /* UNIV_DEBUG && !WITH_WSREP */
+#endif /* UNIV_DEBUG */
+#endif /* !WITH_WSREP */
 
 /*********************************************************************//**
 Return approximate number or record locks (bits set in the bitmap) for
@@ -1656,14 +1658,16 @@ Add the lock to the record lock hash and the transaction's lock list
 @param[in,out] c_lock	conflicting lock
 @param[in,out] thr	query thread handler */
 void
+#ifdef WITH_WSREP
 RecLock::lock_add(
 	lock_t*			lock,
 	bool			add_to_hash
-#ifdef WITH_WSREP
 	,lock_t* const		c_lock,
 	que_thr_t*		thr
-#endif /* WITH_WSREP */
 	)
+#else
+RecLock::lock_add(lock_t* lock, bool add_to_hash)
+#endif /* WITH_WSREP */
 {
 	ut_ad(lock_mutex_own());
 	ut_ad(trx_mutex_own(lock->trx));
@@ -1776,12 +1780,14 @@ RecLock::create(
 	trx_t*			trx,
 	bool			owns_trx_mutex,
 	bool			add_to_hash,
+#ifndef WITH_WSREP
+	const lock_prdt_t*	prdt)
+#else
 	const lock_prdt_t*	prdt
-#ifdef WITH_WSREP
 	,lock_t* const		c_lock,
 	que_thr_t*		thr
+  )
 #endif /* WITH_WSREP */
-	)
 {
 	ut_ad(lock_mutex_own());
 	ut_ad(owns_trx_mutex == trx_mutex_own(trx));
@@ -1803,11 +1809,11 @@ RecLock::create(
 		trx_mutex_enter(trx);
 	}
 
-	lock_add(lock, add_to_hash
-#ifdef WITH_WSREP
-		 , c_lock, thr
+#ifndef WITH_WSREP
+	lock_add(lock, add_to_hash);
+#else
+	lock_add(lock, add_to_hash, c_lock, thr);
 #endif /* WITH_WSREP */
-		);
 
 	if (!owns_trx_mutex) {
 		trx_mutex_exit(trx);
@@ -1977,14 +1983,14 @@ RecLock::add_to_waitq(const lock_t* wait_for, const lock_prdt_t* prdt)
 
 	prepare();
 
+	bool	high_priority = trx_is_high_priority(m_trx);
+#ifdef WITH_WSREP
 	lock_t*		lock;
 
 	/* We don't rollback internal (basically background statistics
 	gathering) transactions. The problem is that we don't currently
 	block them using the TrxInInnoDB() mechanism. */
 
-	bool	high_priority = trx_is_high_priority(m_trx);
-#ifdef WITH_WSREP
 	if (wsrep_on(m_trx->mysql_thd) &&
 	    m_trx->lock.was_chosen_as_deadlock_victim) {
 		return(DB_DEADLOCK);

--- a/storage/innobase/lock/lock0wait.cc
+++ b/storage/innobase/lock/lock0wait.cc
@@ -463,9 +463,10 @@ lock_wait_suspend_thread(
 	if (lock_wait_timeout < 100000000
 	    && wait_time > (double) lock_wait_timeout
 #ifndef WITH_WSREP
-	    && !trx_is_high_priority(trx)
-#endif /* WITH_WSREP */
+	    && !trx_is_high_priority(trx)) {
+#else
 	) {
+#endif /* WITH_WSREP */
 #ifdef WITH_WSREP
                 if (!wsrep_on(trx->mysql_thd) ||
                     (!wsrep_is_BF_lock_timeout(trx) &&

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3709,8 +3709,10 @@ os_file_create_simple_func(
 	*success = false;
 
 	int		create_flag;
+#ifdef WITH_INNODB_DISALLOW_WRITES
 	if (create_mode != OS_FILE_OPEN && create_mode != OS_FILE_OPEN_RAW)
 		WAIT_ALLOW_WRITES();
+#endif
 
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_SILENT));
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_NO_EXIT));
@@ -4045,8 +4047,10 @@ os_file_create_func(
 	bool		on_error_silent;
 	pfs_os_file_t	file;
 
+#ifdef WITH_INNODB_DISALLOW_WRITES
 	if (create_mode != OS_FILE_OPEN && create_mode != OS_FILE_OPEN_RAW)
 		WAIT_ALLOW_WRITES();
+#endif
 
 	*success = false;
 
@@ -4223,8 +4227,10 @@ os_file_create_simple_no_error_handling_func(
 	pfs_os_file_t	file;
 	int		create_flag;
 
+#ifdef WITH_INNODB_DISALLOW_WRITES
 	if (create_mode != OS_FILE_OPEN && create_mode != OS_FILE_OPEN_RAW)
 		WAIT_ALLOW_WRITES();
+#endif
 
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_SILENT));
 	ut_a(!(create_mode & OS_FILE_ON_ERROR_NO_EXIT));

--- a/storage/innobase/os/os0proc.cc
+++ b/storage/innobase/os/os0proc.cc
@@ -205,7 +205,7 @@ skip:
 			&os_total_large_mem_allocated, size);
 		UNIV_MEM_ALLOC(ptr, size);
 	}
-#endif /* _WIN32 */
+#endif
 
 #if defined(WITH_WSREP) && defined(UNIV_LINUX)
 	/* Do not make the pages from this block available to the child after a

--- a/storage/innobase/srv/srv0conc.cc
+++ b/storage/innobase/srv/srv0conc.cc
@@ -52,10 +52,10 @@ Created 2011/04/18 Sunny Bains
 #include "btr0types.h"
 #include "trx0trx.h"
 
-#ifdef WITH_WSREP
 #include "row0mysql.h"
 #include "dict0dict.h"
 
+#ifdef WITH_WSREP
 extern "C" int wsrep_trx_is_aborting(void *thd_ptr);
 extern my_bool wsrep_debug;
 #endif /* WITH_WSREP */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -217,13 +217,12 @@ mysql_pfs_key_t	srv_worker_thread_key;
 
 #ifdef WITH_WSREP
 extern my_bool wsrep_recovery;
+#endif /* WITH_WSREP */
 
 #ifdef WITH_INNODB_DISALLOW_WRITES
 /* Must always init to FALSE. */
 static my_bool	innobase_disallow_writes	= FALSE;
 #endif /* WITH_INNODB_DISALLOW_WRITES */
-
-#endif /* WITH_WSREP */
 
 int unlock_keyrings(THD *thd);
 

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -195,10 +195,11 @@ trx_sys_flush_max_trx_id(void)
 	mtr_t		mtr;
 	trx_sysf_t*	sys_header;
 
-#ifndef WITH_WSREP
+#ifdef WITH_WSREP
 	/* wsrep_fake_trx_id  violates this assert
 	 * Copied from trx_sys_get_new_trx_id
 	 */
+#else
 	ut_ad(trx_sys_mutex_own());
 #endif /* !WITH_WSREP */
 

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -3592,9 +3592,8 @@ Kill all transactions that are blocking this transaction from acquiring locks.
 void
 trx_kill_blocking(trx_t* trx)
 {
-	DBUG_ENTER("trx_kill_blocking");
 	if (trx->hit_list.empty()) {
-		DBUG_VOID_RETURN;
+		return;
 	}
 
 	DEBUG_SYNC_C("trx_kill_blocking_enter");
@@ -3754,5 +3753,4 @@ trx_kill_blocking(trx_t* trx)
 
 		row_mysql_freeze_data_dictionary(trx);
 	}
-	DBUG_VOID_RETURN;
 }

--- a/unittest/gunit/my_decimal-t.cc
+++ b/unittest/gunit/my_decimal-t.cc
@@ -288,7 +288,7 @@ TEST_F(DecimalTest, NegativeZeroAdd)
   my_decimal sum;
   EXPECT_EQ(E_DEC_OK, decimal_add(&d1, &d2, &sum));
   EXPECT_TRUE(sum.sign());
-  // This one will assert
+  // This one will DBUG_ASSERT
   // EXPECT_EQ(0, my_decimal_cmp(&sum, &decimal_zero));
 }
 


### PR DESCRIPTION
* Introduces scripts under the check_src directory, which detect
  differences between the pxc WITH_WSREP=OFF source and PS. For the same
  upstream versions, there shouldn't be any changes except for the
  existing whitelists.

  The script also disables WITH_INNODB_DISALLOW_WRITES, as that's
  another 3rd party path not present in PS.

* Whitelisted product name changes, as PXC should be called PXC even
  without WITH_WSREP.

* Added WITH_WSREP if(n)defs everywhere where PXC added/deleted logic.

* Removed cosmetic differences compared to PS.

Developed-by: Zsolt Parragi <zsolt.parragi@percona.com>

(cherry picked from commit 152d5612d62bd42155ed1ded7abd062ccc88da65)

Testing Done (Test Run in progress)
---
**Manual Testing**
Run the script on PS tag: Percona-Server-5.7.34-37
```
commit 7c516e99cf2f61c804975b946c9a815f2c46875d (HEAD, tag: Percona-Server-5.7.34-37, percona/release-5.7.34-37)
Merge: 086ed5af276 7c60fcc1a3e
Author: Oleksandr Miroshnychenko <alex.miroshnychenko@percona.com>
Date:   Fri May 21 21:39:16 2021

    Merge pull request #4321 from vorsel/ps_update_mysql_patch_5.7.34-37
```
Script output - no errors seen.
```
➜  57 git:(5.7-PXC-3026) ✗ time bash check_src/run.sh /home/venki/work/ps/5734
bash check_src/run.sh /home/venki/work/ps/5734  51.76s user 33.66s system 104% cpu 1:21.94 total

```

**Jenkins**

1. Galera suite: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/172/testReport/
2. Full suite: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/173/testReport/