### PR TITLE
PXC-3724: PXC crashes with long semaphore wait

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6728,6 +6728,13 @@ static int innobase_rollback(handlerton *hton, /*!< in: InnoDB handlerton */
       !thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN)) {
     error = trx_rollback_for_mysql(trx);
 
+#ifdef WITH_WSREP
+    /* If the transaction was aborted at prepare phase, it does not get
+    into commit phase, so we need to clean this flag here.
+    The new transaction will start with the clean state. */
+    trx->lock.was_chosen_as_wsrep_victim = false;
+#endif /* WITH_WSREP */
+
     if (trx->state == TRX_STATE_FORCED_ROLLBACK) {
 #ifdef UNIV_DEBUG
       char buffer[1024];


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3724

Problem:
Under heavy R/W parallel workload, after some time all client sessions
are blocked and the server eventually fails with
[FATAL] Semaphore wait has lasted > 600 seconds.

Cause:
1. Client session 1 (TH1): Execute COMMIT (transaction 1).
During prepare phase (before certification) it is BF aborted by HP
thread. was_chosen_as_wsrep_victim flag is set to true.
It does not get into the commit phase and ha_rollback_trans() is called,
but was_chosen_as_wsrep_victim flag is not cleaned up.
Transaction is finished.

2. Client session 1 (TH1): Execute COMMIT (transaction 2).
It has was_chosen_as_wsrep_victim==true (as not cleaned up before).
It certifies and then enters commit phase. It adds itself to
the wsrep_group_commit_queue and to the mysql group commit queue.
Other threads are added to simultaneously these queues as well
(before and after TH1)

3. Leader starts processing mysql group commit queue. It gets to TH1.
Transaction is committed, but as was_chosen_as_wsrep_victim==true
we skip the call to trx_sys_update_wsrep_checkpoint() (and internal
call to wsrep_unregister_from_group_commit() for this thread).
So TH1 is still at the beginning of wsrep_group_commit_queue

4. Leader goes to the next thread in mysql group commit queue.
It calls trx_sys_update_wsrep_checkpoint() which internally calls
wsrep_wait_for_turn_in_group_commit(). This blocks, as TH1 is still
in front of wsrep_group_commit_queue and the processing thread is the
2nd one in the wsrep_group_commit_queue.

5. The result is that Leader thread waits forever blocking all client
threads

Solution:
Clean was_chosen_as_wsrep_victim flag when the transaction is being
rolled back.

MTR test not provided as the scenario needs multiple client
sessions and applier thread executing group commit logic simultaneously
which is problematic to model in MTR test.