### PR TITLE
Fixed PXC-3387 - Server exit due to intermediate commits

### DIFF
--- a/mysql-test/suite/galera/r/galera_intermediate_commits_autocommit0.result
+++ b/mysql-test/suite/galera/r/galera_intermediate_commits_autocommit0.result
@@ -1,0 +1,6 @@
+CREATE TABLE t1 (a int, b int);
+SET autocommit=0;
+INSERT INTO t1 (a) values (null);
+SELECT * FROM information_schema.statistics;
+SET autocommit=1;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_intermediate_commits_autocommit0.test
+++ b/mysql-test/suite/galera/t/galera_intermediate_commits_autocommit0.test
@@ -1,0 +1,23 @@
+# ==== Purpose ====
+#
+# Verify that the server properly handles multiple intermediate commits in a
+# query when autocommit=0.
+#
+# === Reference ===
+#
+# PXC-3387: Server exit due to intermediate commits
+
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (a int, b int);
+
+SET autocommit=0;
+INSERT INTO t1 (a) values (null);
+
+# The below SELECT performs multiple intermediate commits to DD system table.
+--disable_result_log
+SELECT * FROM information_schema.statistics;
+--enable_result_log
+
+SET autocommit=1;
+DROP TABLE t1;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3387

Problem
=======
Server hits the assertion

1. "state() == s_executing || state() == s_committing || state() == s_must_abort || state() == s_replaying" in debug builds
2. "trx!=0" in release builds and

while the query performs an intermediate commit during updation of table stats
in the Data Dictionary.

Background
==========
Server can perform multiple intermediate commits in the storage engine, during
various stages of execution. These can include updating the Data Dictionary,
Repository Tables and other system tables for the purpose of metadata storage,
crash recovery, etc. In order to avoid these intermediate commits performing
the original transaction commit and to differentiate the original transaction
commit from these intermediate commits, the server sets the
`THD::is_operating_substatement_implicitly` flag before all the intermediate
commits. (See Implicit_substatement_state_guard in sql/thd_raii.h)

Analysis
========
In the context of the current bug, we execute the below queries.

SET autocommit=0;
CREATE TABLE t1 (a int, b int);
INSERT INTO t1 (a) values (null);
SELECT * FROM information_schema.statistics;

1. Since autocommit=0, the INSERT query starts a transaction in WSREP and
   InnoDB.

2. During the execution of the SELECT query, the server perorms multiple
   intermediate commits to SE while persisting the table statistics to the
   `mysql`.`innodb_table_stats` DD tables (these are internal transactions).

3. Since there was no proper handling for these intermediate commits, the first
   ever intermediate commit to makes the transaction to be marked as committed
   in WSREP (changes the WSREP client state to s_committed).

4. When the query enters the second intermediate commit, the WSREP client state
   sees that the transaction is already committed and is still trying to commit
   and thus hits assert "state() == s_executing || state() ==
   s_committing || state() == s_must_abort || state() == s_replaying" in
   `wsrep::transaction::before_commit()` as the transaction in `s_committed`
   state is not supposed to call the `before_commit` hooks.

Solution
========
Do not call wsrep commit hooks when we are performing an intermediate commit
(committing a intermediate substatement).

(cherry picked from commit a4384be9bffb3ccd51cc6a805ef4b81b00c600d4)