### PR TITLE
[8.0] PXC-2367: Flood of log message: WSREP: ready state reached

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -880,10 +880,10 @@ void wsrep_ready_wait ()
   if (mysql_mutex_lock (&LOCK_wsrep_ready)) abort();
   while (!wsrep_ready)
   {
-    WSREP_INFO("Waiting to reach ready state");
+    WSREP_DEBUG("Waiting to reach ready state");
     mysql_cond_wait (&COND_wsrep_ready, &LOCK_wsrep_ready);
   }
-  WSREP_INFO("Ready state reached");
+  WSREP_DEBUG("Ready state reached");
   mysql_mutex_unlock (&LOCK_wsrep_ready);
 }
 


### PR DESCRIPTION
PXC-2367: Flood of log message: WSREP: ready state reached
https://jira.percona.com/browse/PXC-2367

Merge remote-tracking branch 'origin/5.7-PXC-2367' into 8.0-PXC-2367

Problem: Error log floods with the message "Ready state reached" when
event scheduler is enabled.

Solution: Changed the logging level from info to debug.

5.7 PR: https://github.com/percona/percona-xtradb-cluster/pull/1637