### PR TITLE
PXC-4048: Empty GRA_x_y_v2.log files

### DIFF
--- a/mysql-test/suite/galera/r/galera_gra_log.result
+++ b/mysql-test/suite/galera/r/galera_gra_log.result
@@ -11,9 +11,24 @@ COUNT(*) = 0
 /*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
 DELIMITER /*!*/;
 # at 4
-<ISO TIMESTAMP> server id 2  end_log_pos 120 	Start: binlog v 4, server v x.y.z created ###### ##:##:## at startup
-# Warning: this binlog is either in use or was not closed properly.
+<ISO TIMESTAMP> server id 2  end_log_pos 0 	Start: binlog v 4, server v x.y.z created ###### ##:##:## at startup
 ROLLBACK/*!*/;
+# at 126
+<ISO TIMESTAMP> server id 1  end_log_pos 0 	Query	thread_id=<THREAD_ID>	exec_time=0	error_code=0
+use `test`/*!*/;
+SET TIMESTAMP=<TIMESTAMP>/*!*/;
+SET @@session.pseudo_thread_id=<PSEUDO_THREAD_ID>/*!*/;
+SET @@session.foreign_key_checks=1, @@session.sql_auto_is_null=0, @@session.unique_checks=1, @@session.autocommit=1/*!*/;
+SET @@session.sql_mode=1168113696/*!*/;
+SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/;
+/*!\C utf8mb4 *//*!*/;
+SET @@session.character_set_client=255,@@session.collation_connection=255,@@session.collation_server=255/*!*/;
+SET @@session.lc_time_names=0/*!*/;
+SET @@session.collation_database=DEFAULT/*!*/;
+/*!80011 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
+CREATE TABLE t1 (f1 INTEGER)
+/*!*/;
 SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog */ /*!*/;
 DELIMITER ;
 # End of log file

--- a/mysql-test/suite/galera/t/galera_gra_log.test
+++ b/mysql-test/suite/galera/t/galera_gra_log.test
@@ -25,16 +25,20 @@ CREATE TABLE t1 (f1 INTEGER);
 --source include/wsrep_wait_membership.inc
 SELECT COUNT(*) = 0 FROM t1;
 
-# Compose a valid binlog from a header file and the GRA file
-
+# GRA file already contains a header
 --let $gra_binlog_file = $MYSQLTEST_VARDIR/tmp/gra.log
 --exec rm -rf $gra_binlog_file 
---exec cp std_data/binlog-header.log $gra_binlog_file
 --exec cat $MYSQLTEST_VARDIR/mysqld.2/data/GRA_*.log >> $gra_binlog_file
 
 # Make sure the binlog thus produced is readable and contains the failure
 --replace_regex /SET TIMESTAMP=[0-9]+/SET TIMESTAMP=<TIMESTAMP>/ /#[0-9]+ +[0-9]+:[0-9]+:[0-9]+/<ISO TIMESTAMP>/ /pseudo_thread_id=[0-9]+/pseudo_thread_id=<PSEUDO_THREAD_ID>/ /thread_id=[0-9]+/thread_id=<THREAD_ID>/ /server v [0-9].[0-9].[0-9]+.* created/server v x.y.z created/  /created [0-9]+ ( )?[0-9]+:[0-9]+:[0-9]+ at startup/created ###### ##:##:## at startup/
 --exec $MYSQL_BINLOG --base64-output=never $gra_binlog_file
+
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_FILE = $gra_binlog_file
+--let SEARCH_PATTERN = CREATE TABLE t1
+--source include/search_pattern_in_file.inc
+
 --remove_file $gra_binlog_file
 
 # restart and reconnect node_2

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -22,11 +22,57 @@
 #include "binlog.h"
 #include "log.h"
 #include "log_event.h"  // Log_event_writer
+#include "mutex_lock.h"
 #include "mysql/psi/mysql_file.h"
 #include "service_wsrep.h"
+#include "sql/sql_base.h"  // TEMP_PREFIX
 #include "transaction.h"
 #include "wsrep_applier.h"
-#include "mutex_lock.h"
+
+static bool wsrep_dump_cache_common(
+    IO_CACHE_binlog_cache_storage *cache,
+    std::function<bool(unsigned char *, my_off_t)> dumpFn) {
+  my_off_t const saved_pos(cache->position());
+
+  unsigned char *read_pos = NULL;
+  my_off_t read_len = 0;
+
+  if (cache->begin(&read_pos, &read_len)) {
+    WSREP_ERROR("Failed to initialize io-cache");
+    return true;
+  }
+
+  if (read_len == 0 && cache->next(&read_pos, &read_len)) {
+    WSREP_ERROR("Failed to read from io-cache");
+    return true;
+  }
+
+  bool res = false;
+  while (read_len > 0) {
+    if (dumpFn(read_pos, read_len)) {
+      res = true;
+      break;
+    }
+    cache->next(&read_pos, &read_len);
+  }
+
+  if (cache->truncate(saved_pos)) {
+    WSREP_WARN("Failed to reinitialize io-cache");
+    res = true;
+    ;
+  }
+
+  return res;
+}
+
+bool wsrep_write_cache_file(IO_CACHE_binlog_cache_storage *cache, File file) {
+  return wsrep_dump_cache_common(
+      cache, [file](unsigned char *data, my_off_t size) {
+        size_t written = mysql_file_write(file, data, size, MYF(0));
+        if (written != size) return true;
+        return false;
+      });
+}
 
 /*
   Write the contents of a cache to a memory buffer.
@@ -45,25 +91,12 @@
  */
 int wsrep_write_cache_buf(IO_CACHE_binlog_cache_storage *cache, uchar **buf,
                           size_t *buf_len) {
-  my_off_t const saved_pos(cache->position());
-
-  unsigned char *read_pos = NULL;
-  my_off_t read_len = 0;
-
-  if (cache->begin(&read_pos, &read_len)) {
-    WSREP_ERROR("Failed to initialize io-cache");
-    return ER_ERROR_ON_WRITE;
-  }
-
-  if (read_len == 0 && cache->next(&read_pos, &read_len)) {
-    WSREP_ERROR("Failed to read from io-cache");
-    return ER_ERROR_ON_WRITE;
-  }
-
   size_t total_length = *buf_len;
 
-  while (read_len > 0) {
-    total_length += read_len;
+  bool res = wsrep_dump_cache_common(cache, [&total_length, buf, buf_len](
+                                                unsigned char *data,
+                                                my_off_t size) {
+    total_length += size;
 
     /*
       Bail out if buffer grows too large.
@@ -74,7 +107,7 @@ int wsrep_write_cache_buf(IO_CACHE_binlog_cache_storage *cache, uchar **buf,
     if (total_length > wsrep_max_ws_size) {
       WSREP_WARN("Transaction/Write-set size limit (%lu) exceeded: %zu",
                  wsrep_max_ws_size, total_length);
-      goto error;
+      return true;
     }
 
     uchar *tmp =
@@ -85,33 +118,22 @@ int wsrep_write_cache_buf(IO_CACHE_binlog_cache_storage *cache, uchar **buf,
           " write-set for replication."
           " Existing Size: %zu, Requested Size: %lu",
           *buf_len, (long unsigned)total_length);
-      goto error;
+      return true;
     }
     *buf = tmp;
 
-    memcpy(*buf + *buf_len, read_pos, read_len);
+    memcpy(*buf + *buf_len, data, size);
     *buf_len = total_length;
-    cache->next(&read_pos, &read_len);
-  }
+    return false;
+  });
 
-  if (cache->truncate(saved_pos)) {
-    WSREP_WARN("Failed to reinitialize io-cache");
-    goto cleanup;
+  if (res) {
+    my_free(*buf);
+    *buf = NULL;
+    *buf_len = 0;
+    return ER_ERROR_ON_WRITE;
   }
-
   return 0;
-
-error:
-
-  if (cache->truncate(saved_pos)) {
-    WSREP_WARN("Failed to reinitialize io-cache");
-  }
-
-cleanup:
-  my_free(*buf);
-  *buf = NULL;
-  *buf_len = 0;
-  return ER_ERROR_ON_WRITE;
 }
 
 #define STACK_SIZE                                   \
@@ -256,11 +278,7 @@ void wsrep_dump_rbr_buf_with_header(THD *thd, const void *rbr_buf,
   DBUG_ENTER("wsrep_dump_rbr_buf_with_header");
 
   File file;
-  Binlog_cache_storage cache;
-  // IO_CACHE cache;
-  // assert(0);
-  // TODO: need to find way to persist event (Format_description_log_event to
-  // cache) Log_event_writer writer(&cache, 0);
+  IO_CACHE_binlog_cache_storage tmp_io_cache;
   Format_description_log_event *ev = 0;
 
   longlong thd_trx_seqno = (long long)wsrep_thd_trx_seqno(thd);
@@ -293,11 +311,11 @@ void wsrep_dump_rbr_buf_with_header(THD *thd, const void *rbr_buf,
     goto cleanup1;
   }
 
-  if (cache.open(file, 1024000)) {
+  if (tmp_io_cache.open(mysql_tmpdir, TEMP_PREFIX, 1024000, 1024000)) {
     goto cleanup2;
   }
 
-  if (cache.write((const uchar *)BINLOG_MAGIC, BIN_LOG_HEADER_SIZE)) {
+  if (tmp_io_cache.write((const uchar *)BINLOG_MAGIC, BIN_LOG_HEADER_SIZE)) {
     goto cleanup2;
   }
 
@@ -308,17 +326,20 @@ void wsrep_dump_rbr_buf_with_header(THD *thd, const void *rbr_buf,
   ev = (thd->wsrep_applier) ? wsrep_get_apply_format(thd)
                             : (new Format_description_log_event());
 
-  // if (writer.write(ev) || my_b_write(&cache, (uchar *)rbr_buf, buf_len) ||
-  if (((ev->write(&cache) ||
-        cache.write(static_cast<uchar *>(const_cast<void *>(rbr_buf)),
-                    buf_len) ||
-        cache.flush()))) {
+  if (((ev->write(&tmp_io_cache) ||
+        tmp_io_cache.write(static_cast<uchar *>(const_cast<void *>(rbr_buf)),
+                           buf_len)))) {
+    WSREP_ERROR("Failed to write to populate io cache");
+    goto cleanup2;
+  }
+
+  if (wsrep_write_cache_file(&tmp_io_cache, file)) {
     WSREP_ERROR("Failed to write to '%s'.", filename);
     goto cleanup2;
   }
 
 cleanup2:
-  // end_io_cache(&cache);
+  tmp_io_cache.close();
 
 cleanup1:
   free(filename);

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -34,7 +34,7 @@ static bool wsrep_dump_cache_common(
     std::function<bool(unsigned char *, my_off_t)> dumpFn) {
   my_off_t const saved_pos(cache->position());
 
-  unsigned char *read_pos = NULL;
+  unsigned char *read_pos = nullptr;
   my_off_t read_len = 0;
 
   if (cache->begin(&read_pos, &read_len)) {
@@ -59,7 +59,6 @@ static bool wsrep_dump_cache_common(
   if (cache->truncate(saved_pos)) {
     WSREP_WARN("Failed to reinitialize io-cache");
     res = true;
-    ;
   }
 
   return res;
@@ -129,7 +128,7 @@ int wsrep_write_cache_buf(IO_CACHE_binlog_cache_storage *cache, uchar **buf,
 
   if (res) {
     my_free(*buf);
-    *buf = NULL;
+    *buf = nullptr;
     *buf_len = 0;
     return ER_ERROR_ON_WRITE;
   }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4048

Problem:
GRA_* files created in case of applier failures are empty.

Cause:
wsrep_dump_rbr_buf_with_header() which creates GRA_* files used Binlog_cache_storage class object a the auxiliary cache. The case was created by providing paging file used by cache which was target GRA_* file. The idea behing the implementation was that Binlog_cache_storage::flush() should write all the content of the cache kept in the RAM memory into the file. Unfortunately Binlog_cache_storage::flush() method is the dummy one.

Solution:
Used IO_CACHE_binlog_cache_storage which is also used in wsrep_to_buf_helper() during TOI writeset creation. Introduced wsrep_write_cache_file() function which dumps the cache into the provided file.
As wsrep_write_cache_file() and wsrep_write_cache_buf() functions have a lot in common, the common part was extracted.

MTR test has been fixed. It passed before because of wrong output recorded.