### PR TITLE
PXC-3855: Assertion `!thd->in_active_multi_stmt_transaction() || thd->in_multi_stmt_transaction_mode()'

### DIFF
--- a/mysql-test/suite/wsrep/r/pxc_multi_stmt_trx_nobinlog.result
+++ b/mysql-test/suite/wsrep/r/pxc_multi_stmt_trx_nobinlog.result
@@ -1,0 +1,65 @@
+CREATE TABLE `t1` (
+`i` INT NOT NULL AUTO_INCREMENT,
+`s` LONGTEXT DEFAULT NULL,
+PRIMARY KEY (`i`)
+) ENGINE=InnoDB;
+
+# Case 1: AUTOCOMMIT = ON and without explicit BEGIN statement.
+SET AUTOCOMMIT = ON;
+INSERT INTO t1 VALUES (NULL, REPEAT('1', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('1', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('1', 10));
+
+# Case 2: AUTOCOMMIT = ON with explicit BEGIN statement and ROLLBACK
+BEGIN;
+INSERT INTO t1 VALUES (NULL, REPEAT('2', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('2', 10));
+ROLLBACK;
+
+# Case 3: AUTOCOMMIT = ON with explicit BEGIN statement and COMMIT
+BEGIN;
+INSERT INTO t1 VALUES (NULL, REPEAT('3', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('3', 10));
+COMMIT;
+
+# Case 4: AUTOCOMMIT = OFF without explicit BEGIN and ROLLBACK
+SET AUTOCOMMIT = OFF;
+INSERT INTO t1 VALUES (NULL, REPEAT('4', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('4', 10));
+ROLLBACK;
+
+# Case 5: AUTOCOMMIT = OFF without explicit BEGIN and COMMIT
+SET AUTOCOMMIT = OFF;
+INSERT INTO t1 VALUES (NULL, REPEAT('5', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('5', 10));
+COMMIT;
+
+# Case 6: AUTOCOMMIT = OFF with explicit BEGIN and ROLLBACK
+SET AUTOCOMMIT = OFF;
+BEGIN;
+INSERT INTO t1 VALUES (NULL, REPEAT('6', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('6', 10));
+ROLLBACK;
+
+# Case 7: AUTOCOMMIT = OFF with explicit BEGIN and COMMIT
+SET AUTOCOMMIT = OFF;
+BEGIN;
+INSERT INTO t1 VALUES (NULL, REPEAT('7', 8192));
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again
+INSERT INTO t1 VALUES (NULL, REPEAT('7', 10));
+COMMIT;
+SELECT * FROM t1;
+i	s
+3	1111111111
+7	3333333333
+11	5555555555
+15	7777777777
+DROP TABLE t1;
+CALL mtr.add_suppression("Option binlog_cache_size .* is greater than max_binlog_cache_size .* setting binlog_cache_size equal to max_binlog_cache_size");

--- a/mysql-test/suite/wsrep/r/wsrep_set_var_extension.result
+++ b/mysql-test/suite/wsrep/r/wsrep_set_var_extension.result
@@ -26,7 +26,7 @@ CALL test_hint("SET_VAR(wsrep_sync_wait=4)", "wsrep_sync_wait");
 hint_str
 SET_VAR(wsrep_sync_wait=4)
 @before_val	@hint_val	@after_val
-15	4	15
+0	4	0
 SET wsrep_sync_wait=2;
 CALL test_hint("SET_VAR(wsrep_sync_wait=4)", "wsrep_sync_wait");
 hint_str

--- a/mysql-test/suite/wsrep/t/pxc_multi_stmt_trx_nobinlog-master.opt
+++ b/mysql-test/suite/wsrep/t/pxc_multi_stmt_trx_nobinlog-master.opt
@@ -1,0 +1,1 @@
+--skip-log-bin --max-binlog-cache-size=4096

--- a/mysql-test/suite/wsrep/t/pxc_multi_stmt_trx_nobinlog.test
+++ b/mysql-test/suite/wsrep/t/pxc_multi_stmt_trx_nobinlog.test
@@ -1,0 +1,113 @@
+# === Purpose ===
+#
+# This test verifies that binlog cache errors are handled properly in all
+# combinations of AUTOCOMMIT when binlog is disabled and in wsrep emulation
+# mode.
+#
+# === References ===
+#
+# PXC-3855: Assertion `!thd->in_active_multi_stmt_transaction() ||
+#           thd->in_multi_stmt_transaction_mode()' failed.
+
+--source include/have_wsrep_provider.inc
+
+# Create a table with LONGTEXT as one of the columns.
+CREATE TABLE `t1` (
+ `i` INT NOT NULL AUTO_INCREMENT,
+ `s` LONGTEXT DEFAULT NULL,
+ PRIMARY KEY (`i`)
+) ENGINE=InnoDB;
+
+--echo
+--echo # Case 1: AUTOCOMMIT = ON and without explicit BEGIN statement.
+
+SET AUTOCOMMIT = ON;
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('1', 8192));
+
+# Check once again for the ER_TRANS_CACHE_FULL.
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('1', 8192));
+
+# This statement should not cause any error.
+INSERT INTO t1 VALUES (NULL, REPEAT('1', 10));
+
+# Assert that table has one row.
+--assert (`SELECT COUNT(*) = 1 FROM t1`)
+
+--echo
+--echo # Case 2: AUTOCOMMIT = ON with explicit BEGIN statement and ROLLBACK
+
+BEGIN;
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('2', 8192));
+INSERT INTO t1 VALUES (NULL, REPEAT('2', 10)); # This statement should not cause any error.
+ROLLBACK;
+
+# Assert that table has one row.
+--assert (`SELECT COUNT(*) = 1 FROM t1`)
+
+--echo
+--echo # Case 3: AUTOCOMMIT = ON with explicit BEGIN statement and COMMIT
+BEGIN;
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('3', 8192));
+INSERT INTO t1 VALUES (NULL, REPEAT('3', 10)); # This statement should not cause any error.
+COMMIT;
+
+# Assert that table has two rows.
+--assert (`SELECT COUNT(*) = 2 FROM t1`)
+
+--echo
+--echo # Case 4: AUTOCOMMIT = OFF without explicit BEGIN and ROLLBACK
+SET AUTOCOMMIT = OFF;
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('4', 8192));
+INSERT INTO t1 VALUES (NULL, REPEAT('4', 10)); # This statement should not cause any error.
+ROLLBACK;
+
+# Assert that table has two rows.
+--assert (`SELECT COUNT(*) = 2 FROM t1`)
+
+--echo
+--echo # Case 5: AUTOCOMMIT = OFF without explicit BEGIN and COMMIT
+SET AUTOCOMMIT = OFF;
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('5', 8192));
+INSERT INTO t1 VALUES (NULL, REPEAT('5', 10)); # This statement should not cause any error.
+COMMIT;
+
+# Assert that table has three rows.
+--assert (`SELECT COUNT(*) = 3 FROM t1`)
+
+--echo
+--echo # Case 6: AUTOCOMMIT = OFF with explicit BEGIN and ROLLBACK
+SET AUTOCOMMIT = OFF;
+BEGIN;
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('6', 8192));
+INSERT INTO t1 VALUES (NULL, REPEAT('6', 10)); # This statement should not cause any error.
+ROLLBACK;
+
+# Assert that table has three rows.
+--assert (`SELECT COUNT(*) = 3 FROM t1`)
+
+--echo
+--echo # Case 7: AUTOCOMMIT = OFF with explicit BEGIN and COMMIT
+SET AUTOCOMMIT = OFF;
+BEGIN;
+--error ER_TRANS_CACHE_FULL
+INSERT INTO t1 VALUES (NULL, REPEAT('7', 8192));
+INSERT INTO t1 VALUES (NULL, REPEAT('7', 10)); # This statement should not cause any error.
+COMMIT;
+
+# Assert that table has four rows.
+--assert (`SELECT COUNT(*) = 4 FROM t1`)
+
+SELECT * FROM t1;
+
+# Cleanup
+DROP TABLE t1;
+
+# Test Suppressions
+CALL mtr.add_suppression("Option binlog_cache_size .* is greater than max_binlog_cache_size .* setting binlog_cache_size equal to max_binlog_cache_size");


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3855

Problem
=======
Server hits the assertion

    !thd->in_active_multi_stmt_transaction() || thd->in_multi_stmt_transaction_mode()

when AUTOCOMMIT=ON and there is a binlog cache error when binlog is disabled
(i.e, when in binlog emulation mode)

Background
========
1. When a server is in the binlog emulation mode and if there is an error
during the binlog cache write stage, we have a special handling in PXC which
makes the transaction to register with the binlog handlerton by calling
`trans_register_ha()` with binlog_hton, so that WSREP layer can can rollback
the transaction.

2. At the end of every statement, in `mysql_execute_command()` the server
   expects that

  - Session should not have SERVER_STATUS_IN_TRANS flag set.
  - If session has SERVER_STATUS_IN_TRANS flag set, then the session must be in
    multi statement transaction mode (either AUTOCOMMIT = OFF or inside a
    transaction started with BEGIN).

Analysis
========
When the server calls `trans_register_ha()` during binlog cache error, it sets
the `SERVER_STATUS_IN_TRANS` flag indicating that there was a beginning of a
multi-statement transaction, even when there was no multi statements involved
(because AUTOCOMMIT=ON).

This caused the assertion

    !thd->in_active_multi_stmt_transaction() || thd->in_multi_stmt_transaction_mode()

in `mysql_execute_command()` to fail, since we have SERVER_STATUS_IN_TRANS flag
set for the session and the session is not in a multi statement transaction mode
(since AUTOCOMMIT=ON), resulting in server abort.

Solution
========
In case of a binlog cache write error, register the transaction scope
binlog handler (call `trans_register_ha()` with all = true) only when
the server is in multi statement transaction mode, just like what is
being done in `binlog_start_trans_and_stmt()`.

Testing Done
---
galera* suite: https://pxc.cd.percona.com/view/PXC%208.0/job/pxc-8.0-param/385/testReport/
Failing tests:
Failing tests:
1. galera.pxc3444 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-a7a6d5fdbce4f8d0148784d04113fc252647784edbda2485d4e63323647f2191)
2. galera.pxc3733 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-547dd82845ced28a26bae75ec044c217ab5e64ccb4dcf2873f4de51af18bfd9d)
3. galera.pxc_strict_mode - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-2e34c8537043419fde5b741f5a3dbd1aff91bce0b0d24fa28f67872df4b818c5)
4. galera.GCF-360 - Fixed in [8.0.26 merge branch commit](https://github.com/percona/percona-xtradb-cluster/commit/70e244526e6f5ad170cbccb91a5e16488bd3d531#diff-89ec7cddddec219c590d0251ea6dc567ad4156cc679554511e47ec0346084322)
5. galera.galera_sst_xtrabackup-v2_pxc_encrypt - Sporadic in nature
6. galera_3nodes_sr.galera_sr_kill_slave_before_apply - Sporadic in nature