### PR TITLE
PXC-4116: PXC stalls with parallel replication workers

### DIFF
--- a/mysql-test/suite/galera/galera_1node.cnf
+++ b/mysql-test/suite/galera/galera_1node.cnf
@@ -1,0 +1,46 @@
+# Use default setting for mysqld processes
+!include include/default_mysqld.cnf
+
+[mysqld]
+#default-storage-engine=InnoDB
+#mysqlx=0
+
+ssl-ca=@ENV.MYSQLTEST_VARDIR/std_data/cacert.pem
+ssl-cert=@ENV.MYSQLTEST_VARDIR/std_data/server-cert.pem
+ssl-key=@ENV.MYSQLTEST_VARDIR/std_data/server-key.pem
+
+[mysqld.1]
+#log-bin=mysqld-bin
+#binlog-format=row
+
+wsrep_provider=@ENV.WSREP_PROVIDER
+wsrep_cluster_address='gcomm://'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;gmcast.peer_timeout=PT10S;evs.suspect_timeout=PT12S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S'
+
+# enforce read-committed characteristics across the cluster
+wsrep_causal_reads = ON
+wsrep_sync_wait = 15
+
+wsrep_node_address=127.0.0.1
+wsrep_sst_receive_address=127.0.0.1:@mysqld.1.#sst_port
+wsrep_node_incoming_address=127.0.0.1:@mysqld.1.port
+
+# Required for Galera
+innodb_autoinc_lock_mode=2
+
+innodb_flush_log_at_trx_commit=2
+wsrep_node_name=node1
+
+early_plugin_load=keyring_file.so
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.1/keyring.1
+
+[sst]
+encrypt=4
+
+[ENV]
+NODE_MYPORT_1= @mysqld.1.port
+NODE_MYSOCK_1= @mysqld.1.socket
+
+NODE_GALERAPORT_1= @mysqld.1.#galera_port
+
+NODE_SSTPORT_1= @mysqld.1.#sst_port

--- a/mysql-test/suite/galera/r/galera_parallel_slave.result
+++ b/mysql-test/suite/galera/r/galera_parallel_slave.result
@@ -1,0 +1,54 @@
+START REPLICA USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+CREATE TABLE t1(c1 INT PRIMARY KEY, c2 INT, INDEX(c2)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(1, NULL),(2, 2), (3, NULL), (4, 4), (5, NULL), (6, 6);
+CREATE TABLE t2(c1 INT PRIMARY KEY, c2 INT, INDEX(c2)) ENGINE = InnoDB;
+INSERT INTO t2 VALUES(1, NULL),(2, 2), (3, NULL), (4, 4), (5, NULL), (6, 6);
+STOP REPLICA;
+SET GLOBAL replica_transaction_retries = 3;
+SET GLOBAL replica_parallel_workers = 5;
+INSERT INTO t1 VALUES(10, NULL);
+# Adding debug point 'd,set_commit_parent_100' to @@GLOBAL.debug
+INSERT INTO t2 VALUES(11, NULL);
+INSERT INTO t1 VALUES(11, NULL);
+INSERT INTO t2 VALUES(12, NULL);
+INSERT INTO t1 VALUES(12, NULL);
+INSERT INTO t2 VALUES(13, NULL);
+INSERT INTO t1 VALUES(13, NULL);
+FLUSH TABLES t2 WITH READ LOCK;
+START REPLICA USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+UNLOCK TABLES;
+SELECT * FROM t1;
+c1	c2
+1	NULL
+3	NULL
+5	NULL
+10	NULL
+11	NULL
+12	NULL
+13	NULL
+2	2
+4	4
+6	6
+SELECT * FROM t2;
+c1	c2
+1	NULL
+3	NULL
+5	NULL
+11	NULL
+12	NULL
+13	NULL
+2	2
+4	4
+6	6
+#
+# Deinitialize
+#
+# Removing debug point 'd,set_commit_parent_100' from @@GLOBAL.debug
+DROP TABLE t1;
+DROP TABLE t2;
+STOP REPLICA;
+RESET REPLICA ALL;

--- a/mysql-test/suite/galera/t/galera_parallel_slave.cnf
+++ b/mysql-test/suite/galera/t/galera_parallel_slave.cnf
@@ -1,0 +1,11 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+# default is 0 for MTR, but that can cause shutdown crashes with slave threads active
+pxc_maint_transition_period=10
+
+gtid-mode=ON
+log-bin=mysqld-bin
+log-slave-updates
+enforce-gtid-consistency
+binlog-format=ROW

--- a/mysql-test/suite/galera/t/galera_parallel_slave.test
+++ b/mysql-test/suite/galera/t/galera_parallel_slave.test
@@ -1,0 +1,85 @@
+--source include/have_debug.inc
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster_master_slave.inc
+
+--connection node_2
+--source include/only_mts_replica_parallel_workers.inc
+
+--disable_query_log
+--eval CHANGE REPLICATION SOURCE TO SOURCE_HOST='127.0.0.1', SOURCE_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START REPLICA USER='root';
+
+--connection node_1
+# Initialize
+CREATE TABLE t1(c1 INT PRIMARY KEY, c2 INT, INDEX(c2)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(1, NULL),(2, 2), (3, NULL), (4, 4), (5, NULL), (6, 6);
+
+CREATE TABLE t2(c1 INT PRIMARY KEY, c2 INT, INDEX(c2)) ENGINE = InnoDB;
+INSERT INTO t2 VALUES(1, NULL),(2, 2), (3, NULL), (4, 4), (5, NULL), (6, 6);
+
+--connection node_2
+--sleep 1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+
+STOP REPLICA;
+
+SET GLOBAL replica_transaction_retries = 3;
+SET GLOBAL replica_parallel_workers = 5;
+
+--connection node_1
+
+INSERT INTO t1 VALUES(10, NULL);
+
+--let $debug_point= d,set_commit_parent_100
+--source include/add_debug_point.inc
+INSERT INTO t2 VALUES(11, NULL);
+INSERT INTO t1 VALUES(11, NULL);
+INSERT INTO t2 VALUES(12, NULL);
+INSERT INTO t1 VALUES(12, NULL);
+INSERT INTO t2 VALUES(13, NULL);
+INSERT INTO t1 VALUES(13, NULL);
+
+--connection node_2
+# It blocks above INSERT statement
+FLUSH TABLES t2 WITH READ LOCK;
+
+--connection node_2a
+START REPLICA USER='root';
+
+# This sleep is not ideal, but information_schema.processlist selects fail at this point with lock wait timeout
+--sleep 10
+#--let $wait_condition= SELECT count(*) > 0 FROM information_schema.processlist WHERE INFO LIKE "%dependent transaction to commit%"
+#--source include/wait_condition.inc
+
+--connection node_2
+UNLOCK TABLES;
+
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1;
+--source include/wait_condition.inc
+
+SELECT * FROM t1;
+SELECT * FROM t2;
+
+--echo #
+--echo # Deinitialize
+--echo #
+--connection node_1
+--let $debug_point= d,set_commit_parent_100
+--source include/remove_debug_point.inc
+DROP TABLE t1;
+DROP TABLE t2;
+
+--sleep 1
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+STOP REPLICA;
+RESET REPLICA ALL;

--- a/sql/rpl_replica_commit_order_manager.cc
+++ b/sql/rpl_replica_commit_order_manager.cc
@@ -504,6 +504,13 @@ bool has_commit_order_manager(THD *thd) {
          thd->rli_slave->get_commit_order_manager() != nullptr;
 }
 
+#ifdef WITH_WSREP
+Commit_order_manager* get_commit_order_manager(THD *thd) {
+  return !is_mts_worker(thd) ? nullptr :
+    thd->rli_slave->get_commit_order_manager();
+}
+#endif /* WITH_WSREP */
+
 bool Commit_order_manager::wait_for_its_turn_before_flush_stage(THD *thd) {
   switch (thd->lex->sql_command) {
     case SQLCOM_ALTER_TABLE:

--- a/sql/rpl_replica_commit_order_manager.h
+++ b/sql/rpl_replica_commit_order_manager.h
@@ -218,7 +218,10 @@ class Commit_order_manager {
   */
   void register_trx(Slave_worker *worker);
 
+#ifndef WITH_WSREP
  private:
+#endif /* WITH_WSREP */
+
   /**
     Determines if the worker passed as a parameter must wait on the MDL graph
     for other workers to commit and, if it must, will wait for it's turn to
@@ -229,6 +232,10 @@ class Commit_order_manager {
     @return false if the worker is ready to commit, true if not.
    */
   bool wait_on_graph(Slave_worker *worker);
+
+#ifdef WITH_WSREP
+ private:
+#endif /* WITH_WSREP */
   /**
     Wait for its turn to commit or unregister.
 
@@ -511,5 +518,9 @@ class Commit_order_lock_graph : public MDL_wait_for_subgraph {
   @retval true   Commit_order_manager object is initialized
 */
 bool has_commit_order_manager(THD *thd);
+
+#ifdef WITH_WSREP
+Commit_order_manager* get_commit_order_manager(THD *thd);
+#endif /* WITH_WSREP */
 
 #endif /*RPL_REPLICA_COMMIT_ORDER_MANAGER*/

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4431,26 +4431,6 @@ static bool check_not_null_not_empty(sys_var *self, THD *thd, set_var *var) {
   res = var->value ? var->value->val_str(&str) : nullptr;
   if (res && res->is_empty()) return true;
 
-#ifdef WITH_WSREP
-  /* If PXC node is acting as async slave and this slave is trying to enforce
-  order based on master replication then it could interfere with galera
-  commit monitor semantics. Disabling it for now.
-  This can be re-enabled but we just need enough testing for it */
-  if (WSREP(thd) && var->save_result.ulonglong_value == 1) {
-    WSREP_ERROR(
-        "Percona-XtraDB-Cluster prohibits enabling"
-        " slave_preserve_commit_order as it conflicts with galera"
-        " multi-master commit order semantics");
-    char message[1024];
-    sprintf(message,
-            "Percona-XtraDB-Cluster prohibits enabling"
-            " slave_preserve_commit_order as it conflicts with galera"
-            " multi-master commit order semantics");
-    my_message(ER_UNKNOWN_ERROR, message, MYF(0));
-    return true;
-  }
-#endif /* WITH_WSREP */
-
   return false;
 }
 


### PR DESCRIPTION
Issue: MySQL parallel replication workers and galera both order commits in a well defined order, and use locks/signals to enforce it, but they end up generating different sequences.

Galera assigns monotonic sequence numbers in wsrep_before_prepare, at the prepare stage of the commit, and waits for earlier commits in wsrep_before_commit, before starting the commit.

MySQL uses the commit order in the relay log, and waits for earlier commits later before flushing. Up to that point, workers process commits in parallel.

If the parallel workers reach wsrep_before_prepare in a different order than the order in the relay log, wsrep assigns sequence numbers in a different order than MySQL, and the two logics will end up in a deadlock:

Commit A has the higher galera seqno and waits for commit B in the galera code, but Commit B has the higher MySQL seqno and waits for commit A in teh server code.

Additionally, one seqno for Galera means one commit, while for MySQL it can mean multiple commits.

Fix: we disable parallel execution of commits before calling wsrep_before_prepare. Only the worker that is next in line to flush the commit can start preparing the commit.

This strict exclusion is required. A more relaxed implementation, wihch only requires workers to enter wsrep_before_prepare in the same order as their seqnos doesn't work because of the issue described at the end:

As we can process multiple commits with the same server seqno, we can't let other threads proceed until one worker flushed all of its commits. If we allow that, we could assign galera seqno N+1 to the next in line worker, and after that galera seqno N+2 to the second commit of the current worker, resulting in the same deadlock.