### PR TITLE
PXC-3743: Make wsrep session variables updatable through SET_VAR() hint

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -324,6 +324,7 @@ our @DEFAULT_SUITES = qw(
   galera_3nodes_sr
   galera_nbo
   galera_3nodes_nbo
+  wsrep
   );
 
 our $DEFAULT_SUITES = join ',', @DEFAULT_SUITES;

--- a/mysql-test/suite/wsrep/my.cnf
+++ b/mysql-test/suite/wsrep/my.cnf
@@ -2,10 +2,16 @@
 !include include/default_mysqld.cnf
 
 [mysqld.1]
+binlog-format=row
+innodb_autoinc_lock_mode=2
+innodb_flush_log_at_trx_commit=2
+
+# wsrep variables
 wsrep_provider=@ENV.WSREP_PROVIDER
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=10M'
 wsrep_cluster_address='gcomm://'
 wsrep_node_address=127.0.0.1
-binlog-format=row
+wsrep_node_name=node1
 
 [ENV]
 GALERA_BASE_PORT=@mysqld.1.#galera_port

--- a/mysql-test/suite/wsrep/r/wsrep_set_var_extension.result
+++ b/mysql-test/suite/wsrep/r/wsrep_set_var_extension.result
@@ -1,0 +1,86 @@
+CREATE PROCEDURE test_hint (hint_str VARCHAR(255), var_str VARCHAR(64))
+BEGIN
+SET @orig_q= CONCAT("SELECT VARIABLE_VALUE INTO @before_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+SET @hint_q= CONCAT("SELECT /*+ ", hint_str,
+"*/ VARIABLE_VALUE" ,
+" INTO @hint_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+SET @after_q= CONCAT("SELECT VARIABLE_VALUE INTO @after_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+PREPARE orig_stmt FROM @orig_q;
+PREPARE hint_stmt FROM @hint_q;
+PREPARE after_stmt FROM @after_q;
+EXECUTE orig_stmt;
+EXECUTE hint_stmt;
+EXECUTE after_stmt;
+SELECT  hint_str;
+SELECT @before_val, @hint_val, @after_val;
+DEALLOCATE PREPARE orig_stmt;
+DEALLOCATE PREPARE hint_stmt;
+DEALLOCATE PREPARE after_stmt;
+END\\
+#########################################
+# Test SET_VAR hint for wsrep variables #
+#########################################
+
+# Test 1: wsrep_sync_wait
+CALL test_hint("SET_VAR(wsrep_sync_wait=4)", "wsrep_sync_wait");
+hint_str
+SET_VAR(wsrep_sync_wait=4)
+@before_val	@hint_val	@after_val
+15	4	15
+SET wsrep_sync_wait=2;
+CALL test_hint("SET_VAR(wsrep_sync_wait=4)", "wsrep_sync_wait");
+hint_str
+SET_VAR(wsrep_sync_wait=4)
+@before_val	@hint_val	@after_val
+2	4	2
+SET wsrep_sync_wait=default;
+
+# Test 2: wsrep_dirty_reads
+CALL test_hint("SET_VAR(wsrep_dirty_reads=ON)", "wsrep_dirty_reads");
+hint_str
+SET_VAR(wsrep_dirty_reads=ON)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET wsrep_dirty_reads=1;
+CALL test_hint("SET_VAR(wsrep_dirty_reads=OFF)", "wsrep_dirty_reads");
+hint_str
+SET_VAR(wsrep_dirty_reads=OFF)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+SET wsrep_dirty_reads=default;
+
+# Test 3: wsrep_trx_fragment_unit
+CALL test_hint("SET_VAR(wsrep_trx_fragment_unit='statements')", "wsrep_trx_fragment_unit");
+hint_str
+SET_VAR(wsrep_trx_fragment_unit='statements')
+@before_val	@hint_val	@after_val
+bytes	statements	bytes
+SET wsrep_trx_fragment_unit='statements';
+CALL test_hint("SET_VAR(wsrep_trx_fragment_unit=rows)", "wsrep_trx_fragment_unit");
+hint_str
+SET_VAR(wsrep_trx_fragment_unit=rows)
+@before_val	@hint_val	@after_val
+statements	rows	statements
+SET wsrep_trx_fragment_unit=default;
+
+# Test 4: wsrep_trx_fragment_size
+CALL test_hint("SET_VAR(wsrep_trx_fragment_size=100)", "wsrep_trx_fragment_size");
+hint_str
+SET_VAR(wsrep_trx_fragment_size=100)
+@before_val	@hint_val	@after_val
+0	100	0
+SET wsrep_trx_fragment_size=111;
+CALL test_hint("SET_VAR(wsrep_trx_fragment_size=0)", "wsrep_trx_fragment_size");
+hint_str
+SET_VAR(wsrep_trx_fragment_size=0)
+@before_val	@hint_val	@after_val
+111	0	111
+SET wsrep_trx_fragment_size=default;
+
+# Test 5: wsrep_on is not hint updatable.
+CALL test_hint("SET_VAR(wsrep_on=0)", "wsrep_on");
+hint_str
+SET_VAR(wsrep_on=0)
+@before_val	@hint_val	@after_val
+ON	ON	ON
+DROP PROCEDURE test_hint;

--- a/mysql-test/suite/wsrep/t/wsrep_set_var_extension.test
+++ b/mysql-test/suite/wsrep/t/wsrep_set_var_extension.test
@@ -1,0 +1,133 @@
+# === Purpose ===
+#
+# This test verifies that the following wsrep session variables are hint updatable.
+#
+# 1. wsrep_sync_wait
+# 2. wsrep_dirty_reads
+# 3. wsrep_trx_fragment_size
+# 4. wsrep_trx_fragment_unit
+#
+# === References ===
+#
+# PXC-3743: Make wsrep session variables updatable through SET_VAR() hint
+
+--source include/have_wsrep_provider.inc
+
+# Auxiliary SP which returns variable value before hint, with hint and after hint applying
+DELIMITER \\; 
+
+CREATE PROCEDURE test_hint (hint_str VARCHAR(255), var_str VARCHAR(64))
+BEGIN
+
+SET @orig_q= CONCAT("SELECT VARIABLE_VALUE INTO @before_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+
+SET @hint_q= CONCAT("SELECT /*+ ", hint_str,
+                    "*/ VARIABLE_VALUE" ,
+                    " INTO @hint_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+
+SET @after_q= CONCAT("SELECT VARIABLE_VALUE INTO @after_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+
+PREPARE orig_stmt FROM @orig_q;
+PREPARE hint_stmt FROM @hint_q;
+PREPARE after_stmt FROM @after_q;
+
+EXECUTE orig_stmt;
+EXECUTE hint_stmt;
+EXECUTE after_stmt;
+
+SELECT  hint_str;
+SELECT @before_val, @hint_val, @after_val;
+
+DEALLOCATE PREPARE orig_stmt;
+DEALLOCATE PREPARE hint_stmt;
+DEALLOCATE PREPARE after_stmt;
+
+END\\
+
+DELIMITER ;\\
+
+--echo #########################################
+--echo # Test SET_VAR hint for wsrep variables #
+--echo #########################################
+
+--echo
+--echo # Test 1: wsrep_sync_wait
+CALL test_hint("SET_VAR(wsrep_sync_wait=4)", "wsrep_sync_wait");
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 4`)
+
+SET wsrep_sync_wait=2;
+CALL test_hint("SET_VAR(wsrep_sync_wait=4)", "wsrep_sync_wait");
+
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 4`)
+
+SET wsrep_sync_wait=default;
+
+--echo
+--echo # Test 2: wsrep_dirty_reads
+CALL test_hint("SET_VAR(wsrep_dirty_reads=ON)", "wsrep_dirty_reads");
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 'ON'`)
+
+SET wsrep_dirty_reads=1;
+CALL test_hint("SET_VAR(wsrep_dirty_reads=OFF)", "wsrep_dirty_reads");
+
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 'OFF'`)
+
+SET wsrep_dirty_reads=default;
+
+--echo
+--echo # Test 3: wsrep_trx_fragment_unit
+CALL test_hint("SET_VAR(wsrep_trx_fragment_unit='statements')", "wsrep_trx_fragment_unit");
+
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 'statements'`)
+
+SET wsrep_trx_fragment_unit='statements';
+CALL test_hint("SET_VAR(wsrep_trx_fragment_unit=rows)", "wsrep_trx_fragment_unit");
+
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 'rows'`)
+
+SET wsrep_trx_fragment_unit=default;
+
+--echo
+--echo # Test 4: wsrep_trx_fragment_size
+CALL test_hint("SET_VAR(wsrep_trx_fragment_size=100)", "wsrep_trx_fragment_size");
+
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 100`)
+
+SET wsrep_trx_fragment_size=111;
+CALL test_hint("SET_VAR(wsrep_trx_fragment_size=0)", "wsrep_trx_fragment_size");
+
+--assert (`SELECT @before_val != @hint_val`)
+--assert (`SELECT @hint_val != @after_val`)
+--assert (`SELECT @before_val = @after_val`)
+--assert (`SELECT @hint_val = 0`)
+
+SET wsrep_trx_fragment_size=default;
+
+--echo
+--echo # Test 5: wsrep_on is not hint updatable.
+CALL test_hint("SET_VAR(wsrep_on=0)", "wsrep_on");
+--assert (`SELECT @before_val = @hint_val`)
+--assert (`SELECT @hint_val = @after_val`)
+
+DROP PROCEDURE test_hint;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -8037,7 +8037,7 @@ static Sys_var_uint Sys_wsrep_sync_wait(
     "Ensure \"synchronous\" read view before executing an operation of the "
     "type specified by bitmask: 1 - READ(includes SELECT, SHOW and BEGIN/START "
     "TRANSACTION); 2 - UPDATE and DELETE; 4 - INSERT and REPLACE",
-    SESSION_VAR(wsrep_sync_wait), CMD_LINE(OPT_ARG),
+    HINT_UPDATEABLE SESSION_VAR(wsrep_sync_wait), CMD_LINE(OPT_ARG),
     VALID_RANGE(WSREP_SYNC_WAIT_NONE, WSREP_SYNC_WAIT_MAX),
     DEFAULT(WSREP_SYNC_WAIT_NONE), BLOCK_SIZE(1), NO_MUTEX_GUARD, NOT_IN_BINLOG,
     ON_CHECK(0), ON_UPDATE(wsrep_sync_wait_update));
@@ -8118,7 +8118,7 @@ static Sys_var_ulonglong Sys_wsrep_trx_fragment_size(
     "wsrep_trx_fragment_size",
     "Size of transaction fragments for streaming replication (measured in "
     "units of 'wsrep_trx_fragment_unit')",
-    SESSION_VAR(wsrep_trx_fragment_size), CMD_LINE(REQUIRED_ARG),
+    HINT_UPDATEABLE SESSION_VAR(wsrep_trx_fragment_size), CMD_LINE(REQUIRED_ARG),
     VALID_RANGE(0, WSREP_MAX_WS_SIZE), DEFAULT(0), BLOCK_SIZE(1),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(wsrep_trx_fragment_size_check),
     ON_UPDATE(wsrep_trx_fragment_size_update));
@@ -8129,7 +8129,7 @@ static Sys_var_enum Sys_wsrep_trx_fragment_unit(
     "wsrep_trx_fragment_unit",
     "Unit for streaming replication transaction fragments' size: bytes, "
     "rows, statements",
-    SESSION_VAR(wsrep_trx_fragment_unit), CMD_LINE(REQUIRED_ARG),
+    HINT_UPDATEABLE SESSION_VAR(wsrep_trx_fragment_unit), CMD_LINE(REQUIRED_ARG),
     wsrep_fragment_units, DEFAULT(WSREP_FRAG_BYTES), NO_MUTEX_GUARD,
     NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(wsrep_trx_fragment_unit_update));
 
@@ -8141,7 +8141,7 @@ static Sys_var_enum Sys_wsrep_SR_store(
 
 static Sys_var_bool Sys_wsrep_dirty_reads(
     "wsrep_dirty_reads", "Allow reads from a node is not in primary component",
-    SESSION_VAR(wsrep_dirty_reads), CMD_LINE(OPT_ARG), DEFAULT(false),
+    HINT_UPDATEABLE SESSION_VAR(wsrep_dirty_reads), CMD_LINE(OPT_ARG), DEFAULT(false),
     NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
 static Sys_var_uint Sys_wsrep_ignore_apply_errors(


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3743

Allow users to utilize SET_VAR optimizer hint to temporarily set the wsrep
session variables.

This patch allows the following session variables to be updatable through
SET_VAR() extension.

1. wsrep_sync_wait
2. wsrep_dirty_reads
3. wsrep_trx_fragment_size
4. wsrep_trx_fragment_unit
```
Example:

mysql> SELECT @@wsrep_sync_wait; SELECT /*+ SET_VAR(wsrep_sync_wait=4 )*/ @@wsrep_sync_wait; SELECT @@wsrep_sync_wait;
+-------------------+
| @@wsrep_sync_wait |
+-------------------+
|                15 |
+-------------------+
1 row in set (0.00 sec)
+-------------------+
| @@wsrep_sync_wait |
+-------------------+
|                 4 |
+-------------------+
1 row in set (0.00 sec)
+-------------------+
| @@wsrep_sync_wait |
+-------------------+
|                15 |
+-------------------+
1 row in set (0.00 sec)
```
Note: The following session variables cannot be updatable through
SET_VAR

1. wsrep_on: Because it may cause inconsistent read/writes.
2. wsrep_causal_reads: Deprecated.

In addition to the above change, the `wsrep` suite has been added to the
default MTR suite as well.

Testing Done
---
Galera suite: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/364/testReport/
Failing tests: 

1. galera.pxc3444 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-a7a6d5fdbce4f8d0148784d04113fc252647784edbda2485d4e63323647f2191)
2. galera.pxc3733 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-547dd82845ced28a26bae75ec044c217ab5e64ccb4dcf2873f4de51af18bfd9d)
3. galera.pxc_strict_mode - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-2e34c8537043419fde5b741f5a3dbd1aff91bce0b0d24fa28f67872df4b818c5)
4. galera.GCF-360 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-89ec7cddddec219c590d0251ea6dc567ad4156cc679554511e47ec0346084322)
