### PR TITLE
(8.0) PXC-3664: clustercheck in some cases fails to identify correct node state

### DIFF
--- a/scripts/clustercheck.sh
+++ b/scripts/clustercheck.sh
@@ -41,12 +41,16 @@ fi
 #
 # Perform the query to check the wsrep_local_state
 #
-WSREP_STATUS=($($MYSQL_CMDLINE -e "SHOW GLOBAL STATUS LIKE 'wsrep_%';"  \
-    2>${ERR_FILE} | grep -A 1 -E 'wsrep_local_state$|wsrep_cluster_status$' \
-    | sed -n -e '2p'  -e '5p' | tr '\n' ' '))
- 
-if [[ ${WSREP_STATUS[1]} == 'Primary' && ( ${WSREP_STATUS[0]} -eq 4 || \
-    ( ${WSREP_STATUS[0]} -eq 2 && $AVAILABLE_WHEN_DONOR -eq 1 ) ) ]]
+PXC_NODE_STATUS=($($MYSQL_CMDLINE -e "SHOW STATUS LIKE 'wsrep_local_state';SHOW VARIABLES LIKE 'pxc_maint_mode';SHOW GLOBAL STATUS LIKE 'wsrep_cluster_status';" \
+     2>${ERR_FILE} | grep -A 1 -E 'wsrep_local_state$|pxc_maint_mode$|wsrep_cluster_status$' | sed -n -e '2p' -e '5p' -e '8p' | tr '\n' ' '))
+
+# ${PXC_NODE_STATUS[0]} - wsrep_local_state
+# ${PXC_NODE_STATUS[1]} - pxc_maint_mode
+# ${PXC_NODE_STATUS[2]} - wsrep_cluster_status
+
+if [[ ${PXC_NODE_STATUS[2]} == 'Primary' &&  ( ${PXC_NODE_STATUS[0]} -eq 4 || \
+    ( ${PXC_NODE_STATUS[0]} -eq 2 && ${AVAILABLE_WHEN_DONOR} -eq 1 ) ) \
+    && ${PXC_NODE_STATUS[1]} == 'DISABLED' ]];
 then 
 
     # Check only when set to 0 to avoid latency in response.


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3664

This commit aligns the logic of clustercheck.sh with the logic of its
counterpart script check_pxc.sh located in percona-docker repository.
It doesn't solve the problem described in the ticket because it is
HAProxy which assumes the node is OK by default, even before the 1st
check. So the problem is related to HAProxy behavior and should be fixed
by HaProxy state file, not in PXC (there is no way to fix it on PXC or
check the script side).

Original contribution by Antonio Falzarano.
https://github.com/percona/percona-xtradb-cluster/pull/1428
Not merged directly because of GCA merge process which needs to be
applied.