### PR TITLE
PXC-3873: Remove zenfs submodule from PXC-8.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,6 +9,3 @@
 [submodule "extra/coredumper"]
 	path = extra/coredumper
 	url = https://github.com/Percona-Lab/coredumper.git
-[submodule "storage/rocksdb/rocksdb_plugins/zenfs"]
-	path = storage/rocksdb/rocksdb_plugins/zenfs
-	url = https://github.com/westerndigitalcorporation/zenfs.git


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3873

As part of the PXC-8.0.26 merge zenfs was accidentally added as a new
git submodule in PXC.

Ref: https://github.com/percona/percona-xtradb-cluster/blob/release-8.0.26/.gitmodules#L12-L14.

As PXC as it doesn't support RocksDB yet, it was of no use to have it as
a submodue and was removed.