### PR TITLE
8.0 pxc 3444

### DIFF
--- a/mysql-test/suite/galera/r/pxc_log_slave_updates.result
+++ b/mysql-test/suite/galera/r/pxc_log_slave_updates.result
@@ -2,5 +2,8 @@ CREATE TABLE t1 (a INT PRIMARY KEY);
 CREATE TABLE t2 (a INT PRIMARY KEY);
 INSERT INTO t1 VALUES (0);
 INSERT INTO t2 SELECT /*!99997*/ * FROM t1;
+INSERT INTO t2 SELECT /*!99997*/ * FROM t1;
+ERROR 23000: Duplicate entry '0' for key 't2.PRIMARY'
+CALL mtr.add_suppression("Query apply failed");
 include/assert.inc [node_1 should be alive and t2 should contain one row]
 DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/pxc_log_slave_updates.test
+++ b/mysql-test/suite/galera/t/pxc_log_slave_updates.test
@@ -12,8 +12,11 @@ INSERT INTO t1 VALUES (0);
 
 --connection node_2
 INSERT INTO t2 SELECT /*!99997*/ * FROM t1;
+--error ER_DUP_ENTRY
+INSERT INTO t2 SELECT /*!99997*/ * FROM t1;
 
 --connection node_1
+CALL mtr.add_suppression("Query apply failed");
 --let $assert_text = node_1 should be alive and t2 should contain one row
 --let $assert_cond = [SELECT COUNT(*) FROM t2] = 1
 --source include/assert.inc


### PR DESCRIPTION
PXC-3444: Node crashes on TOI DML rollback
    
https://jira.percona.com/browse/PXC-3444

Analysis :
Node crashes while DML is executed in TOI mode,
and getting rollback.
This behavior is specific for PXC only where DML can be replicated in TOI mode. 
This is used by pt-table-checksum tool which injects 99997 version 
into the insert.. select query.

Fix:
Handled m_toi transaction state on rollback,
by aborting transaction while DML is executed in TOI mode.