### PR TITLE
PXC-3731: Fix behavior for sql_log_bin=0

### DIFF
--- a/libbinlogevents/include/statement_events.h
+++ b/libbinlogevents/include/statement_events.h
@@ -932,6 +932,10 @@ class Intvar_event : public Binary_log_event {
     INVALID_INT_EVENT,
     LAST_INSERT_ID_EVENT,
     INSERT_ID_EVENT
+#ifdef WITH_WSREP
+    ,
+    BINLOG_CONTROL_EVENT
+#endif
   };
 
   /**
@@ -954,6 +958,10 @@ class Intvar_event : public Binary_log_event {
         return "LAST_INSERT_ID";
       case INSERT_ID_EVENT:
         return "INSERT_ID";
+#ifdef WITH_WSREP
+      case BINLOG_CONTROL_EVENT:
+        return "BINLOG_CONTROL";
+#endif
       default: /* impossible */
         return "UNKNOWN";
     }

--- a/libbinlogevents/src/statement_events.cpp
+++ b/libbinlogevents/src/statement_events.cpp
@@ -480,6 +480,12 @@ User_var_event::~User_var_event() { bapi_free(const_cast<char *>(name)); }
   * LAST_INSERT_ID_EVENT indicates the value to use for the LAST_INSERT_ID()
     function in the next statement.
 */
+#ifdef WITH_WSREP
+/**
+  * BINLOG_CONTROL_EVENT indicates that for the replication writeset containing
+    this event, binlogging should be set accordingly to the passed value.
+*/
+#endif
 Intvar_event::Intvar_event(const char *buf, const Format_description_event *fde)
     : Binary_log_event(&buf, fde) {
   BAPI_ENTER("Intvar_event::Intvar_event(const char*, ...)");

--- a/mysql-test/suite/galera/r/galera_log_bin.result
+++ b/mysql-test/suite/galera/r/galera_log_bin.result
@@ -45,4 +45,146 @@ mysqld-bin.000001	1393	Anonymous_Gtid	1	1470	SET @@SESSION.GTID_NEXT= 'ANONYMOUS
 mysqld-bin.000001	1470	Query	1	1594	use `test`; ALTER TABLE t1 ADD COLUMN f2 INTEGER /* xid=# */
 DROP TABLE t1;
 DROP TABLE t2;
+#
+# Test that disabling binlog does not prevent Galera replication,
+# but events are not recorded in the binlog
+#
+RESET MASTER;
+RESET MASTER;
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+BEGIN;
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+COMMIT;
+include/assert.inc [assert that the above events are not written to binlog]
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+BEGIN;
+INSERT INTO t2 VALUES (10);
+INSERT INTO t2 VALUES (11);
+INSERT INTO t2 VALUES (12);
+COMMIT;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	125	Previous_gtids	1	156	
+mysqld-bin.000001	156	Anonymous_Gtid	1	233	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	233	Query	1	356	use `test`; CREATE TABLE t2 (a int primary key) /* xid=# */
+mysqld-bin.000001	356	Anonymous_Gtid	1	435	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	435	Query	1	515	BEGIN
+mysqld-bin.000001	515	Table_map	1	563	table_id: # (test.t2)
+mysqld-bin.000001	563	Write_rows	1	603	table_id: # flags: STMT_END_F
+mysqld-bin.000001	603	Xid	1	634	COMMIT /* xid=# */
+mysqld-bin.000001	634	Anonymous_Gtid	1	713	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	713	Query	1	793	BEGIN
+mysqld-bin.000001	793	Table_map	1	841	table_id: # (test.t2)
+mysqld-bin.000001	841	Write_rows	1	881	table_id: # flags: STMT_END_F
+mysqld-bin.000001	881	Table_map	1	929	table_id: # (test.t2)
+mysqld-bin.000001	929	Write_rows	1	969	table_id: # flags: STMT_END_F
+mysqld-bin.000001	969	Table_map	1	1017	table_id: # (test.t2)
+mysqld-bin.000001	1017	Write_rows	1	1057	table_id: # flags: STMT_END_F
+mysqld-bin.000001	1057	Xid	1	1088	COMMIT /* xid=# */
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	125	Previous_gtids	2	156	
+mysqld-bin.000001	156	Anonymous_Gtid	1	233	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	233	Query	1	356	use `test`; CREATE TABLE t2 (a int primary key) /* xid=# */
+mysqld-bin.000001	356	Anonymous_Gtid	1	435	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	435	Query	1	510	BEGIN
+mysqld-bin.000001	510	Table_map	1	558	table_id: # (test.t2)
+mysqld-bin.000001	558	Write_rows	1	598	table_id: # flags: STMT_END_F
+mysqld-bin.000001	598	Xid	1	629	COMMIT /* xid=# */
+mysqld-bin.000001	629	Anonymous_Gtid	1	708	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	708	Query	1	783	BEGIN
+mysqld-bin.000001	783	Table_map	1	831	table_id: # (test.t2)
+mysqld-bin.000001	831	Write_rows	1	871	table_id: # flags: STMT_END_F
+mysqld-bin.000001	871	Table_map	1	919	table_id: # (test.t2)
+mysqld-bin.000001	919	Write_rows	1	959	table_id: # flags: STMT_END_F
+mysqld-bin.000001	959	Table_map	1	1007	table_id: # (test.t2)
+mysqld-bin.000001	1007	Write_rows	1	1047	table_id: # flags: STMT_END_F
+mysqld-bin.000001	1047	Xid	1	1078	COMMIT /* xid=# */
+DROP TABLE t1;
+DROP TABLE t2;
+#
+# The same, but for streaming replication
+#
+RESET MASTER;
+RESET MASTER;
+SET SESSION sql_log_bin = OFF;
+SET SESSION wsrep_trx_fragment_size = 1;
+CREATE TABLE t1 (a int primary key);
+BEGIN;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+COMMIT;
+include/assert.inc [assert that the above events are not written to binlog]
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+BEGIN;
+INSERT INTO t2 VALUES (1);
+INSERT INTO t2 VALUES (2);
+INSERT INTO t2 VALUES (3);
+COMMIT;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	125	Previous_gtids	1	156	
+mysqld-bin.000001	156	Anonymous_Gtid	1	233	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	233	Query	1	356	use `test`; CREATE TABLE t2 (a int primary key) /* xid=# */
+mysqld-bin.000001	356	Anonymous_Gtid	1	435	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	435	Query	1	515	BEGIN
+mysqld-bin.000001	515	Table_map	1	563	table_id: # (test.t2)
+mysqld-bin.000001	563	Write_rows	1	603	table_id: # flags: STMT_END_F
+mysqld-bin.000001	603	Table_map	1	651	table_id: # (test.t2)
+mysqld-bin.000001	651	Write_rows	1	691	table_id: # flags: STMT_END_F
+mysqld-bin.000001	691	Table_map	1	739	table_id: # (test.t2)
+mysqld-bin.000001	739	Write_rows	1	779	table_id: # flags: STMT_END_F
+mysqld-bin.000001	779	Xid	1	810	COMMIT /* xid=# */
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	125	Previous_gtids	2	156	
+mysqld-bin.000001	156	Anonymous_Gtid	1	233	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	233	Query	1	356	use `test`; CREATE TABLE t2 (a int primary key) /* xid=# */
+mysqld-bin.000001	356	Anonymous_Gtid	1	435	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	435	Query	1	510	BEGIN
+mysqld-bin.000001	510	Table_map	1	558	table_id: # (test.t2)
+mysqld-bin.000001	558	Write_rows	1	598	table_id: # flags: STMT_END_F
+mysqld-bin.000001	598	Table_map	1	646	table_id: # (test.t2)
+mysqld-bin.000001	646	Write_rows	1	686	table_id: # flags: STMT_END_F
+mysqld-bin.000001	686	Table_map	1	734	table_id: # (test.t2)
+mysqld-bin.000001	734	Write_rows	1	774	table_id: # flags: STMT_END_F
+mysqld-bin.000001	774	Xid	1	805	COMMIT /* xid=# */
+DROP TABLE t1;
+DROP TABLE t2;
+#
+# Check that log-slave-updates=OFF block all PXC replicated binlogging on node_2
+#
+# restart:--log-slave-updates=OFF --log-bin
+RESET MASTER;
+RESET MASTER;
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	125	Previous_gtids	1	156	
+mysqld-bin.000001	156	Anonymous_Gtid	1	233	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	233	Query	1	356	use `test`; CREATE TABLE t2 (a int primary key) /* xid=# */
+mysqld-bin.000001	356	Anonymous_Gtid	1	435	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	435	Query	1	515	BEGIN
+mysqld-bin.000001	515	Table_map	1	563	table_id: # (test.t2)
+mysqld-bin.000001	563	Write_rows	1	603	table_id: # flags: STMT_END_F
+mysqld-bin.000001	603	Xid	1	634	COMMIT /* xid=# */
+include/assert.inc [assert that the above events are not written to binlog]
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	125	Previous_gtids	2	156	
+DROP TABLE t1;
+DROP TABLE t2;
 RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_log_bin.test
+++ b/mysql-test/suite/galera/t/galera_log_bin.test
@@ -50,5 +50,175 @@ SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
 DROP TABLE t1;
 DROP TABLE t2;
 
+--echo #
+--echo # Test that disabling binlog does not prevent Galera replication,
+--echo # but events are not recorded in the binlog
+--echo #
+--connection node_2
+RESET MASTER;
+
+--connection node_1
+RESET MASTER;
+
+--let $master_pos_before= query_get_value(SHOW MASTER STATUS,Position,1)
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+BEGIN;
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+COMMIT;
+
+# Assert that the above statements are not written to binlog.
+--let $master_pos_after= query_get_value(SHOW MASTER STATUS,Position,1)
+--let $assert_text= assert that the above events are not written to binlog
+--let $assert_cond= $master_pos_before = $master_pos_after
+--source include/assert.inc
+
+# check that turning it back to ON works
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+BEGIN;
+INSERT INTO t2 VALUES (10);
+INSERT INTO t2 VALUES (11);
+INSERT INTO t2 VALUES (12);
+COMMIT;
+
+# we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+
+# Check node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 4 FROM t1
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 4 FROM t2
+--source include/wait_condition.inc
+
+# # we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+--echo #
+--echo # The same, but for streaming replication
+--echo #
+--connection node_2
+RESET MASTER;
+
+--connection node_1
+RESET MASTER;
+
+--let $master_pos_before= query_get_value(SHOW MASTER STATUS,Position,1)
+SET SESSION sql_log_bin = OFF;
+SET SESSION wsrep_trx_fragment_size = 1;
+
+CREATE TABLE t1 (a int primary key);
+BEGIN;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+COMMIT;
+
+# Assert that the above statements are not written to binlog.
+--let $master_pos_after= query_get_value(SHOW MASTER STATUS,Position,1)
+--let $assert_text= assert that the above events are not written to binlog
+--let $assert_cond= $master_pos_before = $master_pos_after
+--source include/assert.inc
+
+# check that turning it back to ON works
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+BEGIN;
+INSERT INTO t2 VALUES (1);
+INSERT INTO t2 VALUES (2);
+INSERT INTO t2 VALUES (3);
+COMMIT;
+
+# we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+
+# Check node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t2
+--source include/wait_condition.inc
+
+# we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+--echo #
+--echo # Check that log-slave-updates=OFF block all PXC replicated binlogging on node_2
+--echo #
+--let $restart_parameters = "restart:--log-slave-updates=OFF --log-bin"
+--source include/restart_mysqld.inc
+
+--connection node_2
+RESET MASTER;
+--let $master_pos_before= query_get_value(SHOW MASTER STATUS,Position,1)
+
+--connection node_1
+RESET MASTER;
+
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+
+# check that turning it back to ON works
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+
+# we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+
+# Check node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t2
+--source include/wait_condition.inc
+
+# Assert that the above statements are not written to binlog.
+--let $master_pos_after= query_get_value(SHOW MASTER STATUS,Position,1)
+--let $assert_text= assert that the above events are not written to binlog
+--let $assert_cond= $master_pos_before = $master_pos_after
+--source include/assert.inc
+
+# we expect nothing in binlog
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 125;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
 --connection node_1
 RESET MASTER;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -12393,7 +12393,7 @@ int THD::binlog_query(THD::enum_binlog_query_type qtype, const char *query_arg,
 
 #ifdef WITH_WSREP
 int prepend_binlog_control_event(THD *const thd) {
-  unsigned char *read_pos = NULL;
+  unsigned char *read_pos = nullptr;
   my_off_t read_len = 0;
 
   if ((thd->variables.option_bits & OPTION_BIN_LOG) != 0) return 0;

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -1018,6 +1018,7 @@ extern ulong rpl_read_size;
 bool normalize_binlog_name(char *to, const char *from, bool is_relay_log);
 
 #ifdef WITH_WSREP
+int prepend_binlog_control_event(THD *const thd);
 IO_CACHE_binlog_cache_storage *wsrep_get_trans_cache(THD *thd,
                                                      bool transaction);
 bool wsrep_trans_cache_is_empty(THD *thd);

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -6078,12 +6078,11 @@ Log_event::enum_skip_reason Intvar_log_event::do_shall_skip(
   */
   return continue_group(rli);
 }
-#endif  // MYSQL_SERVER
 
 /**************************************************************************
   Rand_log_event methods
 **************************************************************************/
-#ifdef MYSQL_SERVER
+
 int Rand_log_event::pack_info(Protocol *protocol) {
   char buf1[256], *pos;
   pos = my_stpcpy(buf1, "rand_seed1=");

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1750,6 +1750,13 @@ class Intvar_log_event : public binary_log::Intvar_event, public Log_event {
                   footer()) {
     common_header->set_is_valid(true);
   }
+#ifdef WITH_WSREP
+  Intvar_log_event(uchar type_arg, ulonglong val_arg)
+      : binary_log::Intvar_event(type_arg, val_arg),
+        Log_event(header(), footer()) {
+    common_header->set_is_valid(true);
+  }
+#endif /* WITH_WSREP */
   int pack_info(Protocol *protocol) override;
 #else
   void print(FILE *file, PRINT_EVENT_INFO *print_event_info) const override;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -449,6 +449,7 @@ THD::THD(bool enable_plugins)
       parsing_system_view(false),
       sp_runtime_ctx(nullptr),
 #ifdef WITH_WSREP
+      wsrep_bin_log_flag_save(0),
       wsrep_applier(is_applier),
       wsrep_applier_closing(false),
       wsrep_client_thread(false),

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2937,6 +2937,7 @@ class THD : public MDL_context_owner,
   } binlog_evt_union;
 
 #ifdef WITH_WSREP
+  ulonglong wsrep_bin_log_flag_save;
   bool wsrep_applier;         /* dedicated slave applier thread */
   bool wsrep_applier_closing; /* applier marked to close */
   bool wsrep_client_thread;   /* to identify client threads */

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -133,6 +133,9 @@ int wsrep_apply_events(THD *thd, Relay_log_info *rli __attribute__((unused)),
     WSREP_DEBUG("Empty apply event found while processing write-set: %lld",
                 (long long)wsrep_thd_trx_seqno(thd));
 
+  if (thd->wsrep_bin_log_flag_save == 0) {
+    thd->wsrep_bin_log_flag_save = thd->variables.option_bits & OPTION_BIN_LOG;
+  }
   while (buf_len) {
     int exec_res;
     Log_event *ev =

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -22,10 +22,8 @@
 #include "binlog.h"
 #include "log.h"
 #include "log_event.h"  // Log_event_writer
-#include "mutex_lock.h"
 #include "mysql/psi/mysql_file.h"
 #include "service_wsrep.h"
-#include "sql_base.h"
 #include "transaction.h"
 #include "wsrep_applier.h"
 

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -22,8 +22,10 @@
 #include "binlog.h"
 #include "log.h"
 #include "log_event.h"  // Log_event_writer
+#include "mutex_lock.h"
 #include "mysql/psi/mysql_file.h"
 #include "service_wsrep.h"
+#include "sql_base.h"
 #include "transaction.h"
 #include "wsrep_applier.h"
 
@@ -220,6 +222,9 @@ cleanup:
 int wsrep_write_cache(THD *const thd,
                       IO_CACHE_binlog_cache_storage *const cache,
                       size_t *const len) {
+  if (int res = prepend_binlog_control_event(thd)) {
+    return res;
+  }
   return wsrep_write_cache_inc(thd, cache, len);
 }
 

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -192,6 +192,12 @@ cleanup:
     WSREP_WARN("Failed to reinitialize IO cache");
     ret = 1;
   }
+
+  // Prepend it here, as we know thd and we can avoid wsrep-lib modifications
+  if (buffer.size() > 0) {
+    ret = prepend_binlog_control_event(thd);
+  }
+
   DBUG_RETURN(ret);
 }
 

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -120,10 +120,13 @@ Wsrep_high_priority_service::Wsrep_high_priority_service(THD *thd)
   /* Disable general logging on applier threads */
   thd->variables.option_bits |= OPTION_LOG_OFF;
   /* Enable binlogging if opt_log_slave_updates is set */
-  if (opt_log_slave_updates)
+  if (opt_log_slave_updates) {
     thd->variables.option_bits |= OPTION_BIN_LOG;
-  else
+    thd->variables.option_bits &= ~(OPTION_BIN_LOG_INTERNAL_OFF);
+  } else {
     thd->variables.option_bits &= ~(OPTION_BIN_LOG);
+    thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+  }
 
   thd->set_active_vio(0);
   thd->reset_db(db_str);
@@ -342,6 +345,10 @@ int Wsrep_high_priority_service::commit(const wsrep::ws_handle &ws_handle,
   thd->lex->sql_command = SQLCOM_END;
 
   must_exit_ = check_exit_status();
+
+  thd->variables.option_bits |= thd->wsrep_bin_log_flag_save;
+  thd->wsrep_bin_log_flag_save = 0;
+
   return ret;
 }
 
@@ -395,6 +402,10 @@ int Wsrep_high_priority_service::rollback(const wsrep::ws_handle &ws_handle,
   m_thd->mdl_context.release_transactional_locks();
   mysql_ull_cleanup(m_thd);
   m_thd->mdl_context.release_explicit_locks();
+
+  m_thd->variables.option_bits |= m_thd->wsrep_bin_log_flag_save;
+  m_thd->wsrep_bin_log_flag_save = 0;
+
   return ret;
 }
 
@@ -416,6 +427,9 @@ int Wsrep_high_priority_service::apply_toi(const wsrep::ws_meta &ws_meta,
                                            wsrep::mutable_buffer &err) {
   DBUG_TRACE;
   THD *thd = m_thd;
+
+  ulonglong option_bin_log_save = thd->variables.option_bits & OPTION_BIN_LOG;
+
   Wsrep_non_trans_mode non_trans_mode(thd, ws_meta);
 
   wsrep::client_state &client_state(thd->wsrep_cs());
@@ -490,7 +504,7 @@ int Wsrep_high_priority_service::apply_toi(const wsrep::ws_meta &ws_meta,
   thd->get_transaction()->xid_state()->get_xid()->reset();
 
   must_exit_ = check_exit_status();
-
+  thd->variables.option_bits |= option_bin_log_save;
   return ret;
 }
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1754,6 +1754,12 @@ int wsrep_to_buf_helper(THD *thd, const char *query, uint query_len,
     *buf_len = thd->wsrep_gtid_event_buf_len;
   }
 
+  if ((thd->variables.option_bits & OPTION_BIN_LOG) == 0) {
+    Intvar_log_event ev((uchar)binary_log::Intvar_event::BINLOG_CONTROL_EVENT,
+                        0);
+    if (ev.write(&tmp_io_cache)) ret = 1;
+  }
+
   /* if there is prepare query, add event for it */
   if (!ret && thd->wsrep_TOI_pre_query) {
     Query_log_event ev(thd, thd->wsrep_TOI_pre_query,


### PR DESCRIPTION
Problem:
1. Fixing PXC-3464 (commit 39bf1f9b408cb163c15cd1d352464d48c5cc0851)
introduced the side effect that even with sql_log_bin=0, events are
logged into the binlog.

2. In the meantime the analysis showed another problem that queries
executed on PXC source with sql_log_bin=0 are replicated using Galera
replication, which is proper behavior, but replica logs these queries
into its binlog if log_slave_updates=1 which is wrong behavior.

Cause:
1. The fix for PXC-3464 was not proper. It was missing the cut-off of
events writing into the binlog

2. The problem is that the information about sql_log_bin state is not
through PXC replication channel, so there is no way to make a decision
on the replica side.

Solution:
1. Proper handling of the case when sql_log_bin=0 was added.

2. Two approaches were considered. The 1st one which propagates new flag
along with replication writeset on Galera replication layer (together
with already existing WSREP_FLAG_* -like flags). It needs changes in
server, wsrep-api, wsrep-lib, Galera layers.
The 2nd approach is to inject additional event at the beginning of
the replication writeset, controlling binlogging on replica side. It
needs changes in server layer only.

The 2nd approach was chosen mainly because its lower cost of further
maintenance and its simplicity.
Intvar_log_event was extended to pass the information about
sql_log_bin=0. Old versions of the server will skip this event and
behave in the old way.

This work is not based on GCA commit, because currently, GCA is too old
and does not contain all necessary changes (code and MTR suite fixes)