### PR TITLE
PXC-4050: 8.0.31 merge - Fix test failures

### DIFF
--- a/mysql-test/suite/galera/t/pxc_component_keyring_file.test
+++ b/mysql-test/suite/galera/t/pxc_component_keyring_file.test
@@ -8,6 +8,9 @@
 #
 # PXC-3989: Support for Keyring Components in PXC
 
+--source include/have_component_keyring_file.inc
+--source include/big_test.inc
+--source include/not_parallel.inc
 --source include/galera_cluster.inc
 
 # Create a helper inc file for test validation


### PR DESCRIPTION
Fix the test failures failing due component initialization error

`pxc_component_keyring_file.test` uses global manifest file during its execution and this can affect other tests if run in parallel. This patch makes the test to not run in parallel.

Before patch:

`./mtr pxc_component_keyring_file galera.pxc_log_slave_updates --parallel=2`

```
==============================================================================
                  TEST NAME                   WORKER RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[ 25%] galera.pxc_log_slave_updates 'enc_off'   w2  [ pass ]     67
worker[2] mysql-test-run: WARNING: Process [mysqld.1 - pid: 51596, winpid: 51596, exit: 256] died after mysql-test-run waited 0.1 seconds for /home/venki/work/pxc/review/80/percona-xtradb-cluster/bld/mysql-test/var/2/run/mysqld.1.pid to be created.
[ 50%] galera.pxc_log_slave_updates 'enc_on'    w2  [ fail ]
        Test ended at 2023-02-23 12:58:27

Server log is:
2023-02-23T07:28:21.301333Z 0 [Note] [MY-013667] [Server] Error-log destination "stderr" is not a file. Can not restore error log messages from previous run.
2023-02-23T07:28:21.296959Z 0 [Warning] [MY-013711] [Server] Manifest file '/home/venki/work/pxc/review/80/percona-xtradb-cluster/bld/runtime_output_directory/mysqld.my' is not read-only. For better security, please make sure that the file is read-only.
2023-02-23T07:28:21.297503Z 0 [ERROR] [MY-048032] [Server] Component component_keyring_file reported: 'Keyring configuration doesn't exists: /home/venki/work/pxc/review/80/percona-xtradb-cluster/bld/mysql-test/var/2/mysqld.1/data//component_keyring_file.cnf'
2023-02-23T07:28:21.297510Z 0 [ERROR] [MY-013714] [Server] Component component_keyring_file reported: 'The component is not initialized properly. Make sure that configuration is proper and use ALTER INSTANCE RELOAD KEYRING to reinitialize the component.'

```

After patch
```
==============================================================================
                  TEST NAME                   WORKER RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[ 25%] galera.pxc_log_slave_updates 'enc_off'   w1  [ pass ]     69
[ 50%] galera.pxc_log_slave_updates 'enc_on'    w2  [ pass ]     68
[ 75%] galera.pxc_component_keyring_file 'enc_off' w2  [ pass ]  238338
[100%] shutdown_report                          w0  [ pass ]       
------------------------------------------------------------------------------

```