### PR TITLE
PXC-3449: Galera fails after MDL BF-BF conflict

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf.result
@@ -27,3 +27,42 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE c1;
 DROP TABLE p1;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+BEGIN;
+INSERT INTO p1 VALUES (1,1);
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE c1;
+DROP TABLE p1;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+CREATE TABLE t1 (pk INTEGER PRIMARY KEY);
+CREATE TEMPORARY TABLE t2 (pk INTEGER PRIMARY KEY);
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+DROP TABLE t1, c1, t2;;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+BEGIN;
+INSERT INTO p1 VALUES (1,1);
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SHOW TABLES;
+Tables_in_test
+p1
+DROP TABLE p1;

--- a/mysql-test/suite/galera/r/galera_flush_local.result
+++ b/mysql-test/suite/galera/r/galera_flush_local.result
@@ -3,7 +3,6 @@ Table	Op	Msg_type	Msg_text
 test.t0	optimize	Warning	Truncated incorrect sort_buffer_size value: '0'
 test.t0	optimize	Warning	Truncated incorrect myisam_repair_threads value: '0'
 test.t0	optimize	Error	Table 'test.t0' doesn't exist
-test.t0	optimize	Error	Table 'test.t0' doesn't exist
 test.t0	optimize	status	Operation failed
 DROP TABLE IF EXISTS t1, t2, x1, x2;
 CREATE TABLE t1 (f1 INTEGER);

--- a/mysql-test/suite/galera/r/pxc_non_existent_tables.result
+++ b/mysql-test/suite/galera/r/pxc_non_existent_tables.result
@@ -11,7 +11,6 @@ test.nonexestint2	analyze	status	Operation failed
 OPTIMIZE TABLE nonexstent1;
 Table	Op	Msg_type	Msg_text
 test.nonexstent1	optimize	Error	Table 'test.nonexstent1' doesn't exist
-test.nonexstent1	optimize	Error	Table 'test.nonexstent1' doesn't exist
 test.nonexstent1	optimize	status	Operation failed
 INSERT INTO t1 VALUES (1);
 ANALYZE TABLE t1, nonexistent3;

--- a/mysql-test/suite/galera/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf.test
@@ -9,6 +9,10 @@
 # transaction which causes its replay. When replaying it conflicts with TOI
 # causing BF-BF conflict.
 #
+# This test checks if child table is included into the certification keys
+# of the writeset related to TOI done on parent table
+# (currently only ALTER TABLE is affected).
+#
 
 --source include/have_debug_sync.inc
 --source suite/galera/include/galera_have_debug_sync.inc
@@ -76,6 +80,140 @@ SET SESSION wsrep_sync_wait = 0;
 DROP TABLE c1;
 DROP TABLE p1;
 
+
+#
+# Similar to the above, but for CREATE TABLE
+#
+# Test that CREATE TABLE on child table is properly ordered with simultaneous
+# transactions that perform DML on parent table.
+#
+# INSERT should fail certification as its certification keys conflict
+# with CREATE TABLE certification keys.
+#
+# Without the fix, INSERT is certified, then aborted by already replicated TOI
+# transaction which causes its replay. When replaying it conflicts with TOI
+# causing BF-BF conflict.
+#
+# This test checks if parent table is included into the certification keys
+# of the writeset related to TOI done on child table.
+# (CREATE TABLE, DROP TABLE are affected).
+#
+
+
+--connection node_1_toi
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
+
+# Replicate CREATE TABLE, but stop just after replicaton, before local execution
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+--send CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+
+--connection node_1
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Without the fix, INSERT will replicate and the test will stop the execution
+# just after the certification (before the local commit)
+# With the fix, COMMIT will fail certification
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+BEGIN;
+INSERT INTO p1 VALUES (1,1);
+--send COMMIT
+
+--connection node_1a
+# Now unblock CREATE TABLE. Without the fix it will BF-abort already certified
+# INSERT which will cause its replay.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+
+
+# Without the fix, if INSERT was replicated, let node_1 to continue.
+# As it was replicated, it needs to replay (hp service)
+# It should now trigger BF-BF conflict with CREATE TABLE
+# With the fix, it already failed certification.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# wait for both to finish
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+--connection node_1_toi
+--reap
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'c1';
+--source include/wait_condition.inc
+
+DROP TABLE c1;
+DROP TABLE p1;
+
+#
+# Similar to the above, but for DROP TABLE
+# Additionally we test multi table drop with temporary tables included.
+#
+
+--connection node_1_toi
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+CREATE TABLE t1 (pk INTEGER PRIMARY KEY);
+CREATE TEMPORARY TABLE t2 (pk INTEGER PRIMARY KEY);
+
+# Replicate DROP TABLE, but stop just after replicaton, before local execution
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+--send DROP TABLE t1, c1, t2;
+
+--connection node_1
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Without the fix, INSERT will replicate and the test will stop the execution
+# just after the certification (before the local commit)
+# With the fix, COMMIT will fail certification
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+BEGIN;
+INSERT INTO p1 VALUES (1,1);
+--send COMMIT
+
+--connection node_1a
+# Now unblock DROP TABLE. Without the fix it will BF-abort already certified
+# INSERT which will cause its replay.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+
+
+# Without the fix, if INSERT was replicated, let node_1 to continue.
+# As it was replicated, it needs to replay (hp service)
+# It should now trigger BF-BF conflict with DROP TABLE
+# With the fix, it already failed certification.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# wait for both to finish
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+--connection node_1_toi
+--reap
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'c1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+SHOW TABLES;
+
+DROP TABLE p1;
+
+
+# cleanup
 --disconnect node_1_toi
 --disconnect node_1a
 --connection node_1

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -566,7 +566,7 @@ static bool wsrep_toi_replication(THD *thd, TABLE_LIST *tables) {
   if (keys.empty()) {
     WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, tables);
   } else {
-    WSREP_TO_ISOLATION_BEGIN_FK_TABLES(NULL, NULL, tables, &keys) {
+    WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(NULL, NULL, tables, &keys) {
       return true;
     }
   }

--- a/sql/sql_cmd_ddl_table.cc
+++ b/sql/sql_cmd_ddl_table.cc
@@ -481,9 +481,9 @@ bool Sql_cmd_create_table::execute(THD *thd) {
 
         /* Note we are explictly opening the macro as we need to perform
         cleanup action on TOI failure. */
-        if (WSREP(thd) &&
-            wsrep_to_isolation_begin(thd, create_table->db,
-                                     create_table->table_name, NULL)) {
+        if (WSREP(thd) && wsrep_to_isolation_begin(thd, create_table->db,
+                                                   create_table->table_name,
+                                                   NULL, NULL, &alter_info)) {
           if (!thd->lex->is_ignore() && thd->is_strict_mode())
             thd->pop_internal_handler();
           if (create_info.tablespace) {

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -159,8 +159,8 @@ extern const LEX_CSTRING command_name[];
       wsrep_to_isolation_begin(thd, db_, table_, table_list_))                \
     goto wsrep_error_label;
 
-#define WSREP_TO_ISOLATION_BEGIN_FK_TABLES(db_, table_, table_list_,          \
-                                           fk_tables)                         \
+#define WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(db_, table_, table_list_,       \
+                                              fk_tables)                      \
   if (WSREP(thd) && thd->wsrep_cs().state() != wsrep::client_state::s_none && \
       !thd->lex->no_write_to_binlog &&                                        \
       wsrep_to_isolation_begin(thd, db_, table_, table_list_, nullptr,        \
@@ -175,7 +175,8 @@ extern const LEX_CSTRING command_name[];
 
 #define WSREP_TO_ISOLATION_BEGIN(db_, table_, table_list_)
 #define WSREP_TO_ISOLATION_BEGIN_ALTER(db_, table_, table_list_, alter_info_)
-#define WSREP_TO_ISOLATION_BEGIN_FK_TABLES(db_, table_, table_list_, fk_tables_)
+#define WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(db_, table_, table_list_, \
+                                              fk_tables_)
 #define WSREP_TO_ISOLATION_END
 #define WSREP_TO_ISOLATION_BEGIN_WRTCHK(db_, table_, table_list_)
 #define WSREP_SYNC_WAIT(thd_, before_)

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -510,7 +510,9 @@ void Sql_cmd_truncate_table::truncate_base(THD *thd, TABLE_LIST *table_ref) {
       return;
     }
   } else {
-    WSREP_TO_ISOLATION_BEGIN_FK_TABLES(NULL, NULL, table_ref, &keys) { return; }
+    WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(NULL, NULL, table_ref, &keys) {
+      return;
+    }
   }
 #endif /* WITH_WSREP */
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3449

This is the follow up of the commit
bd6f682f64da1aa463bd0e9ee37d1542a1b55673.

Problem:
It was discovered that the patch merged from the Codership is not
comprehensive, in particular in addition to OPTIMIZE, REPAIR, ALTER and
TRUNCATE, CREATE TABLE and DROP TABLE are affected by not including
parent table keys in certification set as well.

Solution:
1. CREATE TABLE and DROP TABLE add parent tables keys into the
certification set
2. WSREP_TO_ISOLATION_BEGIN_FK_TABLES renamed to
WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF as it hides 'if' inside
3. wsrep_append_child_tables() and wsrep_append_fk_parent_table()
functions reworked to use only Data Dictionary. This is mostly due to
being able to handle temporary tables.
4. MTR test extended to cover CREATE/DROP TABLE