### PR TITLE
PXC-3839: Improve BiDiScan Azure job to properly handle empty commits (8.0)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,13 @@ jobs:
 
   - script: |
       git fetch origin 8.0
-      python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v $(git diff --name-only --relative --diff-filter AMR origin/8.0 -- . | tr '\n' ' ')
+      CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/8.0 -- . | tr '\n' ' ')
+
+      if [ -z "${CHANGED_FILES}" ]; then
+          echo --- No changed files
+      else
+          python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v ${CHANGED_FILES}
+      fi
 
 - job:
   timeoutInMinutes: 240


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3839

It is possible to have PR which doesn't actually change any file
(Null merge for example). Improve BiDiScan Azure job to skip
actual check in case there are not any files changed in PR.

(cherry picked from commit 4a98cd762e580b4d0ff70ceb7d7155416c35de69)