### PR TITLE
PXC-4051: PXC applier nodes OOM crash on transaction with high volume of statements

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -10397,7 +10397,11 @@ end:
       *not* try to free the memory here. It will be done latter
       in dispatch_command() after command execution is completed.
      */
+#ifdef WITH_WSREP
+    if (thd->wsrep_applier || thd->slave_thread) thd->mem_root->ClearForReuse();
+#else
     if (thd->slave_thread) thd->mem_root->ClearForReuse();
+#endif
   }
   return error;
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4051

Problem:
When large transaction, consisting of many DMLs is replicated it can cause replica OOM.

Cause:
Applier applies the writeset's events one by one. During each event apply the thread allocates memory from its MEM_ROOT. Once events related to the same query are processed, the allocated memory is not needed anymore and can be deallocated. Memory deallocation was not done because the applier thread is not flagged as the slave_thread.

Note: Memory was deallocated at the beginning of the next writeset processing (BEGIN), however because of the allocator algorithm the memory allocated by thd's MEM_ROOT was growing
(MEM_ROOT's ClearForReuse() keeps the last allocated (biggest) block and deallocates other blocks. When the allocator allocates a new block, it allocates it with the size of 1.5 of the currently allocated memory. This way consecutive large writesets caused thd's MEM_ROOT growth)

Solution:
Call ClearForReuse after end of statement-related events as it is done in case of async/semisync replication.