### PR TITLE
PXC-3211 REPLACES GALERA VERSION NUMBERS WITH ENUM VALUES

### DIFF
--- a/include/service_wsrep.h
+++ b/include/service_wsrep.h
@@ -27,12 +27,16 @@ enum Wsrep_service_key_type {
   WSREP_SERVICE_KEY_EXCLUSIVE
 };
 
+namespace wsrep_version {
+enum wsrep_version : long { UNSPECIFIED = 0, V1 = 1, V2 = 2, V3 = 3, V4 = 4 };
+}
+typedef wsrep_version::wsrep_version WsrepVersion;
+
 extern ulong wsrep_debug;
 extern bool wsrep_log_conflicts;
 extern bool wsrep_certify_nonPK;
 extern bool wsrep_load_data_splitting;
 extern bool wsrep_recovery;
-extern long wsrep_protocol_version;
 
 /* Must match to definition in sql/mysqld.h */
 typedef int64 query_id_t;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1732,7 +1732,8 @@ static bool block_write_while_in_rolling_upgrade(THD *thd) {
   bool block = false;
   LEX *lex = thd->lex;
   if (sql_command_flags[lex->sql_command] & CF_CHANGES_DATA) {
-    bool multi_version_cluster = wsrep_protocol_version < 4;
+    bool multi_version_cluster =
+        wsrep_protocol_version < WsrepVersion::V4;
     if (multi_version_cluster ||
         DBUG_EVALUATE_IF("simulate_wsrep_multiple_major_versions", true,
                          false)) {

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -25,6 +25,7 @@
 #include "wsrep/provider.hpp"
 #include "wsrep/streaming_context.hpp"
 #include "wsrep_api.h"
+#include "service_wsrep.h"
 #include "wsrep_server_state.h"
 #include "mysql/components/services/log_builtins.h"  // LogEvent
 #include "sql/system_variables.h"  // struct System_variables. Needed by WSREP_ON
@@ -76,7 +77,7 @@ extern ulong wsrep_max_ws_size;
 extern ulong wsrep_max_ws_rows;
 extern const char *wsrep_notify_cmd;
 extern bool wsrep_certify_nonPK;
-extern long wsrep_protocol_version;
+extern WsrepVersion wsrep_protocol_version;
 extern ulong wsrep_forced_binlog_format;
 extern bool wsrep_desync;
 extern ulong wsrep_reject_queries;

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -192,16 +192,17 @@ void Wsrep_server_service::log_view(
     global_system_variables.auto_increment_offset = view.own_index() + 1;
     global_system_variables.auto_increment_increment = view.members().size();
   }
-  wsrep_protocol_version = view.protocol_version();
+  wsrep_protocol_version = static_cast<WsrepVersion>(view.protocol_version());
   bool not_shutdown = (pxc_maint_mode != PXC_MAINT_MODE_SHUTDOWN);
-  bool multi_version_cluster = wsrep_protocol_version < 4;
+  bool multi_version_cluster = wsrep_protocol_version < WsrepVersion::V4;
   if (not_shutdown &&
       ((multi_version_cluster &&
         (pxc_strict_mode > PXC_STRICT_MODE_PERMISSIVE)) ||
        DBUG_EVALUATE_IF("simulate_wsrep_multiple_major_versions", true,
                         false))) {
     std::ostringstream os;
-    os << "Detected Protocol version: " << wsrep_protocol_version
+    os << "Detected Protocol version: "
+       << wsrep_protocol_version
        << " Changing pxc_maint_mode to "
           "MAINTENANCE.";
     WSREP_INFO("%s", os.str().c_str());
@@ -212,7 +213,8 @@ void Wsrep_server_service::log_view(
     if (wsrep_pxc_maint_mode_forced &&
         pxc_maint_mode != PXC_MAINT_MODE_SHUTDOWN) {
       std::ostringstream os;
-      os << "Detected Protocol version: " << wsrep_protocol_version
+      os << "Detected Protocol version: "
+         << wsrep_protocol_version
          << " Changing pxc_maint_mode to "
             "DISABLED.";
       WSREP_INFO("%s", os.str().c_str());

--- a/sql/wsrep_server_state.cc
+++ b/sql/wsrep_server_state.cc
@@ -50,14 +50,13 @@ void Wsrep_server_state::init_once(const std::string &name,
                                    const std::string &address,
                                    const std::string &working_dir,
                                    const wsrep::gtid &initial_position,
-                                   int max_protocol_version) {
+                                   WsrepVersion max_protocol_version) {
   if (m_instance == 0) {
     mysql_mutex_init(key_LOCK_wsrep_server_state, &LOCK_wsrep_server_state,
                      MY_MUTEX_INIT_FAST);
     mysql_cond_init(key_COND_wsrep_server_state, &COND_wsrep_server_state);
-    m_instance =
-        new Wsrep_server_state(name, incoming_address, address, working_dir,
-                               initial_position, max_protocol_version);
+    m_instance = new Wsrep_server_state(
+        name, incoming_address, address, working_dir, initial_position, max_protocol_version);
   }
 }
 

--- a/sql/wsrep_server_state.h
+++ b/sql/wsrep_server_state.h
@@ -32,7 +32,7 @@ class Wsrep_server_state : public wsrep::server_state {
                         const std::string &address,
                         const std::string &working_dir,
                         const wsrep::gtid &initial_position,
-                        int max_protocol_version);
+                        WsrepVersion max_protocol_version);
   static void destroy();
   static Wsrep_server_state &instance() { return *m_instance; }
 

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -783,7 +783,7 @@ bool wsrep_trx_fragment_size_check(sys_var *, THD *thd, set_var *var) {
     return true;
   }
 
-  if (wsrep_protocol_version < 4 && new_trx_fragment_size > 0) {
+  if (wsrep_protocol_version < WsrepVersion::V4 && new_trx_fragment_size > 0) {
     push_warning(thd, Sql_condition::SL_WARNING, ER_WRONG_VALUE_FOR_VAR,
                  "Cannot set 'wsrep_trx_fragment_size' to a value other than "
                  "0 because cluster is not yet operating in Galera 4 mode.");

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8698,7 +8698,7 @@ int wsrep_innobase_mysql_sort(int mysql_type, uint charset_number,
       ut_a(str_length <= tmp_length);
       memcpy(tmp_str, str, str_length);
 
-      if (wsrep_protocol_version < 3) {
+      if (wsrep_protocol_version < WsrepVersion::V3) {
         tmp_length = charset->coll->strnxfrm(
             charset, str, str_length, str_length, tmp_str, tmp_length, 0);
         assert(tmp_length <= str_length);
@@ -8836,7 +8836,7 @@ uint wsrep_store_key_val_for_row(THD *thd, TABLE *table, uint keynr, char *buff,
           wsrep_innobase_mysql_sort(mysql_type, cs->number, sorted, true_len,
                                     REC_VERSION_56_MAX_INDEX_COL_LEN);
 
-      if (wsrep_protocol_version > 1) {
+      if (wsrep_protocol_version > WsrepVersion::V1) {
         /* Note that we always reserve the maximum possible
         length of the true VARCHAR in the key value, though
         only len first bytes after the 2 length bytes contain
@@ -8916,7 +8916,7 @@ uint wsrep_store_key_val_for_row(THD *thd, TABLE *table, uint keynr, char *buff,
 
       /* Note that we always reserve the maximum possible
       length of the BLOB prefix in the key value. */
-      ut_a(wsrep_protocol_version > 1);
+      ut_a(wsrep_protocol_version > WsrepVersion::V1);
       if (true_len > buff_space) {
         ib::warn() << "WSREP: key truncated: %s " << wsrep_thd_query(thd);
         true_len = buff_space;
@@ -11444,7 +11444,7 @@ func_exit:
   if (!err && wsrep_do_replication(m_user_thd)) {
     DBUG_PRINT("wsrep", ("update row key"));
     if (wsrep_append_keys(m_user_thd,
-                          wsrep_protocol_version >= 4
+                          wsrep_protocol_version >= WsrepVersion::V4
                               ? WSREP_SERVICE_KEY_UPDATE
                               : WSREP_SERVICE_KEY_EXCLUSIVE,
                           old_row, new_row)) {
@@ -12968,7 +12968,7 @@ extern dberr_t wsrep_append_foreign_key(
   key[0] = (char)i;
 
   rcode = wsrep_rec_get_foreign_key(&key[1], &len, rec, index, idx,
-                                    wsrep_protocol_version > 1);
+                                    wsrep_protocol_version > WsrepVersion::V1);
   if (rcode != DB_SUCCESS) {
     WSREP_ERROR(
         "FK key set failed: %d (%d %s), index: %s %s, %s", rcode, referenced,
@@ -12979,7 +12979,7 @@ extern dberr_t wsrep_append_foreign_key(
     return DB_ERROR;
   }
   strncpy(cache_key,
-          (wsrep_protocol_version > 1)
+          (wsrep_protocol_version > WsrepVersion::V1)
               ? ((referenced) ? foreign->referenced_table->name.m_name
                               : foreign->foreign_table->name.m_name)
               : foreign->foreign_table->name.m_name,
@@ -13114,7 +13114,7 @@ int ha_innobase::wsrep_append_keys(
     DBUG_RETURN(0);
   }
 
-  if (wsrep_protocol_version == 0) {
+  if (wsrep_protocol_version == WsrepVersion::UNSPECIFIED) {
     uint len;
     char keyval[WSREP_MAX_SUPPORTED_KEY_LENGTH + 1] = {'\0'};
     char *key = &keyval[0];

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1651,7 +1651,7 @@ dberr_t row_ins_check_foreign_constraint(
 #ifdef WITH_WSREP
           err = wsrep_append_foreign_key(
               thr_get_trx(thr), foreign, rec, check_index, check_ref,
-              (upd_node != NULL && wsrep_protocol_version < 4)
+              (upd_node != NULL && wsrep_protocol_version < WsrepVersion::V4)
                   ? WSREP_SERVICE_KEY_SHARED
                   : WSREP_SERVICE_KEY_REFERENCE);
 #endif /* WITH_WSREP */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3211

The checks used in PXC source code to to write version specific code were using hard coded version numbers in numerous places. Such hard coded version numbers are replaced with a typesafe and meaningful enum variable to improve the quality of the source code.