### PR TITLE
PXC-3831: Nodes fail with two applier threads conflict

### DIFF
--- a/mysql-test/suite/galera/r/galera_UK_conflict.result
+++ b/mysql-test/suite/galera/r/galera_UK_conflict.result
@@ -1,0 +1,108 @@
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 int, f3 int,  unique key keyj (f2));
+INSERT INTO t1 VALUES (1, 1, 0);
+INSERT INTO t1 VALUES (3, 3, 0);
+INSERT INTO t1 VALUES (10, 10, 0);
+SET GLOBAL wsrep_applier_threads = 3;
+SET GLOBAL debug = "d,sync.wsrep_apply_cb";
+SET SESSION wsrep_sync_wait=0;
+START TRANSACTION;
+DELETE FROM t1 WHERE f2 = 3;
+INSERT INTO t1 VALUES (3, 3, 1);
+SET SESSION wsrep_sync_wait=0;
+INSERT INTO t1 VALUES (5, 5, 2);
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (4, 4, 2);
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
+COMMIT;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL debug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug = NULL;
+SET debug_sync='RESET';
+SET GLOBAL debug = "d,sync.wsrep_apply_cb";
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL debug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug = NULL;
+SET debug_sync='RESET';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SELECT * FROM t1;
+f1	f2	f3
+1	1	0
+3	3	1
+4	4	2
+5	5	2
+10	10	0
+SET GLOBAL wsrep_applier_threads = DEFAULT;
+SELECT * FROM t1;
+f1	f2	f3
+1	1	0
+3	3	1
+4	4	2
+5	5	2
+10	10	0
+INSERT INTO t1 VALUES (7,7,7);
+INSERT INTO t1 VALUES (8,8,8);
+DROP TABLE t1;
+Test scenario 2
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 int, f3 int,  unique key keyj (f2));
+INSERT INTO t1 VALUES (1, 1, 0);
+INSERT INTO t1 VALUES (3, 3, 0);
+INSERT INTO t1 VALUES (10, 10, 0);
+SET GLOBAL wsrep_applier_threads = 3;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+SET SESSION wsrep_sync_wait=0;
+START TRANSACTION;
+DELETE FROM t1 WHERE f2 = 3;
+INSERT INTO t1 VALUES (3, 3, 1);
+SET SESSION wsrep_sync_wait=0;
+INSERT INTO t1 VALUES (5, 5, 2);
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
+COMMIT;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL debug = "d,sync.wsrep_replay_cb";
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_replay_cb_reached";
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (4, 4, 2);
+waiting for second applier to reach commit monitor wait
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL debug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_replay_cb";
+SET GLOBAL debug = NULL;
+SET debug_sync='RESET';
+SET GLOBAL wsrep_applier_threads = DEFAULT;
+SELECT * FROM t1;
+f1	f2	f3
+1	1	0
+3	3	1
+4	4	2
+5	5	2
+10	10	0
+INSERT INTO t1 VALUES (7,7,7);
+INSERT INTO t1 VALUES (8,8,8);
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_bf_abort_uk.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_uk.result
@@ -1,0 +1,37 @@
+CREATE TABLE t1 (f1 INT PRIMARY KEY, f2 INT UNIQUE KEY, origin VARCHAR(6));
+START TRANSACTION;
+INSERT INTO t1 VALUES (1, 1, "node_1");
+INSERT INTO t1 VALUES (2, 1, "node_2");
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT * FROM t1;
+f1	f2	origin
+2	1	node_2
+START TRANSACTION;
+UPDATE t1 SET f2 = 2, origin = "node_1" WHERE f1 = 2;
+INSERT INTO t1 VALUES (3, 2, "node_2");
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT * FROM t1;
+f1	f2	origin
+2	1	node_2
+3	2	node_2
+START TRANSACTION;
+INSERT INTO t1 VALUES (4, 3, "node_1");
+UPDATE t1 SET f2 = 3, origin = "node_2" WHERE f1 = 2;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT * FROM t1;
+f1	f2	origin
+2	3	node_2
+3	2	node_2
+START TRANSACTION;
+UPDATE t1 SET f2 = 4, origin = "node_1" WHERE f1 = 2;
+UPDATE t1 SET f2 = 4, origin = "node_2" WHERE f1 = 3;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SELECT * FROM t1;
+f1	f2	origin
+2	3	node_2
+3	4	node_2
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_UK_conflict.cnf
+++ b/mysql-test/suite/galera/t/galera_UK_conflict.cnf
@@ -1,0 +1,2 @@
+!include suite/galera/galera_2nodes.cnf
+!include suite/galera/galera_optimistic_pa.cnf

--- a/mysql-test/suite/galera/t/galera_UK_conflict.test
+++ b/mysql-test/suite/galera/t/galera_UK_conflict.test
@@ -1,0 +1,275 @@
+#
+# This test tests the operation of transaction replay with a scenario
+# where two subsequent write sets in applying conflict with local transaction
+# in commit phase. The conflict is "false positive" confict on GAP lock in
+# secondary unique index.
+# The first applier will cause BF abort for the local committer, which
+# starts replaying because of positive certification.
+# In buggy version, scenatio continues so that ehile the local transaction
+# is replaying, the latter applier experiences similar UK GAP lock conflict
+# and forces the replayer to abort second time.
+# In fixed version, this latter BF abort should not happen.
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source suite/galera/include/galera_have_debug_sync.inc
+
+--let $expected_wsrep_local_replays = `SELECT variable_value+1 FROM performance_schema.global_status WHERE variable_name = 'wsrep_local_replays'`
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 int, f3 int,  unique key keyj (f2));
+INSERT INTO t1 VALUES (1, 1, 0);
+INSERT INTO t1 VALUES (3, 3, 0);
+INSERT INTO t1 VALUES (10, 10, 0);
+
+# we will need 2 appliers threads for applyin two write sets in parallel in node1
+# and 1 applier thread for handling replaying 
+SET GLOBAL wsrep_applier_threads = 3;
+SET GLOBAL debug = "d,sync.wsrep_apply_cb";
+
+--connection node_1
+# starting a transaction, which deletes and inserts the middle row in test table
+# this will be victim of false positive conflict with appliers
+SET SESSION wsrep_sync_wait=0;
+START TRANSACTION;
+
+DELETE FROM t1 WHERE f2 = 3;
+INSERT INTO t1 VALUES (3, 3, 1);
+
+# Control connection to manage sync points for appliers
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+SET SESSION wsrep_sync_wait=0;
+
+# send from node 2 first INSERT transaction,  which will conflict on GAP lock in node 1
+--connection node_2
+INSERT INTO t1 VALUES (5, 5, 2);
+
+--connection node_1a
+# wait to see the INSERT in apply_cb sync point
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+
+# first applier seen in wait point, set sync point for the second INSERT
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_2
+# send second insert into same GAP in test table
+INSERT INTO t1 VALUES (4, 4, 2);
+
+--connection node_1a
+# wait for the second insert to arrive in his sync point
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# both appliers are now waiting in separate sync points
+
+# Block the local commit, send the COMMIT and wait until it gets blocked
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+--send COMMIT
+
+--connection node_1a
+# wait for the local commit to enter in commit monitor wait state
+--let $galera_sync_point = apply_monitor_slave_enter_sync commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# release the local transaction to continue with commit
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# and now release the first applier, it should force local trx to abort
+SET GLOBAL debug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug = NULL;
+SET debug_sync='RESET';
+
+# wait for BF abort to happen and replaying begin
+--let $wait_condition = SELECT VARIABLE_VALUE= $expected_wsrep_local_replays FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'
+--source include/wait_condition.inc
+
+# set another sync point for second applier
+SET GLOBAL debug = "d,sync.wsrep_apply_cb";
+
+# letting the second appier to move forward
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+
+# waiting until second applier is in wait
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+
+# stopping second applier before commit
+--let $galera_sync_point = commit_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# releasing the second insert, with buggy version it will conflict with
+# replayer
+SET GLOBAL debug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug = NULL;
+SET debug_sync='RESET';
+
+# with fixed version, second applier has reached commit monitor, and we can
+# release it to complete
+--let $galera_sync_point = commit_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# local commit should succeed
+--connection node_1
+--reap
+
+SELECT * FROM t1;
+
+# returning original slave thread count
+SET GLOBAL wsrep_applier_threads = DEFAULT;
+
+--connection node_2
+SELECT * FROM t1;
+
+# replicate some transactions, so that wsrep slave thread count can reach
+# original state in node 1
+INSERT INTO t1 VALUES (7,7,7);
+INSERT INTO t1 VALUES (8,8,8);
+
+DROP TABLE t1;
+
+##################################################################################
+# test scenario 2
+#
+# commit order is now: INSERT-1, local COMMIT, INSERT-2
+# while local trx is replaying, the latter applier has applied and is waiting
+# for commit.
+# The point in this scenario is to verify that replayer does not try to abort
+# the latter applier
+#################################################################################
+
+--echo Test scenario 2
+
+--connection node_1
+--let $expected_wsrep_local_replays = `SELECT variable_value+1 FROM performance_schema.global_status WHERE variable_name = 'wsrep_local_replays'`
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 int, f3 int,  unique key keyj (f2));
+INSERT INTO t1 VALUES (1, 1, 0);
+INSERT INTO t1 VALUES (3, 3, 0);
+INSERT INTO t1 VALUES (10, 10, 0);
+
+# we will need 2 appliers threads for applyin two writes sets in parallel in node1
+# and 1 applier thread for handling replaying 
+SET GLOBAL wsrep_applier_threads = 3;
+
+# set sync point for the first INSERT applier
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+# starting a transaction, which deletes and inserts the middle row in test table
+# this will be victim of false positive conflict with appliers
+SET SESSION wsrep_sync_wait=0;
+START TRANSACTION;
+
+DELETE FROM t1 WHERE f2 = 3;
+INSERT INTO t1 VALUES (3, 3, 1);
+
+# Control connection to manage sync points for appliers
+--connection node_1a
+SET SESSION wsrep_sync_wait=0;
+
+# send from node 2 first an INSERT transaction,  which will conflict on GAP lock in node 1
+--connection node_2
+INSERT INTO t1 VALUES (5, 5, 2);
+
+--connection node_1a
+# wait to see the INSERT in apply_cb sync point
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Block the local commit, send the COMMIT and wait until it gets blocked
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+--send COMMIT
+
+--connection node_1a
+# wait for the local commit to enter in commit monitor wait state
+--let $galera_sync_point = apply_monitor_slave_enter_sync commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# first applier is now  waiting in before commit, and local trx in commit monitor
+
+# set sync point before replaying
+SET GLOBAL debug = "d,sync.wsrep_replay_cb";
+
+# release the local transaction to continue with commit
+# it should advance and end up waiting in commit monitor for his turn
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# and now release the first applier, it should force local trx to abort
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# wait for BF abort to happen and replaying begin
+--let $wait_condition = SELECT VARIABLE_VALUE= $expected_wsrep_local_replays FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'
+--source include/wait_condition.inc
+
+# waiting for local replayer to reach sync point
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_replay_cb_reached";
+
+# set sync point before commit for the second INSERT 
+--let $galera_sync_point = commit_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+ 
+--connection node_2
+# send second insert into same GAP in test table
+INSERT INTO t1 VALUES (4, 4, 2);
+
+--connection node_1a
+# wait for the second applier to enter in commit monitor wait state
+--echo waiting for second applier to reach commit monitor wait
+--let $galera_sync_point = commit_monitor_slave_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# and, letting the second appier to move forward, it will stop naturally
+# to wait for commit order after replayer's commit
+--let $galera_sync_point = commit_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# and now release the replayer, if all is good, it will commit before the second applier
+SET GLOBAL debug = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_replay_cb";
+SET GLOBAL debug = NULL;
+SET debug_sync='RESET';
+
+# local commit should succeed
+--connection node_1
+--reap
+
+--let $wait_condition = SELECT COUNT(*)=5 FROM t1;
+--source include/wait_condition.inc
+
+# returning original slave thread count
+SET GLOBAL wsrep_applier_threads = DEFAULT;
+
+--connection node_2
+SELECT * FROM t1;
+
+# replicate some transactions, so that wsrep slave thread count can reach
+# original state in node 1
+INSERT INTO t1 VALUES (7,7,7);
+INSERT INTO t1 VALUES (8,8,8);
+
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_bf_abort_uk.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_uk.test
@@ -1,0 +1,95 @@
+#
+# Verify that BF aborting via unique key conflict works.
+#
+# In all scenarios the affected rows are specified with different
+# primary keys so that the conflict can arise via unique key conflict
+# only.
+#
+
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (f1 INT PRIMARY KEY, f2 INT UNIQUE KEY, origin VARCHAR(6));
+
+--let $galera_connection_name = node_1a
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+
+# Scenario 1: INSERT - INSERT conflict
+
+--connection node_1
+START TRANSACTION;
+INSERT INTO t1 VALUES (1, 1, "node_1");
+
+--connection node_2
+INSERT INTO t1 VALUES (2, 1, "node_2");
+
+--connection node_1a
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 2 AND origin = "node_2"
+--source include/wait_condition.inc
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+SELECT * FROM t1;
+
+# Scenario 2: UPDATE - INSERT conflict
+
+--connection node_1
+START TRANSACTION;
+UPDATE t1 SET f2 = 2, origin = "node_1" WHERE f1 = 2;
+
+--connection node_2
+INSERT INTO t1 VALUES (3, 2, "node_2");
+
+--connection node_1a
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 2 AND origin = "node_2"
+--source include/wait_condition.inc
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+SELECT * FROM t1;
+
+# Scenario 3: INSERT - UPDATE conflict
+
+--connection node_1
+START TRANSACTION;
+INSERT INTO t1 VALUES (4, 3, "node_1");
+
+--connection node_2
+UPDATE t1 SET f2 = 3, origin = "node_2" WHERE f1 = 2;
+
+
+--connection node_1a
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 3 AND origin = "node_2"
+--source include/wait_condition.inc
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+SELECT * FROM t1;
+
+# Scenario 4: UPDATE - UPDATE conflict
+
+--connection node_1
+START TRANSACTION;
+UPDATE t1 SET f2 = 4, origin = "node_1" WHERE f1 = 2;
+
+--connection node_2
+UPDATE t1 SET f2 = 4, origin = "node_2" WHERE f1 = 3;
+
+
+--connection node_1a
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 3 AND origin = "node_2"
+--source include/wait_condition.inc
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+SELECT * FROM t1;
+
+DROP TABLE t1;

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -978,6 +978,15 @@ int Wsrep_replayer_service::apply_write_set(const wsrep::ws_meta &ws_meta,
   assert(thd->wsrep_trx().active());
   assert(thd->wsrep_trx().state() == wsrep::transaction::s_replaying);
 
+  /* Allow tests to block the applier thread using the DBUG facilities */
+  DBUG_EXECUTE_IF("sync.wsrep_replay_cb", {
+    const char act[] =
+        "now "
+        "SIGNAL sync.wsrep_replay_cb_reached "
+        "WAIT_FOR signal.wsrep_replay_cb";
+    assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+  };);
+
   wsrep_setup_uk_and_fk_checks(thd);
 
   int ret = 0;

--- a/storage/innobase/include/lock0priv.h
+++ b/storage/innobase/include/lock0priv.h
@@ -725,12 +725,8 @@ class RecLock {
                                 we've managed to jump in front of other waiting
                                 transactions and got the lock granted, so there
                                 is no need to wait. */
-#ifdef WITH_WSREP
-  dberr_t add_to_waitq(lock_t *const wait_for, const lock_prdt_t *prdt = nullptr);
-#else
   dberr_t add_to_waitq(const lock_t *wait_for,
                        const lock_prdt_t *prdt = nullptr);
-#endif /* WITH_WSREP */
 
   /**
   Create a lock for a transaction and initialise it.

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -1179,10 +1179,6 @@ struct trx_t {
                             mark and the actual async kill because
                             the running thread can change. */
 
-#ifdef WITH_WSREP
-  bool wsrep_UK_scan;
-#endif /* WITH_WSREP */
-
   /* These fields are not protected by any mutex. */
   const char *op_info;   /*!< English text describing the
                          current operation, or an empty

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -247,9 +247,6 @@ static void trx_init(trx_t *trx) {
 
     trx->in_innodb &= TRX_FORCE_ROLLBACK_MASK;
   }
-#ifdef WITH_WSREP
-  trx->wsrep_UK_scan = false;
-#endif /* WITH_WSREP */
 
   trx->flush_observer = nullptr;
 
@@ -376,10 +373,6 @@ struct TrxFactory {
     ut_ad(!trx->abort);
 
     ut_ad(trx->killed_by == std::thread::id{});
-
-#ifdef WITH_WSREP
-    ut_ad(trx->wsrep_UK_scan == false);
-#endif /* WITH_WSREP */
 
     return (true);
   }
@@ -2855,9 +2848,6 @@ void wsrep_trx_print_locking(
 {
   ibool newline;
   const char *op_info;
-
-  ut_ad(locksys::owns_exclusive_global_latch());
-  ut_ad(UT_LIST_GET_LEN(trx->lock.trx_locks) > 0);
 
   fprintf(f, "TRANSACTION " TRX_ID_FMT, trx->id);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3831

1. lock_rec_has_to_wait() function unified with Codership's version
(returns false in case of detection of 2 BF threads attempting to wait.
Our implementation was definitely wrong as we always called
lock_rec_has_to_wait() function with for_locking flag equal 'false'

2. Added upstream MTR tests related to BF abort

3. Cleaned up unused wsrep_UK_scan flag