### PR TITLE
PXC-3982: Slave SQL thread fails with WSREP not ready yet error

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_restart.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_restart.result
@@ -1,0 +1,23 @@
+#node-3 (async slave)
+call mtr.add_suppression("Recovery from master pos");
+call mtr.add_suppression("when attempting to connect");
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+START REPLICA;
+#node-1 (source)
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+#node-3 (async replica)
+#Shutting down node-3 (async replica) ...
+#node-1 (source)
+INSERT INTO t1 VALUES(2);
+#node-3 (async replica)
+# restart:--debug=+d,pause_before_wsrep_ready
+#node-1 (source)
+INSERT INTO t1 VALUES (3);
+#node-3 (async replica)
+DROP TABLE t1;
+STOP REPLICA;
+RESET REPLICA ALL;
+RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave_restart.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_restart.cnf
@@ -1,0 +1,14 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld.2]
+relay_log_info_repository = TABLE
+master_info_repository = TABLE
+relay_log_recovery = 1
+relay-log=mysqld2-relay-bin
+
+[mysqld.3]
+relay_log_info_repository = TABLE
+master_info_repository = TABLE
+relay_log_recovery = 1
+relay-log=mysqld3-relay-bin
+

--- a/mysql-test/suite/galera/t/galera_as_slave_restart.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_restart.test
@@ -1,0 +1,83 @@
+#
+# Test Galera as a replica to a MySQL source being restarted.
+# While restarting Galera replica, new events appear on source.
+# As soon as async replica is started, they are replicated
+# but if WSREP not ready yet (Galera replica node is not in sync state)
+# applying them should be delayed to not cause
+# 'WSREP has not yet prepared node for application use' error.
+#
+# The galera/galera_2node_slave.cnf describes the setup of the nodes
+#
+
+--source include/have_debug.inc
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+# As node #1 is not a Galera node, we connect to node #3 in order to run include/galera_cluster.inc
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--source include/galera_cluster_master_slave.inc
+
+--connection node_3
+--echo #node-3 (async slave)
+call mtr.add_suppression("Recovery from master pos");
+call mtr.add_suppression("when attempting to connect");
+--disable_query_log
+--eval CHANGE REPLICATION SOURCE TO SOURCE_HOST='127.0.0.1',SOURCE_USER='root',SOURCE_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START REPLICA;
+
+#
+# Test if replication is working fine.
+--connection node_1
+--echo #node-1 (source)
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+
+--connection node_3
+--echo #node-3 (async replica)
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
+#
+# shutdown node-3
+--echo #Shutting down node-3 (async replica) ...
+--source include/shutdown_mysqld.inc
+
+#
+# Some new events to be replicated when node-3 restarts.
+--connection node_1
+--echo #node-1 (source)
+INSERT INTO t1 VALUES(2);
+
+#
+# Start node-3 but force async replication to start before WSREP reports being ready.
+--connection node_3
+--echo #node-3 (async replica)
+--let $start_mysqld_params="--debug='+d,pause_before_wsrep_ready'"
+--source include/start_mysqld.inc
+
+#
+# re-test if replication is working fine.
+--connection node_1
+--echo #node-1 (source)
+INSERT INTO t1 VALUES (3);
+
+--connection node_3
+--echo #node-3 (async replica)
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_1
+DROP TABLE t1;
+
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+STOP REPLICA;
+RESET REPLICA ALL;
+
+--connection node_1
+RESET MASTER;

--- a/sql/rpl_replica.cc
+++ b/sql/rpl_replica.cc
@@ -7146,6 +7146,20 @@ wsrep_restart_point :
     goto err;
   }
 
+#ifdef WITH_WSREP
+  /* Initialization of Galera/WSREP and async replication happens in parallel.
+     Allow async replication infrastructure to init up to this point, but
+     wait with applying async-replicated events until WSREP infrastructure
+     is fully initialized (wsrep_ready == true). wsrep_ready is set when
+     server state shifts to s_synced.
+     Before this state, events are rejected with error
+     'WSREP has not yet prepared node for application use' */
+  if (WSREP(thd)) {
+    Wsrep_server_state::instance().wait_until_state(
+        Wsrep_server_state::s_synced);
+  }
+#endif /* WITH_WSREP */
+
   /* MTS: starting the worker pool */
   if (slave_start_workers(rli, rli->opt_replica_parallel_workers,
                           &mts_inited) != 0) {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3982

Problem:
It occurs when PXC node is the async replica to the PS.
When PXC node starts it kicks-off Galera/WSREP initialization which does
SST/IST. While it is happening async replication infrastructure is
initialized in parallel.
It has been observed that sometimes async replica's SQL thread reports
'WSREP has not yet prepared node for application use' upon server start
and async replication stops.

Cause:
PXC node blocks processing of application events until the node reaches
'Synced' state. During the initialization sometimes it happens that
async replication is ready before Galera part finishes initialization
getting to the 'Synced' state. In such a case async-replicated event is
going to be applied, but it is blocked, causing the error, because PXC node
is not in 'Synced' state yet.

Solution:
If replica node is PXC node, delay applying of async-replicated events
(SQL thread) until node reaches 'Synced' state.