### PR TITLE
PXC-3777 : Server crashes due to a deadlock detection of mutexes

### DIFF
--- a/mysql-test/suite/galera/r/pxc_kill_victim_waiting.result
+++ b/mysql-test/suite/galera/r/pxc_kill_victim_waiting.result
@@ -1,0 +1,38 @@
+#
+# PXC-3777 : Server crashes due to a deadlock detection of mutexes
+#
+CREATE TABLE t1(a INT PRIMARY KEY, b VARCHAR(10));
+INSERT INTO t1 VALUES (1, 'hi');
+# connection node_1a
+# Lock the record in this session node_1a
+BEGIN;
+SELECT * FROM t1 WHERE a = 1 FOR UPDATE;
+a	b
+1	hi
+# connection node_1b
+# This update will be waiting for lock that is
+# acquired by node_1a. When TRUNCATE TABLE DDL
+# arrives, this node_1b or node_1c connection
+# will be victim that is waiting for lock
+SET SESSION innodb_lock_wait_timeout=100;
+UPDATE t1 SET b = 'hello' WHERE a = 1;
+# connection node_1c
+# This update will be waiting for lock that is
+# acquired by node_1a. When TRUNCATE TABLE DDL
+# arrives, this node_1b or node_1c connection
+# will be victim that is waiting for lock
+SET SESSION innodb_lock_wait_timeout=100;
+UPDATE t1 SET b = 'hello' WHERE a = 1;
+# connection node_1
+# DDL in TOI will try to kill all conflicting trxs
+# i.e all trxs that acquired conflicting MDLs
+# on table t1 (taken by node_1a,1b,1c)
+# 1b and 1c are victims that are in waiting state
+TRUNCATE TABLE t1;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+COMMIT;
+COMMIT;
+SELECT * FROM t1;
+a	b
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_kill_victim_waiting.test
+++ b/mysql-test/suite/galera/t/pxc_kill_victim_waiting.test
@@ -1,0 +1,66 @@
+--echo #
+--echo # PXC-3777 : Server crashes due to a deadlock detection of mutexes
+--echo #
+
+--source include/galera_cluster.inc
+--source include/wait_wsrep_ready.inc
+--source include/count_sessions.inc
+
+--connection node_1
+CREATE TABLE t1(a INT PRIMARY KEY, b VARCHAR(10));
+INSERT INTO t1 VALUES (1, 'hi');
+
+--connect node_1a, 127.0.0.1, root,,, $NODE_MYPORT_1
+--connection node_1a
+--echo # connection node_1a
+--echo # Lock the record in this session node_1a
+BEGIN;
+SELECT * FROM t1 WHERE a = 1 FOR UPDATE;
+
+--connect node_1b, 127.0.0.1, root,,, $NODE_MYPORT_1
+--connection node_1b
+--echo # connection node_1b
+--echo # This update will be waiting for lock that is
+--echo # acquired by node_1a. When TRUNCATE TABLE DDL
+--echo # arrives, this node_1b or node_1c connection
+--echo # will be victim that is waiting for lock
+SET SESSION innodb_lock_wait_timeout=100;
+--send UPDATE t1 SET b = 'hello' WHERE a = 1
+
+--connect node_1c, 127.0.0.1, root,,, $NODE_MYPORT_1
+--connection node_1c
+--echo # connection node_1c
+--echo # This update will be waiting for lock that is
+--echo # acquired by node_1a. When TRUNCATE TABLE DDL
+--echo # arrives, this node_1b or node_1c connection
+--echo # will be victim that is waiting for lock
+SET SESSION innodb_lock_wait_timeout=100;
+--send UPDATE t1 SET b = 'hello' WHERE a = 1
+
+--echo # connection node_1
+--connection node_1
+--echo # DDL in TOI will try to kill all conflicting trxs
+--echo # i.e all trxs that acquired conflicting MDLs
+--echo # on table t1 (taken by node_1a,1b,1c)
+--echo # 1b and 1c are victims that are in waiting state
+TRUNCATE TABLE t1;
+
+--connection node_1a
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+--connection node_1b
+--reap
+COMMIT;
+
+--connection node_1c
+--reap
+COMMIT;
+
+--connection node_1
+SELECT * FROM t1;
+DROP TABLE t1;
+--disconnect node_1a
+--disconnect node_1b
+--disconnect node_1c
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3777

Problem:
--------

This is because of deadlock of mutexes trx->mutex and lock_sys mutex

1. aborter thread: acquires trx->mutex and wants to acquire lock_sys in X mode
2. Other thread:   acquires lock_sys in S mode and wants to acquire trx->mutex

trx-t1 does DDL tries to acquire X lock MDL and as part of this, we abort all
the trxs with conflicting MDL locks (ie do wsrep_abort_thd) However, the
conflicting trx (t2) is a DML on the same table that is in waiting state.
This trx t2 is in waiting state because another thread t3 is also a DML in
committing state.

t3 is in state of releasing locks: acquires lock_sys in Shared mode and
(requests)tries to acquire trx->mutex.

t1 acquires trx->mutex and requests for lock_sys in X mode (to abort t2)

Fix:
----

When doing BF Abort, if the victim trx is suspended state, we need not explicitly
release locks. The lock_wait_timeout thread will release locks of the
interrupted trx and wakes up the victim that was in the suspended state.