### PR TITLE
PXC-3449: Galera fails after MDL BF-BF conflict

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf.result
@@ -44,6 +44,26 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE c1;
 DROP TABLE p1;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO p1 VALUES (0, 0);
+INSERT INTO c1 VALUES (0, 0, 0);
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+DROP INDEX f2_key ON p1;;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+BEGIN;
+UPDATE c1 SET data = 1 WHERE pk = 0;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE c1;
+DROP TABLE p1;
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
 CREATE TABLE t1 (pk INTEGER PRIMARY KEY);

--- a/mysql-test/suite/galera/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf.test
@@ -152,6 +152,79 @@ DROP TABLE c1;
 DROP TABLE p1;
 
 #
+# Similar to the above, but for DROP INDEX
+#
+# Test that DROP INDEX on parent table is properly ordered with simultaneous
+# transactions that perform DML on child table.
+#
+# UPDATE should fail certification as its certification keys conflict
+# with DROP INDEX certification keys.
+#
+# Without the fix, UPDATE is certified, then aborted by already replicated TOI
+# transaction which causes its replay. When replaying it conflicts with TOI
+# causing BF-BF conflict.
+#
+# This test checks if parent table is included into the certification keys
+# of the writeset related to TOI done on child table.
+#
+
+--connection node_1_toi
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+
+INSERT INTO p1 VALUES (0, 0);
+INSERT INTO c1 VALUES (0, 0, 0);
+
+# Replicate DROP INDEX, but stop just after replicaton, before local execution
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+--send DROP INDEX f2_key ON p1;
+
+--connection node_1
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Without the fix, UPDATE will replicate and the test will stop the execution
+# just after the certification (before the local commit)
+# With the fix, COMMIT will fail certification
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+BEGIN;
+UPDATE c1 SET data = 1 WHERE pk = 0;
+--send COMMIT
+
+--connection node_1a
+# Now unblock DROP INDEX. Without the fix it will BF-abort already certified
+# UPDATE which will cause its replay.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+
+
+# Without the fix, if UPDATE was replicated, let node_1 to continue.
+# As it was replicated, it needs to replay (hp service)
+# It can now trigger BF-BF conflict with DROP INDEX
+# With the fix, it already failed certification.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# wait for both to finish
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+--connection node_1_toi
+--reap
+--let $wait_condition = SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_NAME='p1';
+--source include/wait_condition.inc
+
+DROP TABLE c1;
+DROP TABLE p1;
+
+#
+#
 # Similar to the above, but for DROP TABLE
 # Additionally we test multi table drop with temporary tables included.
 #

--- a/mysql-test/suite/galera_nbo/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera_nbo/r/galera_bf_bf.result
@@ -29,6 +29,26 @@ ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 SET SESSION wsrep_osu_method=TOI;
 DROP TABLE c1;
 DROP TABLE p1;
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+INSERT INTO p1 VALUES (0, 0);
+INSERT INTO c1 VALUES (0, 0, 0);
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+DROP INDEX f2_key ON p1;;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
+BEGIN;
+UPDATE c1 SET data = 1 WHERE pk = 0;
+COMMIT;
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE c1;
+DROP TABLE p1;
 CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
 SET wsrep_retry_autocommit = 1;
 CREATE TABLE t1 (a INT PRIMARY KEY);

--- a/mysql-test/suite/galera_nbo/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera_nbo/t/galera_bf_bf.test
@@ -83,6 +83,77 @@ SET SESSION wsrep_osu_method=TOI;
 DROP TABLE c1;
 DROP TABLE p1;
 
+#
+# Similar to the above, but for DROP INDEX
+#
+# Test that DROP INDEX on parent table is properly ordered with simultaneous
+# transactions that perform DML on child table.
+#
+# UPDATE should fail certification as its certification keys conflict
+# with DROP INDEX certification keys.
+#
+# Without the fix, UPDATE is certified, then aborted by already replicated TOI
+# transaction which causes its replay. When replaying it conflicts with TOI
+# causing BF-BF conflict.
+#
+# This test checks if parent table is included into the certification keys
+# of the writeset related to TOI done on child table.
+#
+
+--connection node_1_toi
+CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
+CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
+
+INSERT INTO p1 VALUES (0, 0);
+INSERT INTO c1 VALUES (0, 0, 0);
+
+# Replicate DROP INDEX, but stop just after replicaton, before local execution
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+--send DROP INDEX f2_key ON p1;
+
+--connection node_1
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Without the fix, UPDATE will replicate and the test will stop the execution
+# just after the certification (before the local commit)
+# With the fix, COMMIT will fail certification
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+BEGIN;
+UPDATE c1 SET data = 1 WHERE pk = 0;
+--send COMMIT
+
+--connection node_1a
+# Now unblock DROP INDEX. Without the fix it will BF-abort already certified
+# UPDATE which will cause its replay.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+
+
+# Without the fix, if UPDATE was replicated, let node_1 to continue.
+# As it was replicated, it needs to replay (hp service)
+# It can now trigger BF-BF conflict with DROP INDEX
+# With the fix, it already failed certification.
+--let $galera_sync_point = apply_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# wait for both to finish
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+--connection node_1_toi
+--reap
+--let $wait_condition = SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_NAME='p1';
+--source include/wait_condition.inc
+
+DROP TABLE c1;
+DROP TABLE p1;
 
 #
 # The fix involves querying Data Dictionary to obtain parent and child foreign


### PR DESCRIPTION
(post merge fix)

https://jira.percona.com/browse/PXC-3449

Problem:
It has been discovered that executing DROP INDEX in parallel to DML can
cause BF-BF abort and node shutdown.

Cause:
The problem is similar to already merged fixes to BF-BF in scope of the
same ticket. When we have 2 tables, parent and child, DROP INDEX
executed in parallel to DML can cause abort of already certified and
replicated DML. In such a case DML is replayed locally, but can cause
BF-BF abort on replica. This is because the certification process has
not enough information about tables dependencies, which leads to faulty
certification process/transactions ordering.

Solution:
Add parent/child tables to certification keys set when executing
DROP/CREATE INDEX. This causes local DML to fail certification.