### PR TITLE
PXC-3639: Incorrect usage of strncpy

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1024,6 +1024,12 @@ int wsrep_init()
             wsrep->provider_version, sizeof(provider_version) - 1);
     strncpy(provider_vendor,
             wsrep->provider_vendor,  sizeof(provider_vendor) - 1);
+
+    /* All three buffers are zero-initialized on declaration, but
+       let's avoid the confusion */
+    provider_name[sizeof(provider_name) - 1] = '\0';
+    provider_version[sizeof(provider_version) - 1] = '\0';
+    provider_vendor[sizeof(provider_vendor) - 1] = '\0';
   }
 
   /* wsrep_cluster_name is restricted to WSREP_CLUSTER_NAME_MAX_LEN characters
@@ -1058,12 +1064,12 @@ int wsrep_init()
   if (!wsrep_data_home_dir || strlen(wsrep_data_home_dir) == 0)
     wsrep_data_home_dir = mysql_real_data_home;
 
-  char node_addr[512]= { 0, };
-  size_t const node_addr_max= sizeof(node_addr) - 1;
+  static const size_t node_addr_buf_size= 512;
+  char node_addr[node_addr_buf_size];
   if (!wsrep_node_address || !strcmp(wsrep_node_address, ""))
   {
-    size_t const ret= wsrep_guess_ip(node_addr, node_addr_max);
-    if (!(ret > 0 && ret < node_addr_max))
+    size_t const ret= wsrep_guess_ip(node_addr, node_addr_buf_size);
+    if (!(ret > 0 && ret < node_addr_buf_size))
     {
       WSREP_WARN("Failed to guess base node address. Set it explicitly via "
                  "wsrep_node_address.");
@@ -1072,7 +1078,22 @@ int wsrep_init()
   }
   else
   {
-    strncpy(node_addr, wsrep_node_address, node_addr_max);
+    /* node_addr is 512 bytes, wsrep_node_address is <ip_address>[:port]
+       so for ipv6 host part is at most 45 characters (IPv4-mapped IPv6).
+       The whole wsrep_nde_address will entirely fit into ip_buf leaving
+       space for trailing zero. */
+    if (unlikely(strlen(wsrep_node_address) >= node_addr_buf_size))
+    {
+      WSREP_ERROR("Failed to initialize node address: "
+                  "Host address does not fit into temporary buffer. "
+                  "wsrep_node_address: %s, length: %lu",
+                  wsrep_node_address, strlen(wsrep_node_address));
+      node_addr[0]= '\0';
+    }
+    else {
+      strncpy(node_addr, wsrep_node_address, node_addr_buf_size - 1);
+      node_addr[node_addr_buf_size - 1] = '\0';
+    }
   }
 
   char inc_addr[512]= { 0, };
@@ -1361,8 +1382,9 @@ void wsrep_filter_new_cluster (int* argc, char* argv[])
   {
     /* make a copy of the argument to convert possible underscores to hyphens.
      * the copy need not to be longer than WSREP_NEW_CLUSTER option */
-    char arg[sizeof(WSREP_NEW_CLUSTER) + 1]= { 0, };
+    char arg[sizeof(WSREP_NEW_CLUSTER) + 1];
     strncpy(arg, argv[i], sizeof(arg) - 1);
+    arg[sizeof(arg) - 1]= '\0';
     char* underscore(arg);
     while (NULL != (underscore= strchr(underscore, '_'))) *underscore= '-';
 

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -876,6 +876,15 @@ unsigned int wsrep_check_ip (const char* const addr)
   return ret;
 }
 
+/* Returns guessed IP.
+   buf      buffer where to store guessed IP zero-terminated string
+   buf_len  length of buf
+   returns  length of string representing IP stored in buf (witnout trailing 0)
+            or 0 in case of failure.
+   In case of success, buffer is filled with IP zero-ended string.
+   This funcion takes care of string fit into the buf. If buf is too small,
+   warning is printed and zero is returned.
+   In case of failure, buf content is not modified. */
 size_t wsrep_guess_ip (char* buf, size_t buf_len)
 {
   size_t ip_len = 0;
@@ -890,7 +899,11 @@ size_t wsrep_guess_ip (char* buf, size_t buf_len)
     }
 
     if (INADDR_ANY != ip_type) {
-      strncpy (buf, my_bind_addr_str, buf_len);
+      if (strlen(my_bind_addr_str) >= buf_len) {
+        WSREP_WARN("default_ip(): buffer too short: %zu <= %zd", buf_len, strlen(my_bind_addr_str));
+        return 0;
+      }
+      strncpy(buf, my_bind_addr_str, buf_len);
       return strlen(buf);
     }
   }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3639

Problem:
strncpy usage in WSREP patch was not respecting buffer overflow in some
cases. Other cases considered it, but code analysis was confusing as
handling of it was not straightforward.

Solution:
Added buffer overflow checks where needed.
Refactored code where confusing.