### PR TITLE
PXC-4003: wsrep_sync_wait has no effect after COM_CHANGE_USER

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1353,7 +1353,6 @@ void THD::cleanup(void) {
   if (wsrep_cs().state() != wsrep::client_state::s_none) {
     wsrep_cs().cleanup();
   }
-  wsrep_client_thread = false;
   wsrep_allow_mdl_conflict = false;
   wsrep_aborter = 0;
 #endif /* WITH_WSREP */

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -1037,6 +1037,7 @@ void end_connection(THD *thd) {
     wsrep_after_command_ignore_result(thd);
   }
   wsrep_close(thd);
+  thd->wsrep_client_thread = false;
 #endif /* WITH_WSREP */
 
   mysql_audit_notify(thd, AUDIT_EVENT(MYSQL_AUDIT_CONNECTION_DISCONNECT), 0);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4003

Problem
-------
wsrep_sync_wait checks are skipped after COM_CHANGE_USER.

Analysis
--------

1. During execution of COM_CHANGE_USER, server calls
   thd->cleanup_connection() in order to clear the context of the
   previous user.
2. thd->cleanup_connection() calls THD::cleanup()
3. THD::cleanup() resets wsrep_client_thread
4. Any query after COM_CHANGE_USER will have the
   thd->wsrep_client_thread set to false.
5. These queries skip wsrep_sync_waits because these checks are done
   only when wsrep_client_thread = true

Fix
---
Move the cleanup of wsrep_client_thread to end_connection() instead of
THD::cleanup_connection().

Note
---
 - This bug is not reproducible on 5.7.


Testing done
----

Without fix
```
$ php -f wsrep_sync_wait---com_change_user.php.txt | sort | uniq -c | sort -k 3,4

     14 LOOP2: node2  count: 19 - sum: 171 - wsrep_sync_wait: 15
     19 LOOP3: node2  count: 18 - sum: 153 - wsrep_sync_wait: 7
      1 LOOP2: node2  count: 11 - sum: 55 - wsrep_sync_wait: 15
      1 LOOP2: node2  count: 4 - sum: 6 - wsrep_sync_wait: 15
      1 LOOP2: node2  count: 7 - sum: 21 - wsrep_sync_wait: 15
      1 LOOP2: node2  count: 8 - sum: 28 - wsrep_sync_wait: 15
      1 LOOP3: node2  count: 11 - sum: 55 - wsrep_sync_wait: 7
      1 LOOP3: node2  count: 12 - sum: 66 - wsrep_sync_wait: 7
     21 LOOP3: node2  count: 19 - sum: 171 - wsrep_sync_wait: 7
      2 LOOP2: node2  count: 13 - sum: 78 - wsrep_sync_wait: 15
      2 LOOP2: node2  count: 15 - sum: 105 - wsrep_sync_wait: 15
      2 LOOP2: node2  count: 16 - sum: 120 - wsrep_sync_wait: 15
      2 LOOP3: node2  count: 13 - sum: 78 - wsrep_sync_wait: 7
      2 LOOP3: node2  count: 15 - sum: 105 - wsrep_sync_wait: 7
    351 LOOP3: node2  count: 20 - sum: 190 - wsrep_sync_wait: 7
    367 LOOP2: node2  count: 20 - sum: 190 - wsrep_sync_wait: 15
      3 LOOP2: node2  count: 10 - sum: 45 - wsrep_sync_wait: 15
      3 LOOP2: node2  count: 14 - sum: 91 - wsrep_sync_wait: 15
      3 LOOP3: node2  count: 14 - sum: 91 - wsrep_sync_wait: 7
      4 LOOP3: node2  count: 16 - sum: 120 - wsrep_sync_wait: 7
    500 LOOP1: node2  count: 20 - sum: 210 - wsrep_sync_wait: 15
      7 LOOP2: node2  count: 17 - sum: 136 - wsrep_sync_wait: 15
      7 LOOP2: node2  count: 18 - sum: 153 - wsrep_sync_wait: 15
     87 LOOP3: node2  count: 20 - sum: 210 - wsrep_sync_wait: 7
     89 LOOP2: node2  count: 20 - sum: 210 - wsrep_sync_wait: 15
      9 LOOP3: node2  count: 17 - sum: 136 - wsrep_sync_wait: 7
     14 LOOP3: node3  count: 18 - sum: 153 - wsrep_sync_wait: 7
     15 LOOP2: node3  count: 19 - sum: 171 - wsrep_sync_wait: 15
      1 LOOP2: node3  count: 10 - sum: 45 - wsrep_sync_wait: 15
      1 LOOP2: node3  count: 8 - sum: 28 - wsrep_sync_wait: 15
      1 LOOP3: node3  count: 10 - sum: 45 - wsrep_sync_wait: 7
      1 LOOP3: node3  count: 12 - sum: 66 - wsrep_sync_wait: 7
      1 LOOP3: node3  count: 14 - sum: 91 - wsrep_sync_wait: 7
      1 LOOP3: node3  count: 2 - sum: 1 - wsrep_sync_wait: 7
      1 LOOP3: node3  count: 6 - sum: 15 - wsrep_sync_wait: 7
      1 LOOP3: node3  count: 7 - sum: 21 - wsrep_sync_wait: 7
     20 LOOP3: node3  count: 19 - sum: 171 - wsrep_sync_wait: 7
      2 LOOP2: node3  count: 12 - sum: 66 - wsrep_sync_wait: 15
      2 LOOP2: node3  count: 13 - sum: 78 - wsrep_sync_wait: 15
    352 LOOP2: node3  count: 20 - sum: 190 - wsrep_sync_wait: 15
    353 LOOP3: node3  count: 20 - sum: 190 - wsrep_sync_wait: 7
      3 LOOP3: node3  count: 13 - sum: 78 - wsrep_sync_wait: 7
      3 LOOP3: node3  count: 15 - sum: 105 - wsrep_sync_wait: 7
      4 LOOP2: node3  count: 14 - sum: 91 - wsrep_sync_wait: 15
      4 LOOP2: node3  count: 16 - sum: 120 - wsrep_sync_wait: 15
    500 LOOP1: node3  count: 20 - sum: 210 - wsrep_sync_wait: 15
      5 LOOP2: node3  count: 15 - sum: 105 - wsrep_sync_wait: 15
      5 LOOP3: node3  count: 17 - sum: 136 - wsrep_sync_wait: 7
      6 LOOP3: node3  count: 16 - sum: 120 - wsrep_sync_wait: 7
     90 LOOP3: node3  count: 20 - sum: 210 - wsrep_sync_wait: 7
     96 LOOP2: node3  count: 20 - sum: 210 - wsrep_sync_wait: 15
      9 LOOP2: node3  count: 17 - sum: 136 - wsrep_sync_wait: 15
      9 LOOP2: node3  count: 18 - sum: 153 - wsrep_sync_wait: 15
```

With fix
```
$ php -f wsrep_sync_wait---com_change_user.php.txt | sort | uniq -c | sort -k 3,4

    500 LOOP1: node2  count: 20 - sum: 210 - wsrep_sync_wait: 15
    500 LOOP2: node2  count: 20 - sum: 210 - wsrep_sync_wait: 15
    500 LOOP3: node2  count: 20 - sum: 210 - wsrep_sync_wait: 7
    500 LOOP1: node3  count: 20 - sum: 210 - wsrep_sync_wait: 15
    500 LOOP2: node3  count: 20 - sum: 210 - wsrep_sync_wait: 15
    500 LOOP3: node3  count: 20 - sum: 210 - wsrep_sync_wait: 7
```
