### PR TITLE
PXC-3720: Assertion failure `assert(0)` in `wsrep_do_action_for_tables()`

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf.result
@@ -66,3 +66,47 @@ SHOW TABLES;
 Tables_in_test
 p1
 DROP TABLE p1;
+CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
+SET wsrep_retry_autocommit = 1;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+ALTER TABLE t1 ADD (b INT);
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `c` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+SET wsrep_retry_autocommit = 0;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+ALTER TABLE t1 ADD (b INT);
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `c` int DEFAULT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;
+SET wsrep_retry_autocommit = 2;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+ALTER TABLE t1 ADD (b INT);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf.test
@@ -213,6 +213,74 @@ SHOW TABLES;
 DROP TABLE p1;
 
 
+#
+# The fix involves querying Data Dictionary to obtain parent and child foreign
+# keys. We need to acquire table MDL lock to be able to access DD.
+# As we do it before entering into TOI, another thread executing TOI in paralel
+# may abort the current thread.
+# In such a case we rely on wsrep_retry_autocommit functionality.
+#
+--connection node_1
+--let $wsrep_retry_autocommit_saved = `SELECT @@wsrep_retry_autocommit`
+CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
+
+SET wsrep_retry_autocommit = 1;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+--send ALTER TABLE t1 ADD (b INT)
+
+--connection node_1a
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+
+--connection node_1
+--reap
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+#
+# Now the same, but with wsrep_retry_autocommit = 0
+#
+SET wsrep_retry_autocommit = 0;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+--send ALTER TABLE t1 ADD (b INT)
+
+--connection node_1a
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--disable_query_log
+--eval set @@wsrep_retry_autocommit = $wsrep_retry_autocommit_saved
+--enable_query_log
+
+#
+# Simulate permanent MDL lock failure
+#
+SET wsrep_retry_autocommit = 2;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+
+--error ER_LOCK_DEADLOCK
+ALTER TABLE t1 ADD (b INT);
+
+SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+
 # cleanup
 --disconnect node_1_toi
 --disconnect node_1a

--- a/mysql-test/suite/galera_nbo/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera_nbo/r/galera_bf_bf.result
@@ -29,3 +29,53 @@ ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 SET SESSION wsrep_osu_method=TOI;
 DROP TABLE c1;
 DROP TABLE p1;
+CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
+SET wsrep_retry_autocommit = 1;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET SESSION wsrep_osu_method=NBO;
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+ALTER TABLE t1 ADD (b INT);
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `c` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;
+SET wsrep_retry_autocommit = 0;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET SESSION wsrep_osu_method=NBO;
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+ALTER TABLE t1 ADD (b INT);
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  `c` int DEFAULT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;
+SET wsrep_retry_autocommit = 2;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET SESSION wsrep_osu_method=NBO;
+SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+ALTER TABLE t1 ADD (b INT);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int NOT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_nbo/r/galera_nbo_alter_optimize.result
+++ b/mysql-test/suite/galera_nbo/r/galera_nbo_alter_optimize.result
@@ -38,4 +38,4 @@ COUNT(*) = 2
 SET SESSION wsrep_OSU_method=TOI;
 DROP TABLE t1;
 DROP TABLE t2;
-CALL mtr.add_suppression("Failed to take MDL for table");
+CALL mtr.add_suppression(".*Unable to acquire shared lock on db.*");

--- a/mysql-test/suite/galera_nbo/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera_nbo/t/galera_bf_bf.test
@@ -84,6 +84,86 @@ DROP TABLE c1;
 DROP TABLE p1;
 
 
+#
+# The fix involves querying Data Dictionary to obtain parent and child foreign
+# keys. We need to acquire table MDL lock to be able to access DD.
+# As we do it before entering into TOI, another thread executing TOI in paralel
+# may abort the current thread.
+# In such a case we rely on wsrep_retry_autocommit functionality.
+#
+--connection node_1
+--let $wsrep_retry_autocommit_saved = `SELECT @@wsrep_retry_autocommit`
+CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
+
+SET wsrep_retry_autocommit = 1;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET SESSION wsrep_osu_method=NBO;
+
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+--send ALTER TABLE t1 ADD (b INT)
+
+--connection node_1a
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+
+--connection node_1
+--reap
+
+SHOW CREATE TABLE t1;
+
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;
+
+#
+# Now the same, but with wsrep_retry_autocommit = 0
+#
+SET wsrep_retry_autocommit = 0;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET SESSION wsrep_osu_method=NBO;
+
+SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+--send ALTER TABLE t1 ADD (b INT)
+
+--connection node_1a
+SET DEBUG_SYNC='now WAIT_FOR reached';
+ALTER TABLE t1 ADD (c INT);
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+SHOW CREATE TABLE t1;
+
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;
+
+--disable_query_log
+--eval set @@wsrep_retry_autocommit = $wsrep_retry_autocommit_saved
+--enable_query_log
+
+#
+# Simulate permanent MDL lock failure
+#
+SET wsrep_retry_autocommit = 2;
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET SESSION wsrep_osu_method=NBO;
+
+SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+
+--error ER_LOCK_DEADLOCK
+ALTER TABLE t1 ADD (b INT);
+
+SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+
+SHOW CREATE TABLE t1;
+
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;
+
+
 # cleanup
 --disconnect node_1_toi
 --disconnect node_1a

--- a/mysql-test/suite/galera_nbo/t/galera_nbo_alter_optimize.test
+++ b/mysql-test/suite/galera_nbo/t/galera_nbo_alter_optimize.test
@@ -57,4 +57,4 @@ SET SESSION wsrep_OSU_method=TOI;
 DROP TABLE t1;
 DROP TABLE t2;
 
-CALL mtr.add_suppression("Failed to take MDL for table");
+CALL mtr.add_suppression(".*Unable to acquire shared lock on db.*");

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -560,7 +560,9 @@ static bool wsrep_toi_replication(THD *thd, TABLE_LIST *tables) {
 
   wsrep::key_array keys;
 
-  wsrep_append_fk_parent_table(thd, tables, &keys);
+  if (wsrep_append_fk_parent_table(thd, tables, &keys)) {
+    return true;
+  }
 
   /* now TOI replication, with no locks held */
   if (keys.empty()) {
@@ -1435,6 +1437,7 @@ err:
   if (thd->sp_runtime_ctx) thd->sp_runtime_ctx->end_partial_result_set = true;
 
   /* Make sure this table instance is not reused after the operation. */
+  /* table can be nullptr if we failed with wsrep_toi_replication() */
   if (table && table->table) table->table->invalidate_dict();
   close_thread_tables(thd);  // Shouldn't be needed
   thd->mdl_context.release_transactional_locks();

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -384,12 +384,9 @@ bool Sql_cmd_alter_table::execute(THD *thd) {
        !find_temporary_table(thd, first_table))) {
     wsrep::key_array keys;
     // append tables referenced by this table
-    if(wsrep_append_fk_parent_table(thd, first_table, &keys)) {
-      WSREP_DEBUG("TOI replication for ALTER failed");
-      return true;
-    }
     // append tables that are referencing this table
-    if(wsrep_append_child_tables(thd, first_table, &keys)) {
+    if (wsrep_append_fk_parent_table(thd, first_table, &keys) ||
+        wsrep_append_child_tables(thd, first_table, &keys)) {
       WSREP_DEBUG("TOI replication for ALTER failed");
       return true;
     }

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4130,7 +4130,9 @@ int mysql_execute_command(THD *thd, bool first_level) {
           // We cannot use WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF, because here
           // lex->no_write_to_binlog is uninitialized
           wsrep::key_array keys;
-          wsrep_append_fk_parent_table(thd, all_tables, &keys);
+          if (wsrep_append_fk_parent_table(thd, all_tables, &keys)) {
+            return true;
+          }
           if (WSREP(thd) &&
               wsrep_to_isolation_begin(thd, NULL, NULL, all_tables, NULL, NULL,
                                        &keys)) {

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -504,7 +504,9 @@ void Sql_cmd_truncate_table::truncate_base(THD *thd, TABLE_LIST *table_ref) {
 
 #ifdef WITH_WSREP
   wsrep::key_array keys;
-  wsrep_append_fk_parent_table(thd, table_ref, &keys);
+  if (wsrep_append_fk_parent_table(thd, table_ref, &keys)) {
+    return;
+  }
   if (keys.empty()) {
     WSREP_TO_ISOLATION_BEGIN_IF(table_ref->db, table_ref->table_name, NULL) {
       return;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3720

This is the follow up of commit bd6f682f64da1aa463bd0e9ee37d1542a1b55673

The fix for BF-BF collision involves querying Data Dictionary to obtain
parent and child foreign keys.
We need to acquire a table MDL lock to be able to access DD. As we do it
before entering into TOI, another thread executing TOI in parallel may
abort the current thread.
In such a case we abort the current execution and rely on
wsrep_retry_autocommit functionality.