### PR TITLE
PXC-4033: Assertion during execution of prepared statement

### DIFF
--- a/mysql-test/suite/galera/r/galera_prepared_statement.result
+++ b/mysql-test/suite/galera/r/galera_prepared_statement.result
@@ -44,3 +44,24 @@ execute stmt;
 ERROR 42S01: Table 'v1' already exists
 drop view v1;
 drop table t1;
+CREATE TABLE t1 (id INT PRIMARY KEY, f1 int);
+INSERT INTO t1 VALUES (0, 0);
+PREPARE stmt FROM 'UPDATE t1 SET f1 = ? WHERE id = ?';
+CREATE INDEX idx1 ON t1 (f1);
+SET @value=10;
+SET @id=0;
+EXECUTE stmt USING @value, @id;
+include/assert.inc [Value should be updated]
+DROP TABLE t1;
+CREATE TABLE t1 (id INT PRIMARY KEY, f1 int);
+INSERT INTO t1 VALUES (0, 0);
+PREPARE stmt FROM 'UPDATE t1 SET f1 = ? WHERE id = ?';
+CREATE INDEX idx1 ON t1 (f1);
+BEGIN;
+SET @value=10;
+SET @id=0;
+EXECUTE stmt USING @value, @id;
+COMMIT;
+include/assert.inc [Value should be updated]
+include/assert.inc [Value should be updated]
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_prepared_statement.test
+++ b/mysql-test/suite/galera/t/galera_prepared_statement.test
@@ -64,3 +64,55 @@ execute stmt;
 execute stmt;
 drop view v1;
 drop table t1;
+
+#
+# Re-execution of the prepared statement with parallel DDL (PXC-4033)
+#
+CREATE TABLE t1 (id INT PRIMARY KEY, f1 int);
+INSERT INTO t1 VALUES (0, 0);
+
+PREPARE stmt FROM 'UPDATE t1 SET f1 = ? WHERE id = ?';
+
+# DDL will change table's metadata, so prepared stmt executed after it will be aborted, it will be re-prepared and re-executed
+CREATE INDEX idx1 ON t1 (f1);
+
+SET @value=10;
+SET @id=0;
+EXECUTE stmt USING @value, @id;
+
+--let $assert_text = Value should be updated
+--let $assert_cond = [SELECT COUNT(*) FROM t1 WHERE f1=10] = 1
+--source include/assert.inc
+
+DROP TABLE t1;
+
+#
+# Similar to the above but for multi statement transaction.
+# Re-execution of the prepared statement with parallel DDL (PXC-4033)
+#
+
+CREATE TABLE t1 (id INT PRIMARY KEY, f1 int);
+INSERT INTO t1 VALUES (0, 0);
+
+PREPARE stmt FROM 'UPDATE t1 SET f1 = ? WHERE id = ?';
+
+# DDL will change table's metadata, so prepared stmt executed after it will be aborted, it will be re-prepared and re-executed
+CREATE INDEX idx1 ON t1 (f1);
+
+BEGIN;
+SET @value=10;
+SET @id=0;
+EXECUTE stmt USING @value, @id;
+COMMIT;
+
+--let $assert_text = Value should be updated
+--let $assert_cond = [SELECT COUNT(*) FROM t1 WHERE f1=10] = 1
+--source include/assert.inc
+
+# Without the fix, the value is updated on node_1, but the change is not replicated
+--connection node_2
+--let $assert_text = Value should be updated
+--let $assert_cond = [SELECT COUNT(*) FROM t1 WHERE f1=10] = 1
+--source include/assert.inc
+
+DROP TABLE t1;

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -179,6 +179,7 @@ When one supplies long data for a placeholder:
 #include "sql/window.h"
 #include "sql_string.h"
 #include "violite.h"
+#include "wsrep_trans_observer.h"
 
 namespace resourcegroups {
 class Resource_group;
@@ -3164,9 +3165,16 @@ reexecute:
       }
     }
 
-    if (!error) /* Success */
+    if (!error) { /* Success */
+#ifdef WITH_WSREP
+      // We are going to retry the statement, so clean up first.
+      wsrep_after_statement(thd);
+#endif
       goto reexecute;
+    }
+#ifdef WITH_WSREP
   }
+#endif
   reset_stmt_parameters(this);
 
   // Reenable the general log if it was temporarily disabled while repreparing


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4033

Problem:
When the prepared statement is executed in parallel to the DDL modifying the table which prepared statement uses the server fails with assertion saying that prepared statement transaction was aborted, so it cannot be commited.

Cause:
When the session executing prepared statement is opening the table it detects that table's metadata changed. Execution is aborted, internal error is propagated up the callstack and as the transaction ended with error, wsrep part marks it as aborted.
Error is internal, its purpose is to trigger prepared statement re-execution, which happens, but wsrep transaction state is in aborted state. Later when the transaction is commited, it is detected that transaction is aborted and the assert triggers.

During the investigation I've found that for multi statement transactions the state is also changed to aborted which causes skipping certification (and replication) of such transaction, but local commit happens which leads to the cluster inconsistency.

Solution:
Before re-execution of aborted prepared statement do the cleanup (call wsrep_after_statement()).
Added assertions in wsrep-lib.