### PR TITLE
PXC-3951: Current computation of disk used with sst-idle-timeout could misidentify SST as idle

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_failure.test
+++ b/mysql-test/suite/galera/t/galera_sst_failure.test
@@ -71,7 +71,7 @@ EOF
 --let $assert_text= Checking node_2 error was due to stale SST
 --let $assert_file= $MYSQLTEST_VARDIR/tmp/test_error_log.err
 --let $assert_select= Killing SST \([0-9]*\) with SIGKILL after stalling for [0-9]* seconds
---let $assert_only_after=CURRENT_TEST: galera.galera_sst_failure2
+--let $assert_only_after=CURRENT_TEST: galera.galera_sst_failure
 --let $assert_count=1
 --source include/assert_grep.inc
 

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -296,7 +296,7 @@ monitor_sst_progress() {
       break;
     fi
 
-    current_size=$(du --max-depth=1 ${tmpsstdir} | tail -n 1 | awk '{print $1}')
+    current_size=$(du -b -s ${tmpsstdir} | awk '{print $1}')
     if [[ ${current_size} -eq  ${previous_size} ]]; then
       current_timeout=$((current_timeout + 1))
       sleep=1


### PR DESCRIPTION
**Note: This is a PR to 8.0.28 release branch**

https://jira.percona.com/browse/PXC-3951

Merge remote-tracking branch 'origin/5.7-PXC-3951' into 8.0-PXC-3951

Problem
=======
Currently, disk usage computation of sst-idle-timeout is:

        du --max-depth=1 ${tmpsstdir} | tail -n 1 | awk '{print $1}'

This logic does not detect the storage size difference in bytes, thereby
causing the SST script to timeout and eventually terminate SST even when the
SST is in progress.

Solution
========
The script now passes `--bytes (-b)` and `--summarize (-s)` to `du` to
get difference of storage in bytes.

(cherry picked from commit c387b056334bdc3d6124a20fb01aca254930b187)