### PR TITLE
PXC-4012: Node leaves PXC cluster when running

### DIFF
--- a/mysql-test/suite/galera/r/galera_password_history.result
+++ b/mysql-test/suite/galera/r/galera_password_history.result
@@ -1,0 +1,3 @@
+This test does not produce the output. It tries to trigger node crash after PK collision in mysql.password_history table.
+include/assert.inc ['node_1: There should be 10 rows in mysql.password_history table.']
+include/assert.inc ['node_2: There should be 10 rows in mysql.password_history table.']

--- a/mysql-test/suite/galera/t/galera_password_history.cnf
+++ b/mysql-test/suite/galera/t/galera_password_history.cnf
@@ -1,4 +1,0 @@
-!include ../galera_2nodes.cnf
-
-[mysqld]
-password_history=10

--- a/mysql-test/suite/galera/t/galera_password_history.cnf
+++ b/mysql-test/suite/galera/t/galera_password_history.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+password_history=10

--- a/mysql-test/suite/galera/t/galera_password_history.test
+++ b/mysql-test/suite/galera/t/galera_password_history.test
@@ -1,0 +1,46 @@
+#
+# Test if replicated events which add rows to mysql.password_history table does not cause PK collision in this table.
+# The timestamp of the event is the part of PK. If replicated events miss usec part of the timestamp and they occur
+# on the same second, they will cause PK collision.
+# This test executes queries in bursts, so at list part of the burst should happen in the same second causing the collision.
+#
+ 
+--source include/galera_cluster.inc
+
+--echo This test does not produce the output. It tries to trigger node crash after PK collision in mysql.password_history table.
+--disable_query_log
+
+--let $count = 100
+# As the user exists it will produce series of 'Note	3163	Authorization ID 'test1'@'%' already exists.'. Disable it.
+--disable_warnings
+while ($count) {
+  CREATE USER IF NOT EXISTS 'test1'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*6C387FC3893DBA1E3BA155E74754DA6682D04747';
+  --dec $count
+}
+--enable_warnings
+
+--let $count = 100
+while ($count) {
+  ALTER USER 'test1'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*6C387FC3893DBA1E3BA155E74754DA6682D04747';
+  --dec $count
+}
+
+SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kzfldhf8daf8fad0adf0ad0f0adf0ad';
+SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kdfad9fad0fad90fa0df8ad0f8a0d9f';
+SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kdf0a8s0d9f80adf808666f6fdadfad';
+SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kzfld77969696969698698690888daf';
+SET PASSWORD FOR 'test1'@'%' = '*6C38fds8s8df8d88sf8d88sf8d8s8f8d8f8s8d8f';
+
+# check if mysql.password_history table was really used
+--let $assert_text = 'node_1: There should be 10 rows in mysql.password_history table.'
+--let $assert_cond = [SELECT COUNT(*) = 10 FROM mysql.password_history WHERE User = "test1"] = 1
+--source include/assert.inc
+
+--connection node_2
+# check if mysql.password_history table was really used
+--let $assert_text = 'node_2: There should be 10 rows in mysql.password_history table.'
+--let $assert_cond = [SELECT COUNT(*) = 10 FROM mysql.password_history WHERE User = "test1"] = 1
+--source include/assert.inc
+
+DROP USER 'test1'@'%';
+--enable_query_log

--- a/mysql-test/suite/galera/t/galera_password_history.test
+++ b/mysql-test/suite/galera/t/galera_password_history.test
@@ -2,7 +2,7 @@
 # Test if replicated events which add rows to mysql.password_history table does not cause PK collision in this table.
 # The timestamp of the event is the part of PK. If replicated events miss usec part of the timestamp and they occur
 # on the same second, they will cause PK collision.
-# This test executes queries in bursts, so at list part of the burst should happen in the same second causing the collision.
+# This test executes queries in bursts, so at least part of the burst should happen in the same second causing the collision.
 #
  
 --source include/galera_cluster.inc
@@ -14,33 +14,44 @@
 # As the user exists it will produce series of 'Note	3163	Authorization ID 'test1'@'%' already exists.'. Disable it.
 --disable_warnings
 while ($count) {
-  CREATE USER IF NOT EXISTS 'test1'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*6C387FC3893DBA1E3BA155E74754DA6682D04747';
+  --let $passwd = 'password_$count'
+  --eval CREATE USER IF NOT EXISTS 'test1'@'%' IDENTIFIED WITH 'mysql_native_password' BY $passwd PASSWORD HISTORY 10
   --dec $count
 }
 --enable_warnings
 
 --let $count = 100
 while ($count) {
-  ALTER USER 'test1'@'%' IDENTIFIED WITH 'mysql_native_password' AS '*6C387FC3893DBA1E3BA155E74754DA6682D04747';
+  --let $passwd = 'password_$count'
+  --eval ALTER USER 'test1'@'%' IDENTIFIED WITH 'mysql_native_password' BY $passwd PASSWORD HISTORY 10
   --dec $count
 }
 
-SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kzfldhf8daf8fad0adf0ad0f0adf0ad';
-SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kdfad9fad0fad90fa0df8ad0f8a0d9f';
-SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kdf0a8s0d9f80adf808666f6fdadfad';
-SET PASSWORD FOR 'test1'@'%' = '*6C387FC38kzfld77969696969698698690888daf';
-SET PASSWORD FOR 'test1'@'%' = '*6C38fds8s8df8d88sf8d88sf8d8s8f8d8f8s8d8f';
+--let $count = 100
+while ($count) {
+  --let $passwd = 'password_$count'
+  --eval SET PASSWORD for 'test1'@'%' = $passwd
+  --dec $count
+}
 
 # check if mysql.password_history table was really used
 --let $assert_text = 'node_1: There should be 10 rows in mysql.password_history table.'
---let $assert_cond = [SELECT COUNT(*) = 10 FROM mysql.password_history WHERE User = "test1"] = 1
+--let $assert_cond = [SELECT COUNT(*) = 10 FROM mysql.password_history] = 1
 --source include/assert.inc
 
 --connection node_2
 # check if mysql.password_history table was really used
 --let $assert_text = 'node_2: There should be 10 rows in mysql.password_history table.'
---let $assert_cond = [SELECT COUNT(*) = 10 FROM mysql.password_history WHERE User = "test1"] = 1
+--let $assert_cond = [SELECT COUNT(*) = 10 FROM mysql.password_history] = 1
 --source include/assert.inc
+
+# All nodes should have the same password history
+# galera_diff.inc disables and re-enables query log internally.
+# Just to keep things clear enable now, then disable again after galera_diff.inc
+--enable_query_log
+--let $galera_diff_statement = SELECT * FROM mysql.password_history ORDER BY Password_timestamp;
+--source include/galera_diff.inc
+--disable_query_log
 
 DROP USER 'test1'@'%';
 --enable_query_log

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1858,7 +1858,7 @@ int wsrep_to_buf_helper(THD *thd, const char *query, uint query_len,
   /* continue to append the actual query */
   Query_log_event ev(thd, query, query_len, false, false, false, 0);
 
-  /* Below commands will enter the row in mysql.password_history table.
+  /* Below commands will insert the row in mysql.password_history table.
      They need to be replicated with usec part of the timestamp, because
      the timestamp is the part of primary key. If we've got only second
      resolution, we can end up with the PK conflict on replica and node
@@ -1869,7 +1869,7 @@ int wsrep_to_buf_helper(THD *thd, const char *query, uint query_len,
      the beginning of query processing.
      Let's play safe, and change the flag only for the time of creation
      of the event which is replicated. This way we will not affect non-wsrep
-     related logic. If it decides to cut precission, it will be still possible.
+     related logic. If it decides to cut precision, it will be still possible.
    */
   bool query_start_usec_used_tmp = thd->query_start_usec_used;
   enum_sql_command command = thd->lex->sql_command;


### PR DESCRIPTION
concurrent CREATE USER with password_history option

https://jira.percona.com/browse/PXC-4012

Problem:
When password history is enabled and CREATE USER is executed in parallel, or one after another, but in the same second the replica node leaves the cluster.

Cause:
mysql.password_history has the primary key on User, Host, and Timestamp columns. Log_event_header carries the timestamp with one-second resolution. The information about the microseconds part of the timestamp is carried by Q_MICROSECONDS variable stored along with the event. However, as Q_MICROSECONDS is needed only for a few events, there is optimization related to THD::query_start_usec_used flag. This flag is set only for queries that require a high-precision timestamp when the query is processed. Then binlog event is logged and replicated (async replication).
With Galera replication in place, we replicate DDL as TOI. It happens at the very beginning of the query and THD::query_start_usec_used flag is not set yet, so the microseconds part of the timestamp is not sent.

Solution:
For user's password-related queries set THD::query_start_usec_used explicitly for the time of construction of Query_log_event which will be replicated. This is a temporary event, only for TOI replication.