### PR TITLE
PXC-3107: Remove plugin dir parameter from SST parameters

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -23,7 +23,6 @@ WSREP_SST_OPT_BINLOG=""
 WSREP_SST_OPT_CONF_SUFFIX=""
 WSREP_SST_OPT_DATA=""
 WSREP_SST_OPT_BASEDIR=""
-WSREP_SST_OPT_PLUGINDIR=""
 WSREP_SST_OPT_USER=""
 WSREP_SST_OPT_PSWD=""
 WSREP_SST_OPT_VERSION=""
@@ -96,10 +95,6 @@ case "$1" in
         ;;
     '--password')
         # Ignore (read value from stdin)
-        shift
-        ;;
-    '--plugindir')
-        readonly WSREP_SST_OPT_PLUGINDIR="$2"
         shift
         ;;
     '--port')
@@ -535,7 +530,6 @@ EOF
 #   WSREP_SST_OPT_CONF
 #   WSREP_SST_OPT_CONF_SUFFIX
 #   WSREP_SST_OPT_BASEDIR
-#   WSREP_SST_OPT_PLUGINDIR
 #   MYSQL_UPGRADE_TMPDIR    (This path will be deleted on exit)
 #
 # Arguments
@@ -803,10 +797,6 @@ function run_post_processing_steps()
 
     if [[ -n $WSREP_SST_OPT_BASEDIR ]]; then
         mysqld_cmdline+=" --basedir=${WSREP_SST_OPT_BASEDIR}"
-    fi
-
-    if [[ -n $WSREP_SST_OPT_PLUGINDIR ]]; then
-        mysqld_cmdline+=" --plugin-dir=${WSREP_SST_OPT_PLUGINDIR}"
     fi
 
     # Generate a new random password to be used by the JOINER

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -50,7 +50,6 @@ extern const char wsrep_defaults_group_suffix[];
 #define WSREP_SST_OPT_AUTH "--auth"
 #define WSREP_SST_OPT_DATA "--datadir"
 #define WSREP_SST_OPT_BASEDIR "--basedir"
-#define WSREP_SST_OPT_PLUGINDIR "--plugindir"
 #define WSREP_SST_OPT_CONF "--defaults-file"
 #define WSREP_SST_OPT_CONF_SUFFIX "--defaults-group-suffix"
 #define WSREP_SST_OPT_PARENT "--parent"
@@ -701,20 +700,18 @@ static ssize_t sst_prepare_other(const char *method, const char *addr_in,
   }
   if (strlen(binlog_opt_val)) binlog_opt = WSREP_SST_OPT_BINLOG;
 
-  ret = snprintf(cmd_str(), cmd_len,
-                 "wsrep_sst_%s " WSREP_SST_OPT_ROLE
-                 " 'joiner' " WSREP_SST_OPT_ADDR " '%s' " WSREP_SST_OPT_DATA
-                 " '%s' " WSREP_SST_OPT_BASEDIR " '%s' " WSREP_SST_OPT_PLUGINDIR
-                 " '%s' " WSREP_SST_OPT_CONF " '%s' " WSREP_SST_OPT_CONF_SUFFIX
-                 " '%s' " WSREP_SST_OPT_PARENT " '%d' " WSREP_SST_OPT_VERSION
-                 " '%s' "
-                 " %s '%s' ",
-                 method, addr_in, mysql_real_data_home,
-                 mysql_home_ptr ? mysql_home_ptr : "",
-                 opt_plugin_dir_ptr ? opt_plugin_dir_ptr : "",
-                 wsrep_defaults_file, wsrep_defaults_group_suffix,
-                 (int)getpid(), MYSQL_SERVER_VERSION MYSQL_SERVER_SUFFIX_DEF,
-                 binlog_opt, binlog_opt_val);
+  ret = snprintf(
+      cmd_str(), cmd_len,
+      "wsrep_sst_%s " WSREP_SST_OPT_ROLE " 'joiner' " WSREP_SST_OPT_ADDR
+      " '%s' " WSREP_SST_OPT_DATA " '%s' " WSREP_SST_OPT_BASEDIR
+      " '%s' " WSREP_SST_OPT_CONF " '%s' " WSREP_SST_OPT_CONF_SUFFIX
+      " '%s' " WSREP_SST_OPT_PARENT " '%d' " WSREP_SST_OPT_VERSION
+      " '%s' "
+      " %s '%s' ",
+      method, addr_in, mysql_real_data_home,
+      mysql_home_ptr ? mysql_home_ptr : "", wsrep_defaults_file,
+      wsrep_defaults_group_suffix, (int)getpid(),
+      MYSQL_SERVER_VERSION MYSQL_SERVER_SUFFIX_DEF, binlog_opt, binlog_opt_val);
   my_free(binlog_opt_val);
 
   if (ret < 0 || ret >= cmd_len) {
@@ -1405,16 +1402,14 @@ static int sst_donate_other(const char *method, const char *addr,
       cmd_str(), cmd_len,
       "wsrep_sst_%s " WSREP_SST_OPT_ROLE " 'donor' " WSREP_SST_OPT_ADDR
       " '%s' " WSREP_SST_OPT_SOCKET " '%s' " WSREP_SST_OPT_DATA
-      " '%s' " WSREP_SST_OPT_BASEDIR " '%s' " WSREP_SST_OPT_PLUGINDIR
-      " '%s' " WSREP_SST_OPT_CONF " '%s' " WSREP_SST_OPT_CONF_SUFFIX
-      " '%s' " WSREP_SST_OPT_VERSION
+      " '%s' " WSREP_SST_OPT_BASEDIR " '%s' " WSREP_SST_OPT_CONF
+      " '%s' " WSREP_SST_OPT_CONF_SUFFIX " '%s' " WSREP_SST_OPT_VERSION
       " '%s' "
       " %s '%s' " WSREP_SST_OPT_GTID
       " '%s:%lld' "
       "%s",
       method, addr, mysqld_unix_port, mysql_real_data_home,
-      mysql_home_ptr ? mysql_home_ptr : "",
-      opt_plugin_dir_ptr ? opt_plugin_dir_ptr : "", wsrep_defaults_file,
+      mysql_home_ptr ? mysql_home_ptr : "", wsrep_defaults_file,
       wsrep_defaults_group_suffix, MYSQL_SERVER_VERSION MYSQL_SERVER_SUFFIX_DEF,
       binlog_opt, binlog_opt_val, uuid_oss.str().c_str(), gtid.seqno().get(),
       bypass ? " " WSREP_SST_OPT_BYPASS : "");


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3107

Support of --plugindir parameter in SST script has been removed as
it is no longer needed ever since we shipped with compatible version
of xtrabackup in PXC packages.


Testing Done
---
Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-pipeline-parallel-mtr/115/
Failing tests: 

1. [galera.galera_garbd_backup](https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-pipeline-parallel-mtr/115/testReport/ubuntu-focal.Debug.galera/galera/galera_garbd_backup/) : Fixed in 8.0.28.
2. [galera.galera_sst_failure](https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-pipeline-parallel-mtr/115/testReport/ubuntu-focal.Debug.galera/galera/galera_sst_failure/) : Fixed in 8.0.28.