### PR TITLE
PXC-3998: PXC 8.0.30 refresh - Q3 2022

### DIFF
--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -851,6 +851,9 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
 
     thd->release_resources();
     thd_manager->remove_thd(thd);
+#ifdef HAVE_PSI_THREAD_INTERFACE
+    mysql_thread_set_psi_THD(nullptr);
+#endif
   });
 
   cv.wait(lk, [&] { return entered_nbo_mode; });

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -936,7 +936,7 @@ void process::terminate() {
   }
 }
 
-thd::thd(bool won) : init(), ptr(new THD) {
+thd::thd(bool won) : ptr(new THD) {
   if (ptr) {
     ptr->thread_stack = (char *)(&ptr);
     wsrep_assign_from_threadvars(ptr);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3998

Fix problem detected by AddressSanitizer

1. heap-use-after-free Wsrep_applier_service::apply_nbo_begin() registers thd in PSI subsystem. my_thread_end() calls get_thd_status_var() if such a case, but the thread was deleted before in wsp::thd() destructor causing AddressSanitizer error heap-use-after-free.

Error detected in the callstack:

get_thd_status_var
aggregate_thread_status
aggregate_thread
pfs_delete_current_thread_vc()
wsp::thd::thd_init::~thd_init()
operator()
(/lib/x86_64-linux-gnu/libstdc++.so.6+0xd6de3)
start_thread
__clone

freed by thread T53 (NBO_upd-0) here:
operator delete
wsp::thd::~thd()
operator()
(/lib/x86_64-linux-gnu/libstdc++.so.6+0xd6de3)

2. stack-use-after-scope change_password() function was using on-stack buffer for rewriting the query. This buffer pointer was then used after the buffer went out of scope. Changed to the buffer allocated from thd's mem_root.