### PR TITLE
PXC-3704: wsrep_max_ws_size not linked to repl.max_ws_size when defined in configuration file

### DIFF
--- a/mysql-test/include/galera_wait_until_synced.inc
+++ b/mysql-test/include/galera_wait_until_synced.inc
@@ -1,0 +1,11 @@
+# === Purpose ===
+#
+# Waits until the node comes to 'Synced' state, or until a timeout is
+# reached.
+#
+# === Usage ===
+#
+# --source include/galera_wait_until_synced.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--source include/wait_condition.inc

--- a/mysql-test/suite/galera/r/galera_repl_max_ws_size.result
+++ b/mysql-test/suite/galera/r/galera_repl_max_ws_size.result
@@ -8,3 +8,79 @@ COUNT(*) = 0
 DROP TABLE t1;
 CALL mtr.add_suppression("Transaction/Write-set size limit.*");
 CALL mtr.add_suppression("Failed to create write-set from binlog.*");
+SET SESSION wsrep_sync_wait = 0;
+
+# Test-1: Verify that value of wsrep_max_ws_size picked from cnf file is
+#         also updated in the provider on server startup.
+#
+# Shutdown node2
+[connection node_2]
+# Shutting down node2
+# restarting node2
+# restart: --defaults-file=CONFIG_FILE
+SET SESSION wsrep_sync_wait = 0;
+SELECT @@wsrep_max_ws_size;
+@@wsrep_max_ws_size
+8192
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+provider_value
+8192
+include/assert.inc [Both wsrep_max_ws_size and repl.max_ws_size have same values]
+
+# Test-2: Verify that value of wsrep_max_ws_size set during runtime is
+#         also updated in the provider immediately.
+#
+SET GLOBAL wsrep_max_ws_size = 40960;
+SELECT @@wsrep_max_ws_size;
+@@wsrep_max_ws_size
+40960
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+provider_value
+40960
+include/assert.inc [Both wsrep_max_ws_size and repl.max_ws_size have same values]
+
+# Test-3: Verify that value of repl.max_ws_size provider option set
+#         during runtime is also updated in the server variable
+#         immediately.
+#
+SET GLOBAL wsrep_provider_options = 'repl.max_ws_size = 204800';
+SELECT @@wsrep_max_ws_size;
+@@wsrep_max_ws_size
+204800
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+provider_value
+204800
+include/assert.inc [Both wsrep_max_ws_size and repl.max_ws_size have same values]
+
+# Test-4: Verify that value of repl.max_ws_size picked from command line is
+#         also updated in the provider on server startup.
+#
+# Shutdown node2
+[connection node_2]
+# Shutting down node2
+SET SESSION wsrep_sync_wait = 0;
+SELECT @@wsrep_max_ws_size;
+@@wsrep_max_ws_size
+102400
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+provider_value
+102400
+include/assert.inc [Both wsrep_max_ws_size and repl.max_ws_size have same values]
+
+# Test-5: Verify that value of repl.max_ws_size is chosen when both
+#         wsrep_max_ws_size and repl.max_ws_size is passed to the
+#         server.
+#
+# Shutdown node2
+[connection node_2]
+# Shutting down node2
+# restarting node2 with repl.max_ws_size=204800
+SET SESSION wsrep_sync_wait = 0;
+SELECT @@wsrep_max_ws_size;
+@@wsrep_max_ws_size
+204800
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+provider_value
+204800
+include/assert.inc [Both wsrep_max_ws_size and repl.max_ws_size have same values]
+# restart

--- a/mysql-test/suite/galera/t/galera_repl_max_ws_size.test
+++ b/mysql-test/suite/galera/t/galera_repl_max_ws_size.test
@@ -28,3 +28,223 @@ DROP TABLE t1;
 #CALL mtr.add_suppression("rbr write fail");
 CALL mtr.add_suppression("Transaction/Write-set size limit.*");
 CALL mtr.add_suppression("Failed to create write-set from binlog.*");
+
+
+# === Purpose ===
+#
+# Test that setting repl.max_ws_size provider option also updates server's
+# wsrep_max_ws_size and vice versa.
+#
+# === References ====
+#
+# PXC-3704: wsrep_max_ws_size not linked to repl.max_ws_size when defined in
+#           configuration file
+
+--connection node_2
+
+# Save the provider options before testing
+--let $wsrep_provider_options_orig = `SELECT @@wsrep_provider_options`
+
+# Check that the cluster started correctly.
+SET SESSION wsrep_sync_wait = 0;
+
+--let $members=2
+--source include/galera_wait_until_synced.inc
+--source include/wsrep_wait_membership.inc
+
+--echo
+--echo # Test-1: Verify that value of wsrep_max_ws_size picked from cnf file is
+--echo #         also updated in the provider on server startup.
+--echo #
+
+# Create a temporary cnf file for testing with wsrep_max_ws_size
+--let $CONFIG_FILE = $MYSQLTEST_VARDIR/tmp/galera_repl_max_ws_size.cnf
+--copy_file $MYSQLTEST_VARDIR/my.cnf $CONFIG_FILE
+--append_file $CONFIG_FILE
+[mysqld.2]
+wsrep-max-ws-size= 8192
+wsrep-debug=1
+EOF
+
+--echo # Shutdown node2
+--connection node_2
+--echo [connection node_2]
+--echo # Shutting down node2
+--source include/shutdown_mysqld.inc
+
+--echo # restarting node2
+--let $restart_parameters = "restart: --defaults-file=$CONFIG_FILE"
+--replace_result $CONFIG_FILE CONFIG_FILE
+--source include/start_mysqld.inc
+
+# Check that the cluster started correctly.
+SET SESSION wsrep_sync_wait = 0;
+--source include/wsrep_wait_membership.inc
+
+# Verify that the value mentioned in the cnf file has been updated in both
+# 'repl.max_ws_size' provider option and also server's 'wsrep_max_ws_size'
+# variable.
+
+# Check the value of server variable.
+SELECT @@wsrep_max_ws_size;
+
+# Check the value in provider.
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+
+# Assert that the value is 8192, which is picked from wsrep-max-ws-size from cnf file.
+--assert (`SELECT @@wsrep_max_ws_size = 8192`)
+
+# Assert that both wsrep_max_ws_size and repl.max_ws_size have same values.
+--let $server_max_ws_value = `SELECT @@wsrep_max_ws_size`
+--let $provide_max_ws_value = `SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1)`
+
+--let $assert_text = Both wsrep_max_ws_size and repl.max_ws_size have same values
+--let $assert_cond = [ SELECT $server_max_ws_value = $provide_max_ws_value ]
+--source include/assert.inc
+
+--echo
+--echo # Test-2: Verify that value of wsrep_max_ws_size set during runtime is
+--echo #         also updated in the provider immediately.
+--echo #
+
+# Set the wsrep_max_ws_size to a new value and test again.
+SET GLOBAL wsrep_max_ws_size = 40960;
+
+# Check the value of server variable.
+SELECT @@wsrep_max_ws_size;
+
+# Check the value in provider.
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+
+# Assert that the value is 40960.
+--assert (`SELECT @@wsrep_max_ws_size = 40960`)
+
+# Assert that both wsrep_max_ws_size and repl.max_ws_size have same values.
+--let $server_max_ws_value = `SELECT @@wsrep_max_ws_size`
+--let $provide_max_ws_value = `SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1)`
+
+--let $assert_text = Both wsrep_max_ws_size and repl.max_ws_size have same values
+--let $assert_cond = [ SELECT $server_max_ws_value = $provide_max_ws_value ]
+--source include/assert.inc
+
+--echo
+--echo # Test-3: Verify that value of repl.max_ws_size provider option set
+--echo #         during runtime is also updated in the server variable
+--echo #         immediately.
+--echo #
+
+# Set the repl.max_ws_size to a new value and test again.
+SET GLOBAL wsrep_provider_options = 'repl.max_ws_size = 204800';
+
+# Check the value of server variable.
+SELECT @@wsrep_max_ws_size;
+
+# Check the value in provider.
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+
+# Assert that the value is 204800.
+--assert (`SELECT @@wsrep_max_ws_size = 204800`)
+
+# Assert that both wsrep_max_ws_size and repl.max_ws_size have same values.
+--let $server_max_ws_value = `SELECT @@wsrep_max_ws_size`
+--let $provide_max_ws_value = `SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1)`
+
+--let $assert_text = Both wsrep_max_ws_size and repl.max_ws_size have same values
+--let $assert_cond = [ SELECT $server_max_ws_value = $provide_max_ws_value ]
+--source include/assert.inc
+
+--echo
+--echo # Test-4: Verify that value of repl.max_ws_size picked from command line is
+--echo #         also updated in the provider on server startup.
+--echo #
+
+--echo # Shutdown node2
+--connection node_2
+--echo [connection node_2]
+--echo # Shutting down node2
+--source include/shutdown_mysqld.inc
+
+--let $suppress_print_params=1
+--let $start_mysqld_params = --wsrep_provider_options=base_port=$NODE_GALERAPORT_2;repl.max_ws_size=102400;
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+--let $suppress_print_params=0
+
+# Check that the cluster started correctly.
+SET SESSION wsrep_sync_wait = 0;
+--source include/wsrep_wait_membership.inc
+
+# Check the value of server variable.
+SELECT @@wsrep_max_ws_size;
+
+# Check the value in provider.
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+
+# Assert that the value is 102400, which is picked from repl.max_ws_size from command line.
+--assert (`SELECT @@wsrep_max_ws_size = 102400`)
+
+# Assert that both wsrep_max_ws_size and repl.max_ws_size have same values.
+--let $server_max_ws_value = `SELECT @@wsrep_max_ws_size`
+--let $provide_max_ws_value = `SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1)`
+
+--let $assert_text = Both wsrep_max_ws_size and repl.max_ws_size have same values
+--let $assert_cond = [ SELECT $server_max_ws_value = $provide_max_ws_value ]
+--source include/assert.inc
+
+--echo
+--echo # Test-5: Verify that value of repl.max_ws_size is chosen when both
+--echo #         wsrep_max_ws_size and repl.max_ws_size is passed to the
+--echo #         server.
+--echo #
+
+# Create a temporary cnf file for testing with wsrep_max_ws_size=8192
+--remove_file $CONFIG_FILE
+--copy_file $MYSQLTEST_VARDIR/my.cnf $CONFIG_FILE
+--append_file $CONFIG_FILE
+[mysqld.2]
+wsrep-max-ws-size= 8192
+wsrep-debug=1
+EOF
+
+--echo # Shutdown node2
+--connection node_2
+--echo [connection node_2]
+--echo # Shutting down node2
+--source include/shutdown_mysqld.inc
+
+--echo # restarting node2 with repl.max_ws_size=204800
+--let $suppress_print_params=1
+--let $start_mysqld_params =  --defaults-file=$CONFIG_FILE --wsrep_provider_options=base_port=$NODE_GALERAPORT_2;repl.max_ws_size=204800;
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+--let $suppress_print_params=0
+
+# Check that the cluster started correctly.
+SET SESSION wsrep_sync_wait = 0;
+--let $members=2
+--source include/galera_wait_until_synced.inc
+--source include/wsrep_wait_membership.inc
+
+# Check the value of server variable.
+SELECT @@wsrep_max_ws_size;
+
+# Check the value in provider.
+SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1) AS provider_value;
+
+# Assert that the value is 204800, which is picked from repl.max_ws_size from command line and wsrep_max_ws_size is ignored.
+--assert (`SELECT @@wsrep_max_ws_size = 204800`)
+
+# Assert that both wsrep_max_ws_size and repl.max_ws_size have same values.
+--let $server_max_ws_value = `SELECT @@wsrep_max_ws_size`
+--let $provide_max_ws_value = `SELECT SUBSTRING_INDEX(SUBSTR(@@wsrep_provider_options, LOCATE('repl.max_ws_size =', @@wsrep_provider_options) + LENGTH('repl.max_ws_size = ')), '; ', 1)`
+
+--let $assert_text = Both wsrep_max_ws_size and repl.max_ws_size have same values
+--let $assert_cond = [ SELECT $server_max_ws_value = $provide_max_ws_value ]
+--source include/assert.inc
+
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+# Cleanup
+--remove_file $CONFIG_FILE

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -284,8 +284,8 @@ void wsrep_start_position_init(const char *val) {
   wsrep_set_local_position(NULL, val, strlen(val), false);
 }
 
-static int get_provider_option_value(const char *opts, const char *opt_name,
-                                     ulong *opt_value) {
+int get_provider_option_value(const char *opts, const char *opt_name,
+                              ulong *opt_value) {
   int ret = 1;
   ulong opt_value_tmp;
   char *opt_value_str, *s,
@@ -309,19 +309,21 @@ end:
 }
 
 static bool refresh_provider_options() {
-  WSREP_DEBUG("refresh_provider_options: %s",
-              (wsrep_provider_options) ? wsrep_provider_options : "null");
-
+  bool ret{false};
   try {
     std::string opts = Wsrep_server_state::instance().provider().options();
     wsrep_provider_options_init(opts.c_str());
     get_provider_option_value(wsrep_provider_options, "repl.max_ws_size",
                               &wsrep_max_ws_size);
-    return false;
+    ret = false;
   } catch (...) {
     WSREP_ERROR("Failed to get provider options");
-    return true;
+    ret = true;
   }
+
+  WSREP_DEBUG("refresh_provider_options: %s",
+              (wsrep_provider_options) ? wsrep_provider_options : "null");
+  return ret;
 }
 
 static int wsrep_provider_verify(const char *provider_str) {

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -32,6 +32,8 @@ class set_var;
 class THD;
 
 int wsrep_init_vars();
+int get_provider_option_value(const char *opts, const char *opt_name,
+                              ulong *opt_value);
 
 #define CHECK_ARGS (sys_var * self, THD * thd, set_var * var)
 #define UPDATE_ARGS (sys_var * self, THD * thd, enum_var_type type)


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3704

Problem
=======
Server variable `wsrep_max_ws_size` and provider option `repl.max_size` have
been linked together from a long time. However, passing `wsrep_max_ws_size` in
the cnf file has no effect on the provider's repl.max_size option and the
server shows different values post startup.

Solution
========
1. When only `wsrep_max_ws_size` is passed during startup, then the same value
   used as the maximum writeset size.
2. When only `repl.max_ws_size` is passed during startup, then the same value
   used as the maximum writeset size.
3. When both `repl.max_ws_size` and `wsrep_max_ws_size` are passed during
   startup, then `repl.max_ws_size` takes precedence over `wsrep_max_ws_size`.

Testing Done
---
galera* suite: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/377/console
Failing tests:
1. galera.pxc3444 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-a7a6d5fdbce4f8d0148784d04113fc252647784edbda2485d4e63323647f2191)
2. galera.pxc3733 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-547dd82845ced28a26bae75ec044c217ab5e64ccb4dcf2873f4de51af18bfd9d)
3. galera.pxc_strict_mode - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-2e34c8537043419fde5b741f5a3dbd1aff91bce0b0d24fa28f67872df4b818c5)
4. galera.GCF-360 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-89ec7cddddec219c590d0251ea6dc567ad4156cc679554511e47ec0346084322)