### PR TITLE
PXC-3996: Merge PS-5.7.39, Part 2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,7 @@ Introduction
    third-party software which may be included in this distribution of
    MySQL 5.7.28 (and later).
 
-   Last updated: January 2022
+   Last updated: May 2022
 
 Licensing Information
 
@@ -3655,48 +3655,6 @@ That's all there is to it!
    ======================================================================
    ======================================================================
 
-Linux-PAM
-
-Unless otherwise *explicitly* stated the following text describes the licensed
-conditions under which the contents of this Linux-PAM release may be
-distributed:
-
--------------------------------------------------------------------------
-Redistribution and use in source and binary forms of Linux-PAM, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain any existing copyright notice, and
-   this entire permission notice in its entirety, including the disclaimer of
-   warranties.
-
-2. Redistributions in binary form must reproduce all prior and current copyright
-   notices, this list of conditions, and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-
-3. The name of any author may not be used to endorse or promote products derived
-   from this software without their specific prior written permission.
-
-ALTERNATIVELY, this product may be distributed under the terms of the GNU
-General Public License, in which case the provisions of the GNU GPL are required
-INSTEAD OF the above restrictions.  (This clause is necessary due to a potential
-conflict between the GNU GPL and the restrictions contained in a BSD-style
-copyright.)
-
-THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S)
-BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
--------------------------------------------------------------------------
-Oracle elects the BSD-style license
-
-   ======================================================================
-   ======================================================================
-
 LZ4
 
 LZ4 Library
@@ -3924,53 +3882,7 @@ code is licensed under the LGPLv2.1 license.
    ======================================================================
    ======================================================================
 
-OpenPAM
-
-   OpenPAM
-
-Copyright (c) 2002-2003 Networks Associates Technology, Inc.
-Copyright (c) 2004-2007 Dag-Erling Smørgrav
-All rights reserved.
-
-This software was developed for the FreeBSD Project by
-ThinkSec AS and Network Associates Laboratories, the
-Security Research Division of Network Associates, Inc.
-under DARPA/SPAWAR contract N66001-01-C-8035 ("CBOSS"),
-as part of the DARPA CHATS research program.
-
-Redistribution and use in source and binary forms,
-with or without modification, are permitted provided
-that the following conditions are met:
-
-1. Redistributions of source code must retain the above
-   copyright notice, this list of conditions and the
-   following disclaimer.
-2. Redistributions in binary form must reproduce the
-   above copyright notice, this list of conditions and
-   the following disclaimer in the documentation and/or
-   other materials provided with the distribution.
-3. The name of the author may not be used to endorse or
-   promote products derived from this software without
-   specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN
-NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-   ======================================================================
-   ======================================================================
-
-OpenSSL License
+OpenSSL 1.x
 
    You are receiving a copy of OpenSSL as part of this product in object
    code form. The terms of the Oracle license do NOT apply to OpenSSL.
@@ -4712,7 +4624,7 @@ zlib
    and Mark Adler in creating the zlib general purpose compression library
    which is used in this product.
 
-(C) 1995-2017 Jean-loup Gailly and Mark Adler
+Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages


### PR DESCRIPTION
Implemented PXC-3996 (Merge PS-5.7.39, Part 2 no conflicts)

https://jira.percona.com/browse/PXC-3996

Merge tag 'Percona-Server-5.7.39-42' into merge-mysql-5.7.39-part2

Percona Server release 5.7.39-42

Testing Done
----
**Jenkins**
- galera suites: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/340/console
Failing tests: None

- Full MTR: https://pxc.cd.percona.com/view/PXC%205.7/job/pxc-5.7-param/341/console
Failing tests: `main.merge` and `main.merge_mmap`. These are known failures. https://jira.percona.com/browse/PXC-3296. `gr_ssl_mode_verify_identity_error` failed on centos7. False positive. 