### PR TITLE
Fix big endian issue for seqno during SST

### DIFF
--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -69,7 +69,7 @@ const wsrep::id &wsrep_xid_uuid(const XID &xid) {
 long long wsrep_xid_seqno(const XID *xid) {
   long long ret = wsrep::seqno::undefined().get();
   if (wsrep_is_wsrep_xid(xid)) {
-    memcpy(&ret, xid->get_data() + WSREP_XID_SEQNO_OFFSET, sizeof(ret));
+    int8store(reinterpret_cast<uchar*>(&ret),*reinterpret_cast<const unsigned long long*>(xid->get_data() + WSREP_XID_SEQNO_OFFSET));
   }
   return ret;
 }

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -391,7 +391,7 @@ static unsigned char trx_sys_cur_xid_uuid[16];
 long long read_wsrep_xid_seqno(const XID *xid) {
   // TODO: replace this with XID provided functions.
   long long seqno;
-  memcpy(&seqno, xid->get_data() + 24, sizeof(long long));
+  int8store(reinterpret_cast<uchar*>(&seqno),*reinterpret_cast<const unsigned long long*>(xid->get_data() + 24));
   return seqno;
 }
 


### PR DESCRIPTION
Fixes https://jira.percona.com/browse/PXB-2652

Tested using Xtrabackup as the SST method on x86 and s390s architectures