### PR TITLE
8.0 Fixed PXC-3766 - Xtrabackup based SST always runs version-check procedure

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -1614,7 +1614,7 @@ if [[ "$pxc_encrypt_cluster_traffic" == "on" ]]; then
     wsrep_log_debug "with encrypt=4  ssl_ca=$ssl_ca  ssl_cert=$ssl_cert  ssl_key=$ssl_key"
 fi
 
-if ${INNOBACKUPEX_BIN} /tmp --help 2>/dev/null | grep -q -- '--version-check'; then
+if ${INNOBACKUPEX_BIN} --help 2>/dev/null | grep -q -- '--version-check'; then
     disver="--no-version-check"
 fi
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3766

Problem:
Half way thorught the life of xtrabackup/innobackupex, --version-check
functionality was added. This made SST script to validate if pxb
had support for --version-check, if true we were adding
--no-version-check parameter to skip it. By default, SST was using
innobackupex script. The script got deprecated and during the process of
migrating to xtrabackup binary we left the check passing what was
suppose to be the --target-dir without properly setting it as parameter,
causing xtrabackup command to fail and the check never resolving to
true.
This particular check is no longer necessary since current version of
PXC will always be running on a version of xtrabackup that has
--version-check support.

Fix:
Removed the check for the said functionality and always run xtrabackup
with --no-version-check.