### PR TITLE
PXC-512: Replication slave from PXC can crash if wsrep_forced_binlog_format=ROW

### DIFF
--- a/mysql-test/suite/galera/r/galera_forced_binlog_format.result
+++ b/mysql-test/suite/galera/r/galera_forced_binlog_format.result
@@ -20,3 +20,5 @@ mysqld-bin.000001	<Pos>	Table_map	1	<End_log_pos>	table_id: ### (test.t1)
 mysqld-bin.000001	<Pos>	Write_rows	1	<End_log_pos>	table_id: ### flags: STMT_END_F
 mysqld-bin.000001	<Pos>	Xid	1	<End_log_pos>	COMMIT /* xid=### */
 DROP TABLE t1;
+CREATE PROCEDURE p1() BEGIN SELECT(1); END |
+DROP PROCEDURE p1;

--- a/mysql-test/suite/galera/t/galera_forced_binlog_format.test
+++ b/mysql-test/suite/galera/t/galera_forced_binlog_format.test
@@ -1,11 +1,11 @@
-#
-# Test that wsrep_forced_binlog_format=ROW indeed prevents the log to be switched to STATEMENT format on a per-connection basis
-# 
-
+--source include/have_debug.inc
 --source include/have_log_bin.inc
 --source include/have_innodb.inc
 --source include/galera_cluster.inc
 
+#
+# Test that wsrep_forced_binlog_format=ROW indeed prevents the log to be switched to STATEMENT format on a per-connection basis
+#
 --connection node_1
 RESET MASTER;
 
@@ -27,3 +27,12 @@ INSERT INTO t1 VALUES (2);
 SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
 
 DROP TABLE t1;
+
+#
+# PXC-512: Replication slave from PXC can crash if wsrep_forced_binlog_format=ROW
+# https://jira.percona.com/browse/PXC-512
+#
+DELIMITER |;
+CREATE PROCEDURE p1() BEGIN SELECT(1); END |
+DELIMITER ;|
+DROP PROCEDURE p1;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -11942,7 +11942,7 @@ int THD::decide_logging_format(TABLE_LIST *tables, bool use_cached_table_flags)
 #ifdef WITH_WSREP
   if ((WSREP_EMULATE_BINLOG_NNULL(this) ||
        (mysql_bin_log.is_open() && (variables.option_bits & OPTION_BIN_LOG))) &&
-      !(WSREP_BINLOG_FORMAT(variables.binlog_format) == BINLOG_FORMAT_STMT    &&
+      !(WSREP_BINLOG_FORMAT(this, variables.binlog_format) == BINLOG_FORMAT_STMT    &&
         !binlog_filter->db_ok(m_db.str)))
 #else
   if (mysql_bin_log.is_open() && (variables.option_bits & OPTION_BIN_LOG) &&
@@ -12036,7 +12036,7 @@ int THD::decide_logging_format(TABLE_LIST *tables, bool use_cached_table_flags)
 #endif
 
 #ifdef WITH_WSREP
-    if (WSREP_BINLOG_FORMAT(variables.binlog_format) != BINLOG_FORMAT_ROW && tables)
+    if (WSREP_BINLOG_FORMAT(this, variables.binlog_format) != BINLOG_FORMAT_ROW && tables)
 #else
     if (variables.binlog_format != BINLOG_FORMAT_ROW && tables)
 #endif /* WITH_WSREP */
@@ -12294,7 +12294,7 @@ int THD::decide_logging_format(TABLE_LIST *tables, bool use_cached_table_flags)
         my_error((error= ER_BINLOG_ROW_INJECTION_AND_STMT_ENGINE), MYF(0));
       }
 #ifdef WITH_WSREP
-      else if (WSREP_BINLOG_FORMAT(variables.binlog_format) == BINLOG_FORMAT_ROW &&
+      else if (WSREP_BINLOG_FORMAT(this, variables.binlog_format) == BINLOG_FORMAT_ROW &&
                sqlcom_can_generate_row_events(this->lex->sql_command))
 #else
       else if (variables.binlog_format == BINLOG_FORMAT_ROW &&
@@ -12342,7 +12342,7 @@ int THD::decide_logging_format(TABLE_LIST *tables, bool use_cached_table_flags)
     {
       /* binlog_format = STATEMENT */
 #ifdef WITH_WSREP
-      if (WSREP_BINLOG_FORMAT(variables.binlog_format) == BINLOG_FORMAT_STMT)
+      if (WSREP_BINLOG_FORMAT(this, variables.binlog_format) == BINLOG_FORMAT_STMT)
 #else
       if (variables.binlog_format == BINLOG_FORMAT_STMT)
 #endif /* WITH_WSREP */
@@ -12534,7 +12534,7 @@ int THD::decide_logging_format(TABLE_LIST *tables, bool use_cached_table_flags)
                         mysql_bin_log.is_open(),
                         (variables.option_bits & OPTION_BIN_LOG),
 #ifdef WITH_WSREP
-                        WSREP_BINLOG_FORMAT(variables.binlog_format),
+                        WSREP_BINLOG_FORMAT(this, variables.binlog_format),
                         binlog_filter->db_ok(m_db.str)));
 #else
                         variables.binlog_format,

--- a/sql/log.h
+++ b/sql/log.h
@@ -986,11 +986,5 @@ IO_CACHE* wsrep_get_trans_log(THD * thd, bool transaction);
 bool wsrep_trans_cache_is_empty(THD *thd);
 void wsrep_thd_binlog_flush_pending_rows_event(THD *thd, bool stmt_end);
 void wsrep_thd_binlog_trx_reset(THD * thd);
-
-#define WSREP_BINLOG_FORMAT(my_format)                         \
-   ((wsrep_forced_binlog_format != BINLOG_FORMAT_UNSPEC) ?     \
-   wsrep_forced_binlog_format : my_format)
-#else
-#define WSREP_BINLOG_FORMAT(my_format) my_format
 #endif /* WITH_WSREP */
 #endif /* LOG_H */

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -4980,7 +4980,7 @@ thr_lock_type read_lock_type_for_table(THD *thd,
 #ifdef WITH_WSREP
   ulong binlog_format= thd->variables.binlog_format;
   if (log_on == false ||
-      (WSREP_BINLOG_FORMAT(binlog_format) == BINLOG_FORMAT_ROW))
+      (WSREP_BINLOG_FORMAT(thd, binlog_format) == BINLOG_FORMAT_ROW))
 #else
   if (log_on == false ||
       thd->variables.binlog_format == BINLOG_FORMAT_ROW)

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1583,6 +1583,7 @@ THD::THD(bool enable_plugins)
   wsrep_skip_wsrep_GTID   = false;
   wsrep_split_trx         = false;
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;
+  m_wsrep_forced_binlog_format_override = BINLOG_FORMAT_UNSPEC;
   wsrep_skip_SE_checkpoint = false;
   wsrep_skip_wsrep_hton   = false;
 #endif /* WITH_WSREP */
@@ -1984,6 +1985,7 @@ void THD::init(void)
   wsrep_gtid_event_buf    = NULL;
   wsrep_gtid_event_buf_len = 0;
   m_wsrep_next_trx_id     = WSREP_UNDEFINED_TRX_ID;
+  m_wsrep_forced_binlog_format_override = BINLOG_FORMAT_UNSPEC;
   wsrep_sst_donor= false;
   wsrep_void_applier_trx  = true;
   wsrep_skip_SE_checkpoint = false;
@@ -4558,7 +4560,7 @@ extern "C" int thd_binlog_format(const MYSQL_THD thd)
 #ifdef WITH_WSREP
   if (((WSREP(thd) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()) &&
       !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF))
-    return (int) WSREP_BINLOG_FORMAT(thd->variables.binlog_format);
+    return (int) WSREP_BINLOG_FORMAT(thd, thd->variables.binlog_format);
 #else
   if (mysql_bin_log.is_open() && (thd->variables.option_bits & OPTION_BIN_LOG))
     return (int) thd->variables.binlog_format;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3928,7 +3928,7 @@ case SQLCOM_PREPARE:
       if (thd->query_name_consts && 
           mysql_bin_log.is_open() &&
 #ifdef WITH_WSREP
-          WSREP_BINLOG_FORMAT(thd->variables.binlog_format) == BINLOG_FORMAT_STMT &&
+          WSREP_BINLOG_FORMAT(thd, thd->variables.binlog_format) == BINLOG_FORMAT_STMT &&
 #else
           thd->variables.binlog_format == BINLOG_FORMAT_STMT &&
 #endif /* WITH_WSREP */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-512

Problem:
Duplication of procedure on replication if `wsrep_forced_binlog_format=ROW`.

Cause:
`THD::set_current_stmt_binlog_format_row` and `THD::clear_current_stmt_binlog_format_row` methods inconsistent with `THD::is_current_stmt_binlog_format_row` (when `wsrep_forced_binlog_format` is enabled): `THD::is_current_stmt_binlog_format_row` returns value of `wsrep_forced_binlog_format`, but modifying methods update `THD::current_stmt_binlog_format` variable. So, when we temporary clear binlog format it continues to be forced set and this breaks replication logic.

Solution:
Update also `wsrep_forced_binlog_format` variable. For simplicity, global variable is updated for all sessions. Because `wsrep_forced_binlog_format` is deprecated this is considered enough.

Comment: probably this is dirty solution, but I tried for the first time assuming this can be enough.

Alternative approach, may be it will be better:
Create `THD::wsrep_forced_binlog_format_save` variable and modify it instead of global variable. Also it requires to pass `thd` into `WSREP_BINLOG_FORMAT`, because we need to check not only `wsrep_forced_binlog_format` but also `THD::wsrep_forced_binlog_format_save`.