### PR TITLE
PXC-3584 : Assertion failure: lock0lock.cc:6588:!(&trx->mutex)->is_owned()

### DIFF
--- a/mysql-test/suite/galera/r/pxc_trx_replay_bf_abort.result
+++ b/mysql-test/suite/galera/r/pxc_trx_replay_bf_abort.result
@@ -1,0 +1,96 @@
+#
+# PXC-3584 : Assertion failure: lock0lock.cc:6588:!(&trx->mutex)->is_owned()
+#
+# When does replaying of trx happen?
+# 1. Two transactions that are not conflicting at certification level but
+#    are conflicting at trx commit can lead to situation where one trx
+#    can be replayed. (See below for example)
+# 2. Trx is replayed only if Victim will have higher seqno than the trx
+#    that initiated the abort
+# 3. During the replay, before replay is initiated, if a new trx holds
+#    locks that will be required by replayed trx, replayed trx will try
+#    to BF Abort the new trx that is open and uncommitted
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+INSERT INTO t1 VALUES (1, 'a');
+INSERT INTO t1 VALUES (2, 'a');
+# This trx is used to acquire conflicting locks just before
+# replaying of trx is started.
+# Connection node_1b
+START TRANSACTION;
+# Connection node_1
+START TRANSACTION;
+UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+SELECT * FROM t1 WHERE f1 = 2 FOR UPDATE;
+f1	f2
+2	a
+# Block the applier on node1 and issue a conflicting update on node #2
+# Trx from node2 is replicated and certified first. Will have lower global sequence
+# number
+# Connection node_1a
+SET SESSION wsrep_sync_wait=0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+# Connection node_2
+UPDATE t1 SET f2 = 'c' WHERE f1 = 2;
+# Connection node_1a
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+# Block the commit, send the COMMIT and wait until it gets blocked
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
+# Trx from Node 1 Will have higher sequence number and will be a victim because the trx
+# from Node 2 is allowed to proceed first and it will try to BF-Abort
+# the higher global seqno trx from node1 (certified but not committed yet)
+# Connection node_1
+COMMIT;
+# Connection node_1a
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+# Let the conflicting UPDATE (from node 2) proceed and wait until it hits abort_trx_end.
+# The victim transaction(node 1) still sits in commit_monitor_master_sync_point.
+SET GLOBAL wsrep_provider_options = 'dbug=d,abort_trx_end';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+# Let the transactions proceed
+SET GLOBAL wsrep_provider_options = 'dbug=';
+# Node 1 trx will be scheduled for replay and wait just before replaying of trx
+SET GLOBAL wsrep_provider_options = 'dbug=d,start_of_replay_trx';
+SET GLOBAL wsrep_provider_options = 'signal=abort_trx_end';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+# Now replaying of trx is paused, at this time, we initiate a trx that acquires
+# conflicting locks required by replay trx
+# Connection node_1b
+UPDATE t1 SET f2 = 'd' WHERE f1 = 1;
+UPDATE t1 SET f2 = 'e' WHERE f1 = 2;
+# Let the replay of trx to proceed. This will BF-Abort the new conflicting and
+# not yet committed trx.
+# Connection node_1a
+SET GLOBAL wsrep_provider_options = 'signal=start_of_replay_trx';
+# Commit succeeds
+# Connection node_1
+# The new conflicting trx started just before the replay of node1 trx has been
+# BF-Aborted, so we get ER_LOCK_DEADLOCK
+# Connection node_1b
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'b';
+COUNT(*) = 1
+1
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'c';
+COUNT(*) = 1
+1
+# wsrep_local_replays has increased by 1
+wsrep_local_replays
+1
+# Connection node_2
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'b';
+COUNT(*) = 1
+1
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'c';
+COUNT(*) = 1
+1
+include/diff_servers.inc [servers=1 2]
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_trx_replay_bf_abort.test
+++ b/mysql-test/suite/galera/t/pxc_trx_replay_bf_abort.test
@@ -1,0 +1,148 @@
+--echo #
+--echo # PXC-3584 : Assertion failure: lock0lock.cc:6588:!(&trx->mutex)->is_owned()
+--echo #
+
+--echo # When does replaying of trx happen?
+--echo # 1. Two transactions that are not conflicting at certification level but
+--echo #    are conflicting at trx commit can lead to situation where one trx
+--echo #    can be replayed. (See below for example)
+--echo # 2. Trx is replayed only if Victim will have higher seqno than the trx
+--echo #    that initiated the abort
+--echo # 3. During the replay, before replay is initiated, if a new trx holds
+--echo #    locks that will be required by replayed trx, replayed trx will try
+--echo #    to BF Abort the new trx that is open and uncommitted
+
+--source suite/galera/include/galera_have_debug_sync.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--let $wsrep_local_replays_old = `SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+INSERT INTO t1 VALUES (1, 'a');
+INSERT INTO t1 VALUES (2, 'a');
+
+--echo # This trx is used to acquire conflicting locks just before
+--echo # replaying of trx is started.
+--echo # Connection node_1b
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+START TRANSACTION;
+
+--echo # Connection node_1
+--connection node_1
+START TRANSACTION;
+
+UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+SELECT * FROM t1 WHERE f1 = 2 FOR UPDATE;
+
+--echo # Block the applier on node1 and issue a conflicting update on node #2
+--echo # Trx from node2 is replicated and certified first. Will have lower global sequence
+--echo # number
+--echo # Connection node_1a
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--echo # Connection node_2
+--connection node_2
+UPDATE t1 SET f2 = 'c' WHERE f1 = 2;
+
+--echo # Connection node_1a
+--connection node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+--echo # Block the commit, send the COMMIT and wait until it gets blocked
+
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+
+--echo # Trx from Node 1 Will have higher sequence number and will be a victim because the trx
+--echo # from Node 2 is allowed to proceed first and it will try to BF-Abort
+--echo # the higher global seqno trx from node1 (certified but not committed yet)
+--echo # Connection node_1
+--connection node_1
+--send COMMIT
+
+--echo # Connection node_1a
+--connection node_1a
+
+--let $galera_sync_point = apply_monitor_slave_enter_sync commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+--echo # Let the conflicting UPDATE (from node 2) proceed and wait until it hits abort_trx_end.
+--echo # The victim transaction(node 1) still sits in commit_monitor_master_sync_point.
+
+--let $galera_sync_point = abort_trx_end
+--source include/galera_set_sync_point.inc
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--let $galera_sync_point = abort_trx_end commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+
+--echo # Let the transactions proceed
+--source include/galera_clear_sync_point.inc
+
+--echo # Node 1 trx will be scheduled for replay and wait just before replaying of trx
+--let $galera_sync_point = start_of_replay_trx
+--source include/galera_set_sync_point.inc
+
+--let $galera_sync_point = abort_trx_end
+--source include/galera_signal_sync_point.inc
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+
+--let $galera_sync_point = start_of_replay_trx
+--source include/galera_wait_sync_point.inc
+
+--echo # Now replaying of trx is paused, at this time, we initiate a trx that acquires
+--echo # conflicting locks required by replay trx
+--echo # Connection node_1b
+--connection node_1b
+UPDATE t1 SET f2 = 'd' WHERE f1 = 1;
+UPDATE t1 SET f2 = 'e' WHERE f1 = 2;
+
+--echo # Let the replay of trx to proceed. This will BF-Abort the new conflicting and
+--echo # not yet committed trx.
+--echo # Connection node_1a
+--connection node_1a
+--let $galera_sync_point = start_of_replay_trx
+--source include/galera_signal_sync_point.inc
+
+--echo # Commit succeeds
+--echo # Connection node_1
+--connection node_1
+--reap
+
+--echo # The new conflicting trx started just before the replay of node1 trx has been
+--echo # BF-Aborted, so we get ER_LOCK_DEADLOCK
+--echo # Connection node_1b
+--connection node_1b
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'b';
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'c';
+
+--echo # wsrep_local_replays has increased by 1
+--let $wsrep_local_replays_new = `SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_new - $wsrep_local_replays_old = 1 AS wsrep_local_replays;
+--enable_query_log
+
+--echo # Connection node_2
+--connection node_2
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'b';
+SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'c';
+
+--let $diff_servers = 1 2
+--source include/diff_servers.inc
+
+DROP TABLE t1;
+
+--connection default
+--disconnect node_1a
+--disconnect node_1b
+--source include/wait_until_count_sessions.inc

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -288,6 +288,7 @@ extern "C" bool wsrep_thd_set_wsrep_aborter(THD *bf_thd, THD *victim_thd)
     return true;
   }
   victim_thd->wsrep_aborter = bf_thd->thread_id();
+  assert(bf_thd->thread_id() != 0);
   WSREP_DEBUG("wsrep_thd_set_wsrep_aborter setting wsrep_aborter %u",
               victim_thd->wsrep_aborter);
   return false;

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -271,6 +271,7 @@ enum wsrep::provider::status Wsrep_client_service::replay() {
   replayer_thd->set_time();
   replayer_thd->set_command(COM_SLEEP);
   replayer_thd->reset_for_next_command();
+  replayer_thd->set_new_thread_id();
 
   enum wsrep::provider::status ret;
   {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3584

When does replaying of trx happen?

1. Two transactions that are not conflicting at certification level but
   are conflicting at trx commit can lead to situation where one trx
   can be replayed. (See below for example)
2. Trx is replayed only if Victim will have higher seqno than the trx
   that initiated the abort
3. During the replay, before replay is initiated, if a new trx holds
   locks that will be required by replayed trx, replayed trx will try
   to BF Abort the new trx that is open and uncommitted

Problem:
--------
When a trx is about to be replayed and if there exists a conflicting
transaction, the replaying trx will try to BF Abort the conflicting
trx.

During this BF-Abort, an assertion occurred because replaying trx
didn't set the BF-abort thread id.


Fix:
----
Replaying transactions should set proper thread id to do BF Aborts.