### PR TITLE
PXC-4087: BF abort for MDL conflict causes a crash

### DIFF
--- a/mysql-test/suite/galera/r/galera_kill_connection.result
+++ b/mysql-test/suite/galera/r/galera_kill_connection.result
@@ -1,0 +1,15 @@
+CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT);
+INSERT INTO t1 VALUES (NULL);
+Making t1 bigger...
+SET DEBUG_SYNC = 'ha_rollback_low_after_ha_reset SIGNAL ha_rollback_low_after_ha_reset.reached';
+BEGIN;
+INSERT INTO t1 SELECT NULL FROM t1;
+# Killing query on node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR ha_rollback_low_after_ha_reset.reached';
+BEGIN;
+Inserting conflicting rows.
+COMMIT;
+Waiting for node_2 transaction to be replicated. This needs node_1 rollback to finish first.
+node_2 transaction replicated.
+DROP TABLE t1;
+SET DEBUG_SYNC='RESET';

--- a/mysql-test/suite/galera/t/galera_kill_connection-master.opt
+++ b/mysql-test/suite/galera/t/galera_kill_connection-master.opt
@@ -1,0 +1,1 @@
+--thread-handling=pool-of-threads --thread-pool-size=2

--- a/mysql-test/suite/galera/t/galera_kill_connection.test
+++ b/mysql-test/suite/galera/t/galera_kill_connection.test
@@ -1,0 +1,86 @@
+# Test that rollback of the local transaction caused by connection kill is handled properly
+# if parallel wsrep-replicated conflicting transaction is being applied.
+# We cannot use DEBUG_SYNC WAIT_FOR facitlity in killed connection, because it doesn't work for THDs marked as killed ones.
+# Instead of this, we will create the transaction which rollback takes significant amount of time
+# and when its rollback is in progress, we will replicate conflicting transaction from node_2
+
+--source include/have_debug_sync.inc
+--source include/big_test.inc
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+# Save original values, because they may be auto enabled when replication transaction waits for
+# killed transaction rollback.
+--let $innodb_status_output_saved = `SELECT @@GLOBAL.innodb_status_output`
+--let $innodb_status_output_locks_saved = `SELECT @@GLOBAL.innodb_status_output_locks`
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--let $node1a_connection_id = `SELECT CONNECTION_ID()`
+
+CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT);
+INSERT INTO t1 VALUES (NULL);
+
+# Probably cnt=10 would be enough, but as we rely on rollback taking significant time,
+# let's play safe
+--echo Making t1 bigger...
+--let cnt = 20
+--disable_query_log
+while ($cnt)
+{
+  INSERT INTO t1 SELECT NULL from t1; 
+  --dec $cnt
+}
+--enable_query_log
+
+# SIGNAL works for killed threads. Signal, that at least one ha_info has been cleared.
+# This condition is enough for bug reproduction.
+SET DEBUG_SYNC = 'ha_rollback_low_after_ha_reset SIGNAL ha_rollback_low_after_ha_reset.reached';
+
+# Now start the transactions which is going to be rolled back
+BEGIN;
+INSERT INTO t1 SELECT NULL FROM t1; 
+
+--connection node_1
+# Kill the connection. This will trigger started transaction's rollback.
+--disable_query_log
+--echo # Killing query on node_1a
+--eval KILL $node1a_connection_id
+--enable_query_log
+
+# Wait for 1st ha_info being cleaned.
+SET DEBUG_SYNC = 'now WAIT_FOR ha_rollback_low_after_ha_reset.reached';
+
+--connection node_2
+# This transaction will conflict with the ongoing transaction on node_1, so when replicated it will trigger BF-abort
+# This is two-node cluster, so inserting 2 rows with consecutive auto increment values is enough to have PK clash
+--let $max_id = `SELECT id FROM t1 ORDER BY id DESC LIMIT 1`
+
+BEGIN;
+--echo Inserting conflicting rows.
+--disable_query_log
+--let $cnt = 2
+while ($cnt)
+{
+--inc $max_id
+--eval INSERT INTO t1 VALUES ($max_id)
+--dec $cnt
+}
+--enable_query_log
+COMMIT;
+
+--echo Waiting for node_2 transaction to be replicated. This needs node_1 rollback to finish first.
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE id = $max_id
+--source include/wait_condition.inc
+--echo node_2 transaction replicated.
+
+# cleanup
+# node_1a is already disconnected
+DROP TABLE t1;
+SET DEBUG_SYNC='RESET';
+--disable_query_log
+--eval SET @@GLOBAL.innodb_status_output = $innodb_status_output_saved
+--eval SET @@GLOBAL.innodb_status_output_locks = $innodb_status_output_locks_saved
+--enable_query_log
+--source include/wait_until_count_sessions.inc

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2110,6 +2110,9 @@ int ha_rollback_low(THD *thd, bool all)
       if (restore_backup_ha_data)
         reattach_engine_ha_data_to_thd(thd, ht);
       ha_info->reset(); /* keep it conveniently zero-filled */
+#ifdef WITH_WSREP
+      DEBUG_SYNC(thd, "ha_rollback_low_after_ha_reset");
+#endif
     }
     trn_ctx->reset_scope(trx_scope);
   }

--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -282,17 +282,6 @@ int threadpool_process_request(THD *thd)
   }
 
 end:
-
-#ifdef WITH_WSREP
-    /* Set the thd->wsrep_query_state back to the QUERY_IDLE state. */
-    if (WSREP_ON)
-    {
-      mysql_mutex_lock(&thd->LOCK_wsrep_thd);
-      wsrep_thd_set_query_state(thd, QUERY_IDLE);
-      mysql_mutex_unlock(&thd->LOCK_wsrep_thd);
-    }
-#endif /* WITH_WSREP */
-
   if (!retval && !thd->m_server_idle) {
     MYSQL_SOCKET_SET_STATE(thd->get_protocol_classic()->get_vio()
                            ->mysql_socket, PSI_SOCKET_STATE_IDLE);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -23360,10 +23360,10 @@ wsrep_innobase_kill_one_trx(void * const bf_thd_ptr,
 
 	WSREP_LOG_CONFLICT(bf_thd, thd, TRUE);
 
-        WSREP_DEBUG("BF thread %u (with write-set: %lld)"
-                    " aborting Victim thread %u with transaction (%llu)",
-                    wsrep_thd_thread_id(bf_thd), (long long) bf_seqno,
-                    wsrep_thd_thread_id(thd), (long long)victim_trx->id);
+	WSREP_DEBUG("BF thread %u (with write-set: %lld)"
+				" aborting Victim thread %u with transaction (%llu)",
+				wsrep_thd_thread_id(bf_thd), (long long) bf_seqno,
+				wsrep_thd_thread_id(thd), (long long)victim_trx->id);
 
 	WSREP_DEBUG("Aborting query: %s", 
 		    (thd && wsrep_thd_query(thd)) ? wsrep_thd_query(thd) : "void");


### PR DESCRIPTION
when the victim thread is executing a rollback and thread pool is enabled

https://jira.percona.com/browse/PXC-4087

Problem:
The connection on node-1 having big uncommited transaction is killed. This causes transaction on node-1 being rolled back. If during the rollback node-2 issures another transaction which confilcts with the one from node-1, the server asserts (debug) or crashes (release). It only happens if thread_handling is 'pool-of-threads'.

Cause:
The proper flow is:
1. node-1 transaction (T1) is being rolled back as the consequence of connection KILL. THD::wsrep_query_state is QUERY_EXEC, which indicates ongoing query.
2. Transaction (T2) from node-2 is replicated. It sees that there is conflicting T1, so T1 has to be BF-aborted.
3. T1 abort is triggered, however applier thread (T2) waits for T1's rollback
4. Applier thread continues with T2

The problem was that in case of 'pool-of-threads' usage, THD::wsrep_query_state was set to QUERY_IDLE instead of QUERY_EXEC for the time of rollback. This caused logic of applier to not wait for T1, but to delegate the rollback to the wsrep rollbacker thread.

ha_rollback_low() is executed as a consequence of connection KILL resets/clears ha_info of rolled back SE.
In the same time rollbacker thread tries to register wsrep handlerton in wsrep_register_hton(). It iterates over ha_infos of transaction and tries to dereference already cleared m_ht.

Solution:
Changed how THD::wsrep_query_state is set to QUERY_EXEC/QUERY_IDLE to include the case when the connection is killed and does rollback as the part of error handling.