### PR TITLE
(5.7) PXC-3821: Truncating performance_schema's table in one node, replicating the truncate statement in other nodes also

### DIFF
--- a/mysql-test/suite/galera/r/galera_truncate.result
+++ b/mysql-test/suite/galera/r/galera_truncate.result
@@ -27,3 +27,5 @@ DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
+include/assert.inc ["performance_schema.events_statements_summary_by_digest table should be truncated"]
+include/assert.inc ["performance_schema.events_statements_summary_by_digest table should not be truncated"]

--- a/mysql-test/suite/galera/t/galera_truncate.test
+++ b/mysql-test/suite/galera/t/galera_truncate.test
@@ -55,3 +55,34 @@ DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
+
+#
+# TRUNCATE TABLE performance_schema.<table> should not be replicated
+#
+--disable_query_log
+--disable_result_log
+
+--connection node_2
+# We need to execute SELECT COUNT before getting the actual result to have it already in events_statements_summary_by_digest table 
+SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest;
+--let $node_2_count_before = `SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest`
+
+--connection node_1
+TRUNCATE TABLE performance_schema.events_statements_summary_by_digest;
+
+# It should be 1 at the moment. We will not use assert.inc directly, as it sends more queries, and the result is not deterministic.
+--let $node_1_count = `SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest`
+--let $assert_text = "performance_schema.events_statements_summary_by_digest table should be truncated"
+--let $assert_cond = $node_1_count = 1
+--source include/assert.inc
+
+--connection node_2
+--let $node_2_count_after = `SELECT COUNT(*) FROM performance_schema.events_statements_summary_by_digest`
+
+# Check if node_2 is not affected
+--let $assert_text = "performance_schema.events_statements_summary_by_digest table should not be truncated"
+--let $assert_cond = $node_2_count_before = $node_2_count_after
+--source include/assert.inc
+
+--enable_result_log
+--enable_query_log

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -493,7 +493,14 @@ bool Sql_cmd_truncate_table::truncate_table(THD *thd, TABLE_LIST *table_ref)
 
 #ifdef WITH_WSREP
     error= true;
-    WSREP_TO_ISOLATION_BEGIN(table_ref->db, table_ref->table_name, NULL);
+    /* We are going to skip replication for Performance Schema tables,
+       but at this moment tables are closed and we have no clue if
+       P_S table (or even existing schema) is referred.
+       The best we can do is to recognize P_S by name. */
+    if (!is_perfschema_db(table_ref->db))
+    {
+      WSREP_TO_ISOLATION_BEGIN(table_ref->db, table_ref->table_name, NULL);
+    }
 #endif /* WITH_WSREP */
 
     if (lock_table(thd, table_ref, &hton_can_recreate))

--- a/storage/perfschema/ha_perfschema.h
+++ b/storage/perfschema/ha_perfschema.h
@@ -237,6 +237,11 @@ private:
   {
     assert(table != NULL);
     assert(table->in_use != NULL);
+  #ifdef WITH_WSREP
+    if (table->in_use->wsrep_applier) {
+      return true;
+    }
+  #endif
     return table->in_use->slave_thread;
 
   }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3821

Problem:
Truncation of P_S table is replicated across the cluster

Cause:
Truncation of P_S tables is done exactly the same as for any other table, so the query is replicated as TOI.

Solution:
1. Filter out P_S tables truncation and do not initiate TOI for them.
2. For the case when there is source node without this fix, filter out truncation on the replica node in the same way as it was introduced in commit 44c56d37dfe767c31b5ca80812229881c32140f3 (is_executed_by_slave() function fixed to be aware of wsrep applier thread).