### PR TITLE
PXC-3388: PXC in a Desynced state after joiner being killed (5.7)

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -369,3 +369,5 @@ function get_absolute_path()
 readonly WSREP_SST_DONOR_TIMEOUT=$(parse_cnf sst donor-timeout 10)
 # For backward compatiblitiy: joiner timeout waiting for donor connection
 readonly WSREP_SST_JOINER_TIMEOUT=$(parse_cnf sst joiner-timeout $(parse_cnf sst sst-initial-timeout 60) )
+# if the SST process stuck for this amount of time (no data transfered), it will be interrupted
+readonly WSREP_SST_IDLE_TIMEOUT=$(parse_cnf sst sst-idle-timeout 120)


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3388

Problem:
There are two cases:
1. Joiner requests for SST from Donor. socat transfer is about to start
and the network partitioning occurs.
2. Joiner requests for SST from Donor. socat transfer is in the middle
and the network partitioning occurs.

In both cases the Donor is detecting the Joiner to be inactive and
"forgets" it on the Galera layer, but the SST script still waits in
socat. This causes Donor to be stuck in DONOR/DESYNCED state.
SST script will be unblocked when socat time-outs, but in practice
it may take hours as it is done on TCP/IP layer.

Solution:
Partial fix was there in place for encrypted SST. It involved usage of
'donor-timeout' (default 10 sec). But it didn't work for unencrypted SST
It doesn't solve the case 2.

In similar to what we already have on Joiner side, we need to monitor
if Donor is sending anything.

Case 1:
1. -T flag works only if socat is in sending loop (already sending data)
Network outage may occur before socat connects. For this case add
'connect-timeout' parameter. It works in conjunction with 'retry' socket
option (defautl 30).
If 'sst-idle-timeout' is zero, do not add connect-timeout.

Case 2:
1. Add -T flag for socat. Its value is equal 'sst-idle-timeout' with
the default of 120sec (the same parameter is used to set Joiner iddle
timeout). If the value is zero, -T flag is not added and we wait without
timeout.

So now we have the following parameters of [sst] section in
the configuration file to control SST timeouts:
sockopt - if it contains retry=N, N will be used, otherwise 30
donor-timeout - (default: 10). The value of 'connect-timeout' on the
donor side
joiner-timeout (sst-initial-timeout) - (default: 60). Time for joiner
to wait for SST transfer start.
sst-idle-timeout - (default: 120). Timeout for transfer stuck. If no
data is send or received in this time window, SST process is aborted.