### PR TITLE
[5.7] PXC-3118: BF abort for MDL conflict stuck when Thread Pool used

### DIFF
--- a/mysql-test/suite/galera/r/pxc_local_bf_abort_threadpool.result
+++ b/mysql-test/suite/galera/r/pxc_local_bf_abort_threadpool.result
@@ -1,0 +1,16 @@
+SELECT @@thread_handling;
+@@thread_handling
+pool-of-threads
+CREATE TABLE t1(i INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3);
+BEGIN;
+SELECT * FROM t1 FOR UPDATE;
+i
+1
+2
+3
+TRUNCATE TABLE t1;
+SELECT * FROM t1;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+include/assert.inc [wsrep_local_bf_aborts has been incremented once]
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_local_bf_abort_threadpool-master.opt
+++ b/mysql-test/suite/galera/t/pxc_local_bf_abort_threadpool-master.opt
@@ -1,0 +1,1 @@
+--thread_handling=pool-of-threads

--- a/mysql-test/suite/galera/t/pxc_local_bf_abort_threadpool.test
+++ b/mysql-test/suite/galera/t/pxc_local_bf_abort_threadpool.test
@@ -1,0 +1,54 @@
+# ==== Purpose ===
+#
+# This test verifies that DDLs bf-abort the local transactions when threadpool
+# is enabled.
+#
+# === References ===
+#
+# PXC-3118: BF abort for MDL conflict stuck when Thread Pool used
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+# Check that threadpool is enabled.
+SELECT @@thread_handling;
+
+# Create auxiliary connections for the test.
+--connect(con1,localhost,root,,test, $NODE_MYPORT_1)
+--connect(con2,localhost,root,,test, $NODE_MYPORT_1)
+
+--connection con1
+CREATE TABLE t1(i INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2),(3);
+
+# Capture the `wsrep_local_bf_aborts` status var.
+--let $wsrep_local_bf_aborts_before = `SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
+
+# Lock few rows
+BEGIN;
+SELECT * FROM t1 FOR UPDATE;
+
+# Perform a DDL on the same node from a different client session.
+# Without the fix to PXC-3118, the below TRUCATE TABLE query shall
+# wait on an MDL failing to bf-abort the local transaction.
+--connection con2
+TRUNCATE TABLE t1;
+
+# Check that the session has been killed
+--connection con1
+--error ER_LOCK_DEADLOCK
+SELECT * FROM t1;
+
+# Validate that wsrep_local_bf_aborts has been incremented once
+--let $wsrep_local_bf_aborts_after = `SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_bf_aborts'`
+--let $assert_text = wsrep_local_bf_aborts has been incremented once
+--let $assert_cond = $wsrep_local_bf_aborts_after - $wsrep_local_bf_aborts_before = 1
+--source include/assert.inc
+
+--disconnect con1
+--disconnect con2
+
+# Cleanup
+--connection node_1
+DROP TABLE t1;
+--source include/wait_until_count_sessions.inc

--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -282,6 +282,17 @@ int threadpool_process_request(THD *thd)
   }
 
 end:
+
+#ifdef WITH_WSREP
+    /* Set the thd->wsrep_query_state back to the QUERY_IDLE state. */
+    if (WSREP_ON)
+    {
+      mysql_mutex_lock(&thd->LOCK_wsrep_thd);
+      wsrep_thd_set_query_state(thd, QUERY_IDLE);
+      mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
+    }
+#endif /* WITH_WSREP */
+
   if (!retval && !thd->m_server_idle) {
     MYSQL_SOCKET_SET_STATE(thd->get_protocol_classic()->get_vio()
                            ->mysql_socket, PSI_SOCKET_STATE_IDLE);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3118

Problem
-------
DDLs fail to bf-abort local transactions when threadpool is used.

Analysis
--------
When thread pool is used, the local statement does not reset
thd->wsrep_query_state back to QUERY_IDLE from QUERY_EXEC on completion
of the statement. This caused the attempt to bf-abort the local statemet
to fail, there by making the DDL to continue waitin for the MDL.

Solution
--------
Reset the thd->wsrep_query_state to QUERY_IDLE on completion of
statement when threadpool is loaded.


Testing Done
---
Jenkins: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/299/
Failing Tests: None

8.0 PR: https://github.com/percona/percona-xtradb-cluster/pull/1636