### PR TITLE
PXC-4120: Error log gets spammed with wsrep_commit_empty() when wsrep-debug is enabled

### DIFF
--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -547,7 +547,6 @@ static inline enum wsrep::provider::status wsrep_current_error_status(
 */
 static inline void wsrep_commit_empty(THD *thd, bool all) {
   DBUG_ENTER("wsrep_commit_empty");
-  WSREP_DEBUG("wsrep_commit_empty(%u)", thd->thread_id());
   if (wsrep_is_real(thd, all) && wsrep_thd_is_local(thd) &&
       thd->wsrep_trx().active() &&
       thd->wsrep_trx().state() != wsrep::transaction::s_committed) {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4120

Problem:
In PXC, the error log gets spammed with messages like

    [WSREP] wsrep_commit_empty()

when wsrep-debug is enabled since the message is written to the log everytime a query is executed.

Solution:
Don't write the above message to error log when wsrep-debug is enabled.