### PR TITLE
PXC-3923: ANALYZE TABLE crashes node when [super_]read_only is set

### DIFF
--- a/mysql-test/suite/galera/r/galera_admin.result
+++ b/mysql-test/suite/galera/r/galera_admin.result
@@ -38,5 +38,17 @@ COUNT(*) = 10000
 SELECT COUNT(*) = 10 FROM x2;
 COUNT(*) = 10
 1
+SET GLOBAL super_read_only=1;
+ANALYZE TABLE t1;
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+SET GLOBAL super_read_only=0;
+SET GLOBAL read_only=1;
+CREATE USER 'testuser'@'%' IDENTIFIED WITH 'mysql_native_password' BY 'testuser';
+GRANT SELECT, UPDATE, INSERT, DELETE ON *.* to 'testuser'@'%';
+ANALYZE TABLE t1;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+SET global read_only = 0;
+SET global super_read_only = 0;
+DROP USER 'testuser'@'%';
 DROP TABLE t1, t2;
 DROP TABLE x1, x2;

--- a/mysql-test/suite/galera/t/galera_admin.test
+++ b/mysql-test/suite/galera/t/galera_admin.test
@@ -82,6 +82,34 @@ SELECT COUNT(*) = 10 FROM x1;
 SELECT COUNT(*) = 10000 FROM t2;
 SELECT COUNT(*) = 10 FROM x2;
 
+
+# Check that super_read_only and read_only are handled properly (PXC-3923)
+--connection node_1
+--let super_read_only_saved = `SELECT @@super_read_only`
+--let read_only_saved = `SELECT @@read_only`
+
+# super_read_only
+SET GLOBAL super_read_only=1;
+--error ER_OPTION_PREVENTS_STATEMENT
+ANALYZE TABLE t1;
+
+# read_only
+SET GLOBAL super_read_only=0;
+SET GLOBAL read_only=1;
+
+CREATE USER 'testuser'@'%' IDENTIFIED WITH 'mysql_native_password' BY 'testuser';
+GRANT SELECT, UPDATE, INSERT, DELETE ON *.* to 'testuser'@'%';
+--connect node_1a, 127.0.0.1, testuser, testuser, test, $NODE_MYPORT_1
+--connection node_1a
+--error ER_OPTION_PREVENTS_STATEMENT
+ANALYZE TABLE t1;
+
+--connection node_1
+--eval SET global read_only = $read_only_saved
+--eval SET global super_read_only = $super_read_only_saved
+DROP USER 'testuser'@'%';
+
+
 --connection node_1
 DROP TABLE t1, t2;
 DROP TABLE x1, x2;

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -1737,6 +1737,7 @@ bool Sql_cmd_analyze_table::execute(THD *thd) {
 
 #ifdef WITH_WSREP
   if (pxc_strict_mode_admin_check(thd, first_table)) return res;
+  if (WSREP(thd) && check_readonly(thd, true)) return res;
 
   DBUG_EXECUTE_IF("sql_cmd.before_toi_begin.log_command", {
     sql_print_information("In Sql_cmd_analyze_table::execute()");


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3923

Problem:
When super_read_only or read_only is set, ANALYZE TABLE fails
(as expected) which triggers consistency voting mechanism and causes
node to leave the cluster

Cause:
In original flow the validation if admin action can be done in readonly
mode is done on transaction commit. As the statement is replicated as
TOI it is too late.

Solution:
Check if action can be done before starting TOI.