### PR TITLE
PXC-4077: Skipping GTID events introduce GTID

### DIFF
--- a/mysql-test/suite/galera/r/galera_gtid.result
+++ b/mysql-test/suite/galera/r/galera_gtid.result
@@ -1,5 +1,9 @@
 CREATE TABLE t1 (f1 INT PRIMARY KEY);
 INSERT INTO t1 VALUES (1);
+SET @@SESSION.GTID_NEXT= 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1';
+BEGIN;
+COMMIT;
+SET @@SESSION.GTID_NEXT= 'automatic';
 UPDATE t1 SET f1 = 2;
 SET SESSION wsrep_sync_wait = 7;
 gtid_executed_equal

--- a/mysql-test/suite/galera/t/galera_gtid.test
+++ b/mysql-test/suite/galera/t/galera_gtid.test
@@ -10,6 +10,13 @@ CREATE TABLE t1 (f1 INT PRIMARY KEY);
 
 INSERT INTO t1 VALUES (1);
 
+# Empty transaction with GTID. Used for skipping transactions on replica.
+# (PXC being async replica to some async source node)
+SET @@SESSION.GTID_NEXT= 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1';
+BEGIN;
+COMMIT;
+SET @@SESSION.GTID_NEXT= 'automatic';
+
 --connection node_2
 --let $wait_condition = SELECT COUNT(*) = 1 FROM t1
 --source include/wait_condition.inc


### PR DESCRIPTION
inconsistencies between PXC nodes

https://jira.percona.com/browse/PXC-4077

Problem:
When PXC cluster acts as the async replica to some async source, it may be the case when we want to skip some events on async replica by commiting empty transactions with GTID. Doing so on one of PXC nodes is not replicated among PXC cluster which leads to GTID inconsistencies between PXC cluster nodes.

Cause:
GTID event is not generated and replicated if the transaction is empty. It is only replicated if it is received from async source and processed by replica thread.

Solution:
Allow processing replication of GTID event for all threads besides wsrep applier threads.