### PR TITLE
PXC-3698: Error log indicates wrong Galera build commit hash

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -257,7 +257,15 @@ PS_VERSION="$MYSQL_VERSION-$PERCONA_SERVER_EXTENSION"
 WSREP_VERSION="$(grep WSREP_INTERFACE_VERSION wsrep-lib/wsrep-API/v26/wsrep_api.h | cut -d '"' -f2).$(grep 'SET(WSREP_PATCH_VERSION'  "cmake/wsrep-lib.cmake" | cut -d '"' -f2)"
 
 if [[ $COPYGALERA -eq 0 ]];then
-    GALERA_REVISION="$(cd "$SOURCEDIR/percona-xtradb-cluster-galera"; test -r GALERA-REVISION && cat GALERA-REVISION)"
+	if [[ -n "$(which git)" ]] && [[ -f "$SOURCEDIR/percona-xtradb-cluster-galera/.git" ]]; then
+		pushd $SOURCEDIR/percona-xtradb-cluster-galera
+		GALERA_REVISION=$(git rev-parse --short HEAD)
+		popd
+	else
+		# When in troubles while getting Galera commit hash, fall back to well known
+		# and distinguishable value.
+		GALERA_REVISION="0000000"
+	fi
 fi
 TOKUDB_BACKUP_VERSION="${MYSQL_VERSION}${MYSQL_VERSION_EXTRA}"
 

--- a/build-ps/pxc_builder.sh
+++ b/build-ps/pxc_builder.sh
@@ -153,7 +153,9 @@ get_sources(){
     WSREP_VERSION="$(grep WSREP_INTERFACE_VERSION wsrep-lib/wsrep-API/v26/wsrep_api.h | cut -d '"' -f2).$(grep 'SET(WSREP_PATCH_VERSION'  "cmake/wsrep-lib.cmake" | cut -d '"' -f2)"
     WSREP_REV="$(test -r WSREP-REVISION && cat WSREP-REVISION)"
     REVISION=$(git rev-parse --short HEAD)
-    GALERA_REVNO="$(test -r percona-xtradb-cluster-galera/GALERA-REVISION && cat percona-xtradb-cluster-galera/GALERA-REVISION)"
+    pushd $SOURCEDIR/percona-xtradb-cluster-galera
+    GALERA_REVNO=$(git rev-parse --short HEAD)
+    popd
     if [ -f VERSION ]; then
         source VERSION
     elif [ -f MYSQL_VERSION ]; then


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3698

1. build-binary.sh gets the actual Galera repo git hash with the
fallback to '000000'
2. pxc_builder.sh gets the actual Galera repo git hash with the fallback
to '000000'
3. Galera repo pointer updated

@dutow @Sudokamikaze @vorsel , I'm adding all of you guys as the reviewers, because this change needs touching 3 pieces (there will be 3 PRs):
1. Dev Jenkins build script
2. pxc_builder.sh and build-binary.sh scripts used by release/packaging Jenkins pipeline
3. Galera repository