### PR TITLE
PXC-3989: Support for Keyring Components in PXC

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -476,7 +476,7 @@ INSERT INTO global_suppressions VALUES
    enabling pxc_encrypt_cluster_traffic.
  */
  ("You have enabled keyring plugin. SST encryption is mandatory."),
- ("No suitable 'keyring_component_metadata_query' service"),
+ ("No suitable '.*' service implementation found"),
 
 
  ("THE_LAST_SUPPRESSION");

--- a/mysql-test/suite/galera/include/pxc_setup_components_2nodes.inc
+++ b/mysql-test/suite/galera/include/pxc_setup_components_2nodes.inc
@@ -1,0 +1,72 @@
+# Setup test to use keyring component
+
+--echo # ----------------------------------------------------------------------
+--echo # Setup
+
+
+--let COMPONENT_LIBRARY = `SELECT SUBSTRING_INDEX('$KEYRING_FILE_COMPONENT_LOAD', '=', -1)`
+--let COMPONENT_DIR = $KEYRING_FILE_COMPONENT_DIR
+--let COMPONENT_NAME = `SELECT SUBSTRING_INDEX('$COMPONENT_LIBRARY', '.', 1)`
+
+#
+# Create keyring manifest and config for donor node
+#
+--connection node_1
+--let CURRENT_DATADIR = `SELECT @@datadir`
+
+if ($global_manifest)
+{
+  # Backup the global manifest file
+  --source include/keyring_tests/helper/binary_backup_manifest.inc
+
+  # Create manifest file for mysqld binary
+  --let GLOBAL_MANIFEST_CONTENT = `SELECT CONCAT('{ \"components\": \"file://', '$COMPONENT_NAME', '\" }')`
+  --source include/keyring_tests/helper/binary_create_customized_manifest.inc
+}
+
+if ($donor_local_manifest)
+{
+  # Create global manifest file
+  --source include/keyring_tests/helper/binary_create_manifest.inc
+
+  # Create local manifest file for current server instance
+  --let LOCAL_MANIFEST_CONTENT = `SELECT CONCAT('{ \"components\": \"file://', '$COMPONENT_NAME', '\" }')`
+  --source include/keyring_tests/helper/instance_create_manifest.inc
+}
+
+# Create local keyring config as we cannot test global keyring config in MTR environment
+--let KEYRING_FILE_PATH = `SELECT CONCAT( '$MYSQLTEST_VARDIR', '/keyring_file_donor')`
+--let KEYRING_CONFIG_CONTENT = `SELECT CONCAT('{ \"path\": \"', '$KEYRING_FILE_PATH','\", \"read_only\": false }')`
+--source include/keyring_tests/helper/local_keyring_create_config.inc
+
+--let DONOR_DATADIR = $CURRENT_DATADIR
+--let DONOR_KEYRING_FILE_PATH = $KEYRING_FILE_PATH
+
+#
+# Create keyring manifest and config for joiner node
+#
+
+--connection node_2
+--let CURRENT_DATADIR = `SELECT @@datadir`
+
+if ($joiner_local_manifest)
+{
+  # Create global manifest file
+  --source include/keyring_tests/helper/binary_create_manifest.inc
+
+  # Create local manifest file for current server instance
+  --let LOCAL_MANIFEST_CONTENT = `SELECT CONCAT('{ \"components\": \"file://', '$COMPONENT_NAME', '\" }')`
+  --source include/keyring_tests/helper/instance_create_manifest.inc
+}
+
+# Create local keyring config as we cannot test global keyring config in MTR environment
+--let KEYRING_FILE_PATH = `SELECT CONCAT( '$MYSQLTEST_VARDIR', '/keyring_file_joiner')`
+--let KEYRING_CONFIG_CONTENT = `SELECT CONCAT('{ \"path\": \"', '$KEYRING_FILE_PATH','\", \"read_only\": false }')`
+--source include/keyring_tests/helper/local_keyring_create_config.inc
+
+--let JOINER_DATADIR = $CURRENT_DATADIR
+--let JOINER_KEYRING_FILE_PATH = $KEYRING_FILE_PATH
+
+--connection node_1
+--let CURRENT_DATADIR = `SELECT @@datadir`
+--echo # ----------------------------------------------------------------------

--- a/mysql-test/suite/galera/include/pxc_teardown_components_2nodes.inc
+++ b/mysql-test/suite/galera/include/pxc_teardown_components_2nodes.inc
@@ -1,0 +1,36 @@
+# Teardown
+
+--echo # ----------------------------------------------------------------------
+--echo # Teardown
+
+if ($global_manifest) {
+  # Restore the manifest file
+  --source include/keyring_tests/helper/binary_restore_manifest.inc
+}
+
+# Remove local manifest file on the donor
+if ($donor_local_manifest) {
+  --let CURRENT_DATADIR = $DONOR_DATADIR
+  --source include/keyring_tests/helper/instance_remove_manifest.inc
+}
+
+if ($joiner_local_manifest) {
+  --let CURRENT_DATADIR = $JOINER_DATADIR
+  --source include/keyring_tests/helper/instance_remove_manifest.inc
+}
+
+# Remove keyring file
+--let KEYRING_FILE_PATH = $DONOR_KEYRING_FILE_PATH
+--source include/keyring_tests/helper/local_keyring_file_remove.inc
+--let KEYRING_FILE_PATH = $JOINER_KEYRING_FILE_PATH
+--source include/keyring_tests/helper/local_keyring_file_remove.inc
+
+# Remove local keyring config
+--let CURRENT_DATADIR = $DONOR_DATADIR
+--source include/keyring_tests/helper/local_keyring_remove_config.inc
+--let CURRENT_DATADIR = $JOINER_DATADIR
+--source include/keyring_tests/helper/local_keyring_remove_config.inc
+
+# Restart server without manifest file
+--source include/keyring_tests/helper/cleanup_server_with_manifest.inc
+--echo # ----------------------------------------------------------------------

--- a/mysql-test/suite/galera/include/restart_cluster_with_sst.inc
+++ b/mysql-test/suite/galera/include/restart_cluster_with_sst.inc
@@ -1,0 +1,47 @@
+#
+# This helper restarts the running cluster by performing SST
+#
+
+# Shutdown the cluster
+--echo # shutting down node2
+--connection node_2
+--echo [connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+--source include/shutdown_mysqld.inc
+
+--echo # shutting down node1
+--connection node_1
+--echo [connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+--source include/shutdown_mysqld.inc
+
+# Remove the grastate.dat files to restart the cluster.
+--error 0,1 
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/grastate.dat
+--error 0,1 
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+--echo "Restarting node 1"
+--connection node_1
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+--echo "Restarting node 2"
+--connection node_2
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+
+# Wait for the cluster size to become 2
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Switch the connection back to node_1
+--connection node_1

--- a/mysql-test/suite/galera/r/pxc_component_keyring_file.result
+++ b/mysql-test/suite/galera/r/pxc_component_keyring_file.result
@@ -1,0 +1,157 @@
+# Scenario 1
+# Donor: Global manifest, local config
+# Joiner: Global manifest, local config
+# ----------------------------------------------------------------------
+# Setup
+# Taking backup of global manifest file for MySQL server
+# Creating custom global manifest file for MySQL server
+# Creating local configuration file for keyring component: component_keyring_file
+# Creating local configuration file for keyring component: component_keyring_file
+# ----------------------------------------------------------------------
+# shutting down node2
+[connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+# shutting down node1
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+"Restarting node 1"
+# restart
+"Restarting node 2"
+# restart
+include/assert.inc [Assert that the server has started with a keyring component]
+include/assert.inc [Assert that the server is component_keyring_file enabled]
+include/assert.inc [Assert that the server has no keys created in the keyring]
+include/assert.inc [Assert that the server has started with a keyring component]
+include/assert.inc [Assert that the server is component_keyring_file enabled]
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENCRYPTION='Y';
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+include/assert.inc [Assert that the server has created the master key on node_1]
+include/assert.inc [Assert that the server has created the master key on node_2]
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f1` int NOT NULL,
+  PRIMARY KEY (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
+SELECT * FROM t1;
+f1
+1
+2
+3
+4
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+include/assert.inc [Assert that the server has rotated the master key on node_2]
+# shutting down node2
+[connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+# shutting down node1
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+"Restarting node 1"
+# restart:--wsrep-disk-pages-encrypt=ON --wsrep-gcache-encrypt=ON
+"Restarting node 2"
+# restart:--wsrep-disk-pages-encrypt=ON --wsrep-gcache-encrypt=ON
+include/assert_grep.inc [Assert that GCache is encrypted on node_1]
+include/assert_grep.inc [Assert that GCache is encrypted on node_2]
+# shutting down node2
+[connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+# shutting down node1
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+"Restarting node 1"
+# restart
+"Restarting node 2"
+# restart
+include/assert_grep.inc [Assert that GCache is not encrypted on node_1]
+include/assert_grep.inc [Assert that GCache is not encrypted on node_2]
+DROP TABLE t1;
+# ----------------------------------------------------------------------
+# Teardown
+# Restore global manifest file for MySQL server from backup
+# Removing local keyring file for keyring component: component_keyring_file
+# Removing local keyring file for keyring component: component_keyring_file
+# Removing local configuration file for keyring component: component_keyring_file
+# Removing local configuration file for keyring component: component_keyring_file
+# Restarting server without the manifest file
+# ----------------------------------------------------------------------
+# Scenario 2
+# Donor: local manifest, local config
+# Joiner: local manifest, local config
+# ----------------------------------------------------------------------
+# Setup
+# Creating global manifest file for MySQL server
+# Creating manifest file for current MySQL server instance
+# Creating local configuration file for keyring component: component_keyring_file
+# Creating global manifest file for MySQL server
+# Creating manifest file for current MySQL server instance
+# Creating local configuration file for keyring component: component_keyring_file
+# ----------------------------------------------------------------------
+# shutting down node2
+[connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+# shutting down node1
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+"Restarting node 1"
+# restart
+"Restarting node 2"
+# restart
+include/assert.inc [Assert that the server has started with a keyring component]
+include/assert.inc [Assert that the server is component_keyring_file enabled]
+include/assert.inc [Assert that the server has no keys created in the keyring]
+include/assert.inc [Assert that the server has started with a keyring component]
+include/assert.inc [Assert that the server is component_keyring_file enabled]
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENCRYPTION='Y';
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+include/assert.inc [Assert that the server has created the master key on node_1]
+include/assert.inc [Assert that the server has created the master key on node_2]
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f1` int NOT NULL,
+  PRIMARY KEY (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
+SELECT * FROM t1;
+f1
+1
+2
+3
+4
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+include/assert.inc [Assert that the server has rotated the master key on node_2]
+# shutting down node2
+[connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+# shutting down node1
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+"Restarting node 1"
+# restart:--wsrep-disk-pages-encrypt=ON --wsrep-gcache-encrypt=ON
+"Restarting node 2"
+# restart:--wsrep-disk-pages-encrypt=ON --wsrep-gcache-encrypt=ON
+include/assert_grep.inc [Assert that GCache is encrypted on node_1]
+include/assert_grep.inc [Assert that GCache is encrypted on node_2]
+# shutting down node2
+[connection node_2]
+SET SESSION wsrep_sync_wait = 0;
+# shutting down node1
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+"Restarting node 1"
+# restart
+"Restarting node 2"
+# restart
+include/assert_grep.inc [Assert that GCache is not encrypted on node_1]
+include/assert_grep.inc [Assert that GCache is not encrypted on node_2]
+DROP TABLE t1;
+# ----------------------------------------------------------------------
+# Teardown
+# Removing manifest file for current MySQL server instance
+# Removing manifest file for current MySQL server instance
+# Removing local keyring file for keyring component: component_keyring_file
+# Removing local keyring file for keyring component: component_keyring_file
+# Removing local configuration file for keyring component: component_keyring_file
+# Removing local configuration file for keyring component: component_keyring_file
+# Restarting server without the manifest file
+# ----------------------------------------------------------------------

--- a/mysql-test/suite/galera/t/pxc_component_keyring_file.cnf
+++ b/mysql-test/suite/galera/t/pxc_component_keyring_file.cnf
@@ -1,0 +1,58 @@
+# Use default setting for mysqld processes
+!include include/default_mysqld.cnf
+
+[mysqld]
+mysqlx=0
+
+ssl-ca=@ENV.MYSQLTEST_VARDIR/std_data/cacert.pem
+ssl-cert=@ENV.MYSQLTEST_VARDIR/std_data/server-cert.pem
+ssl-key=@ENV.MYSQLTEST_VARDIR/std_data/server-key.pem
+
+[mysqld.1]
+wsrep_provider=@ENV.WSREP_PROVIDER
+wsrep_cluster_address='gcomm://'
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;socket.ssl=yes;socket.ssl_cert=@ENV.MYSQL_TEST_DIR/std_data/galera-cert.pem;socket.ssl_key=@ENV.MYSQL_TEST_DIR/std_data/galera-key.pem'
+
+# enforce read-committed characteristics across the cluster
+wsrep_causal_reads=ON
+wsrep_sync_wait = 15
+
+wsrep_node_address=127.0.0.1
+wsrep_sst_receive_address=127.0.0.1:@mysqld.1.#sst_port
+wsrep_node_incoming_address=127.0.0.1:@mysqld.1.port
+
+# Required for Galera
+innodb_autoinc_lock_mode=2
+
+[mysqld.2]
+wsrep_provider=@ENV.WSREP_PROVIDER
+wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;socket.ssl=yes;socket.ssl_cert=@ENV.MYSQL_TEST_DIR/std_data/galera-cert.pem;socket.ssl_key=@ENV.MYSQL_TEST_DIR/std_data/galera-key.pem'
+
+# enforce read-committed characteristics across the cluster
+wsrep_causal_reads=ON
+wsrep_sync_wait = 15
+
+wsrep_node_address=127.0.0.1
+wsrep_sst_receive_address=127.0.0.1:@mysqld.2.#sst_port
+wsrep_node_incoming_address=127.0.0.1:@mysqld.2.port
+
+# Required for Galera
+innodb_autoinc_lock_mode=2
+
+[sst]
+encrypt=4
+wsrep-debug=1
+
+[ENV]
+NODE_MYPORT_1= @mysqld.1.port
+NODE_MYSOCK_1= @mysqld.1.socket
+
+NODE_MYPORT_2= @mysqld.2.port
+NODE_MYSOCK_2= @mysqld.2.socket
+
+NODE_GALERAPORT_1= @mysqld.1.#galera_port
+NODE_GALERAPORT_2= @mysqld.2.#galera_port
+
+NODE_SSTPORT_1= @mysqld.1.#sst_port
+NODE_SSTPORT_2= @mysqld.2.#sst_port

--- a/mysql-test/suite/galera/t/pxc_component_keyring_file.combinations
+++ b/mysql-test/suite/galera/t/pxc_component_keyring_file.combinations
@@ -1,0 +1,3 @@
+[enc_off]
+wsrep-gcache-encrypt=OFF
+wsrep-disk-pages-encrypt=OFF

--- a/mysql-test/suite/galera/t/pxc_component_keyring_file.test
+++ b/mysql-test/suite/galera/t/pxc_component_keyring_file.test
@@ -1,0 +1,138 @@
+# === Purpose ===
+#
+# This tests verifies that snapshot transfer is handled properly by the SST
+# script when the cluster uses components. This tests also verifies that gcache
+# encryption works well with components.
+#
+# === References ===
+#
+# PXC-3989: Support for Keyring Components in PXC
+
+--source include/galera_cluster.inc
+
+# Create a helper inc file for test validation
+--write_file $MYSQLTEST_VARDIR/tmp/pxc_keyring_validation.inc END_OF_PROCEDURE
+  # Ensure that the server is component enabled
+  --connection node_1
+  --let $assert_text= Assert that the server has started with a keyring component
+  --let $assert_cond= [SELECT STATUS_VALUE = "Active" FROM performance_schema.keyring_component_status WHERE STATUS_KEY="Component_status"]
+  --source include/assert.inc
+
+  --let $assert_text= Assert that the server is component_keyring_file enabled
+  --let $assert_cond= [SELECT STATUS_VALUE = "component_keyring_file" FROM performance_schema.keyring_component_status WHERE STATUS_KEY="Implementation_name"]
+  --source include/assert.inc
+
+  --let $assert_text= Assert that the server has no keys created in the keyring
+  --let $assert_cond= [SELECT COUNT(*) = 0 from performance_schema.keyring_keys]
+  --source include/assert.inc
+
+  --connection node_2
+  --let $assert_text= Assert that the server has started with a keyring component
+  --let $assert_cond= [SELECT STATUS_VALUE = "Active" FROM performance_schema.keyring_component_status WHERE STATUS_KEY="Component_status"]
+  --source include/assert.inc
+
+  --let $assert_text= Assert that the server is component_keyring_file enabled
+  --let $assert_cond= [SELECT STATUS_VALUE = "component_keyring_file" FROM performance_schema.keyring_component_status WHERE STATUS_KEY="Implementation_name"]
+  --source include/assert.inc
+
+  --connection node_1
+  # Create an encrypted table
+  CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENCRYPTION='Y';
+  INSERT INTO t1 VALUES (1),(2),(3),(4);
+
+  --let $assert_text= Assert that the server has created the master key on node_1
+  --let $assert_cond= [SELECT COUNT(*) = 1 from performance_schema.keyring_keys]
+  --source include/assert.inc
+
+  --connection node_2
+  # Joiner will have two keys. The one restored by PXB, and the other one by server.
+  --let $assert_text= Assert that the server has created the master key on node_2
+  --let $assert_cond= [SELECT COUNT(*) = 2 from performance_schema.keyring_keys]
+  --source include/assert.inc
+
+  SHOW CREATE TABLE t1;
+  SELECT * FROM t1;
+
+  ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+  --let $assert_text= Assert that the server has rotated the master key on node_2
+  --let $assert_cond= [SELECT COUNT(*) = 3 from performance_schema.keyring_keys]
+  --source include/assert.inc
+
+  --connection node_1
+  --let $assert_text= Assert that the server has rotated the master key on node_1
+  --let $assert_cond= [SELECT COUNT(*) = 2 from performance_schema.keyring_keys]
+
+  # Test with record set and gcache encryption
+  --let $restart_parameters = "restart:--wsrep-disk-pages-encrypt=ON --wsrep-gcache-encrypt=ON"
+  --source suite/galera/include/restart_cluster_with_sst.inc
+
+  # Check that GCache ring buffer file content is encrypted on node_1
+  --connection node_1
+  --let $MYSQL_DATA_DIR = `SELECT @@datadir`
+  --let $assert_text = Assert that GCache is encrypted on node_1
+  --let $assert_file = $MYSQL_DATA_DIR/galera.cache
+  --let $assert_select = enc_encrypted: 1
+  --let $assert_count = 1
+  --source include/assert_grep.inc
+
+  # Check that GCache ring buffer file content is encrypted on node_2
+  --connection node_2
+  --let $MYSQL_DATA_DIR = `SELECT @@datadir`
+  --let $assert_text = Assert that GCache is encrypted on node_2
+  --let $assert_file = $MYSQL_DATA_DIR/galera.cache
+  --let $assert_select = enc_encrypted: 1
+  --let $assert_count = 1
+  --source include/assert_grep.inc
+
+  --let $restart_parameters = "restart"
+  --source suite/galera/include/restart_cluster_with_sst.inc
+
+  # Check that GCache ring buffer file content is not encrypted on node_1
+  --connection node_1
+  --let $MYSQL_DATA_DIR = `SELECT @@datadir`
+  --let $assert_text = Assert that GCache is not encrypted on node_1
+  --let $assert_file = $MYSQL_DATA_DIR/galera.cache
+  --let $assert_select = enc_encrypted: 0
+  --let $assert_count = 1
+  --source include/assert_grep.inc
+
+  # Check that GCache ring buffer file content is not encrypted on node_2
+  --connection node_2
+  --let $MYSQL_DATA_DIR = `SELECT @@datadir`
+  --let $assert_text = Assert that GCache is not encrypted on node_2
+  --let $assert_file = $MYSQL_DATA_DIR/galera.cache
+  --let $assert_select = enc_encrypted: 0
+  --let $assert_count = 1
+  --source include/assert_grep.inc
+
+  DROP TABLE t1;
+END_OF_PROCEDURE
+
+--echo # Scenario 1
+--echo # Donor: Global manifest, local config
+--echo # Joiner: Global manifest, local config
+
+--let $global_manifest = 1
+--let $donor_local_manifest = 0
+--let $joiner_local_manifest = 0
+
+--source ../include/pxc_setup_components_2nodes.inc
+--source ../include/restart_cluster_with_sst.inc
+--source $MYSQLTEST_VARDIR/tmp/pxc_keyring_validation.inc
+--source ../include/pxc_teardown_components_2nodes.inc
+
+--echo # Scenario 2
+--echo # Donor: local manifest, local config
+--echo # Joiner: local manifest, local config
+
+--let $global_manifest = 0
+--let $donor_local_manifest = 1
+--let $joiner_local_manifest = 1
+
+--source ../include/pxc_setup_components_2nodes.inc
+--source ../include/restart_cluster_with_sst.inc
+--source $MYSQLTEST_VARDIR/tmp/pxc_keyring_validation.inc
+--source ../include/pxc_teardown_components_2nodes.inc
+
+--remove_file $MYSQLTEST_VARDIR/tmp/pxc_keyring_validation.inc

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -38,6 +38,7 @@ readonly MYSQLD_NAME=mysqld
 readonly MYSQLADMIN_NAME=mysqladmin
 readonly MYSQL_CLIENT_NAME=mysql
 
+declare MYSQLD_PATH=""
 declare MYSQL_UPGRADE_TMPDIR=""
 declare WSREP_LOG_DIR=""
 
@@ -145,6 +146,40 @@ readonly WSREP_SST_OPT_BYPASS
 readonly WSREP_SST_OPT_BINLOG
 readonly WSREP_SST_OPT_CONF_SUFFIX
 
+# try to use my_print_defaults, mysql and mysqldump that come with the sources
+# (for MTR suite)
+SCRIPTS_DIR="$(cd $(dirname "$0"); pwd -P)"
+EXTRA_DIR="$SCRIPTS_DIR/../extra"
+CLIENT_DIR="$SCRIPTS_DIR/../client"
+
+if [ -x "$CLIENT_DIR/mysql" ]; then
+    MYSQL_CLIENT="$CLIENT_DIR/mysql"
+else
+    MYSQL_CLIENT=$(which mysql)
+fi
+
+if [ -x "$CLIENT_DIR/mysqldump" ]; then
+    MYSQLDUMP="$CLIENT_DIR/mysqldump"
+else
+    MYSQLDUMP=$(which mysqldump)
+fi
+
+if [ -x "$SCRIPTS_DIR/my_print_defaults" ]; then
+    MY_PRINT_DEFAULTS="$SCRIPTS_DIR/my_print_defaults"
+elif [ -x "$EXTRA_DIR/my_print_defaults" ]; then
+    MY_PRINT_DEFAULTS="$EXTRA_DIR/my_print_defaults"
+else
+    MY_PRINT_DEFAULTS=$(which my_print_defaults)
+fi
+
+
+if [ -n "${WSREP_SST_OPT_DATA:-}" ]
+then
+    SST_PROGRESS_FILE="$WSREP_SST_OPT_DATA/sst_in_progress"
+else
+    SST_PROGRESS_FILE=""
+fi
+
 #
 # user can specify xtrabackup specific settings that will be used during sst
 # process like encryption, etc.....
@@ -210,42 +245,6 @@ normalize_boolean()
     return 0
 }
 
-
-# try to use my_print_defaults, mysql and mysqldump that come with the sources
-# (for MTR suite)
-SCRIPTS_DIR="$(cd $(dirname "$0"); pwd -P)"
-EXTRA_DIR="$SCRIPTS_DIR/../extra"
-CLIENT_DIR="$SCRIPTS_DIR/../client"
-
-if [ -x "$CLIENT_DIR/mysql" ]; then
-    MYSQL_CLIENT="$CLIENT_DIR/mysql"
-else
-    MYSQL_CLIENT=$(which mysql)
-fi
-
-if [ -x "$CLIENT_DIR/mysqldump" ]; then
-    MYSQLDUMP="$CLIENT_DIR/mysqldump"
-else
-    MYSQLDUMP=$(which mysqldump)
-fi
-
-if [ -x "$SCRIPTS_DIR/my_print_defaults" ]; then
-    MY_PRINT_DEFAULTS="$SCRIPTS_DIR/my_print_defaults"
-elif [ -x "$EXTRA_DIR/my_print_defaults" ]; then
-    MY_PRINT_DEFAULTS="$EXTRA_DIR/my_print_defaults"
-else
-    MY_PRINT_DEFAULTS=$(which my_print_defaults)
-fi
-
-
-if [ -n "${WSREP_SST_OPT_DATA:-}" ]
-then
-    SST_PROGRESS_FILE="$WSREP_SST_OPT_DATA/sst_in_progress"
-else
-    SST_PROGRESS_FILE=""
-fi
-
-
 WSREP_LOG_DEBUG=$(parse_cnf sst wsrep-debug "")
 if [ -z "$WSREP_LOG_DEBUG" ]; then
     WSREP_LOG_DEBUG=$(parse_cnf mysqld wsrep-debug "")
@@ -280,6 +279,40 @@ wsrep_log_debug()
     if [[ -n "$WSREP_LOG_DEBUG" ]]; then
         wsrep_log "DBG:(debug) $*"
     fi
+}
+
+#
+# This functions stores the mysqld path in the MYSQLD_PATH
+# global variable
+#
+get_mysqld_path()
+{
+    # Locate mysqld
+    # mysqld (depending on the distro) may be in a different
+    # directory from the SST scripts (it may be in /usr/sbin not /usr/bin)
+    # So, first, try to use readlink to read from /proc/<pid>/exe
+    if which readlink >/dev/null; then
+        # Check to see if the symlink for the exe exists
+        if [[ -L /proc/${WSREP_SST_OPT_PARENT}/exe ]]; then
+            MYSQLD_PATH=$(readlink -f /proc/${WSREP_SST_OPT_PARENT}/exe)
+        fi
+    fi
+    if [[ -z $MYSQLD_PATH ]]; then
+        # We don't have readlink, so look for mysqld in the path
+        MYSQLD_PATH=$(which ${MYSQLD_NAME})
+    fi
+
+    if [[ -z $MYSQLD_PATH ]]; then
+        wsrep_log_error "******************* FATAL ERROR ********************** "
+        wsrep_log_error "Could not locate ${MYSQLD_NAME} (needed for post-processing)"
+        wsrep_log_error "Please ensure that ${MYSQLD_NAME} is in the path"
+        wsrep_log_error "Line $LINENO"
+        wsrep_log_error "******************* FATAL ERROR ********************** "
+        exit 22
+    fi
+
+    wsrep_log_debug "Found the ${MYSQLD_NAME} binary in ${MYSQLD_PATH}"
+    wsrep_log_debug "--$("$MYSQLD_PATH" --version | cut -d' ' -f2-)"
 }
 
 wsrep_cleanup_progress_file()
@@ -656,21 +689,7 @@ function run_post_processing_steps()
         return 0
     fi
 
-    # Locate mysqld
-    # mysqld (depending on the distro) may be in a different
-    # directory from the SST scripts (it may be in /usr/sbin not /usr/bin)
-    # So, first, try to use readlink to read from /proc/<pid>/exe
-    if which readlink >/dev/null; then
-
-        # Check to see if the symlink for the exe exists
-        if [[ -L /proc/${WSREP_SST_OPT_PARENT}/exe ]]; then
-            mysqld_path=$(readlink -f /proc/${WSREP_SST_OPT_PARENT}/exe)
-        fi
-    fi
-    if [[ -z $mysqld_path ]]; then
-        # We don't have readlink, so look for mysqld in the path
-        mysqld_path=$(which ${MYSQLD_NAME})
-    fi
+    local mysqld_path=$MYSQLD_PATH
     if [[ $mysqld_path == *"memcheck"* ]]; then
       wsrep_log_debug "Detected valgrind, adjusting mysqld path accordingly"
       while read -r line
@@ -681,16 +700,6 @@ function run_post_processing_steps()
         fi
       done < <(cat /proc/${WSREP_SST_OPT_PARENT}/cmdline | strings -1)
     fi
-    if [[ -z $mysqld_path ]]; then
-        wsrep_log_error "******************* FATAL ERROR ********************** "
-        wsrep_log_error "Could not locate ${MYSQLD_NAME} (needed for post-processing)"
-        wsrep_log_error "Please ensure that ${MYSQLD_NAME} is in the path"
-        wsrep_log_error "Line $LINENO"
-        wsrep_log_error "******************* FATAL ERROR ********************** "
-        return 2
-    fi
-    wsrep_log_debug "Found the ${MYSQLD_NAME} binary in ${mysqld_path}"
-    wsrep_log_debug "--$("$mysqld_path" --version | cut -d' ' -f2-)"
 
     # Verify any other needed programs
     wsrep_check_program "${MYSQLADMIN_NAME}"
@@ -946,6 +955,33 @@ EOF
     return 0
 }
 
+function exec_sql() {
+  local user=$1
+  local password=$2
+  local socket=$3
+  local query=$4
+  local args=""
+  local retvalue
+  local retoutput
+  local default_auth=""
+
+  if [[ $# -ge 5 ]]; then
+    args=$5
+  fi
+
+  defaults=$(printf '[client]\nuser=%s\npassword="%s"\nsocket=%s\n%s' \
+    "${user}" \
+    "${password}" \
+    "${socket}" \
+    "${default_auth}"
+  )
+
+  retoutput=$(mysql --defaults-file=<(echo "${defaults}") --unbuffered --batch --silent ${args} -e "$query")
+  retvalue=$?
+
+  printf "%s" "${retoutput}"
+  return $retvalue
+}
 
 # Reads incoming data from STDIN and sets the variables
 #

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -23,6 +23,7 @@ WSREP_SST_OPT_BINLOG=""
 WSREP_SST_OPT_CONF_SUFFIX=""
 WSREP_SST_OPT_DATA=""
 WSREP_SST_OPT_BASEDIR=""
+WSREP_SST_OPT_PLUGINDIR=""
 WSREP_SST_OPT_USER=""
 WSREP_SST_OPT_PSWD=""
 WSREP_SST_OPT_VERSION=""
@@ -95,6 +96,10 @@ case "$1" in
         ;;
     '--password')
         # Ignore (read value from stdin)
+        shift
+        ;;
+    '--plugindir')
+        readonly WSREP_SST_OPT_PLUGINDIR="$2"
         shift
         ;;
     '--port')
@@ -530,6 +535,7 @@ EOF
 #   WSREP_SST_OPT_CONF
 #   WSREP_SST_OPT_CONF_SUFFIX
 #   WSREP_SST_OPT_BASEDIR
+#   WSREP_SST_OPT_PLUGINDIR
 #   MYSQL_UPGRADE_TMPDIR    (This path will be deleted on exit)
 #
 # Arguments
@@ -797,6 +803,10 @@ function run_post_processing_steps()
 
     if [[ -n $WSREP_SST_OPT_BASEDIR ]]; then
         mysqld_cmdline+=" --basedir=${WSREP_SST_OPT_BASEDIR}"
+    fi
+
+    if [[ -n $WSREP_SST_OPT_PLUGINDIR ]]; then
+        mysqld_cmdline+=" --plugin-dir=${WSREP_SST_OPT_PLUGINDIR}"
     fi
 
     # Generate a new random password to be used by the JOINER

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -30,6 +30,7 @@
 #include "sql_class.h"
 #include "sql_parse.h"
 #include "sql_plugin.h"  // SHOW_MY_BOOL
+#include "sql/server_component/mysql_server_keyring_lockable_imp.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -1273,6 +1274,9 @@ void wsrep_init_startup(bool sst_first) {
   // We need to force keyring cache to repopulate
   // after SST, because SST might have add some keys.
   // GCache recovery won't work without this.
+  if (keyring_status_no_error() && srv_keyring_load) {
+    srv_keyring_load->load(opt_plugin_dir, mysql_real_data_home);
+  }
   plugin_reinit_keyring();
 }
 

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -50,6 +50,7 @@ extern const char *wsrep_defaults_group_suffix;
 #define WSREP_SST_OPT_AUTH "--auth"
 #define WSREP_SST_OPT_DATA "--datadir"
 #define WSREP_SST_OPT_BASEDIR "--basedir"
+#define WSREP_SST_OPT_PLUGINDIR "--plugindir"
 #define WSREP_SST_OPT_CONF "--defaults-file"
 #define WSREP_SST_OPT_CONF_SUFFIX "--defaults-group-suffix"
 #define WSREP_SST_OPT_PARENT "--parent"
@@ -700,18 +701,20 @@ static ssize_t sst_prepare_other(const char *method, const char *addr_in,
   }
   if (strlen(binlog_opt_val)) binlog_opt = WSREP_SST_OPT_BINLOG;
 
-  ret = snprintf(
-      cmd_str(), cmd_len,
-      "wsrep_sst_%s " WSREP_SST_OPT_ROLE " 'joiner' " WSREP_SST_OPT_ADDR
-      " '%s' " WSREP_SST_OPT_DATA " '%s' " WSREP_SST_OPT_BASEDIR
-      " '%s' " WSREP_SST_OPT_CONF " '%s' " WSREP_SST_OPT_CONF_SUFFIX
-      " '%s' " WSREP_SST_OPT_PARENT " '%d' " WSREP_SST_OPT_VERSION
-      " '%s' "
-      " %s '%s' ",
-      method, addr_in, mysql_real_data_home,
-      mysql_home_ptr ? mysql_home_ptr : "", wsrep_defaults_file,
-      wsrep_defaults_group_suffix, (int)getpid(),
-      MYSQL_SERVER_VERSION MYSQL_SERVER_SUFFIX_DEF, binlog_opt, binlog_opt_val);
+  ret = snprintf(cmd_str(), cmd_len,
+                 "wsrep_sst_%s " WSREP_SST_OPT_ROLE
+                 " 'joiner' " WSREP_SST_OPT_ADDR " '%s' " WSREP_SST_OPT_DATA
+                 " '%s' " WSREP_SST_OPT_BASEDIR " '%s' " WSREP_SST_OPT_PLUGINDIR
+                 " '%s' " WSREP_SST_OPT_CONF " '%s' " WSREP_SST_OPT_CONF_SUFFIX
+                 " '%s' " WSREP_SST_OPT_PARENT " '%d' " WSREP_SST_OPT_VERSION
+                 " '%s' "
+                 " %s '%s' ",
+                 method, addr_in, mysql_real_data_home,
+                 mysql_home_ptr ? mysql_home_ptr : "",
+                 opt_plugin_dir_ptr ? opt_plugin_dir_ptr : "",
+                 wsrep_defaults_file, wsrep_defaults_group_suffix,
+                 (int)getpid(), MYSQL_SERVER_VERSION MYSQL_SERVER_SUFFIX_DEF,
+                 binlog_opt, binlog_opt_val);
   my_free(binlog_opt_val);
 
   if (ret < 0 || ret >= cmd_len) {
@@ -1415,14 +1418,16 @@ static int sst_donate_other(const char *method, const char *addr,
       cmd_str(), cmd_len,
       "wsrep_sst_%s " WSREP_SST_OPT_ROLE " 'donor' " WSREP_SST_OPT_ADDR
       " '%s' " WSREP_SST_OPT_SOCKET " '%s' " WSREP_SST_OPT_DATA
-      " '%s' " WSREP_SST_OPT_BASEDIR " '%s' " WSREP_SST_OPT_CONF
-      " '%s' " WSREP_SST_OPT_CONF_SUFFIX " '%s' " WSREP_SST_OPT_VERSION
+      " '%s' " WSREP_SST_OPT_BASEDIR " '%s' " WSREP_SST_OPT_PLUGINDIR
+      " '%s' " WSREP_SST_OPT_CONF " '%s' " WSREP_SST_OPT_CONF_SUFFIX
+      " '%s' " WSREP_SST_OPT_VERSION
       " '%s' "
       " %s '%s' " WSREP_SST_OPT_GTID
       " '%s:%lld' "
       "%s",
       method, addr, mysqld_unix_port, mysql_real_data_home,
-      mysql_home_ptr ? mysql_home_ptr : "", wsrep_defaults_file,
+      mysql_home_ptr ? mysql_home_ptr : "",
+      opt_plugin_dir_ptr ? opt_plugin_dir_ptr : "", wsrep_defaults_file,
       wsrep_defaults_group_suffix, MYSQL_SERVER_VERSION MYSQL_SERVER_SUFFIX_DEF,
       binlog_opt, binlog_opt_val, uuid_oss.str().c_str(), gtid.seqno().get(),
       bypass ? " " WSREP_SST_OPT_BYPASS : "");


### PR DESCRIPTION
 PXC-3989: Support for Keyring Components in PXC
 
https://jira.percona.com/browse/PXC-3989

**Design**
    
    1. Donor and Joiner nodes have their respective keyring components
       configured. It is the requirement for plugins as well. i.e, the
       manifest and component’s cnf file must be in-place prior to startup of
       joiner node.
    
    2. Joiner asks donor for SST.
    
    3. Donor spawns SST script and the script checks if keyring component is
       active. To get this information, the SST script will now connect to
       dono server as 'mysql.pxc.sst.user' user and queries the server's
       performance_schema.keyring_component_status table.
    
    4. Donor creates the backup using transition key, and send the
       transition key to joiner through the sst-info file.
    
    5. Transition-key encrypted backup is transferred to the Joiner
    
    6. Upon receiving the backup, the joiner node sees that transition-key
       is used and prepares the backup using the transition key received
       from the donor server.
    
    7. Joiner copies its keyring_component config file into the received backup
        directory (this is needed by PXB).
    
    8. Joiner copy-back the backup and creates a new master key and
       reencrypts the tablespace headers with the new master key.
    
    9. Once the SST is completed, the server reloads the keyring component
       to fetch the new Master Key generated by PXB.
    
       This is necessary because the server initializes keyring component
       before SST, and would have already cached the key before SST takes
       place, so the server will need to reload the component/invalidate its
       cache to learn about new MK generated by xtrabackup copy-back.

**Testing Done**

Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/84/

Result: 

Failing tests:
1. sys_vars.wsrep_incoming_addresses_basic - Fails due to port collision
2. sys_vars.wsrep_min_log_verbosity - Fails due to port collision
3. galera_3nodes_nbo.galera_nbo_master_non_prim_failure - sporadic failure - reported https://jira.percona.com/browse/PXC-4125
4. galera_3nodes.galera_parallel_autoinc_manytrx2 - sporadic failure