### PR TITLE
PXC-3767: IPv6 support in PXC (wsrep_sst_xtrabackup-v2)

### DIFF
--- a/mysql-test/suite/galera_3nodes/t/galera_ipv6_xtrabackup-v2.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_ipv6_xtrabackup-v2.cnf
@@ -26,5 +26,3 @@ wsrep_provider_options='base_host=[::1];base_port=@mysqld.3.#galera_port;gmcast.
 wsrep_sst_receive_address='[::1]:@mysqld.3.#sst_port'
 wsrep_node_incoming_address='[::1]:@mysqld.3.port'
 
-[SST]
-sockopt=",pf=ip6"

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -652,7 +652,13 @@ get_transfer()
             fi
 
             if [[ "$WSREP_SST_OPT_ROLE"  == "joiner" ]]; then
-                tcmd="socat -u TCP-LISTEN:${TSST_PORT},reuseaddr${sockopt} stdio"
+                # PXC-3767 - IPv6 support in PXC (wsrep_sst_xtrabackup-v2)
+                # socat require TCP6-LISTEN to work with ip version6 addresses
+                if [[ "$WSREP_SST_OPT_HOST" =~ .*:.* ]]; then
+                    tcmd="socat -u TCP6-LISTEN:${TSST_PORT},reuseaddr${sockopt} stdio"
+                else
+                    tcmd="socat -u TCP-LISTEN:${TSST_PORT},reuseaddr${sockopt} stdio"
+                fi
             else
                 tcmd="socat -u stdio TCP:${REMOTEIP}:${TSST_PORT}${sockopt}"
             fi


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3767

Analysis
Joiner nodes are failing , becuase they are using
socat utility with IPv6 and currently wsrep_sst_xtrabackup-v2 script
doesn't support socat command with IPv6 option.

Fix
Added IPv6 support for socat command inside wsrep_sst_xtrabackup-v2 script
for Joiner nodes.