### PR TITLE
PXC-3641: [MTR] Upgrade tests fail due to PXC users

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -282,14 +282,6 @@ galera.MW-284 : BUG#0000 test is incompatible with native mysql8.0 server slave 
 galera.galera_fk_lock_parent_update_child : BUG#0 Few cases have timing issues(PXC-3431) and few are invalid after PXC-3501
 galera.galera_toi_ddl_fk_insert : BUG#0 CODERSHIP qa#39 test fails sporadically (PXC-3431)
 
-# Bugs failing due to PXC-3548
-binlog.binlog_stm_unsafe_read_acl_tables_in_dml_ddl : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
-main.mysql_upgrade_grant                            : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
-main.ps_sys_upgrade                                 : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
-sysschema.mysqldump                                 : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
-main.transactional_acl_tables                       : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
-main.schema_read_only_cs                            : BUG#3548 / PS-6837 Timestamp is not set to CURRENT_TIMESTAMP in mysql.tables_priv
-
 # encryption
 # Probably we should use upstream version of encryption tests for PXC
 # https://jira.percona.com/browse/PXC-3557

--- a/mysql-test/r/grant.result
+++ b/mysql-test/r/grant.result
@@ -822,6 +822,7 @@ GRANT USAGE ON *.* TO `mysqltest_8`@`%`
 GRANT UPDATE ON `test`.`t1` TO `mysqltest_8`@`%`
 select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
+'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	ALTER	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	CREATE	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	INSERT	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	SELECT	NO
@@ -839,6 +840,7 @@ Grants for mysqltest_8@%
 GRANT USAGE ON *.* TO `mysqltest_8`@`%`
 select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
+'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	ALTER	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	CREATE	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	INSERT	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	SELECT	NO

--- a/mysql-test/r/information_schema_cs.result
+++ b/mysql-test/r/information_schema_cs.result
@@ -550,6 +550,7 @@ GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	SELECT	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	INSERT	NO
 'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	CREATE	NO
+'mysql.pxc.sst.role'@'localhost'	def	PERCONA_SCHEMA	xtrabackup_history	ALTER	NO
 drop view v1, v2, v3;
 drop table t1;
 delete from mysql.user where user='joe';

--- a/mysql-test/r/mysql_upgrade_grant.result
+++ b/mysql-test/r/mysql_upgrade_grant.result
@@ -286,6 +286,8 @@ Warning	1287	The SUPER privilege identifier is deprecated
 # mysql server without support for XA_RECOVER_ADMIN.
 REVOKE XA_RECOVER_ADMIN ON *.* FROM root@localhost;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
 # We show here that the users root@localhost and u1 have the privilege
 # SUPER and don't have the privilege XA_RECOVER_ADMIN
 SHOW GRANTS FOR root@localhost;
@@ -321,6 +323,8 @@ GRANT XA_RECOVER_ADMIN ON *.* TO `u1`@`%`
 # mysql.session@localhost
 REVOKE XA_RECOVER_ADMIN ON *.* FROM u1;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
 # Start upgrade
 # restart:--upgrade=FORCE --log-error=test_error_log
 # It is expected that after upgrade be finished the privilege
@@ -348,6 +352,10 @@ REVOKE BACKUP_ADMIN ON *.* FROM root@localhost;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM root@localhost;
 REVOKE BACKUP_ADMIN ON *.* FROM `mysql.session`@localhost;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE BACKUP_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE BACKUP_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
 CREATE USER u1;
 CREATE USER u2;
 GRANT RELOAD ON *.* TO u1;
@@ -380,11 +388,13 @@ GRANT BACKUP_ADMIN,XA_RECOVER_ADMIN ON *.* TO `u2`@`%` WITH GRANT OPTION
 DROP USER u1;
 DROP USER u2;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 #
 # Bug#26948662 - REMOVE SUPER_ACL CHECK IN RESOURCE GROUPS.
 #
 REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM root@localhost;
 REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 CREATE USER user1;
 GRANT SUPER ON *.* TO user1;
 Warnings:
@@ -412,6 +422,7 @@ GRANT SUPER ON *.* TO `user1`@`%`
 GRANT RESOURCE_GROUP_ADMIN ON *.* TO `user1`@`%`
 DROP USER user1;
 REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 #
 # Tests for WL#12138
 # Check that users with SUPER privilege (root@localhost and
@@ -433,6 +444,7 @@ Warning	1287	The SUPER privilege identifier is deprecated
 # mysql server without support for SERVICE_CONNECTION_ADMIN.
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM root@localhost;
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 # We show here that the users root@localhost and u1 have the privilege
 # SUPER and don't have the privilege SERVICE_CONNECTION_ADMIN
 SHOW GRANTS FOR root@localhost;
@@ -467,6 +479,7 @@ GRANT SERVICE_CONNECTION_ADMIN ON *.* TO `u1`@`%`
 # mysql.session@localhost
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM u1;
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 # Start upgrade
 # restart:--upgrade=FORCE --log-error=test_error_log
 # It is expected that after upgrade be finished the privilege
@@ -505,6 +518,8 @@ Warning	1287	The SUPER privilege identifier is deprecated
 # mysql server without support for them.
 REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM root@localhost;;
 REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM `mysql.session`@localhost;;
+REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM `mysql.pxc.sst.role`@localhost;
 # Show here that the users root@localhost and u1 have the privilege
 # SUPER and don't have the @privileges
 SHOW GRANTS FOR root@localhost;
@@ -534,6 +549,8 @@ GRANT AUDIT_ADMIN,BINLOG_ADMIN,BINLOG_ENCRYPTION_ADMIN,CONNECTION_ADMIN,ENCRYPTI
 # Revoke the @privileges from the user u1 and mysql.session@localhost
 REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM u1;;
 REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM `mysql.session`@localhost;;
+REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE AUDIT_ADMIN, BINLOG_ADMIN, BINLOG_ENCRYPTION_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, PERSIST_RO_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, RESOURCE_GROUP_USER, ROLE_ADMIN, SESSION_VARIABLES_ADMIN, SET_USER_ID, SYSTEM_VARIABLES_ADMIN, REPLICATION_APPLIER ON *.* FROM `mysql.pxc.sst.role`@localhost;
 # Start upgrade
 # restart:--upgrade=FORCE --log-error=test_error_log
 # It is expected that after upgrade be finished the @privileges won't be
@@ -559,6 +576,7 @@ DROP USER u1;
 ######################################################################
 # Revoke SHOW_ROUTINE from root user (since the upgrade scenario takes place only if no user had this privilege before)
 REVOKE SHOW_ROUTINE ON *.* FROM root@localhost;
+REVOKE SHOW_ROUTINE ON *.* FROM `mysql.pxc.internal.session`@localhost;
 # Create new user
 CREATE USER sheldon;
 # Grant global select privilege to new user

--- a/mysql-test/r/ps_sys_upgrade.result
+++ b/mysql-test/r/ps_sys_upgrade.result
@@ -208,12 +208,20 @@ CREATE TABLE mysql.db_backup SELECT * FROM mysql.db;
 ALTER TABLE mysql.tables_priv
 MODIFY User char(16) NOT NULL default '',
 MODIFY Grantor char(77) DEFAULT '' NOT NULL;
+Warnings:
+Warning	1265	Data truncated for column 'User' at row 1
 ALTER TABLE mysql.columns_priv
 MODIFY User char(16) NOT NULL default '';
 ALTER TABLE mysql.user
 MODIFY User char(16) NOT NULL default '';
+Warnings:
+Warning	1265	Data truncated for column 'User' at row 2
+Warning	1265	Data truncated for column 'User' at row 3
 ALTER TABLE mysql.db
 MODIFY User char(16) NOT NULL default '';
+Warnings:
+Warning	1265	Data truncated for column 'User' at row 2
+Warning	1265	Data truncated for column 'User' at row 3
 ALTER TABLE mysql.procs_priv
 MODIFY User char(16) binary DEFAULT '' NOT NULL,
 MODIFY Grantor char(77) DEFAULT '' NOT NULL;

--- a/mysql-test/r/transactional_acl_tables.result
+++ b/mysql-test/r/transactional_acl_tables.result
@@ -1364,6 +1364,7 @@ SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.t
 host	db	user	table_name	grantor	table_priv	column_priv
 h	test	u1	t1	root@localhost		Select,Insert,Update,References
 h	test	u1	t2	root@localhost		Insert
+localhost	PERCONA_SCHEMA	mysql.pxc.sst.role	xtrabackup_history	boot@	Select,Insert,Create,Alter	
 localhost	mysql	mysql.session	user	root@localhost	Select	
 localhost	sys	mysql.sys	sys_config	root@localhost	Select	
 DELETE FROM mysql.columns_priv WHERE host = 'h' AND user = 'u1'
@@ -1374,6 +1375,7 @@ SELECT host, db, user, table_name, column_name, column_priv FROM mysql.columns_p
 host	db	user	table_name	column_name	column_priv
 SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv;
 host	db	user	table_name	grantor	table_priv	column_priv
+localhost	PERCONA_SCHEMA	mysql.pxc.sst.role	xtrabackup_history	boot@	Select,Insert,Create,Alter	
 localhost	mysql	mysql.session	user	root@localhost	Select	
 localhost	sys	mysql.sys	sys_config	root@localhost	Select	
 SHOW GRANTS FOR u1@h;
@@ -1544,8 +1546,12 @@ CREATE USER u1@h;
 
 # Remove the session user
 DELETE FROM mysql.tables_priv WHERE user='mysql.session';
+DELETE FROM mysql.tables_priv WHERE user='mysql.pxc.sst.role';
 DELETE FROM mysql.user WHERE user='mysql.session';
+DELETE FROM mysql.user WHERE user='mysql.pxc.internal.session';
+DELETE FROM mysql.user WHERE user='mysql.pxc.sst.role';
 DELETE FROM mysql.db WHERE user='mysql.session';
+DELETE FROM mysql.db WHERE user='mysql.pxc.sst.role';
 
 # Backup privilege tables and drop original ones
 RENAME TABLE mysql.user TO mysql.user_bak;

--- a/mysql-test/suite/funcs_1/r/is_table_privileges.result
+++ b/mysql-test/suite/funcs_1/r/is_table_privileges.result
@@ -55,6 +55,7 @@ IS_GRANTABLE	varchar(3)	NO
 SELECT table_catalog, table_schema, table_name, privilege_type
 FROM information_schema.table_privileges WHERE table_catalog IS NOT NULL;
 table_catalog	table_schema	table_name	privilege_type
+def	PERCONA_SCHEMA	xtrabackup_history	ALTER
 def	PERCONA_SCHEMA	xtrabackup_history	CREATE
 def	PERCONA_SCHEMA	xtrabackup_history	INSERT
 def	PERCONA_SCHEMA	xtrabackup_history	SELECT

--- a/mysql-test/t/mysql_upgrade_grant.test
+++ b/mysql-test/t/mysql_upgrade_grant.test
@@ -363,6 +363,8 @@ GRANT SUPER ON *.* TO u1;
 --echo # mysql server without support for XA_RECOVER_ADMIN.
 REVOKE XA_RECOVER_ADMIN ON *.* FROM root@localhost;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
 
 --echo # We show here that the users root@localhost and u1 have the privilege
 --echo # SUPER and don't have the privilege XA_RECOVER_ADMIN
@@ -394,6 +396,8 @@ SHOW GRANTS FOR u1;
 --echo # mysql.session@localhost
 REVOKE XA_RECOVER_ADMIN ON *.* FROM u1;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
 
 --echo # Start upgrade
 
@@ -425,6 +429,10 @@ REVOKE BACKUP_ADMIN ON *.* FROM root@localhost;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM root@localhost;
 REVOKE BACKUP_ADMIN ON *.* FROM `mysql.session`@localhost;
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE BACKUP_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
+REVOKE BACKUP_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.sst.role`@localhost;
 CREATE USER u1;
 CREATE USER u2;
 
@@ -455,6 +463,7 @@ DROP USER u2;
 # Revoke privilege XA_RECOVER_ADMIN from the user mysql.session@localhost in order to
 # match contol checksum for mysql.global_grants
 REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 
 --echo #
 --echo # Bug#26948662 - REMOVE SUPER_ACL CHECK IN RESOURCE GROUPS.
@@ -462,6 +471,7 @@ REVOKE XA_RECOVER_ADMIN ON *.* FROM `mysql.session`@localhost;
 
 REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM root@localhost;
 REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 
 
 # Create a new user user1 and grant super privilege to user1.
@@ -486,6 +496,7 @@ DROP USER user1;
 # Revoke privilege RESOURCE_GROUP_ADMIN from the user mysql.session@localhost in order to
 # match contol checksum for mysql.global_grants
 REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE RESOURCE_GROUP_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 
 --echo #
 --echo # Tests for WL#12138
@@ -505,6 +516,7 @@ GRANT SUPER ON *.* TO u1;
 --echo # mysql server without support for SERVICE_CONNECTION_ADMIN.
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM root@localhost;
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 
 --echo # We show here that the users root@localhost and u1 have the privilege
 --echo # SUPER and don't have the privilege SERVICE_CONNECTION_ADMIN
@@ -534,6 +546,7 @@ SHOW GRANTS FOR u1;
 --echo # mysql.session@localhost
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM u1;
 REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.session`@localhost;
+REVOKE SERVICE_CONNECTION_ADMIN ON *.* FROM `mysql.pxc.internal.session`@localhost;
 
 --echo # Start upgrade
 
@@ -574,6 +587,8 @@ GRANT SUPER ON *.* TO u1;
 --echo # mysql server without support for them.
 --eval REVOKE $privileges ON *.* FROM root@localhost;
 --eval REVOKE $privileges ON *.* FROM `mysql.session`@localhost;
+--eval REVOKE $privileges ON *.* FROM `mysql.pxc.internal.session`@localhost
+--eval REVOKE $privileges ON *.* FROM `mysql.pxc.sst.role`@localhost
 
 --echo # Show here that the users root@localhost and u1 have the privilege
 --echo # SUPER and don't have the @privileges
@@ -598,6 +613,8 @@ SHOW GRANTS FOR u1;
 --echo # Revoke the @privileges from the user u1 and mysql.session@localhost
 --eval REVOKE $privileges ON *.* FROM u1;
 --eval REVOKE $privileges ON *.* FROM `mysql.session`@localhost;
+--eval REVOKE $privileges ON *.* FROM `mysql.pxc.internal.session`@localhost
+--eval REVOKE $privileges ON *.* FROM `mysql.pxc.sst.role`@localhost
 
 --echo # Start upgrade
 
@@ -626,6 +643,7 @@ DROP USER u1;
 
 --echo # Revoke SHOW_ROUTINE from root user (since the upgrade scenario takes place only if no user had this privilege before)
 REVOKE SHOW_ROUTINE ON *.* FROM root@localhost;
+REVOKE SHOW_ROUTINE ON *.* FROM `mysql.pxc.internal.session`@localhost;
 
 --echo # Create new user
 CREATE USER sheldon;

--- a/mysql-test/t/transactional_acl_tables.test
+++ b/mysql-test/t/transactional_acl_tables.test
@@ -2022,8 +2022,14 @@ CREATE USER u1@h;
 let $date_to_restore=`SELECT password_last_changed from mysql.user where user='mysql.session'`;
 let $sess_user_account_priv=`SELECT timestamp from mysql.tables_priv where user='mysql.session'`;
 DELETE FROM mysql.tables_priv WHERE user='mysql.session';
+DELETE FROM mysql.tables_priv WHERE user='mysql.pxc.sst.role';
+
 DELETE FROM mysql.user WHERE user='mysql.session';
+DELETE FROM mysql.user WHERE user='mysql.pxc.internal.session';
+DELETE FROM mysql.user WHERE user='mysql.pxc.sst.role';
+
 DELETE FROM mysql.db WHERE user='mysql.session';
+DELETE FROM mysql.db WHERE user='mysql.pxc.sst.role';
 
 --echo
 --echo # Backup privilege tables and drop original ones

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -790,9 +790,9 @@ COMMIT;
 
 -- Add the privilege SHOW_ROUTINE for every user who has global SELECT privilege
 -- provided that there isn't a user who already has the privilege SHOW_ROUTINE
-SET @hadShowRoutinePriv = (SELECT COUNT(*) FROM global_grants WHERE priv = 'SHOW_ROUTINE');
+SET @hadShowRoutinePriv = (SELECT COUNT(*) FROM global_grants WHERE priv = 'SHOW_ROUTINE' AND user NOT IN ('mysql.infoschema','mysql.session','mysql.sys','mysql.pxc.internal.session'));
 INSERT INTO global_grants SELECT user, host, 'SHOW_ROUTINE', IF(grant_priv = 'Y', 'Y', 'N')
-FROM mysql.user WHERE select_priv = 'Y' AND @hadShowRoutinePriv = 0 AND user NOT IN ('mysql.infoschema','mysql.session','mysql.sys');
+FROM mysql.user WHERE select_priv = 'Y' AND @hadShowRoutinePriv = 0 AND user NOT IN ('mysql.infoschema','mysql.session','mysql.sys','mysql.pxc.internal.session');
 COMMIT;
 
 # Activate the new, possible modified privilege tables
@@ -1336,6 +1336,7 @@ INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'lo
 #  GRANT SELECT ON performance_schema.* TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT CREATE ON PERCONA_SCHEMA.* to 'mysql.pxc.sst.role'@localhost;
 INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.sst.role','N','N','N','N','N','N','Y','N','Y','N','N','N','N','N','N','Y','N','Y','N','N','Y','N','N','N','N','N','N','N','N','','','','',0,0,0,0,'caching_sha2_password','','Y',CURRENT_TIMESTAMP,NULL,'Y','N','N',NULL,NULL,NULL,NULL);
+
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'BACKUP_ADMIN', 'N');
 INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Alter,Select,Insert,Create', '');
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'performance_schema', 'mysql.pxc.sst.role','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N');
@@ -1632,29 +1633,33 @@ INSERT IGNORE INTO global_grants (USER,HOST,PRIV,WITH_GRANT_OPTION)
 -- Add the privilege FLUSH_OPTIMIZER_COSTS for every user who has the
 -- privilege RELOAD provided that there isn't a user who already has
 -- privilege FLUSH_OPTIMIZER_COSTS
-INSERT IGNORE INTO global_grants SELECT user, host, 'FLUSH_OPTIMIZER_COSTS', IF(grant_priv = 'Y', 'Y', 'N')
-FROM mysql.user WHERE Reload_priv = 'Y' AND USER != 'mysql.pxc.sst.role';
+SET @hadFlushOptimizerCostsPriv = (SELECT COUNT(*) FROM global_grants WHERE priv = 'FLUSH_OPTIMIZER_COSTS' AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role'));
+INSERT INTO global_grants SELECT user, host, 'FLUSH_OPTIMIZER_COSTS', IF(grant_priv = 'Y', 'Y', 'N')
+FROM mysql.user WHERE Reload_priv = 'Y' AND @hadFlushOptimizerCostsPriv = 0 AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role');
 COMMIT;
 
 -- Add the privilege FLUSH_STATUS for every user who has the
 -- privilege RELOAD provided that there isn't a user who already has
 -- privilege FLUSH_STATUS
-INSERT IGNORE INTO global_grants SELECT user, host, 'FLUSH_STATUS', IF(grant_priv = 'Y', 'Y', 'N')
-FROM mysql.user WHERE Reload_priv = 'Y' AND USER != 'mysql.pxc.sst.role';
+SET @hadFlushStatusPriv = (SELECT COUNT(*) FROM global_grants WHERE priv = 'FLUSH_STATUS' AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role'));
+INSERT INTO global_grants SELECT user, host, 'FLUSH_STATUS', IF(grant_priv = 'Y', 'Y', 'N')
+FROM mysql.user WHERE Reload_priv = 'Y' AND @hadFlushStatusPriv = 0 AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role');
 COMMIT;
 
 -- Add the privilege FLUSH_USER_RESOURCES for every user who has the
 -- privilege RELOAD provided that there isn't a user who already has
 -- privilege FLUSH_USER_RESOURCES
-INSERT IGNORE INTO global_grants SELECT user, host, 'FLUSH_USER_RESOURCES', IF(grant_priv = 'Y', 'Y', 'N')
-FROM mysql.user WHERE Reload_priv = 'Y' AND USER != 'mysql.pxc.sst.role';
+SET @hadFlushUserResourcesPriv = (SELECT COUNT(*) FROM global_grants WHERE priv = 'FLUSH_USER_RESOURCES' AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role'));
+INSERT INTO global_grants SELECT user, host, 'FLUSH_USER_RESOURCES', IF(grant_priv = 'Y', 'Y', 'N')
+FROM mysql.user WHERE Reload_priv = 'Y' AND @hadFlushUserResourcesPriv = 0 AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role');
 COMMIT;
 
 -- Add the privilege FLUSH_TABLES for every user who has the
 -- privilege RELOAD provided that there isn't a user who already has
 -- privilege FLUSH_TABLES
-INSERT IGNORE INTO global_grants SELECT user, host, 'FLUSH_TABLES', IF(grant_priv = 'Y', 'Y', 'N')
-FROM mysql.user WHERE Reload_priv = 'Y' AND USER != 'mysql.pxc.sst.role';
+SET @hadFlushTablesPriv = (SELECT COUNT(*) FROM global_grants WHERE priv = 'FLUSH_TABLES' AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role'));
+INSERT INTO global_grants SELECT user, host, 'FLUSH_TABLES', IF(grant_priv = 'Y', 'Y', 'N')
+FROM mysql.user WHERE Reload_priv = 'Y' AND @hadFlushTablesPriv = 0 AND user NOT IN ('mysql.pxc.internal.session','mysql.pxc.sst.role');
 COMMIT;
 
 SET @@session.sql_mode = @old_sql_mode;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3641

Problem
---
Due to presence of pxc internal users mysql.pxc.internal.session and
mysql.pxc.sst.role which already had FLUSH_* privileges, the logic of
fixing system tables was broken during the upgrade of the server with
--upgrade=FORCE, and the below tests were failing.

1. ps_sys_upgrade - failed with result content mismatch due to the PXC
   user `mysql.pxc.internal.session`.

2. transactional_acl_tables - failed with result content mismatch due to
   the PXC user  `mysql.pxc.internal.session`.

3. mysql_upgrade_grant - failed due to result content mismatch because
   of the missing XA_RECOVER_ADMIN privilege of a super user after the
   upgrade. This failure is also because of the user
   `mysql.pxc.internal.session`.

Fix
---

Adjusted scripts/mysql_system_tables_fix.sql to exclude PXC internal
users while adding FLUSH_* privileges to users with RELOAD privilege
(during --upgrade=FORCE).


Testing Done
---
Full MTR: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/284/console 
Galera & sys var: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/285/console

Failing tests are unrelated to this patch.