### PR TITLE
[8.0] PXC-3710: PXC server causes the client libraries to crash

### DIFF
--- a/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
+++ b/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
@@ -37,7 +37,7 @@ PARTITION p1 VALUES LESS THAN (4)
 # 2. Execute CHECK TABLE query on node_1 and halt the query in
 #    ha_innobase::check() function.
 SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
-CHECK TABLE t1;
+ALTER TABLE t1 CHECK PARTITION p0;
 [node_1b]
 SET DEBUG_SYNC="now WAIT_FOR reached";
 #

--- a/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
+++ b/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
@@ -12,7 +12,8 @@
 #    node_1.
 # 4. ALTER TABLE, being replicated as TOI, aborts the CHECK TABLE query. Verify
 #    that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
-# 5. Repeat steps 1-4 with partitioned table.
+# 5. Repeat steps 1-4 with partitioned table, but using ALTER TABLE .. CHECK
+#    PARTITION instead
 # 6. Cleanup
 #
 # ==== References ====
@@ -51,7 +52,12 @@ while ($i < 2) {
   --echo # 2. Execute CHECK TABLE query on node_1 and halt the query in
   --echo #    ha_innobase::check() function.
   SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
-  --send CHECK TABLE t1
+  if ($i == 0) {
+    --send CHECK TABLE t1
+  }
+  if ($i == 1) {
+    --send ALTER TABLE t1 CHECK PARTITION p0
+  }
 
   --echo [node_1b]
   --connection node_1b

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -195,8 +195,7 @@
 #include "wsrep_trans_observer.h"
 
 static bool wsrep_dispatch_sql_command(THD *thd, const char *rawbuf,
-                                       uint length,
-                                       Parser_state *parser_state,
+                                       uint length, Parser_state *parser_state,
                                        bool update_userstat);
 #endif /* WITH_WSREP */
 
@@ -2232,8 +2231,9 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
 
 #ifdef WITH_WSREP
       if (WSREP_ON) {
-        if (wsrep_dispatch_sql_command(thd, thd->query().str, thd->query().length,
-                              &parser_state, false)) {
+        if (wsrep_dispatch_sql_command(thd, thd->query().str,
+                                       thd->query().length, &parser_state,
+                                       false)) {
           WSREP_DEBUG("Deadlock error for: %s", thd->query().str);
           mysql_mutex_lock(&thd->LOCK_wsrep_thd);
           thd->killed = THD::NOT_KILLED;
@@ -2334,7 +2334,7 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
 
         if (WSREP_ON) {
           if (wsrep_dispatch_sql_command(thd, beginning_of_next_stmt, length,
-                                &parser_state, false)) {
+                                         &parser_state, false)) {
             WSREP_DEBUG("Deadlock error for: %s", thd->query().str);
             mysql_mutex_lock(&thd->LOCK_wsrep_thd);
             thd->killed = THD::NOT_KILLED;
@@ -7394,7 +7394,7 @@ static void wsrep_prepare_for_autocommit_retry(THD *thd, const char *rawbuf,
   thd->set_query_id(next_query_id());
 }
 
-static bool wsrep_should_retry_in_autocommit(enum_sql_command &sql_command) {
+static bool wsrep_should_retry_in_autocommit(const THD *thd) {
   /*
     We are here could mean that the query resulted in a cluster-wide
     conflict and had to be aborted. While it happened, it is possible that
@@ -7416,18 +7416,23 @@ static bool wsrep_should_retry_in_autocommit(enum_sql_command &sql_command) {
     same symptom is found for other commands, then please add it to the
     below list.
   */
-  switch (sql_command) {
+  switch (thd->lex->sql_command) {
     case SQLCOM_CHECK:
     case SQLCOM_SELECT:
       return false;
+    case SQLCOM_ALTER_TABLE: {
+      return (thd->lex->alter_info->flags & Alter_info::ALTER_ADMIN_PARTITION
+                  ? false
+                  : true);
+    }
     default:
       return true;
   }
 }
 
-static bool wsrep_dispatch_sql_command(THD *thd, const char *rawbuf, uint length,
-                              Parser_state *parser_state,
-                              bool update_userstat) {
+static bool wsrep_dispatch_sql_command(THD *thd, const char *rawbuf,
+                                       uint length, Parser_state *parser_state,
+                                       bool update_userstat) {
   DBUG_TRACE;
   bool is_autocommit = !thd->in_multi_stmt_transaction_mode() &&
                        wsrep_read_only_option(thd, thd->lex->query_tables);
@@ -7462,8 +7467,7 @@ static bool wsrep_dispatch_sql_command(THD *thd, const char *rawbuf, uint length
     if (wsrep_after_statement(thd) && is_autocommit) {
       thd->reset_for_next_command();
       thd->killed = THD::NOT_KILLED;
-      if (is_autocommit &&
-          wsrep_should_retry_in_autocommit(thd->lex->sql_command) &&
+      if (is_autocommit && wsrep_should_retry_in_autocommit(thd) &&
           thd->wsrep_retry_counter < thd->variables.wsrep_retry_autocommit) {
         DBUG_EXECUTE_IF("sync.wsrep_retry_autocommit", {
           const char act[] =


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3710

This is a follow-up of commit 0dc85026.

Problem
-------
PXC node can send malformed packets to client and can cause client to fail with
asserion

  `!check_buffer || (vio_pending(net->vio) <= 1)' in net_clear().

Background
----------
For any query that sends result set to the client, the server does the following
things as per classic protocol.

1. Result metadata specifying the number of fields in the result set
   i.e, `protocol->start_result_metadata()`.
2. The field metadata specifying the types of fields in the result set
   i.e, `protocol->send_field_metadata()` followed by
   `protocol->end_result_metadata()`.
3. Actual row data (any data sent between `protocol->start_row()` and
   `protocol->end_row()`
4. An OK/EOF packet indicating the end of result set.
   `protocol->send_eof()` / `protocol->send_ok()` usually called from
   `THD::send_statement_status()` in the end of `dispatch_command()`

Analysis
--------
When the server is running in autocommit mode and when it is executing a query
that sends some result set to client programs and it was BF aborted by TOI or
high priority transactions, the `wsrep_retry_autocommit` mechanism comes into
effect and the server retries the autocommit query withouy returning the error
to the client.

However, when the server is retrying the query, it is possible that the client
program may have already received partial result from server and may have been
already waiting for the OK/EOF packet to report it to the user (i.e, Steps 1-3
are over and waiting for the step 4 to happen).

In such a scenario, when a retry is performed, the server shall start executing
from Step-1 to Step-4 and if the query execution is successful, it sends OK/EOF
packet in the end to indicate that the query is complete. But on the client
side, this causes the client program to receive unexepected result metadata in
place of an OK/EOF packet and thus causes the client to error out with Malformed
packet error.

This issue was earlier seen with CHECK TABLE query and was fixed as part
of commit 0dc85026. However, didn't fix it for ALTER TABLE..CHECK
PARTITION, as both commands have same path of excution. This commit adds
additional check for ALTER TABLE CHECK PARTITION in
`wsrep_should_retry_in_autocommit()` to avoid retry after BF-abort.

(cherry picked from commit 43c2f695479dc3fc5aba79e950b99ea68ba4a608)

Note to Reviewers
===
As the 5.7 commit was not based on GCA, this commit is cherrypicked from 43c2f695479dc3fc5ab (PR https://github.com/percona/percona-xtradb-cluster/pull/1473)

Testind Done
---
Jenkins: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/293/console
Failing Tests:
1. galera.pxc_strict_mode - permanent failure.
2. galera_3nodes.galera_parallel_autoinc_manytrx2 - fails sporadically
3. galera_sr.galera_sr_bf_abort - fails sporadically
4. galera.galera_alter_table_big - fails sporadically
5. galera.galera_bf_bf - fails sporadically

