### PR TITLE
PXC-3731: Fix behavior for sql_log_bin=0

### DIFF
--- a/libbinlogevents/include/statement_events.h
+++ b/libbinlogevents/include/statement_events.h
@@ -930,6 +930,9 @@ public:
     INVALID_INT_EVENT,
     LAST_INSERT_ID_EVENT,
     INSERT_ID_EVENT
+#ifdef WITH_WSREP
+    , BINLOG_CONTROL_EVENT
+#endif
   };
 
   /**
@@ -958,6 +961,10 @@ public:
       return "LAST_INSERT_ID";
     case INSERT_ID_EVENT:
       return "INSERT_ID";
+#ifdef WITH_WSREP
+    case BINLOG_CONTROL_EVENT:
+      return "BINLOG_CONTROL";
+#endif
     default: /* impossible */
       return "UNKNOWN";
     }

--- a/libbinlogevents/src/statement_events.cpp
+++ b/libbinlogevents/src/statement_events.cpp
@@ -596,6 +596,12 @@ err:
   * LAST_INSERT_ID_EVENT indicates the value to use for the LAST_INSERT_ID()
     function in the next statement.
 */
+#ifdef WITH_WSREP
+/**
+  * BINLOG_CONTROL_EVENT indicates that for the replication writeset containing
+    this event, binlogging should be set accordingly to the passed value.
+*/
+#endif
 Intvar_event::Intvar_event(const char* buf,
                            const Format_description_event* description_event)
 : Binary_log_event(&buf, description_event->binlog_version,

--- a/mysql-test/suite/galera/r/galera_log_bin.result
+++ b/mysql-test/suite/galera/r/galera_log_bin.result
@@ -45,4 +45,95 @@ mysqld-bin.000001	1267	Anonymous_Gtid	1	1332	SET @@SESSION.GTID_NEXT= 'ANONYMOUS
 mysqld-bin.000001	1332	Query	1	1442	use `test`; ALTER TABLE t1 ADD COLUMN f2 INTEGER
 DROP TABLE t1;
 DROP TABLE t2;
+#
+# Test that disabling binlog does not prevent Galera replication,
+# but events are not recorded in the binlog
+#
+RESET MASTER;
+RESET MASTER;
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+BEGIN;
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+COMMIT;
+include/assert.inc [assert that the above events are not written to binlog]
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+BEGIN;
+INSERT INTO t2 VALUES (10);
+INSERT INTO t2 VALUES (11);
+INSERT INTO t2 VALUES (12);
+COMMIT;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Previous_gtids	1	154	
+mysqld-bin.000001	154	Anonymous_Gtid	1	219	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	219	Query	1	328	use `test`; CREATE TABLE t2 (a int primary key)
+mysqld-bin.000001	328	Anonymous_Gtid	1	393	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	393	Query	1	470	BEGIN
+mysqld-bin.000001	470	Table_map	1	515	table_id: # (test.t2)
+mysqld-bin.000001	515	Write_rows	1	555	table_id: # flags: STMT_END_F
+mysqld-bin.000001	555	Xid	1	586	COMMIT /* xid=# */
+mysqld-bin.000001	586	Anonymous_Gtid	1	651	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	651	Query	1	728	BEGIN
+mysqld-bin.000001	728	Table_map	1	773	table_id: # (test.t2)
+mysqld-bin.000001	773	Write_rows	1	813	table_id: # flags: STMT_END_F
+mysqld-bin.000001	813	Table_map	1	858	table_id: # (test.t2)
+mysqld-bin.000001	858	Write_rows	1	898	table_id: # flags: STMT_END_F
+mysqld-bin.000001	898	Table_map	1	943	table_id: # (test.t2)
+mysqld-bin.000001	943	Write_rows	1	983	table_id: # flags: STMT_END_F
+mysqld-bin.000001	983	Xid	1	1014	COMMIT /* xid=# */
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Previous_gtids	2	154	
+mysqld-bin.000001	154	Anonymous_Gtid	1	219	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	219	Query	1	328	use `test`; CREATE TABLE t2 (a int primary key)
+mysqld-bin.000001	328	Anonymous_Gtid	1	393	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	393	Query	1	461	BEGIN
+mysqld-bin.000001	461	Table_map	1	506	table_id: # (test.t2)
+mysqld-bin.000001	506	Write_rows	1	546	table_id: # flags: STMT_END_F
+mysqld-bin.000001	546	Xid	1	577	COMMIT /* xid=# */
+mysqld-bin.000001	577	Anonymous_Gtid	1	642	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	642	Query	1	710	BEGIN
+mysqld-bin.000001	710	Table_map	1	755	table_id: # (test.t2)
+mysqld-bin.000001	755	Write_rows	1	795	table_id: # flags: STMT_END_F
+mysqld-bin.000001	795	Table_map	1	840	table_id: # (test.t2)
+mysqld-bin.000001	840	Write_rows	1	880	table_id: # flags: STMT_END_F
+mysqld-bin.000001	880	Table_map	1	925	table_id: # (test.t2)
+mysqld-bin.000001	925	Write_rows	1	965	table_id: # flags: STMT_END_F
+mysqld-bin.000001	965	Xid	1	996	COMMIT /* xid=# */
+DROP TABLE t1;
+DROP TABLE t2;
+#
+# Check that log-slave-updates=OFF block all PXC replicated binlogging on node_2
+#
+# restart:--log-slave-updates=OFF --log-bin
+RESET MASTER;
+RESET MASTER;
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Previous_gtids	1	154	
+mysqld-bin.000001	154	Anonymous_Gtid	1	219	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	219	Query	1	328	use `test`; CREATE TABLE t2 (a int primary key)
+mysqld-bin.000001	328	Anonymous_Gtid	1	393	SET @@SESSION.GTID_NEXT= 'ANONYMOUS'
+mysqld-bin.000001	393	Query	1	470	BEGIN
+mysqld-bin.000001	470	Table_map	1	515	table_id: # (test.t2)
+mysqld-bin.000001	515	Write_rows	1	555	table_id: # flags: STMT_END_F
+mysqld-bin.000001	555	Xid	1	586	COMMIT /* xid=# */
+include/assert.inc [assert that the above events are not written to binlog]
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000001	123	Previous_gtids	2	154	
+DROP TABLE t1;
+DROP TABLE t2;
 RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_log_bin.test
+++ b/mysql-test/suite/galera/t/galera_log_bin.test
@@ -50,5 +50,116 @@ SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
 DROP TABLE t1;
 DROP TABLE t2;
 
+--echo #
+--echo # Test that disabling binlog does not prevent Galera replication,
+--echo # but events are not recorded in the binlog
+--echo #
+--connection node_2
+RESET MASTER;
+
+--connection node_1
+RESET MASTER;
+
+--let $master_pos_before= query_get_value(SHOW MASTER STATUS,Position,1)
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+BEGIN;
+INSERT INTO t1 VALUES (10);
+INSERT INTO t1 VALUES (11);
+INSERT INTO t1 VALUES (12);
+COMMIT;
+
+# Assert that the above statements are not written to binlog.
+--let $master_pos_after= query_get_value(SHOW MASTER STATUS,Position,1)
+--let $assert_text= assert that the above events are not written to binlog
+--let $assert_cond= $master_pos_before = $master_pos_after
+--source include/assert.inc
+
+# check that turning it back to ON works
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+BEGIN;
+INSERT INTO t2 VALUES (10);
+INSERT INTO t2 VALUES (11);
+INSERT INTO t2 VALUES (12);
+COMMIT;
+
+# we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+
+# Check node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 4 FROM t1
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 4 FROM t2
+--source include/wait_condition.inc
+
+# # we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+--echo #
+--echo # Check that log-slave-updates=OFF block all PXC replicated binlogging on node_2
+--echo #
+--let $restart_parameters = "restart:--log-slave-updates=OFF --log-bin"
+--source include/restart_mysqld.inc
+
+--connection node_2
+RESET MASTER;
+--let $master_pos_before= query_get_value(SHOW MASTER STATUS,Position,1)
+
+--connection node_1
+RESET MASTER;
+
+SET SESSION sql_log_bin = OFF;
+CREATE TABLE t1 (a int primary key);
+INSERT INTO t1 VALUES (1);
+
+# check that turning it back to ON works
+SET SESSION sql_log_bin = ON;
+CREATE TABLE t2 (a int primary key);
+INSERT INTO t2 VALUES (1);
+
+# we expect only t2 operations to be logged
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+
+# Check node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t2
+--source include/wait_condition.inc
+
+# Assert that the above statements are not written to binlog.
+--let $master_pos_after= query_get_value(SHOW MASTER STATUS,Position,1)
+--let $assert_text= assert that the above events are not written to binlog
+--let $assert_cond= $master_pos_before = $master_pos_after
+--source include/assert.inc
+
+# we expect nothing in binlog
+SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
 --connection node_1
 RESET MASTER;

--- a/sql/auth/auth_common.h
+++ b/sql/auth/auth_common.h
@@ -714,7 +714,7 @@ bool delete_precheck(THD *thd, TABLE_LIST *tables);
 bool lock_tables_precheck(THD *thd, TABLE_LIST *tables);
 bool create_table_precheck(THD *thd, TABLE_LIST *tables,
                            TABLE_LIST *create_table);
-#if WITH_WSREP
+#ifdef WITH_WSREP
 bool check_fk_parent_table_access(THD *thd,
                                   const char *child_table_db,
                                   HA_CREATE_INFO *create_info,

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -60,7 +60,7 @@
 #include "sql_class.h"
 #include "mysql/psi/mysql_transaction.h"
 #include "sql_plugin.h" // plugin_foreach
-#if WITH_WSREP
+#ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
 #endif
 #define window_size Log_throttle::LOG_THROTTLE_WINDOW_SIZE
@@ -7187,6 +7187,12 @@ void Intvar_log_event::print(FILE* file, PRINT_EVENT_INFO* print_event_info)
   case INSERT_ID_EVENT:
     msg="INSERT_ID";
     break;
+#ifdef WITH_WSREP
+  case BINLOG_CONTROL_EVENT:
+    msg="BINLOG_CONTROL";
+    assert(0);
+    break;
+#endif
   case INVALID_INT_EVENT:
   default: // cannot happen
     msg="INVALID_INT";
@@ -7223,6 +7229,14 @@ int Intvar_log_event::do_apply_event(Relay_log_info const *rli)
   case INSERT_ID_EVENT:
     thd->force_one_auto_inc_interval(val);
     break;
+#ifdef WITH_WSREP
+  case BINLOG_CONTROL_EVENT:
+   if (val == 0)
+   {
+     thd->variables.option_bits &= ~(OPTION_BIN_LOG);
+   }
+   break;
+#endif  /* WITH_WSREP */
   }
   return 0;
 }

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1953,6 +1953,14 @@ public:
   {
     is_valid_param= true;
   }
+#ifdef WITH_WSREP
+  Intvar_log_event(uchar type_arg, ulonglong val_arg)
+  : binary_log::Intvar_event(type_arg, val_arg),
+    Log_event(header(), footer())
+  {
+    is_valid_param= true;
+  }
+#endif  /* WITH_WSREP */
 #ifdef HAVE_REPLICATION
   int pack_info(Protocol* protocol);
 #endif /* HAVE_REPLICATION */

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1430,6 +1430,7 @@ THD::THD(bool enable_plugins)
    derived_tables_processing(FALSE),
    sp_runtime_ctx(NULL),
 #ifdef WITH_WSREP
+   wsrep_bin_log_flag_save(0),
    wsrep_applier(is_applier),
    wsrep_applier_closing(FALSE),
    wsrep_client_thread(0),

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3550,6 +3550,7 @@ public:
   } binlog_evt_union;
 
 #ifdef WITH_WSREP
+  ulonglong                 wsrep_bin_log_flag_save;
   const bool                wsrep_applier; /* dedicated slave applier thread */
   bool                      wsrep_applier_closing; /* applier marked to close */
   bool                      wsrep_client_thread; /* to identify client threads*/

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -117,6 +117,7 @@ static wsrep_cb_status_t wsrep_apply_events(THD*        thd,
     WSREP_DEBUG("Empty apply event found while processing write-set: %lld",
                 (long long) wsrep_thd_trx_seqno(thd));
 
+  thd->wsrep_bin_log_flag_save = thd->variables.option_bits & OPTION_BIN_LOG;
   while(buf_len)
   {
     int exec_res;
@@ -439,6 +440,9 @@ wsrep_cb_status_t wsrep_commit_cb(void*         const     ctx,
     rcode = wsrep_commit(thd);
   else
     rcode = wsrep_rollback(thd);
+
+  thd->variables.option_bits |= thd->wsrep_bin_log_flag_save;
+  thd->wsrep_bin_log_flag_save = 0;
 
   wsrep_set_apply_format(thd, NULL);
   thd->mdl_context.release_transactional_locks();

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -115,9 +115,15 @@ static void wsrep_prepare_bf_thd(THD *thd, struct wsrep_thd_shadow* shadow)
   thd->variables.option_bits |= OPTION_LOG_OFF;
   // Enable binlogging if opt_log_slave_updates is set
   if (opt_log_slave_updates)
+  {
     thd->variables.option_bits|= OPTION_BIN_LOG;
+    thd->variables.option_bits&= ~(OPTION_BIN_LOG_INTERNAL_OFF);
+  }
   else
+  {
     thd->variables.option_bits&= ~(OPTION_BIN_LOG);
+    thd->variables.option_bits|= OPTION_BIN_LOG_INTERNAL_OFF;
+  }
 
 #ifdef GALERA
   /*


### PR DESCRIPTION
Problem:
1. Fixing PXC-3464 (commit 4f83f7217782ec1c7541046d5458d380e7242150)
introduced the side effect that even with sql_log_bin=0, events are
logged into the binlog.

2. In the meantime the analysis showed another problem that queries
executed on PXC source with sql_log_bin=0 are replicated using Galera
replication, which is proper behavior, but replica logs these queries
into its binlog if log_slave_updates=1 which is wrong behavior.

Cause:
1. The fix for PXC-3464 was not proper. It was missing the cut-off of
events writing into the binlog

2. The problem is that the information about sql_log_bin state is not
through PXC replication channel, so there is no way to make a decision
on the replica side.

Solution:
1. Proper handling of the case when sql_log_bin=0 was added.

2. Two approaches were considered. The 1st one which propagates new flag
along with replication writeset on Galera replication layer (together
with already existing WSREP_FLAG_* -like flags). It needs changes in
server, wsrep-api, wsrep-lib, Galera layers.
The 2nd approach is to inject additional event at the beginning of
the replication writeset, controlling binlogging on replica side. It
needs changes in server layer only.

The 2nd approach was chosen mainly because its lower cost of further
maintenance and its simplicity.
Intvar_log_event was extended to pass the information about
sql_log_bin=0. Old versions of the server will skip this event and
behave in the old way.

This work is not based on GCA commit, because currently, GCA is too old
and does not contain all necessary changes (code and MTR suite fixes)