### PR TITLE
PXC-3872: Normal user dropping system user

### DIFF
--- a/mysql-test/suite/galera/r/pxc_drop_user.result
+++ b/mysql-test/suite/galera/r/pxc_drop_user.result
@@ -1,0 +1,55 @@
+CREATE USER 'x'@'localhost' IDENTIFIED BY 'x';
+GRANT CREATE USER, EXECUTE, ALTER ROUTINE, DROP ROLE, ROLE_ADMIN, SELECT, UPDATE, SYSTEM_VARIABLES_ADMIN ON *.* TO 'x'@'localhost' WITH GRANT OPTION;
+CREATE USER 'y'@'localhost' IDENTIFIED BY 'y';
+GRANT ALL ON *.* TO 'y'@'localhost' WITH GRANT OPTION;
+CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO t1 (a) VALUES (1);
+END//
+CREATE ROLE 'test_role';
+GRANT ALL ON *.* TO 'test_role';
+CREATE TABLE t1 (a INT PRIMARY KEY);
+DROP USER 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+ALTER USER 'y'@'localhost' PASSWORD EXPIRE NEVER;
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+REVOKE EXECUTE ON *.* FROM 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+GRANT EXECUTE ON PROCEDURE test.p1 TO 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+REVOKE EXECUTE ON PROCEDURE test.p1 FROM 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+GRANT 'test_role' TO 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+REVOKE 'test_role' FROM 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+GRANT SELECT ON test.t1 TO 'y'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+ALTER USER 'y'@'localhost' DEFAULT ROLE NONE;
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+DROP PROCEDURE test.p1;
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+RENAME USER 'y'@'localhost' TO 'z'@'localhost';
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+SET PASSWORD FOR 'y'@'localhost' TO RANDOM;
+ERROR 42000: Access denied; you need (at least one of) the SYSTEM_USER privilege(s) for this operation
+DROP USER 'utilityuser'@'localhost';
+ERROR HY000: Operation DROP USER failed for 'utilityuser'@'localhost'
+CALL mtr.add_suppression(".*Operation DROP USER failed.*");
+CALL mtr.add_suppression(".*Fail to replicate: DROP USER.*");
+CALL mtr.add_suppression(".*Operation DROP USER failed.*");
+CALL mtr.add_suppression(".*Query apply failed.*");
+CREATE USER 'z'@'localhost' IDENTIFIED BY 'z';
+GRANT ALL ON *.* TO 'z'@'localhost' WITH GRANT OPTION;
+SET DEBUG_SYNC = 'wl14084_after_table_locks SIGNAL after_table_locks.reached WAIT_FOR after_table_locks.continue';
+DROP USER 'z'@'localhost';;
+SET DEBUG_SYNC = 'now WAIT_FOR after_table_locks.reached';
+DROP USER 'z'@'localhost';
+ERROR HY000: Operation DROP USER failed for 'z'@'localhost'
+DROP TABLE t1;
+DROP USER 'x'@'localhost';
+DROP USER 'y'@'localhost';
+DROP PROCEDURE test.p1;
+DROP ROLE 'test_role';

--- a/mysql-test/suite/galera/t/pxc_drop_user.opt
+++ b/mysql-test/suite/galera/t/pxc_drop_user.opt
@@ -1,0 +1,1 @@
+--utility_user=utilityuser@localhost --utility_user_password=utilityuserpass

--- a/mysql-test/suite/galera/t/pxc_drop_user.test
+++ b/mysql-test/suite/galera/t/pxc_drop_user.test
@@ -1,0 +1,116 @@
+# Test that DROP USER executed on the user with SYSTEM_USER privilege
+# is not replicated when executing user has no SYSTEM_USER
+
+--source include/have_debug_sync.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+CREATE USER 'x'@'localhost' IDENTIFIED BY 'x';
+GRANT CREATE USER, EXECUTE, ALTER ROUTINE, DROP ROLE, ROLE_ADMIN, SELECT, UPDATE, SYSTEM_VARIABLES_ADMIN ON *.* TO 'x'@'localhost' WITH GRANT OPTION;
+
+CREATE USER 'y'@'localhost' IDENTIFIED BY 'y';
+GRANT ALL ON *.* TO 'y'@'localhost' WITH GRANT OPTION;
+
+DELIMITER //;
+
+CREATE PROCEDURE p1()
+BEGIN
+  INSERT INTO t1 (a) VALUES (1);
+END//
+
+DELIMITER ;//
+
+CREATE ROLE 'test_role';
+GRANT ALL ON *.* TO 'test_role';
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+
+--connect node_1a, 127.0.0.1, x, x, test, $NODE_MYPORT_1
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+DROP USER 'y'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+ALTER USER 'y'@'localhost' PASSWORD EXPIRE NEVER;
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'y'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+REVOKE EXECUTE ON *.* FROM 'y'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+GRANT EXECUTE ON PROCEDURE test.p1 TO 'y'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+REVOKE EXECUTE ON PROCEDURE test.p1 FROM 'y'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+GRANT 'test_role' TO 'y'@'localhost';
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+REVOKE 'test_role' FROM 'y'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+GRANT SELECT ON test.t1 TO 'y'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+ALTER USER 'y'@'localhost' DEFAULT ROLE NONE;
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+DROP PROCEDURE test.p1;
+
+#
+# not affected, but let's test them anyway
+#
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+RENAME USER 'y'@'localhost' TO 'z'@'localhost';
+
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+SET PASSWORD FOR 'y'@'localhost' TO RANDOM;
+
+#
+# utility user drop
+#
+--error ER_CANNOT_USER
+DROP USER 'utilityuser'@'localhost';
+
+
+#
+# Two nodes interaction
+#
+--connection node_1
+CALL mtr.add_suppression(".*Operation DROP USER failed.*");
+CALL mtr.add_suppression(".*Fail to replicate: DROP USER.*");
+
+--connection node_2
+CALL mtr.add_suppression(".*Operation DROP USER failed.*");
+CALL mtr.add_suppression(".*Query apply failed.*");
+
+--connection node_1
+CREATE USER 'z'@'localhost' IDENTIFIED BY 'z';
+GRANT ALL ON *.* TO 'z'@'localhost' WITH GRANT OPTION;
+
+# It will be BF aborted so will continue automatically after abortion, but we need to wait anyway
+SET DEBUG_SYNC = 'wl14084_after_table_locks SIGNAL after_table_locks.reached WAIT_FOR after_table_locks.continue';
+--send DROP USER 'z'@'localhost';
+
+--connection node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR after_table_locks.reached';
+
+--connection node_2
+DROP USER 'z'@'localhost';
+
+--connection node_1
+--error ER_CANNOT_USER
+--reap
+
+
+--connection node_1
+
+--disconnect node_1a
+--connection node_1
+DROP TABLE t1;
+DROP USER 'x'@'localhost';
+DROP USER 'y'@'localhost';
+DROP PROCEDURE test.p1;
+DROP ROLE 'test_role';
+--source include/wait_until_count_sessions.inc

--- a/sql/auth/auth_internal.h
+++ b/sql/auth/auth_internal.h
@@ -204,12 +204,11 @@ int replace_routine_table(THD *thd, GRANT_NAME *grant_name, TABLE *table,
                           const LEX_USER &combo, const char *db,
                           const char *routine_name, bool is_proc, ulong rights,
                           bool revoke_grant);
-#ifdef WITH_WSREP
-int open_grant_tables(THD *thd, TABLE_LIST *tables, bool *transactional_tables,
-                      const char *db = WSREP_MYSQL_DB,
-                      const char *table = NULL);
-#else
 int open_grant_tables(THD *thd, TABLE_LIST *tables, bool *transactional_tables);
+#ifdef WITH_WSREP
+bool start_toi_after_open_grant_tables(THD *thd,
+                                       const char *db = WSREP_MYSQL_DB,
+                                       const char *table = nullptr);
 #endif /* WITH_WSREP */
 void acl_tables_setup_for_read(TABLE_LIST *tables);
 void acl_print_ha_error(int handler_error);

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -2788,6 +2788,13 @@ int mysql_table_grant(THD *thd, TABLE_LIST *table_list,
       return true;
     }
 
+#ifdef WITH_WSREP
+    if (start_toi_after_open_grant_tables(thd)) {
+      commit_and_close_mysql_tables(thd);
+      return true;
+    }
+#endif
+
     MEM_ROOT *old_root = thd->mem_root;
     thd->mem_root = &memex;
     grant_version++;
@@ -2993,6 +3000,13 @@ bool mysql_routine_grant(THD *thd, TABLE_LIST *table_list, bool is_proc,
       return true;
     }
 
+#ifdef WITH_WSREP
+    if (start_toi_after_open_grant_tables(thd)) {
+      commit_and_close_mysql_tables(thd);
+      return true;
+    }
+#endif
+
     MEM_ROOT *old_root = thd->mem_root;
     thd->mem_root = &memex;
 
@@ -3143,6 +3157,13 @@ bool mysql_revoke_role(THD *thd, const List<LEX_USER> *users,
       commit_and_close_mysql_tables(thd);
       return true;
     }
+
+#ifdef WITH_WSREP
+    if (start_toi_after_open_grant_tables(thd)) {
+      commit_and_close_mysql_tables(thd);
+      return true;
+    }
+#endif
 
     table = tables[ACL_TABLES::TABLE_ROLE_EDGES].table;
 
@@ -3358,6 +3379,13 @@ bool mysql_grant_role(THD *thd, const List<LEX_USER> *users,
       return true;
     }
 
+#ifdef WITH_WSREP
+    if (start_toi_after_open_grant_tables(thd)) {
+      commit_and_close_mysql_tables(thd);
+      return true;
+    }
+#endif
+
     table = tables[6].table;
 
     while ((lex_user = users_it++) && !errors) {
@@ -3515,6 +3543,13 @@ bool mysql_grant(THD *thd, const char *db, List<LEX_USER> &list, ulong rights,
       commit_and_close_mysql_tables(thd);
       return true;
     }
+
+#ifdef WITH_WSREP
+    if (start_toi_after_open_grant_tables(thd)) {
+      commit_and_close_mysql_tables(thd);
+      return true;
+    }
+#endif
 
     /* go through users in user_list */
     grant_version++;
@@ -5172,6 +5207,13 @@ bool mysql_revoke_all(THD *thd, List<LEX_USER> &list) {
       return true;
     }
 
+#ifdef WITH_WSREP
+    if (start_toi_after_open_grant_tables(thd)) {
+      commit_and_close_mysql_tables(thd);
+      return true;
+    }
+#endif
+
     TABLE *dynpriv_table = tables[ACL_TABLES::TABLE_DYNAMIC_PRIV].table;
     LEX_USER *lex_user, *tmp_lex_user;
     List_iterator<LEX_USER> user_list(list);
@@ -5323,6 +5365,13 @@ bool sp_revoke_privileges(THD *thd, const char *sp_db, const char *sp_name,
     commit_and_close_mysql_tables(thd);
     return true;
   }
+
+#ifdef WITH_WSREP
+  if (start_toi_after_open_grant_tables(thd)) {
+    commit_and_close_mysql_tables(thd);
+    return true;
+  }
+#endif
 
   /* Be sure to pop this before exiting this scope! */
   thd->push_internal_handler(&error_handler);
@@ -6466,6 +6515,13 @@ bool mysql_alter_or_clear_default_roles(THD *thd, role_enum role_type,
       commit_and_close_mysql_tables(thd);
       return true;
     }
+
+#ifdef WITH_WSREP
+    if (start_toi_after_open_grant_tables(thd)) {
+      commit_and_close_mysql_tables(thd);
+      return true;
+    }
+#endif
 
     while ((user = users_it++) && !ret) {
       // Check for CURRENT_USER token

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5340,15 +5340,24 @@ int mysql_execute_command(THD *thd, bool first_level) {
       assert(thd->get_transaction()->is_empty(Transaction_ctx::STMT));
       close_thread_tables(thd);
 
-      if (sp_result != SP_DOES_NOT_EXISTS && sp_automatic_privileges &&
-          !opt_noacl &&
-          sp_revoke_privileges(thd, db, name,
-                               lex->sql_command == SQLCOM_DROP_PROCEDURE)) {
-        push_warning(thd, Sql_condition::SL_WARNING, ER_PROC_AUTO_REVOKE_FAIL,
-                     ER_THD(thd, ER_PROC_AUTO_REVOKE_FAIL));
-        /* If this happens, an error should have been reported. */
-        goto error;
+#ifdef WITH_WSREP
+      // sp_drop_routine() returns SP_INTERNAL_ERROR in case of system user
+      // privileges check failure. In such a case we don't want to proceed with
+      // sp_revoke_privileges which will fail anyway.
+      if (sp_result != SP_INTERNAL_ERROR) {
+#endif
+        if (sp_result != SP_DOES_NOT_EXISTS && sp_automatic_privileges &&
+            !opt_noacl &&
+            sp_revoke_privileges(thd, db, name,
+                                 lex->sql_command == SQLCOM_DROP_PROCEDURE)) {
+          push_warning(thd, Sql_condition::SL_WARNING, ER_PROC_AUTO_REVOKE_FAIL,
+                       ER_THD(thd, ER_PROC_AUTO_REVOKE_FAIL));
+          /* If this happens, an error should have been reported. */
+          goto error;
+        }
+#ifdef WITH_WSREP
       }
+#endif
 
       res = sp_result;
       switch (sp_result) {
@@ -5535,8 +5544,7 @@ int mysql_execute_command(THD *thd, bool first_level) {
         WSREP_SYNC_WAIT(thd, WSREP_SYNC_WAIT_BEFORE_SHOW);
       }
 
-      if (lex->sql_command == SQLCOM_ALTER_USER_DEFAULT_ROLE ||
-          lex->sql_command == SQLCOM_CREATE_SRS ||
+      if (lex->sql_command == SQLCOM_CREATE_SRS ||
           lex->sql_command == SQLCOM_DROP_SRS ||
           lex->sql_command == SQLCOM_INSTALL_COMPONENT ||
           lex->sql_command == SQLCOM_UNINSTALL_COMPONENT) {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3872

Problem:
When user with SYSTEM_USER privilege is dropped by the user without
SYSTEM_USER privilege on node_1, node_2 initiates consistency voting
mechanism and self-leaves the cluster.
During the investigation I've found that not only DROP USER is affected,
but ALTER USER, RENAME USER, REVOKE ALL PRIVILEGES, REVOKE ... ON,
GRANT ... ON PROCEDURE, REVOKE ... ON PROCEDURE, GRANT <role> TO,
REVOKE <role> FROM, DROP PROCEDURE.

Cause:
Affected statements are replicated as TOI. Replication was initated
before checking if SYSTEM_USER privileges for both users allow to
proceed. As the applier thread on node_2 works in superuser context,
it is allowed to proceed with affected statement, which leads to cluster
inconsistency.

Solution:
Move initiation of TOI replication after SYSTEM_USER privileges
validation.