### PR TITLE
PXC-3901: BF-BF conflict with the dict stats thread

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -484,6 +484,7 @@ THD::THD(bool enable_plugins)
       wsrep_applier(is_applier),
       wsrep_applier_closing(false),
       wsrep_client_thread(false),
+      wsrep_allow_mdl_conflict(false),
       wsrep_last_query_id(0),
       wsrep_xid(),
       wsrep_skip_locking(false),
@@ -1129,6 +1130,7 @@ void THD::cleanup(void) {
     wsrep_cs().cleanup();
   }
   wsrep_client_thread = false;
+  wsrep_allow_mdl_conflict = false;
   wsrep_aborter = 0;
 #endif /* WITH_WSREP */
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2977,6 +2977,7 @@ class THD : public MDL_context_owner,
   bool wsrep_applier;         /* dedicated slave applier thread */
   bool wsrep_applier_closing; /* applier marked to close */
   bool wsrep_client_thread;   /* to identify client threads */
+  bool wsrep_allow_mdl_conflict;
   query_id_t wsrep_last_query_id;
   XID wsrep_xid;
 

--- a/sql/sql_thd_internal_api.cc
+++ b/sql/sql_thd_internal_api.cc
@@ -64,10 +64,17 @@
 struct mysql_cond_t;
 struct mysql_mutex_t;
 
+#ifdef WITH_WSREP
+THD *create_internal_thd(bool allow_mdl_conflict) {
+#else
 THD *create_internal_thd() {
+#endif /* WITH_WSREP */
   /* For internal threads, use enabled_plugins = false. */
   THD *thd = new THD(false);
   thd->system_thread = SYSTEM_THREAD_BACKGROUND;
+#ifdef WITH_WSREP
+  thd->wsrep_allow_mdl_conflict = allow_mdl_conflict;
+#endif /* WITH_WSREP */
   // Skip grants and set the system_user flag in THD.
   thd->security_context()->skip_grants();
   thd->thread_stack = reinterpret_cast<char *>(&thd);

--- a/sql/sql_thd_internal_api.h
+++ b/sql/sql_thd_internal_api.h
@@ -42,7 +42,11 @@ class THD;
 class partition_info;
 struct fragmentation_stats_t;
 
+#ifdef WITH_WSREP
+THD *create_internal_thd(bool allow_mdl_conflict = false);
+#else
 THD *create_internal_thd();
+#endif /* WITH_WSREP */
 void destroy_internal_thd(THD *thd);
 
 /**

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2909,6 +2909,13 @@ bool wsrep_handle_mdl_conflict(const MDL_context *requestor_ctx,
       ticket->wsrep_report(wsrep_debug);
       mysql_mutex_unlock(&granted_thd->LOCK_wsrep_thd);
       ret = false;
+    } else if (granted_thd->wsrep_allow_mdl_conflict) {
+      WSREP_DEBUG("Background thread caused BF abort, conf %s",
+                  wsrep_thd_transaction_state_str(granted_thd));
+      ticket->wsrep_report(wsrep_debug);
+      mysql_mutex_unlock(&granted_thd->LOCK_wsrep_thd);
+      wsrep_abort_thd(request_thd, granted_thd, true);
+      ret = false;
     } else if (request_thd->lex->sql_command == SQLCOM_DROP_TABLE) {
       WSREP_DEBUG("DROP caused BF abort, conf %s",
                   wsrep_thd_transaction_state_str(granted_thd));

--- a/storage/innobase/dict/dict0stats_bg.cc
+++ b/storage/innobase/dict/dict0stats_bg.cc
@@ -357,7 +357,11 @@ the auto recalc list and proceeds them, eventually recalculating their
 statistics. */
 void dict_stats_thread() {
   ut_a(!srv_read_only_mode);
+#ifdef WITH_WSREP
+  THD *thd = create_internal_thd(true);
+#else
   THD *thd = create_internal_thd();
+#endif /* WITH_WSREP */
 
   while (!SHUTTING_DOWN()) {
     /* Wake up periodically even if not signaled. This is


### PR DESCRIPTION
Issue: a few galera_nbo MTR tests fail with BF-BF conflict when ran with
the --mem options. These failures are all caused by the NBO applier
conflicting with the innodb dict stats thread.

Fix: as there is no way to detect if a THD is the dict stats thread,
this patch introduces a flag background threads can set to prevent BF-BF
abort caused by them.

Since the dict thread only holds this lock for a short time, and there
is no way to kill it anyway, this is the safest and easiest solution.