### PR TITLE
[5.7] PXC-3609: Do not update binlog status vars when binlog is disabled

### DIFF
--- a/mysql-test/suite/galera/r/galera_binlog_cache_use_nobinlog.result
+++ b/mysql-test/suite/galera/r/galera_binlog_cache_use_nobinlog.result
@@ -1,0 +1,16 @@
+CREATE TABLE `t1` (
+`i` int NOT NULL AUTO_INCREMENT,
+`s` TEXT DEFAULT NULL,
+PRIMARY KEY (`i`)
+) ENGINE=InnoDB;
+INSERT INTO `t1` (s) VALUES (REPEAT('a',40000));
+INSERT INTO `t1` (s) VALUES (REPEAT('b',40000));
+include/assert.inc [Binlog_cache_use should be 0]
+include/assert.inc [Binlog_cache_disk_use should be 0]
+SHOW GLOBAL STATUS LIKE '%binlog%cache%';
+Variable_name	Value
+Binlog_cache_disk_use	0
+Binlog_cache_use	0
+Binlog_stmt_cache_disk_use	0
+Binlog_stmt_cache_use	0
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_binlog_cache_use_nobinlog.cnf
+++ b/mysql-test/suite/galera/t/galera_binlog_cache_use_nobinlog.cnf
@@ -1,0 +1,7 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+skip-log-bin
+
+[mysqld.2]
+skip-log-bin

--- a/mysql-test/suite/galera/t/galera_binlog_cache_use_nobinlog.test
+++ b/mysql-test/suite/galera/t/galera_binlog_cache_use_nobinlog.test
@@ -1,0 +1,40 @@
+# === Purpose ===
+#
+# This test verifies that binlog cache related status variables are not updated
+# when binlog is turned off.
+#
+# === References ===
+#
+# PXC-3609: Binlog_cache_disk_use not zero
+#
+--source include/have_wsrep_provider.inc
+CREATE TABLE `t1` (
+  `i` int NOT NULL AUTO_INCREMENT,
+  `s` TEXT DEFAULT NULL,
+  PRIMARY KEY (`i`)
+) ENGINE=InnoDB;
+
+# The below INSERT shall generate writeset that exceeds the default
+# binlog_cache_size (32k) resulting in writing to temp file duing the
+# transaction and results in incrementing the counter of
+# `Binlog_cache_disk_use` status var when binary log is enabled.
+INSERT INTO `t1` (s) VALUES (REPEAT('a',40000));
+INSERT INTO `t1` (s) VALUES (REPEAT('b',40000));
+
+
+--let $binlog_cache_use=`SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'Binlog_cache_use';`
+--let $binlog_cache_disk_use=`SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'Binlog_cache_disk_use';`
+
+# Assert that Binlog_cache_use is 0
+--let $assert_text = Binlog_cache_use should be 0
+--let $assert_cond = $binlog_cache_use = 0
+--source include/assert.inc
+
+# Assert that Binlog_cache_disk_use is 0
+--let $assert_text = Binlog_cache_disk_use should be 0
+--let $assert_cond = $binlog_cache_disk_use = 0
+--source include/assert.inc
+
+SHOW GLOBAL STATUS LIKE '%binlog%cache%';
+
+DROP TABLE t1;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -729,6 +729,10 @@ private:
   */
   void compute_statistics()
   {
+#ifdef WITH_WSREP
+    if (wsrep_emulate_bin_log)
+      return;
+#endif /* WITH_WSREP */
     if (!is_binlog_empty())
     {
       (*ptr_binlog_cache_use)++;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3609

Problem: In cluster mode, binlog related status vars are updated even
when binlog is disabled.

Solution: Do not register the status variables in the cache manager when
in binlog emulation mode (i.e, binlog is disabled)