### PR TITLE
PXC-3628: Server allows mysql.wsrep_* tables to be converted to MyISAM

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -283,9 +283,7 @@ galera.galera_fk_lock_parent_update_child : BUG#0 Few cases have timing issues(P
 galera.galera_toi_ddl_fk_insert : BUG#0 CODERSHIP qa#39 test fails sporadically (PXC-3431)
 
 # Bugs failing due to PXC-3548
-main.system_tables_myisam                           : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
 binlog.binlog_stm_unsafe_read_acl_tables_in_dml_ddl : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
-main.system_tables_myisam_lctn_1                    : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
 main.mysql_upgrade_grant                            : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
 main.ps_sys_upgrade                                 : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
 sysschema.mysqldump                                 : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv

--- a/mysql-test/r/system_tables_myisam.result
+++ b/mysql-test/r/system_tables_myisam.result
@@ -178,6 +178,18 @@ Storage engine 'MyISAM' does not support system tables. [mysql.time_zone_transit
 mysql.user
 ERROR
 Storage engine 'MyISAM' does not support system tables. [mysql.user]
+@table_name
+mysql.wsrep_cluster
+ERROR
+Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster]
+@table_name
+mysql.wsrep_cluster_members
+ERROR
+Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster_members]
+@table_name
+mysql.wsrep_streaming_log
+ERROR
+Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_streaming_log]
 DROP PROCEDURE test_system_table_alter_engine;
 #-----------------------------------------------------------------------
 # Test case to verify system table creation in MyISAM engine. Creating
@@ -298,6 +310,12 @@ SEVERITY	ERRNO	MESSAGE
 Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.time_zone_transition_type]
 SEVERITY	ERRNO	MESSAGE
 Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.user]
+SEVERITY	ERRNO	MESSAGE
+Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster]
+SEVERITY	ERRNO	MESSAGE
+Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster_members]
+SEVERITY	ERRNO	MESSAGE
+Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_streaming_log]
 DROP PROCEDURE test_create_system_table;
 DROP PROCEDURE execute_stmt;
 DROP TABLE system_tables;

--- a/mysql-test/r/system_tables_myisam_lctn_1.result
+++ b/mysql-test/r/system_tables_myisam_lctn_1.result
@@ -178,6 +178,18 @@ Storage engine 'MyISAM' does not support system tables. [mysql.time_zone_transit
 MYSQL.USER
 ERROR
 Storage engine 'MyISAM' does not support system tables. [mysql.user]
+@table_name
+MYSQL.WSREP_CLUSTER
+ERROR
+Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster]
+@table_name
+MYSQL.WSREP_CLUSTER_MEMBERS
+ERROR
+Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster_members]
+@table_name
+MYSQL.WSREP_STREAMING_LOG
+ERROR
+Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_streaming_log]
 DROP PROCEDURE test_system_table_alter_engine;
 #-----------------------------------------------------------------------
 # Test case to verify system table creation in MyISAM engine. Creating
@@ -298,6 +310,12 @@ SEVERITY	ERRNO	MESSAGE
 Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.time_zone_transition_type]
 SEVERITY	ERRNO	MESSAGE
 Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.user]
+SEVERITY	ERRNO	MESSAGE
+Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster]
+SEVERITY	ERRNO	MESSAGE
+Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_cluster_members]
+SEVERITY	ERRNO	MESSAGE
+Warning	1726	Storage engine 'MyISAM' does not support system tables. [mysql.wsrep_streaming_log]
 DROP PROCEDURE test_create_system_table;
 DROP PROCEDURE execute_stmt;
 DROP TABLE system_tables;

--- a/sql/dd/impl/system_registry.cc
+++ b/sql/dd/impl/system_registry.cc
@@ -246,6 +246,12 @@ void System_tables::add_remaining_dd_tables() {
   register_table("time_zone_transition_type", system);
   register_table("user", system);
 
+#ifdef WITH_WSREP
+  register_table("wsrep_cluster", system);
+  register_table("wsrep_cluster_members", system);
+  register_table("wsrep_streaming_log", system);
+#endif /* WITH_WSREP */
+
   /*
     MTR tests expects following tables to be created in the 'mysql' tablespace.
     So tables are listed here.


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3628

Analysis

Server is allowing to change engine for alter table statements
because wsrep_cluster,wsrep_cluster_members and wsrep_streaming_log
tables are not registered as system tables.

Fix

Added wsrep_cluster,wsrep_cluster_members and wsrep_streaming_log
tables to system tables registry.