### PR TITLE
Fixed PXC-3611 ("Encryption can't find master key" after SST when key…

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_keyring.result
@@ -15,6 +15,14 @@ select * from e1;
 id	text
 1	aaaaa
 2	bbbbb
+Killing server ...
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+Restarting node 2 ...
+# restart
+select * from e1;
+id	text
+1	aaaaa
+2	bbbbb
 #shutting down node-2
 #node-1
 INSERT INTO e1(text) VALUES('aaaaa2');

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_keyring.test
@@ -50,6 +50,29 @@ INSERT INTO e1(text) VALUES('bbbbb');
 select * from e1;
 
 #
+# PXC-3611 - Test SST with presence of .backup keyring file
+#
+
+# Kill node 2 to force an SST
+--connection node_2
+--source include/kill_galera.inc
+
+# Generate a new master key that will be missing on node_2 and simulate a .backup without the new key
+--exec mv $MYSQL_TMP_DIR/mysqld.2/keyring.2 $MYSQL_TMP_DIR/mysqld.2/keyring.2.backup
+--connection node_1
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+# Restart the server
+--connection node_2
+--echo Restarting node 2 ...
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+select * from e1;
+
+#
 # test IST with keyring enabled.
 #
 --connection node_2

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -2076,6 +2076,12 @@ then
         # with ever increasing number of files and achieve nothing.
         find $ib_home_dir $ib_log_dir $ib_undo_dir $DATA -mindepth 1  -regex $cpat  -prune  -o -exec rm -rfv {} 1>/dev/null \+
 
+        if [[ -r "$keyring_file_data" ]] || [[ -r "${keyring_file_data}.backup" ]];
+        then
+          wsrep_log_info "Cleaning the existing keyring file"
+          rm -f "$keyring_file_data" "${keyring_file_data}.backup"
+        fi
+
         # Clean the binlog dir (if it's explicitly specified)
         # By default it'll be in the datadir
         tempdir=$(parse_cnf mysqld log-bin "")


### PR DESCRIPTION
…ring_file is used if keyring.backup file exists)

https://jira.percona.com/browse/PXC-3611

Problem
Under some circumstances, MySQL can leave a keyring .backup file. In
this case, once the server starts again, the .backup file will take
place of the current keyring file. This becomes a problem at SST as once
the server start again, either the keyring received from donor or the
one generated by xtrabackup will be overwritten with the staled .backup.

Fix
Since SST uses either a transaction key, which makes xtrabackup to
operate without having access to keyring file, or it receives a copy of
donor keyring file, we can remove joiner keyring file and .backup file
as part of the cleanup that precedes the SST.