### PR TITLE
[5.7] PXC-3710: PXC server causes the client libraries to crash

### DIFF
--- a/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
+++ b/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
@@ -6,7 +6,7 @@ CREATE TABLE t1(i INT PRIMARY KEY);
 # 2. Execute CHECK TABLE query on node_1 and halt the query in
 #    ha_innobase::check() function.
 SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
-CHECK TABLE t1;;
+CHECK TABLE t1;
 [node_1b]
 SET DEBUG_SYNC="now WAIT_FOR reached";
 #
@@ -37,7 +37,7 @@ PARTITION p1 VALUES LESS THAN (4)
 # 2. Execute CHECK TABLE query on node_1 and halt the query in
 #    ha_innobase::check() function.
 SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
-CHECK TABLE t1;;
+ALTER TABLE t1 CHECK PARTITION p0;
 [node_1b]
 SET DEBUG_SYNC="now WAIT_FOR reached";
 #

--- a/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
+++ b/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
@@ -12,7 +12,8 @@
 #    node_1.
 # 4. ALTER TABLE, being replicated as TOI, aborts the CHECK TABLE query. Verify
 #    that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
-# 5. Repeat steps 1-4 with partitioned table.
+# 5. Repeat steps 1-4 with partitioned table, but using ALTER TABLE .. CHECK
+#    PARTITION instead
 # 6. Cleanup
 #
 # ==== References ====
@@ -51,7 +52,12 @@ while ($i < 2) {
   --echo # 2. Execute CHECK TABLE query on node_1 and halt the query in
   --echo #    ha_innobase::check() function.
   SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
-  --send CHECK TABLE t1;
+  if ($i == 0) {
+    --send CHECK TABLE t1
+  }
+  if ($i == 1) {
+    --send ALTER TABLE t1 CHECK PARTITION p0
+  }
 
   --echo [node_1b]
   --connection node_1b


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3710

This is a follow-up of commit 0dc85026.

Problem
-------
PXC node can send malformed packets to client and can cause client to fail with
asserion

  `!check_buffer || (vio_pending(net->vio) <= 1)' in net_clear().

Background
----------
For any query that sends result set to the client, the server does the following
things as per classic protocol.

1. Result metadata specifying the number of fields in the result set
   i.e, `protocol->start_result_metadata()`.
2. The field metadata specifying the types of fields in the result set
   i.e, `protocol->send_field_metadata()` followed by
   `protocol->end_result_metadata()`.
3. Actual row data (any data sent between `protocol->start_row()` and
   `protocol->end_row()`
4. An OK/EOF packet indicating the end of result set.
   `protocol->send_eof()` / `protocol->send_ok()` usually called from
   `THD::send_statement_status()` in the end of `dispatch_command()`

Analysis
--------
When the server is running in autocommit mode and when it is executing a query
that sends some result set to client programs and it was BF aborted by TOI or
high priority transactions, the `wsrep_retry_autocommit` mechanism comes into
effect and the server retries the autocommit query withouy returning the error
to the client.

However, when the server is retrying the query, it is possible that the client
program may have already received partial result from server and may have been
already waiting for the OK/EOF packet to report it to the user (i.e, Steps 1-3
are over and waiting for the step 4 to happen).

In such a scenario, when a retry is performed, the server shall start executing
from Step-1 to Step-4 and if the query execution is successful, it sends OK/EOF
packet in the end to indicate that the query is complete. But on the client
side, this causes the client program to receive unexepected result metadata in
place of an OK/EOF packet and thus causes the client to error out with Malformed
packet error.

This issue was earlier seen with CHECK TABLE query and was fixed as part
of commit 0dc85026. However, didn't fix it for ALTER TABLE..CHECK
PARTITION, as both commands have same path of excution. This commit adds
additional check for ALTER TABLE CHECK PARTITION in
`wsrep_should_retry_in_autocommit()` to avoid retry after BF-abort.


Note to reviewers
---
This is not a GCA based commit as the dependent commit 0dc85026 doesn't exist in the GCA branch.

Testing Done
---
Jenkins: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/178/console
Failing tests: None