### PR TITLE
PXC-3599 SST fails with gtid=on: Move file mysqld-bin.index to /otherfs/mysqld-bin.log.index failed: Destination file exists (8.0)

### DIFF
--- a/doc/source/limitation.rst
+++ b/doc/source/limitation.rst
@@ -93,3 +93,11 @@ The following limitations apply to |PXC|:
   * An INPLACE ``ALTER TABLE`` query in one session or being applied as Total Order Isolation (TOI) 
 
   * A DML on the same table from another session
+
+Do not use one or more dot characters (.) when defining the values for the following variables:
+
+* `log_bin <https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#option_mysqld_log-bin>`__  
+
+* `log_bin_index <https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log html#option_mysqld_log-bin-index>`__
+
+MySQL and **XtraBackup** handles the value in different ways and this difference causes unpredictable behavior.


### PR DESCRIPTION
Merged 5.7 version
fixed conflict in source/limitation