### PR TITLE
Fixed PXC-3387 - Server exit due to intermediate commits

### DIFF
--- a/mysql-test/suite/galera/r/galera_intermediate_commits_autocommit0.result
+++ b/mysql-test/suite/galera/r/galera_intermediate_commits_autocommit0.result
@@ -1,0 +1,6 @@
+CREATE TABLE t1 (a int, b int);
+SET autocommit=0;
+INSERT INTO t1 (a) values (null);
+SELECT * FROM information_schema.statistics;
+SET autocommit=1;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_intermediate_commits_autocommit0.test
+++ b/mysql-test/suite/galera/t/galera_intermediate_commits_autocommit0.test
@@ -1,0 +1,23 @@
+# ==== Purpose ====
+#
+# Verify that the server properly handles multiple intermediate commits in a
+# query when autocommit=0.
+#
+# === Reference ===
+#
+# PXC-3387: Server exit due to intermediate commits
+
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (a int, b int);
+
+SET autocommit=0;
+INSERT INTO t1 (a) values (null);
+
+# The below SELECT performs multiple intermediate commits to DD system table.
+--disable_result_log
+SELECT * FROM information_schema.statistics;
+--enable_result_log
+
+SET autocommit=1;
+DROP TABLE t1;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3387

Problem
=======
Server hits the assertion

1. `state() == s_executing || state() == s_committing || state() == s_must_abort || state() == s_replaying` in debug builds
2. `trx!=0` in release builds and

while the query performs an intermediate commit during updation of table stats
in the Data Dictionary.

Background
==========
Server can perform multiple intermediate commits in the storage engine, during
various stages of execution. These can include updating the Data Dictionary,
Repository Tables and other system tables for the purpose of metadata storage,
crash recovery, etc. In order to avoid these intermediate commits performing
the original transaction commit and to differentiate the original transaction
commit from these intermediate commits, the server sets the
`THD::is_operating_substatement_implicitly` flag before all the intermediate
commits. (See `Implicit_substatement_state_guard` in `sql/thd_raii.h`)

Analysis
========
In the context of the current bug, we execute the below queries.

```
SET autocommit=0;
CREATE TABLE t1 (a int, b int);
INSERT INTO t1 (a) values (null);
SELECT * FROM information_schema.statistics;
```

1. Since autocommit=0, the INSERT query starts a transaction in WSREP and
   InnoDB.

2. During the execution of the SELECT query, the server perorms multiple
   intermediate commits to SE while persisting the table statistics to the
   `mysql`.`innodb_table_stats` DD tables (these are internal transactions).

3. Since there was no proper handling for these intermediate commits, the first
   ever intermediate commit to makes the transaction to be marked as committed
   in WSREP (changes the WSREP client state to s_committed).

4. When the query enters the second intermediate commit, the WSREP client state
   sees that the transaction is already committed and is still trying to commit
   and thus hits assert "state() == s_executing || state() ==
   s_committing || state() == s_must_abort || state() == s_replaying" in
   `wsrep::transaction::before_commit()` as the transaction in `s_committed`
   state is not supposed to call the `before_commit` hooks.

Solution
========
Do not call wsrep commit hooks when we are performing an intermediate commit
(committing a intermediate substatement).


Note
===
1. Debug build crash
```
#5  0x00007f45cce74859 in __GI_abort () at abort.c:79
#6  0x00007f45cce74729 in __assert_fail_base (fmt=0x7f45cd00a588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", 
    assertion=0x559d6f0b6418 "state() == s_executing || state() == s_committing || state() == s_must_abort || state() == s_replaying", 
    file=0x559d6f0b5ce0 "/home/venki/work/pxc/80/wsrep-lib/src/transaction.cpp", line=376, function=<optimized out>) at assert.c:92
#7  0x00007f45cce85f36 in __GI___assert_fail (assertion=0x559d6f0b6418 "state() == s_executing || state() == s_committing || state() == s_must_abort || state() == s_replaying", 
    file=0x559d6f0b5ce0 "/home/venki/work/pxc/80/wsrep-lib/src/transaction.cpp", line=376, function=0x559d6f0b63b8 "int wsrep::transaction::before_commit()") at assert.c:101
#8  0x0000559d6d7725e8 in wsrep::transaction::before_commit (this=0x7f44f801fdf0) at /home/venki/work/pxc/80/wsrep-lib/src/transaction.cpp:376
#9  0x0000559d6b15015d in wsrep::client_state::before_commit (this=0x7f44f801fd88) at /home/venki/work/pxc/80/wsrep-lib/include/wsrep/client_state.hpp:436
#10 0x0000559d6b12d30c in wsrep_before_commit (thd=0x7f44f801d4f0, all=true) at /home/venki/work/pxc/80/sql/wsrep_trans_observer.h:298
#11 0x0000559d6b131dbc in ha_commit_low (thd=0x7f44f801d4f0, all=true, run_after_commit=true) at /home/venki/work/pxc/80/sql/handler.cc:1978
#12 0x0000559d6c6d790e in MYSQL_BIN_LOG::commit (this=0x559d703df120 <mysql_bin_log>, thd=0x7f44f801d4f0, all=true) at /home/venki/work/pxc/80/sql/binlog.cc:8468
#13 0x0000559d6b131885 in ha_commit_trans (thd=0x7f44f801d4f0, all=true, ignore_global_read_lock=true) at /home/venki/work/pxc/80/sql/handler.cc:1854
#14 0x0000559d6b7b611b in trans_commit (thd=0x7f44f801d4f0, ignore_global_read_lock=true) at /home/venki/work/pxc/80/sql/transaction.cc:272
#15 0x0000559d6cb1fd6b in (anonymous namespace)::store_statistics_record<dd::Index_stat> (thd=0x7f44f801d4f0, object=0x7f44f82a28e8) at /home/venki/work/pxc/80/sql/dd/info_schema/table_stats.cc:163
#16 0x0000559d6cb1d20b in (anonymous namespace)::persist_i_s_index_stats (thd=0x7f44f801d4f0, schema_name_ptr=..., table_name_ptr=..., index_name_ptr=..., column_name_ptr=..., records=8)
    at /home/venki/work/pxc/80/sql/dd/info_schema/table_stats.cc:276
#17 0x0000559d6cb1e7ea in dd::info_schema::Table_statistics::read_stat_from_SE (this=0x7f44f8031248, thd=0x7f44f801d4f0, schema_name_ptr=..., table_name_ptr=..., index_name_ptr=..., column_name_ptr=..., 
    index_ordinal_position=0, column_ordinal_position=1, se_private_id=3, ts_se_private_data=0x0, tbl_se_private_data=0x0, stype=dd::info_schema::enum_table_stats_type::INDEX_COLUMN_CARDINALITY, 
    hton=0x559d7296b970) at /home/venki/work/pxc/80/sql/dd/info_schema/table_stats.cc:629
#18 0x0000559d6cb1df9c in dd::info_schema::Table_statistics::read_stat (this=0x7f44f8031248, thd=0x7f44f801d4f0, schema_name_ptr=..., table_name_ptr=..., index_name_ptr=..., partition_name=0x0, 
    column_name_ptr=..., index_ordinal_position=0, column_ordinal_position=1, engine_name_ptr=..., se_private_id=3, ts_se_private_data=0x0, tbl_se_private_data=0x0, 
    table_stat_data=@0x7f45b40a2780: 18446744073709551615, cached_timestamp=@0x7f45b40a2788: 0, stype=dd::info_schema::enum_table_stats_type::INDEX_COLUMN_CARDINALITY)
    at /home/venki/work/pxc/80/sql/dd/info_schema/table_stats.cc:496
#19 0x0000559d6b22be31 in Item_func_internal_index_column_cardinality::val_int (this=0x7f44f826fff0) at /home/venki/work/pxc/80/sql/item_func.cc:9339
#20 0x0000559d6b1739cc in Item::send (this=0x7f44f826fff0, protocol=0x7f44f800fcd0, buffer=0x7f45b40a2a20) at /home/venki/work/pxc/80/sql/item.cc:6788
#21 0x0000559d6b176f48 in Item_ref::send (this=0x7f44f828a6b0, prot=0x7f44f800fcd0, tmp=0x7f45b40a2a20) at /home/venki/work/pxc/80/sql/item.cc:7773
#22 0x0000559d6b178392 in Item_view_ref::send (this=0x7f44f828a6b0, prot=0x7f44f800fcd0, tmp=0x7f45b40a2a20) at /home/venki/work/pxc/80/sql/item.cc:8111
#23 0x0000559d6b523712 in THD::send_result_set_row (this=0x7f44f801d4f0, row_items=...) at /home/venki/work/pxc/80/sql/sql_class.cc:3046
#24 0x0000559d6b46ffdd in Query_result_send::send_data (this=0x7f44f82868b8, thd=0x7f44f801d4f0, items=...) at /home/venki/work/pxc/80/sql/query_result.cc:114
#25 0x0000559d6b738808 in SELECT_LEX_UNIT::ExecuteIteratorQuery (this=0x7f44f813a0f8, thd=0x7f44f801d4f0) at /home/venki/work/pxc/80/sql/sql_union.cc:1244
#26 0x0000559d6b738a88 in SELECT_LEX_UNIT::execute (this=0x7f44f813a0f8, thd=0x7f44f801d4f0) at /home/venki/work/pxc/80/sql/sql_union.cc:1282
#27 0x0000559d6b675554 in Sql_cmd_dml::execute_inner (this=0x7f44f813c218, thd=0x7f44f801d4f0) at /home/venki/work/pxc/80/sql/sql_select.cc:845
#28 0x0000559d6b674a12 in Sql_cmd_dml::execute (this=0x7f44f813c218, thd=0x7f44f801d4f0) at /home/venki/work/pxc/80/sql/sql_select.cc:630
#29 0x0000559d6b5eff59 in mysql_execute_command (thd=0x7f44f801d4f0, first_level=true) at /home/venki/work/pxc/80/sql/sql_parse.cc:5440
#30 0x0000559d6b5f27c4 in dispatch_sql_command (thd=0x7f44f801d4f0, parser_state=0x7f45b40a4a50, update_userstat=false) at /home/venki/work/pxc/80/sql/sql_parse.cc:6123
#31 0x0000559d6b5f6ba9 in wsrep_dispatch_sql_command (thd=0x7f44f801d4f0, rawbuf=0x7f44f813a098 "SELECT * FROM information_schema.statistics", length=43, parser_state=0x7f45b40a4a50, update_userstat=false)
    at /home/venki/work/pxc/80/sql/sql_parse.cc:7443
#32 0x0000559d6b5e531d in dispatch_command (thd=0x7f44f801d4f0, com_data=0x7f45b40a5b40, command=COM_QUERY) at /home/venki/work/pxc/80/sql/sql_parse.cc:2234
#33 0x0000559d6b5e2b6c in do_command (thd=0x7f44f801d4f0) at /home/venki/work/pxc/80/sql/sql_parse.cc:1518
#34 0x0000559d6b806859 in handle_connection (arg=0x559d72b483a0) at /home/venki/work/pxc/80/sql/conn_handler/connection_handler_per_thread.cc:311
#35 0x0000559d6d3fb1c0 in pfs_spawn_thread (arg=0x559d72872b60) at /home/venki/work/pxc/80/storage/perfschema/pfs.cc:2901
#36 0x00007f45cd88a609 in start_thread (arg=<optimized out>) at pthread_create.c:477
```
2. Release build crash
```
#5  0x00007f0a93470859 in __GI_abort () at abort.c:79
#6  0x00007f0a93470729 in __assert_fail_base (fmt=0x7f0a93606588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x7f0a8dd2ff6c "trx != 0", file=0x7f0a8dd2fbdd "galera/src/wsrep_provider.cpp", line=303, 
    function=<optimized out>) at assert.c:92
#7  0x00007f0a93481f36 in __GI___assert_fail (assertion=0x7f0a8dd2ff6c "trx != 0", file=0x7f0a8dd2fbdd "galera/src/wsrep_provider.cpp", line=303, 
    function=0x7f0a8dd2ff20 "wsrep_status_t galera_replay_trx(wsrep_t*, const wsrep_ws_handle_t*, void*)") at assert.c:101
#8  0x00007f0a8dcd4e76 in galera_replay_trx (gh=0x5640f4ea3550, trx_handle=0x7f0a625ed428, recv_ctx=0x7f0a625ed480) at galera/src/wsrep_provider.cpp:303
#9  0x00005640f0386c3c in wsrep::wsrep_provider_v26::replay (this=<optimized out>, ws_handle=..., reply_service=<optimized out>) at /home/venki/work/pxc/80/wsrep-lib/src/wsrep_provider_v26.cpp:222
#10 0x00005640eeba2653 in Wsrep_client_service::replay (this=0x7f09fc424250) at /home/venki/work/pxc/80/wsrep-lib/include/wsrep/transaction.hpp:203
#11 0x00005640f03853fd in wsrep::transaction::after_statement (this=this@entry=0x7f09fc4242d0) at /home/venki/work/pxc/80/wsrep-lib/src/transaction.cpp:736
#12 0x00005640f0370da6 in wsrep::client_state::after_statement (this=this@entry=0x7f09fc424268) at /home/venki/work/pxc/80/wsrep-lib/src/client_state.cpp:245
#13 0x00005640eea39610 in wsrep_after_statement (thd=0x7f09fc4219e0) at /home/venki/work/pxc/80/sql/sql_class.h:3141
#14 wsrep_dispatch_sql_command (thd=0x7f09fc4219e0, rawbuf=0x7f09fc132c28 "SELECT * FROM information_schema.statistics", length=<optimized out>, parser_state=0x7f0a625edb50, update_userstat=false)
    at /home/venki/work/pxc/80/sql/sql_parse.cc:7467
#15 0x00005640eea3dbc7 in dispatch_command (thd=0x7f09fc4219e0, com_data=<optimized out>, command=COM_QUERY) at /home/venki/work/pxc/80/sql/sql_class.h:4442
#16 0x00005640eea3e2e1 in do_command (thd=thd@entry=0x7f09fc4219e0) at /home/venki/work/pxc/80/sql/sql_parse.cc:1518
#17 0x00005640eeb841b0 in handle_connection (arg=arg@entry=0x5640f515d310) at /home/venki/work/pxc/80/sql/conn_handler/connection_handler_per_thread.cc:311
#18 0x00005640f0155922 in pfs_spawn_thread (arg=0x5640f4f427e0) at /home/venki/work/pxc/80/storage/perfschema/pfs.cc:2901
#19 0x00007f0a93e09609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#20 0x00007f0a9356d103 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Testing Done
===
Jenkins:https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/338/console
Failing Tests: 
pxc_strict_mode - a permanent failure on 8.0 trunk.
galera_bf_bf - sporadic failure