### PR TITLE
PXC-2687: BF abort of a SP causes a write-after-free error

### DIFF
--- a/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
+++ b/mysql-test/suite/galera/r/galera_disable_retry_for_check_table.result
@@ -55,3 +55,43 @@ ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try r
 #
 # 5. Cleanup
 DROP TABLE t1;
+#
+# 1. Create a table on node_1.
+[node_1a]
+CREATE TABLE t1(i INT PRIMARY KEY)
+PARTITION BY RANGE (i)
+(
+PARTITION p0 VALUES LESS THAN (2),
+PARTITION p1 VALUES LESS THAN (4)
+);
+CREATE PROCEDURE p1()
+BEGIN
+ALTER TABLE t1 CHECK PARTITION p0;
+END|
+#
+# 2. Execute CHECK TABLE query on node_1 and halt the query in
+#    ha_innobase::check() function.
+SET DEBUG_SYNC="ha_innobase_check SIGNAL reached WAIT_FOR continue";
+CALL p1();;
+[node_1b]
+SET DEBUG_SYNC="now WAIT_FOR reached";
+#
+# 3. Execute an ALTER TABLE query on node_2 and wait for it to be
+#    replicated to node_1.
+[node_2]
+ALTER TABLE t1 ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+SET DEBUG_SYNC="now SIGNAL continue";
+SET DEBUG_SYNC="RESET";
+#
+# 4. ALTER TABLE, being replicated as TOI, aborts the CHECK TABLE
+#    query. Verify that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
+Table	Op	Msg_type	Msg_text
+test.t1	check	error	Partition p0 returned error
+test.t1	check	Error	Query execution was interrupted
+test.t1	check	error	Unknown - internal error 168 during operation
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+#
+# 5. Cleanup
+DROP TABLE t1;
+DROP PROCEDURE p1;

--- a/mysql-test/suite/galera/r/galera_sp_bf_abort2.result
+++ b/mysql-test/suite/galera/r/galera_sp_bf_abort2.result
@@ -8,6 +8,14 @@ UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
 INSERT INTO t1 VALUES (10, "from sp");
 COMMIT;
 END|
+CREATE PROCEDURE proc_with_transaction_and_select()
+BEGIN
+START TRANSACTION;
+SELECT 1;
+UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+INSERT INTO t1 VALUES (10, "from sp");
+COMMIT;
+END|
 CREATE PROCEDURE proc_with_transaction_continue_handler()
 BEGIN
 DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
@@ -184,6 +192,48 @@ f1	f2
 3	from sp
 4	from sp
 10	from sp
+DROP TABLE t1;
+# Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+# Node 1
+USE database1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 TEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'initial');
+INSERT INTO t1 VALUES (2, 'initial');
+INSERT INTO t1 VALUES (3, 'initial');
+INSERT INTO t1 VALUES (4, 'initial');
+# Node 1a
+USE database1;
+SET DEBUG_SYNC = "ha_innobase_end_of_write_row SIGNAL entered WAIT_FOR continue";
+CALL proc_with_transaction_and_select;
+# Node 1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = "now WAIT_FOR entered";
+# Node 2
+UPDATE database1.t1 SET f2 = "from node2" WHERE f1 < 4;
+# Node 1
+SET DEBUG_SYNC = "now SIGNAL continue";
+# Node 1a
+1
+1
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+# Node 1
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
+SET DEBUG_SYNC = "RESET";
+# Node 2
+SELECT * FROM database1.t1;
+f1	f2
+1	from node2
+2	from node2
+3	from node2
+4	initial
 DROP TABLE t1;
 # Node 1a
 USE database1;

--- a/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
+++ b/mysql-test/suite/galera/t/galera_disable_retry_for_check_table.test
@@ -14,7 +14,9 @@
 #    that CHECK TABLE query fails with ER_LOCK_DEADLOCK error.
 # 5. Repeat steps 1-4 with partitioned table, but using ALTER TABLE .. CHECK
 #    PARTITION instead
-# 6. Cleanup
+# 6. Repeat steps 1-4 with partitioned table, but using procedure with
+#    ALTER TABLE .. CHECK PATITION inside.
+# 7. Cleanup
 #
 # ==== References ====
 #
@@ -30,7 +32,7 @@
 --connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
 
 --let $i = 0
-while ($i < 2) {
+while ($i < 3) {
 
   --echo #
   --echo # 1. Create a table on node_1.
@@ -39,13 +41,21 @@ while ($i < 2) {
   if ($i == 0) {
     CREATE TABLE t1(i INT PRIMARY KEY);
   }
-  if ($i == 1) {
+  if ($i != 0) {
     CREATE TABLE t1(i INT PRIMARY KEY)
     PARTITION BY RANGE (i)
     (
       PARTITION p0 VALUES LESS THAN (2),
       PARTITION p1 VALUES LESS THAN (4)
     );
+  }
+  if ($i == 2) {
+    DELIMITER |;
+    CREATE PROCEDURE p1()
+    BEGIN
+      ALTER TABLE t1 CHECK PARTITION p0;
+    END|
+    DELIMITER ;|
   }
 
   --echo #
@@ -57,6 +67,9 @@ while ($i < 2) {
   }
   if ($i == 1) {
     --send ALTER TABLE t1 CHECK PARTITION p0
+  }
+  if ($i == 2) {
+    --send CALL p1();
   }
 
   --echo [node_1b]
@@ -89,6 +102,9 @@ while ($i < 2) {
   --echo #
   --echo # 5. Cleanup
   DROP TABLE t1;
+  if ($i == 2) {
+    DROP PROCEDURE p1;
+  }
   --inc $i
 }
 

--- a/mysql-test/suite/galera/t/galera_sp_bf_abort2.test
+++ b/mysql-test/suite/galera/t/galera_sp_bf_abort2.test
@@ -24,6 +24,16 @@ BEGIN
   COMMIT;
 END|
 
+CREATE PROCEDURE proc_with_transaction_and_select()
+BEGIN
+  START TRANSACTION;
+    SELECT 1;
+    UPDATE t1 SET f2 = "from sp" WHERE f1 > 1;
+    INSERT INTO t1 VALUES (10, "from sp");
+  COMMIT;
+END|
+
+
 CREATE PROCEDURE proc_with_transaction_continue_handler()
 BEGIN
   DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
@@ -105,6 +115,23 @@ SET SESSION wsrep_retry_autocommit = 1;
 
 
 # ------------------------------------
+# Test 2a-1: no handlers, wsrep_retry_autocommit=1,
+# but there are no retry due to the presence of SELECT
+# statement in the procedure (see
+# wsrep_should_retry_in_autocommit).
+# The call to the SP will fail and return an error.
+#
+--connection node_1a
+--echo # Node 1a
+USE database1;
+SET SESSION wsrep_retry_autocommit = 1;
+--let $galera_sp_bf_abort_proc = proc_with_transaction_and_select
+
+--let $galera_sp_bf_abort2_expect_error = 1
+--source galera_sp_bf_abort2.inc
+
+
+# -----------------------------------
 # Test 2b: exit handler, wsrep_retry_autocommit=1
 # The first call to the SP will fail, but it will be retried
 # and will return success.

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -7655,6 +7655,7 @@ extern "C" void *start_wsrep_THD(void *arg)
   return(NULL);
 }
 
+#if 0
 /**/
 static inline bool is_client_connection(THD *thd)
 {
@@ -7683,7 +7684,6 @@ static inline bool is_committing_connection(THD *thd)
   return ret;
 }
 
-#if 0
 /*
    returns the number of wsrep appliers running.
    However, the caller (thd parameter) is not taken in account

--- a/sql/sp_instr.h
+++ b/sql/sp_instr.h
@@ -246,6 +246,10 @@ public:
       return m_lex ? m_lex->sql_command : -1;
   }
 
+#ifdef WITH_WSREP
+  const LEX *get_lex() const { return m_lex; }
+#endif
+
   const LEX_CSTRING *get_prepared_stmt_name() const {
     return m_lex ? &m_lex->prepared_stmt_name : NULL;
   }

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6407,7 +6407,7 @@ static Sys_var_charptr Sys_wsrep_data_home_dir(
 
 static Sys_var_charptr Sys_wsrep_cluster_name(
        "wsrep_cluster_name", "Name for the cluster",
-       READ_ONLY GLOBAL_VAR(wsrep_cluster_name), CMD_LINE(REQUIRED_ARG),
+       READ_ONLY PREALLOCATED GLOBAL_VAR(wsrep_cluster_name), CMD_LINE(REQUIRED_ARG),
        IN_FS_CHARSET, DEFAULT(WSREP_CLUSTER_NAME),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(wsrep_cluster_name_check),

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9508,6 +9508,7 @@ no_commit:
 			dberr_t err = row_lock_table_for_mysql(
 			    m_prebuilt, locked_table[i], LOCK_IX);
 			ut_ad(err == DB_SUCCESS);
+			(void)err;
 		}
                 locked_table.clear();
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-2687

Extend PXC-3226: disable wsrep_retry_autocommit mechanism for all required commands inside CALL statement.

Bug is not reproduced in 8.0.