### PR TITLE
PXC-3639: Incorrect usage of strncpy (post push fix)

### DIFF
--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -39,6 +39,7 @@
 #include <unistd.h>    // pipe()
 
 #include "sql/conn_handler/socket_connection.h"  // MY_BIND_ALL_ADDRESSES
+#include "sql/raii/sentry.h"
 #include "sql/sql_lex.h"                         // lex_start/lex_end
 
 #ifdef HAVE_SYS_PRCTL_H
@@ -1045,27 +1046,28 @@ size_t wsrep_guess_ip(char *buf, size_t buf_len) {
 
     if (!single_addr) return 0;
 
+    raii::Sentry<> single_addr_sentry(
+        [single_addr]() { my_free(single_addr); });
+
     wsrep_get_single_address(my_bind_addr_str, single_addr,
                              single_addr_buf_size);
     unsigned int const ip_type = wsrep_check_ip(single_addr, &unused);
 
     if (INADDR_NONE == ip_type) {
       WSREP_ERROR("Networking not configured, cannot receive state transfer.");
-      my_free(single_addr);
       return 0;
     }
 
     if (INADDR_ANY != ip_type) {
-      if (strlen(my_bind_addr_str) >= buf_len) {
+      if (strlen(single_addr) >= buf_len) {
         WSREP_WARN("default_ip(): buffer too short: %zu <= %zd", buf_len,
-                   strlen(my_bind_addr_str));
+                   strlen(single_addr));
         return 0;
       }
-      strncpy(buf, my_bind_addr_str, buf_len);
+      strncpy(buf, single_addr, buf_len);
       return strlen(buf);
     }
 
-    my_free(single_addr);
   }
 
   // mysqld binds to all interfaces - try IP from wsrep_node_address


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3639

Commit 5c5368424774b3473bb59060a5b3fda6fcd71836 fixed the issue with handling multiple addresses specified in 'bind-address' variable. Commit 86b7c673c21e86f811a2249e9d524f59ff06e81c introduced the regression. Address is correctly splited into the single address, single address is validated, but at the end multi-address value of 'bind-address' is used.

Fixed to use proper single-address value.
Added better memory management to avoid possible memory leaks.