### PR TITLE
PXC-3801 Documentation: bootstrapping node with systemctl fails (5.7)

### DIFF
--- a/doc/source/bootstrap.rst
+++ b/doc/source/bootstrap.rst
@@ -11,19 +11,18 @@ which you want to be replicated to other nodes.
 
 Bootstrapping implies starting the node without any known cluster addresses.
 If the :variable:`wsrep_cluster_address` variable is empty,
-|PXC| assumes that this is the first node and initializes the cluster.
+*Percona XtraDB Cluster* assumes that this is the first node and initializes the cluster.
 
 Instead of changing the configuration,
-start the first node and use either of the following commands:
+start the first node with the following command on Debian or Ubuntu:
 
 .. code-block:: bash
 
    [root@pxc1 ~]# /etc/init.d/mysql bootstrap-pxc
-
-or
+   
+Start the first node with the following command on RedHat or CentOS:
 
 .. code-block:: bash
-
     [root@pxc1 ~]# systemctl start mysql@bootstrap.service
 
 When you start the node using the ``bootstrap.server`` command,

--- a/doc/source/howtos/centos_howto.rst
+++ b/doc/source/howtos/centos_howto.rst
@@ -85,7 +85,7 @@ For more information about bootstrapping the cluster, see :ref:`bootstrap`.
    .. note:: In case you're running CentOS 7,
       the bootstrap service should be used instead: ::
 
-         [root@percona1 ~]#  systemctl start mysql@bootstrap.service
+         [root@percona1 ~]# systemctl start mysql@bootstrap.service
 
    The previous command will start the cluster
    with initial :variable:`wsrep_cluster_address` variable

--- a/doc/source/howtos/crash-recovery.rst
+++ b/doc/source/howtos/crash-recovery.rst
@@ -83,7 +83,13 @@ advanced node (most likely the last stopped). The cluster must be bootstrapped
 using this node, otherwise nodes that had a more advanced position will have to
 perform the full :term:`SST` to join the cluster initialized from the less
 advanced one. As a result, some transactions will be lost). To bootstrap the
-first node, invoke the startup script like this:
+first node, invoke the startup script like this on Debian or Ubuntu:
+
+.. code-block:: bash
+
+   $ /etc/init.d/mysql bootstrap-pxc
+   
+If you are using RedHat or CentOS, use the following script:
 
 .. code-block:: bash
 


### PR DESCRIPTION
modified:   bootstrap.rst
	modified:   howtos/centos_howto.rst
	modified:   howtos/crash-recovery.rst