### PR TITLE
PXC-3729 : Nodes fail when two applier threads conflict

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -611,8 +611,8 @@ request is really for a 'gap' type lock */
                      << " - " << lock2->index->table_name << "n_uniq "
                      << lock2->index->n_uniq << " n_user "
                      << lock2->index->n_user_defined_cols;
-          return false;
         }
+        return false;
       }
     }
 #endif /* WITH_WSREP */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3729

Scenario:
---------

In a typical 3-node PXC cluster, the load is executed only on one node,
the remaining 2 nodes dont receive the writes (from user). The receiver
nodes find that applier threads (wsrep_slave_threads) conflict on InnoDB
locks and one applier thread tries to Brute-Force(BF) abort the other
applier thread. The BF-Aborted applier thread exits, causing the node to
fail

The applier threads execute certified transactions and are in High-Priority
transaction mode. They can BruteForce (BF) abort the local transactions but
they will never BF-Abort another transaction from applier threads. The applier
thread transactions have been certified, so they should never conflict. But
alas, we found such a violation!

Two certified transactions indeed conflict in this rare case!

How?
----
Let me explain with an example

create table t1(a INT, b INT, UNIQUE KEY(b), PRIMARY KEY(a));
INSERT INTO t1 VALUES (1,1),(2,2),(3,3),(4,4);

Trx-1
------
mysql> UPDATE t1 SET b=10 WHERE a=3;
Query OK, 1 row affected (0.01 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> BEGIN;
Query OK, 0 rows affected (0.00 sec)

mysql> UPDATE t1 SET b=3 WHERE a=3;
Query OK, 1 row affected (0.01 sec)
Rows matched: 1  Changed: 1  Warnings: 0

Trx-2:
------
mysql> UPDATE t1 SET b=11 WHERE a = 2;
Query OK, 1 row affected (0.00 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> BEGIN;
Query OK, 0 rows affected (0.00 sec)

mysql> UPDATE t1 SET b=2 WHERE a = 2;
ERROR 1205 (HY000): Lock wait timeout exceeded; try restarting transaction

As you can see, there is Lock-conflict between these two updates, the row
modifying 2 timed out waiting for 3. Certification based on keys cannot detect
such conflict.

There are few conditions for this anomaly to be met

1. Table should have UNIQUE INDEX
2. UPDATES should happen on two rows that are consecutive in unique index.
3. And order of transaction commit

Why do these even conflict/wait each other?
-------------------------------------------
Right, let me explain this InnoDB behaviour.

An update in secondary index is basically delete-mark old record and insert the
new record in secondary index.

This insert of new record into UNIQUE secondary index, to guarantee uniqueness,
it first searches for a duplicate record and tries to lock the GAP to protect
uniqueness of the record it inserts. Infact, it uses LOCK_ORDINARY which uses
regular next-key lock + GAP (independent of trx isolation). Here it (UPDATE that
inserts record 2) tries to put SHARED Lock on record 3 + GAP before it.

And the other transaction (UPDATE to 3), holds EXCLUSIVE (LOCK_X) on the
record 3. So until we commit the UPDATE on record 3 transaction, UPDATE on
record 2 transaction cannot proceed. It waits for a lock and eventually timeout.

How does this 'unexpected conflict' translate to PXC world
----------------------------------------------------------
In PXC, such certified transactions can be applied in parallel
(wsrep_slave_threads > 1). These certified transactions fail to
apply.

Because of the above explained lock conflict, one applier thread BruteForce (BF)
aborts another applier thread transaction, causing the nodes to fail. Applier
thread should never fail to apply a transaction.

Fix:
----
Since these transactions are certified at originator, we know for sure, that
these cannot conflict and cannot violate the uniqueness constraint, we will let
these high-priority transactions proceed without the lock-conflict.

We already have such logic to handle BF-BF lock conflict but it seems we didn't handle
this (probably a merge mistake) in 8.0.

5.7 is not affected by this bug.