### PR TITLE
PXC-4137: WSREP applier threads fail to modify read only schemas

### DIFF
--- a/libbinlogevents/include/binlog_event.h
+++ b/libbinlogevents/include/binlog_event.h
@@ -116,6 +116,7 @@
   packet (i.e. a query) sent from client to master;
   First, an auxiliary log_event status vars estimation:
 */
+#ifdef WITH_WSREP
 #define MAX_SIZE_LOG_EVENT_STATUS                                             \
   (1U + 4 /* type, flags2 */ + 1U + 8 /* type, sql_mode */ + 1U + 1 +         \
    255 /* type, length, catalog */ + 1U + 4 /* type, auto_increment */ + 1U + \
@@ -129,10 +130,27 @@
    1 + 255 /* host_len, host */ + 1U + 1 /* type, explicit_def..ts*/ + 1U +   \
    8 /* type, xid of DDL */ + 1U +                                            \
    2 /* type, default_collation_for_utf8mb4_number */ + 1U +                  \
-   1 /* type, sql_require_primary_key */ + 1U +                                     \
+   1 /* type, sql_require_primary_key */ + 1U +                               \
    1 /* type, default_table_encryption */ + 1U +                              \
-   1 /* type, binlog_ddl_skip_rewrite */)
-
+   1 /* type, binlog_ddl_skip_rewrite */ + 1U +                               \
+   1 /* type, wsrep_applier_skip_readonly_checks */)
+#else
+#define MAX_SIZE_LOG_EVENT_STATUS                                             \
+  (1U + 4 /* type, flags2 */ + 1U + 8 /* type, sql_mode */ + 1U + 1 +         \
+   255 /* type, length, catalog */ + 1U + 4 /* type, auto_increment */ + 1U + \
+   6 /* type, charset */ + 1U + 1 + 255 /* type, length, time_zone */ + 1U +  \
+   2 /* type, lc_time_names_number */ + 1U +                                  \
+   2 /* type, charset_database_number */ + 1U +                               \
+   8 /* type, table_map_for_update */ + 1U +                                  \
+   4 /* type, master_data_written */ + /* type, db_1, db_2, ... */            \
+   1U + (MAX_DBS_IN_EVENT_MTS * (1 + NAME_LEN)) + 3U +                        \
+   /* type, microseconds */ +1U + 32 * 3 + /* type, user_len, user */         \
+   1 + 255 /* host_len, host */ + 1U + 1 /* type, explicit_def..ts*/ + 1U +   \
+   8 /* type, xid of DDL */ + 1U +                                            \
+   2 /* type, default_collation_for_utf8mb4_number */ + 1U +                  \
+   1 /* type, sql_require_primary_key */ + 1U +                               \
+   1 /* type, default_table_encryption */)
+#endif /* WITH_WSREP */
 /**
    Uninitialized timestamp value (for either last committed or sequence number).
    Often carries meaning of the minimum value in the logical timestamp domain.

--- a/libbinlogevents/include/statement_events.h
+++ b/libbinlogevents/include/statement_events.h
@@ -670,8 +670,10 @@ class Query_event : public Binary_log_event {
   uint8_t sql_require_primary_key;
 
   uint8_t default_table_encryption;
+#ifdef WITH_WSREP
   uint8_t ddl_skip_rewrite;
   uint8_t wsrep_applier_skip_readonly_checks;
+#endif /* WITH_WSREP */
 
   /**
     The constructor will be used while creating a Query_event, to be

--- a/libbinlogevents/include/statement_events.h
+++ b/libbinlogevents/include/statement_events.h
@@ -552,7 +552,7 @@ class Query_event : public Binary_log_event {
     /*
       Replicate Q_WSREP_SKIP_READONLY_CHECKS.
     */
-    Q_WSREP_SKIP_READONLY_CHECKS
+    Q_WSREP_SKIP_READONLY_CHECKS = 128
 #endif /* WITH_WSREP */
   };
   const char *query;

--- a/libbinlogevents/include/statement_events.h
+++ b/libbinlogevents/include/statement_events.h
@@ -426,12 +426,20 @@ const uint64_t INVALID_XID = 0xffffffffffffffffULL;
     <td>2 byte integer</td>
     <td>Value of the config variable default_table_encryption</td>
   </tr>
+#ifdef WITH_WSREP
   <tr>
     <td>ddl_skip_rewrite</td>
     <td>Q_DDL_SKIP_REWRITE</td>
     <td>2 byte integer</td>
     <td>Value of the config variable ddl_skip_rewrite</td>
   </tr>
+  <tr>
+    <td>wsrep_applier_skip_readonly_checks</td>
+    <td>Q_WSREP_SKIP_READONLY_CHECKS</td>
+    <td>2 byte integer</td>
+    <td> This will be set only for replication applier threads </td>
+  </tr>
+#endif
   </table>
 
   @subsection Query_event_notes_on_previous_versions Notes on Previous Versions
@@ -534,12 +542,18 @@ class Query_event : public Binary_log_event {
     /*
       Replicate default_table_encryption.
     */
-    Q_DEFAULT_TABLE_ENCRYPTION,
-
+    Q_DEFAULT_TABLE_ENCRYPTION
+#ifdef WITH_WSREP
+    ,
     /*
       Replicate ddl_skip_rewrite.
     */
-    Q_DDL_SKIP_REWRITE
+    Q_DDL_SKIP_REWRITE,
+    /*
+      Replicate Q_WSREP_SKIP_READONLY_CHECKS.
+    */
+    Q_WSREP_SKIP_READONLY_CHECKS
+#endif /* WITH_WSREP */
   };
   const char *query;
   const char *db;
@@ -657,6 +671,7 @@ class Query_event : public Binary_log_event {
 
   uint8_t default_table_encryption;
   uint8_t ddl_skip_rewrite;
+  uint8_t wsrep_applier_skip_readonly_checks;
 
   /**
     The constructor will be used while creating a Query_event, to be

--- a/libbinlogevents/src/statement_events.cpp
+++ b/libbinlogevents/src/statement_events.cpp
@@ -84,8 +84,14 @@ Query_event::Query_event(
       ddl_xid(INVALID_XID),
       default_collation_for_utf8mb4_number(0),
       sql_require_primary_key(0xff),
-      default_table_encryption(0xff),
-      ddl_skip_rewrite(0) {}
+      default_table_encryption(0xff)
+#ifdef WITH_WSREP
+      ,
+      ddl_skip_rewrite(0),
+      wsrep_applier_skip_readonly_checks(0)
+#endif /* WITH_WSREP */
+{
+}
 
 /**
   Utility function for the Query_event constructor.
@@ -136,8 +142,13 @@ Query_event::Query_event(const char *buf, const Format_description_event *fde,
       ddl_xid(INVALID_XID),
       default_collation_for_utf8mb4_number(0),
       sql_require_primary_key(0xff),
-      default_table_encryption(0xff),
-      ddl_skip_rewrite(0) {
+      default_table_encryption(0xff)
+#ifdef WITH_WSREP
+      ,
+      ddl_skip_rewrite(0),
+      wsrep_applier_skip_readonly_checks(0)
+#endif /* WITH_WSREP */
+{
   BAPI_ENTER("Query_event::Query_event(const char*, ...)");
   READER_TRY_INITIALIZATION;
   READER_ASSERT_POSITION(fde->common_header_len);
@@ -331,9 +342,14 @@ Query_event::Query_event(const char *buf, const Format_description_event *fde,
       case Q_DEFAULT_TABLE_ENCRYPTION:
         READER_TRY_SET(default_table_encryption, read<uint8_t>);
         break;
+#ifdef WITH_WSREP
       case Q_DDL_SKIP_REWRITE:
         READER_TRY_SET(ddl_skip_rewrite, read<uint8_t>);
         break;
+      case Q_WSREP_SKIP_READONLY_CHECKS:
+        READER_TRY_SET(wsrep_applier_skip_readonly_checks, read<uint8_t>);
+        break;
+#endif /* WITH_WSREP */
       default:
         /* That's why you must write status vars in growing order of code */
         READER_CALL(go_to, end_variable_part);  // Break loop

--- a/mysql-test/suite/galera/r/galera_as_slave_read_only_schema.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_read_only_schema.result
@@ -1,0 +1,38 @@
+# connection node_2
+# connection node_2
+START REPLICA USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+# connection node_1
+CREATE DATABASE testdb;
+# connection node_2
+# connection node_3
+# connection node_2
+ALTER SCHEMA testdb READ ONLY = 1;
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+ERROR HY000: Schema 'testdb' is in read only mode.
+# connection node_3
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+ERROR HY000: Schema 'testdb' is in read only mode.
+# connection node_1
+use testdb;
+CREATE TABLE t1(i int PRIMARY KEY);
+INSERT INTO t1 VALUES(1),(2),(3),(4);
+UPDATE t1 SET i=i+10;
+DELETE FROM t1 WHERE i>11;
+# connection node_2
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+ERROR HY000: Schema 'testdb' is in read only mode.
+# connection node_3
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+ERROR HY000: Schema 'testdb' is in read only mode.
+ALTER SCHEMA testdb READ ONLY = 0;
+DROP DATABASE testdb;
+# connection node_2
+STOP REPLICA;
+RESET REPLICA ALL;
+CALL mtr.add_suppression("Schema 'testdb' is in read only mode.");
+CALL mtr.add_suppression("Query apply failed");
+CALL mtr.add_suppression("Schema 'testdb' is in read only mode.");
+CALL mtr.add_suppression("Query apply failed");
+RESET MASTER;

--- a/mysql-test/suite/galera/r/pxc_read_only_schema.result
+++ b/mysql-test/suite/galera/r/pxc_read_only_schema.result
@@ -1,0 +1,612 @@
+CREATE SCHEMA S;
+CREATE TABLE S.t1(i INT, j INT, INDEX i1(i));
+ALTER SCHEMA S read only=1;
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */ /* READ ONLY = 1 */
+ALTER SCHEMA S read only=0;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# Invalid option in CREATE SCHEMA.
+#--------------------------------------------------------------------
+CREATE SCHEMA S read only=0;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'read only=0' at line 1
+#--------------------------------------------------------------------
+# ALTER privilege needed to change read only.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+CREATE USER s_usr;
+ALTER SCHEMA S read only=1;
+ERROR 42000: Access denied for user 's_usr'@'%' to database 'S'
+GRANT ALTER ON S.* TO s_usr;
+ALTER SCHEMA S read only=1;
+ALTER SCHEMA S read only=0;
+DROP USER s_usr;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# The read only option affects all users.
+#--------------------------------------------------------------------
+CREATE USER con_adm_usr;
+GRANT ALL ON *.* TO con_adm_usr;
+GRANT CONNECTION_ADMIN ON *.* TO con_adm_usr;
+CREATE USER super_usr;
+GRANT ALL ON *.* TO super_usr;
+GRANT SUPER ON *.* TO super_usr;
+Warnings:
+Warning	1287	The SUPER privilege identifier is deprecated
+CREATE SCHEMA S;
+CREATE TABLE S.t(i INT);
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=1;
+CREATE TABLE S.t(i INT);
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+CREATE TABLE S.t(i INT);
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=1;
+CREATE TABLE S.t(i INT);
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+CREATE TABLE S.t(i INT);
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=1;
+CREATE TABLE S.t(i INT);
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+DROP USER con_adm_usr;
+DROP USER super_usr;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# Statements in an init file shall not be affected.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+# restart: --init-file=MYSQLTEST_VARDIR/tmp/schema_read_only.sql
+SHOW CREATE SCHEMA schema_read_only;
+ERROR 42000: Unknown database 'schema_read_only'
+SHOW TABLES IN S;
+Tables_in_S
+init_file
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# No ALTER for mysql, I_S, P_S and sys.
+#--------------------------------------------------------------------
+ALTER SCHEMA mysql READ ONLY=1;
+ERROR HY000: Access to system schema 'mysql' is rejected.
+ALTER SCHEMA information_schema READ ONLY=1;
+ERROR 42000: Access denied for user 'root'@'localhost' to database 'information_schema'
+ALTER SCHEMA performance_schema READ ONLY=1;
+ERROR 42000: Access denied for user 'root'@'localhost' to database 'performance_schema'
+CREATE SCHEMA S;
+CREATE TABLE S.t1(i INT, j INT, INDEX i1(i));
+ALTER SCHEMA S READ ONLY = 1;
+#--------------------------------------------------------------------
+# Schema operations.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+ERROR HY000: Can't create database 'S'; database exists
+ALTER SCHEMA S COLLATE utf8mb4_bin;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S CHARACTER SET ascii;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP SCHEMA S;
+ERROR HY000: Schema 'S' is in read only mode.
+#--------------------------------------------------------------------
+# Table operations.
+#--------------------------------------------------------------------
+CREATE TABLE S.t2(i INT);
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER TABLE S.t1 ADD COLUMN (k INT), ALGORITHM INSTANT;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER TABLE S.t1 ADD COLUMN (k INT), ALGORITHM INPLACE;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER TABLE S.t1 ADD COLUMN (k INT), ALGORITHM COPY;
+ERROR HY000: Schema 'S' is in read only mode.
+CREATE INDEX i2 ON S.t1(j);
+ERROR HY000: Schema 'S' is in read only mode.
+DROP INDEX i1 ON S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+RENAME TABLE S.t1 TO S.t2;
+ERROR HY000: Schema 'S' is in read only mode.
+CREATE TABLE test.t1 LIKE S.t1;
+RENAME TABLE S.t1 TO S.t2;
+ERROR HY000: Schema 'S' is in read only mode.
+RENAME TABLE test.t1 TO test.t2, S.t1 TO S.t2;
+ERROR HY000: Schema 'S' is in read only mode.
+TRUNCATE TABLE S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP TABLE S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP TABLE test.t1, S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP TABLE test.t1;
+SELECT * FROM S.t1;
+i	j
+DELETE FROM S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+INSERT INTO S.t1 VALUES (1, 1);
+ERROR HY000: Schema 'S' is in read only mode.
+REPLACE INTO S.t1 VALUES (1, 1);
+ERROR HY000: Schema 'S' is in read only mode.
+UPDATE S.t1 SET i = j;
+ERROR HY000: Schema 'S' is in read only mode.
+#--------------------------------------------------------------------
+# Import
+#--------------------------------------------------------------------
+ALTER SCHEMA S READ ONLY=0;
+CREATE TABLE S.t_imp (i INT) ENGINE=MYISAM;
+INSERT INTO S.t_imp VALUES (1), (3), (5);
+SELECT * FROM S.t_imp;
+i
+1
+3
+5
+FLUSH TABLES WITH READ LOCK;
+UNLOCK TABLES;
+DROP TABLE S.t_imp;
+ALTER SCHEMA S READ ONLY=1;
+USE S;
+IMPORT TABLE FROM 't_imp*.sdi';
+ERROR HY000: Schema 'S' is in read only mode.
+#--------------------------------------------------------------------
+# LOAD DATA INFILE/XML
+#--------------------------------------------------------------------
+SELECT 1, 1 INTO OUTFILE 't.txt';
+LOAD DATA INFILE 't.txt' INTO TABLE S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+CREATE TABLE test.t1 LIKE S.t1;
+INSERT INTO test.t1 VALUES (1, 1);
+LOAD XML INFILE "MYSQLTEST_VARDIR/tmp/t1.xml" INTO TABLE S.t1;;
+ERROR HY000: Schema 'S' is in read only mode.
+#--------------------------------------------------------------------
+# View operations.
+#--------------------------------------------------------------------
+CREATE VIEW S.v1 AS SELECT * FROM S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+CREATE VIEW S.v1 AS SELECT * FROM test.t1;
+ALTER SCHEMA S READ ONLY=1;
+# Operations altering the validity of a view in a read only schema are
+# rejected.
+DROP TABLE test.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP DATABASE test;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+DROP TABLE test.t1;
+ALTER SCHEMA S READ ONLY=1;
+CREATE TABLE test.t1 LIKE S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER VIEW S.v1 AS SELECT * FROM S.t1;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP VIEW S.v1;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+DROP VIEW S.v1;
+ALTER SCHEMA S READ ONLY=1;
+# Inserts in updatable view will fail.
+CREATE VIEW test.v AS SELECT * FROM S.t1;
+SELECT * FROM test.v;
+i	j
+INSERT INTO test.v VALUES(1, 1);
+ERROR HY000: Schema 'S' is in read only mode.
+DROP VIEW test.v;
+#--------------------------------------------------------------------
+# Functions. Recursion not allowed, DDL causing implicit commit not
+# allowed.
+#--------------------------------------------------------------------
+CREATE FUNCTION S.f() RETURNS INT RETURN 1;
+ERROR HY000: Schema 'S' is in read only mode.
+CREATE TABLE test.t1 LIKE S.t1;
+ALTER SCHEMA S READ ONLY=0;
+CREATE FUNCTION S.f(stmt VARCHAR(20)) RETURNS INT
+BEGIN
+CASE stmt
+WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+ELSE BEGIN END;
+END CASE;
+RETURN 1;
+END|
+CREATE VIEW S.v_s AS SELECT S.f('INSERT s');
+CREATE VIEW S.v_test AS SELECT S.f('INSERT test');
+ALTER SCHEMA S READ ONLY=1;
+CREATE FUNCTION test.f(stmt VARCHAR(20)) RETURNS INT
+BEGIN
+CASE stmt
+WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+ELSE BEGIN END;
+END CASE;
+RETURN 1;
+END|
+CREATE VIEW test.v_s AS SELECT test.f('INSERT s');
+CREATE VIEW test.v_test AS SELECT test.f('INSERT test');
+# Fails due to prelocking strategy.
+SELECT S.f('INSERT test');
+ERROR HY000: Schema 'S' is in read only mode.
+SELECT S.f('INSERT s');
+ERROR HY000: Schema 'S' is in read only mode.
+SELECT * FROM S.v_test;
+ERROR HY000: Schema 'S' is in read only mode.
+SELECT * FROM S.v_s;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP FUNCTION S.f;
+ERROR HY000: Schema 'S' is in read only mode.
+# Fails due to prelocking strategy.
+SELECT test.f('INSERT test');
+ERROR HY000: Schema 'S' is in read only mode.
+SELECT test.f('INSERT s');
+ERROR HY000: Schema 'S' is in read only mode.
+SELECT * FROM test.v_test;
+ERROR HY000: Schema 'S' is in read only mode.
+SELECT * FROM test.v_s;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+SELECT S.f('INSERT test');
+S.f('INSERT test')
+1
+SELECT S.f('INSERT s');
+S.f('INSERT s')
+1
+SELECT * FROM S.v_test;
+S.f('INSERT test')
+1
+SELECT * FROM S.v_s;
+S.f('INSERT s')
+1
+SELECT test.f('INSERT test');
+test.f('INSERT test')
+1
+SELECT test.f('INSERT s');
+test.f('INSERT s')
+1
+SELECT * FROM test.v_test;
+test.f('INSERT test')
+1
+SELECT * FROM test.v_s;
+test.f('INSERT s')
+1
+DROP VIEW S.v_s;
+DROP VIEW S.v_test;
+DROP FUNCTION S.f;
+ALTER SCHEMA S READ ONLY=1;
+DROP VIEW test.v_s;
+DROP VIEW test.v_test;
+DROP FUNCTION test.f;
+DROP TABLE test.t1;
+#--------------------------------------------------------------------
+# Procedures.
+#--------------------------------------------------------------------
+CREATE PROCEDURE S.p() BEGIN END;
+ERROR HY000: Schema 'S' is in read only mode.
+CREATE TABLE test.t1 LIKE S.t1;
+ALTER SCHEMA S READ ONLY=0;
+CREATE PROCEDURE S.p(stmt VARCHAR(20))
+BEGIN
+CASE stmt
+WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+ELSE BEGIN END;
+END CASE;
+END|
+ALTER SCHEMA S READ ONLY=1;
+CREATE PROCEDURE test.p(stmt VARCHAR(20))
+BEGIN
+CASE stmt
+WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+ELSE BEGIN END;
+END CASE;
+END|
+CALL S.p('INSERT s');
+ERROR HY000: Schema 'S' is in read only mode.
+# Succeeds due to no prelocking for CALL.
+CALL S.p('INSERT test');
+DROP PROCEDURE S.p;
+ERROR HY000: Schema 'S' is in read only mode.
+CALL test.p('INSERT s');
+ERROR HY000: Schema 'S' is in read only mode.
+# Succeeds due to no prelocking for CALL.
+CALL test.p('INSERT test');
+ALTER SCHEMA S READ ONLY=0;
+CALL S.p('INSERT s');
+CALL S.p('INSERT test');
+DROP PROCEDURE S.p;
+CALL test.p('INSERT s');
+CALL test.p('INSERT test');
+ALTER SCHEMA S READ ONLY=1;
+DROP PROCEDURE test.p;
+DROP TABLE test.t1;
+#--------------------------------------------------------------------
+# Triggers.
+#--------------------------------------------------------------------
+CREATE TABLE test.t1 LIKE S.t1;
+CREATE TRIGGER S.eq BEFORE INSERT ON S.t1 FOR EACH ROW SET NEW.j = NEW.i;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+CREATE TRIGGER S.ins_upd
+BEFORE INSERT ON S.t1 FOR EACH ROW UPDATE test.t1 SET i = j;
+ALTER SCHEMA S READ ONLY=1;
+DROP TRIGGER S.ins_upd;
+ERROR HY000: Schema 'S' is in read only mode.
+CREATE TRIGGER test.ins_upd
+BEFORE INSERT ON test.t1 FOR EACH ROW UPDATE S.t1 SET j = i;
+INSERT INTO S.t1 VALUES (1, 2);
+ERROR HY000: Schema 'S' is in read only mode.
+INSERT INTO test.t1 VALUES (3, 4);
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+INSERT INTO S.t1 VALUES (1, 2);
+INSERT INTO test.t1 VALUES (3, 4);
+DROP TRIGGER S.ins_upd;
+ALTER SCHEMA S READ ONLY=1;
+DROP TRIGGER test.ins_upd;
+DROP TABLE test.t1;
+#--------------------------------------------------------------------
+# Events.
+#--------------------------------------------------------------------
+# Restart to get a separate log file.
+# restart: --log-error=MYSQLD_LOG
+CREATE TABLE test.t1 LIKE S.t1;
+CREATE EVENT test.ev
+ON SCHEDULE EVERY 1 SECOND DO INSERT INTO S.t1 VALUES (1, 2);
+CREATE EVENT S.ev
+ON SCHEDULE EVERY 1 SECOND DO INSERT INTO test.t1 VALUES (1, 2);
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+CREATE EVENT S.ev
+ON SCHEDULE EVERY 1 SECOND DO INSERT INTO test.t1 VALUES (1, 2);
+ALTER SCHEMA S READ ONLY=1;
+ALTER EVENT S.ev DISABLE;
+ERROR HY000: Schema 'S' is in read only mode.
+DROP EVENT S.ev;
+ERROR HY000: Schema 'S' is in read only mode.
+# Reject executing events located in a read only schema because
+# last_executed timestamp must be updated.
+Pattern not found.
+Pattern not found.
+#--------------------------------------------------------------------
+# Reject executing events accessing read only entities.
+#--------------------------------------------------------------------
+Pattern not found.
+Pattern not found.
+ALTER SCHEMA S READ ONLY=0;
+ALTER EVENT S.ev DISABLE;
+DROP EVENT S.ev;
+DROP EVENT test.ev;
+DROP TABLE test.t1;
+ALTER SCHEMA S READ ONLY=1;
+#--------------------------------------------------------------------
+# Non-cascading foreign keys.
+#--------------------------------------------------------------------
+CREATE TABLE test.p (
+id INT NOT NULL,
+PRIMARY KEY (id)
+);
+INSERT INTO test.p VALUES (1), (2), (3), (4);
+ALTER SCHEMA S READ ONLY=0;
+CREATE TABLE S.c (
+p_id INT,
+FOREIGN KEY (p_id)
+REFERENCES test.p(id)
+);
+INSERT INTO S.c VALUES (1), (2);
+ALTER SCHEMA S READ ONLY=1;
+DELETE FROM test.p WHERE id=1;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`S`.`c`, CONSTRAINT `c_ibfk_1` FOREIGN KEY (`p_id`) REFERENCES `test`.`p` (`id`))
+DELETE FROM test.p WHERE id=4;
+SELECT * FROM test.p;
+id
+1
+2
+3
+SELECT * FROM S.c;
+p_id
+1
+2
+# Parent of non-cascading FK may be locked.
+LOCK TABLE test.p WRITE;
+UNLOCK TABLES;
+ALTER SCHEMA S READ ONLY=0;
+DROP TABLE S.c;
+#--------------------------------------------------------------------
+# Cascading foreign keys.
+#--------------------------------------------------------------------
+INSERT INTO test.p VALUES (4);
+CREATE TABLE S.c (
+p_id INT,
+FOREIGN KEY (p_id)
+REFERENCES test.p(id)
+ON DELETE CASCADE
+ON UPDATE CASCADE
+);
+INSERT INTO S.c VALUES (1), (2);
+ALTER SCHEMA S READ ONLY=1;
+# Prelocking will reject any parent update/delete + LOCK TABLE.
+DELETE FROM test.p WHERE id=1;
+ERROR HY000: Schema 'S' is in read only mode.
+DELETE FROM test.p WHERE id=4;
+ERROR HY000: Schema 'S' is in read only mode.
+UPDATE test.p SET id=5 WHERE id=2;
+ERROR HY000: Schema 'S' is in read only mode.
+UPDATE test.p SET id=5 WHERE id=4;
+ERROR HY000: Schema 'S' is in read only mode.
+LOCK TABLE test.p WRITE;
+ERROR HY000: Schema 'S' is in read only mode.
+#--------------------------------------------------------------------
+# Turning off FKC will allow changes and skip updating child, but still
+# reject LOCK TABLE.
+#--------------------------------------------------------------------
+SET @@session.foreign_key_checks=0;
+DELETE FROM test.p WHERE id=1;
+DELETE FROM test.p WHERE id=4;
+UPDATE test.p SET id=5 WHERE id=2;
+UPDATE test.p SET id=2 WHERE id=3;
+SELECT * FROM test.p;
+id
+2
+5
+SELECT * FROM S.c;
+p_id
+1
+2
+LOCK TABLE test.p WRITE;
+ERROR HY000: Schema 'S' is in read only mode.
+SET @@session.foreign_key_checks=1;
+#--------------------------------------------------------------------
+# Turning off read only will allow changes and update child + allow
+# LOCK TABLE.
+#--------------------------------------------------------------------
+ALTER SCHEMA S READ ONLY=0;
+UPDATE test.p SET id=6 WHERE id=2;
+SELECT * FROM test.p;
+id
+5
+6
+SELECT * FROM S.c;
+p_id
+1
+6
+DELETE FROM test.p WHERE id=6;
+SELECT * FROM test.p;
+id
+5
+SELECT * FROM S.c;
+p_id
+1
+LOCK TABLE test.p WRITE;
+#--------------------------------------------------------------------
+# LOCK will block altering schema from same connection.
+#--------------------------------------------------------------------
+ALTER SCHEMA S READ ONLY=1;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+UNLOCK TABLES;
+ALTER SCHEMA S READ ONLY=1;
+#--------------------------------------------------------------------
+# Trigger deleting/updating parent with a cascading FK child in
+# read only schema.
+#--------------------------------------------------------------------
+CREATE TABLE test.t(i INT);
+CREATE TRIGGER test.ins_upd
+BEFORE INSERT ON test.t FOR EACH ROW
+UPDATE test.p SET id = id + 1 WHERE id = NEW.i;
+CREATE TRIGGER test.ins_del
+AFTER INSERT ON test.t FOR EACH ROW DELETE FROM test.p WHERE id = NEW.i-1;
+SELECT * FROM test.p;
+id
+5
+SELECT * FROM S.c;
+p_id
+1
+INSERT INTO test.t VALUES (4);
+ERROR HY000: Schema 'S' is in read only mode.
+LOCK TABLE test.t WRITE;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY=0;
+INSERT INTO test.t VALUES (4);
+SELECT * FROM test.p;
+id
+5
+SELECT * FROM S.c;
+p_id
+1
+# LOCK TABLES of table in read only schema.
+ALTER SCHEMA S READ ONLY=1;
+LOCK TABLE S.c WRITE;
+ERROR HY000: Schema 'S' is in read only mode.
+# Restart with default log file.
+# restart:
+# Intermediate cleanup.
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+DROP TABLE test.t;
+DROP TABLE test.p;
+#--------------------------------------------------------------------
+# The option shall not have any affect on temporary tables.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+CREATE TEMPORARY TABLE S.t(i INT);
+INSERT INTO S.t VALUES(1);
+SELECT * FROM S.t;
+i
+1
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# Conflicting options.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY = 0 READ ONLY = 0;
+ALTER SCHEMA S READ ONLY = 0 READ ONLY = 1;
+ERROR HY000: Conflicting declarations: 'READ ONLY=0' and 'READ ONLY=1'
+ALTER SCHEMA S READ ONLY = 0 READ ONLY = DEFAULT;
+ALTER SCHEMA S READ ONLY = 1 READ ONLY = 0;
+ERROR HY000: Conflicting declarations: 'READ ONLY=0' and 'READ ONLY=1'
+ALTER SCHEMA S READ ONLY = 1 READ ONLY = 1;
+ALTER SCHEMA S READ ONLY = 1 READ ONLY = DEFAULT;
+ERROR HY000: Conflicting declarations: 'READ ONLY=0' and 'READ ONLY=1'
+ALTER SCHEMA S READ ONLY = DEFAULT READ ONLY = 0;
+ALTER SCHEMA S READ ONLY = DEFAULT READ ONLY = 1;
+ERROR HY000: Conflicting declarations: 'READ ONLY=0' and 'READ ONLY=1'
+ALTER SCHEMA S READ ONLY = DEFAULT READ ONLY = DEFAULT;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# ALTER READ ONLY allowed for read only schema.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */ /* READ ONLY = 1 */
+ALTER SCHEMA S READ ONLY=DEFAULT;
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */
+ALTER SCHEMA S READ ONLY=1;
+Repeated READ ONLY = 1 is allowed
+ALTER SCHEMA S READ ONLY=1;
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */ /* READ ONLY = 1 */
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# ALTER SCHEMA rejected for read only schema.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */ /* READ ONLY = 1 */
+ALTER SCHEMA S COLLATE utf8mb4_bin;
+ERROR HY000: Schema 'S' is in read only mode.
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci */ /*!80016 DEFAULT ENCRYPTION='N' */ /* READ ONLY = 1 */
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+#--------------------------------------------------------------------
+# ALTER SCHEMA for a mix of options.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+ALTER SCHEMA S READ ONLY = 1 COLLATE utf8mb4_bin;
+ERROR HY000: Schema 'S' is in read only mode.
+ALTER SCHEMA S READ ONLY = 0 COLLATE utf8mb4_bin;
+SHOW CREATE SCHEMA S;
+Database	Create Database
+S	CREATE DATABASE `S` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin */ /*!80016 DEFAULT ENCRYPTION='N' */
+ALTER SCHEMA S READ ONLY = 1 COLLATE utf8mb4_general_ci;
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+CALL mtr.add_suppression("Can't create database 'S'; database exists");
+CALL mtr.add_suppression("Query apply failed");
+CALL mtr.add_suppression("Access to system schema 'mysql' is rejected.");
+CALL mtr.add_suppression("Schema 'S' is in read only mode.");
+CALL mtr.add_suppression("Schema 'S' is in read only mode.");

--- a/mysql-test/suite/galera/t/galera_as_slave_read_only_schema.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_read_only_schema.cnf
@@ -1,0 +1,1 @@
+!include ../galera_2nodes_as_slave.cnf

--- a/mysql-test/suite/galera/t/galera_as_slave_read_only_schema.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_read_only_schema.test
@@ -1,0 +1,120 @@
+# === Purpose ===
+# This test verifies that updats on read only schemas are successfully
+# processed by wsrep applier threads.
+#
+# Test Galera as a replica to a MySQL master
+#
+# === Reference ===
+# PXC-4137: WSREP applier threads fail to modify read only schemas
+#
+# Note: The galera/galera_2node_slave.cnf describes the setup of the nodes
+
+--source include/have_log_bin.inc
+
+# As node_1 is not a Galera node, we connect to node_2 in order to run include/galera_cluster.inc
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster_master_slave.inc
+
+--connection node_2
+--echo # connection node_2
+--source include/galera_wait_ready.inc
+
+--connection node_2
+--echo # connection node_2
+--disable_query_log
+--eval CHANGE REPLICATION SOURCE TO SOURCE_HOST='127.0.0.1', SOURCE_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START REPLICA USER='root';
+
+--connection node_1
+--echo # connection node_1
+CREATE DATABASE testdb;
+
+# Ensure that replication is working
+--connection node_2
+--echo # connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='testdb';
+--source include/wait_condition.inc
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--echo # connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='testdb';
+--source include/wait_condition.inc
+
+# Alter the schema to be read only in the PXC cluster
+--connection node_2
+--echo # connection node_2
+ALTER SCHEMA testdb READ ONLY = 1;
+
+# Assert that the schema is read only on node_2
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+
+# Assert that the schema is read only on node_3
+--connection node_3
+--echo # connection node_3
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+
+# Now perform some basic operations on node_1. Since the table is not read only
+# on node_1, these operations should be successful on node_1.
+--connection node_1
+--echo # connection node_1
+use testdb;
+CREATE TABLE t1(i int PRIMARY KEY);
+INSERT INTO t1 VALUES(1),(2),(3),(4);
+UPDATE t1 SET i=i+10;
+DELETE FROM t1 WHERE i>11;
+
+--connection node_2
+--echo # connection node_2
+
+# Wait for node_2 to catch up
+--let $wait_condition = SELECT COUNT(*) = 1 FROM testdb.t1;
+--source include/wait_condition.inc
+
+# Assert that table has only one row on node_2
+--assert(`SELECT COUNT(*) = 1 FROM testdb.t1`)
+
+# Assert that the schema is still read only on node_2
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+--assert(`SELECT OPTIONS="READ ONLY=1" from INFORMATION_SCHEMA.SCHEMATA_EXTENSIONS WHERE SCHEMA_NAME='testdb'`)
+
+# Assert that table has only one row on node_3
+--connection node_3
+--echo # connection node_3
+--assert(`SELECT COUNT(*) = 1 FROM testdb.t1`)
+
+# Assert that the schema is still read only
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE testdb.tt1 (i INT PRIMARY KEY);
+--assert(`SELECT OPTIONS="READ ONLY=1" from INFORMATION_SCHEMA.SCHEMATA_EXTENSIONS WHERE SCHEMA_NAME='testdb'`)
+
+# Verify that ALTER SCHEMA READ ONLY=0 is allowed
+ALTER SCHEMA testdb READ ONLY = 0;
+
+# Test cleanup
+--connection node_1
+DROP DATABASE testdb;
+
+--connection node_2
+--echo # connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='testdb';
+--source include/wait_condition.inc
+STOP REPLICA;
+RESET REPLICA ALL;
+
+--connection node_2
+CALL mtr.add_suppression("Schema 'testdb' is in read only mode.");
+CALL mtr.add_suppression("Query apply failed");
+
+--connection node_3
+CALL mtr.add_suppression("Schema 'testdb' is in read only mode.");
+CALL mtr.add_suppression("Query apply failed");
+
+--disconnect node_3
+--disconnect node_2a
+--connection node_1
+RESET MASTER;
+

--- a/mysql-test/suite/galera/t/pxc_read_only_schema.test
+++ b/mysql-test/suite/galera/t/pxc_read_only_schema.test
@@ -1,0 +1,756 @@
+# === Purpose ===
+# This test verifies that operations on read only schemas as handled properly
+# by the cluster.
+#
+# === References ===
+#
+# PXC-4137: WSREP applier threads fail to modify read only schemas
+
+--source include/galera_cluster.inc
+CREATE SCHEMA S;
+
+CREATE TABLE S.t1(i INT, j INT, INDEX i1(i));
+ALTER SCHEMA S read only=1;
+SHOW CREATE SCHEMA S;
+ALTER SCHEMA S read only=0;
+DROP SCHEMA S;
+
+--echo #--------------------------------------------------------------------
+--echo # Invalid option in CREATE SCHEMA.
+--echo #--------------------------------------------------------------------
+--error ER_PARSE_ERROR
+CREATE SCHEMA S read only=0;
+
+--echo #--------------------------------------------------------------------
+--echo # ALTER privilege needed to change read only.
+--echo #--------------------------------------------------------------------
+eval CREATE SCHEMA S;
+CREATE USER s_usr;
+--connect (s_con, localhost, s_usr,,)
+--error ER_DBACCESS_DENIED_ERROR
+ALTER SCHEMA S read only=1;
+
+--connection default
+GRANT ALTER ON S.* TO s_usr;
+
+--connection s_con
+ALTER SCHEMA S read only=1;
+ALTER SCHEMA S read only=0;
+
+--connection default
+--disconnect s_con
+DROP USER s_usr;
+DROP SCHEMA S;
+
+--echo #--------------------------------------------------------------------
+--echo # The read only option affects all users.
+--echo #--------------------------------------------------------------------
+CREATE USER con_adm_usr;
+GRANT ALL ON *.* TO con_adm_usr;
+GRANT CONNECTION_ADMIN ON *.* TO con_adm_usr;
+
+CREATE USER super_usr;
+GRANT ALL ON *.* TO super_usr;
+GRANT SUPER ON *.* TO super_usr;
+
+eval CREATE SCHEMA S;
+
+--connect (root_con, localhost, root,,)
+CREATE TABLE S.t(i INT);
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=1;
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE S.t(i INT);
+ALTER SCHEMA S READ ONLY=0;
+
+--connect (con_adm_con, localhost, con_adm_usr,,)
+CREATE TABLE S.t(i INT);
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=1;
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE S.t(i INT);
+ALTER SCHEMA S READ ONLY=0;
+
+--connect (super_con, localhost, super_usr,,)
+CREATE TABLE S.t(i INT);
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=1;
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE S.t(i INT);
+ALTER SCHEMA S READ ONLY=0;
+
+--connection default
+--disconnect root_con
+--disconnect con_adm_con
+--disconnect super_con
+
+DROP USER con_adm_usr;
+DROP USER super_usr;
+
+DROP SCHEMA S;
+
+--echo #--------------------------------------------------------------------
+--echo # Statements in an init file shall not be affected.
+--echo #--------------------------------------------------------------------
+--connection node_2
+CREATE SCHEMA S;
+let INIT_FILE=$MYSQLTEST_VARDIR/tmp/schema_read_only.sql;
+write_file $INIT_FILE;
+  CREATE SCHEMA schema_read_only;
+  ALTER SCHEMA schema_read_only READ ONLY=1;
+  ALTER SCHEMA schema_read_only COLLATE utf8_bin;
+  CREATE TABLE schema_read_only.t(i INT) TABLESPACE innodb_system;
+  DROP SCHEMA schema_read_only;
+  CREATE TABLE S.init_file(i INT);
+EOF
+
+let $wait_counter= 10000;
+let $restart_parameters= "restart: --init-file=$INIT_FILE";
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+source include/restart_mysqld.inc;
+
+--error ER_BAD_DB_ERROR
+SHOW CREATE SCHEMA schema_read_only;
+
+SHOW TABLES IN S;
+SHOW CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+
+--remove_file $INIT_FILE
+--connection node_1
+
+--echo #--------------------------------------------------------------------
+--echo # No ALTER for mysql, I_S, P_S and sys.
+--echo #--------------------------------------------------------------------
+--error ER_NO_SYSTEM_SCHEMA_ACCESS
+ALTER SCHEMA mysql READ ONLY=1;
+--error ER_DBACCESS_DENIED_ERROR
+ALTER SCHEMA information_schema READ ONLY=1;
+--error ER_DBACCESS_DENIED_ERROR
+ALTER SCHEMA performance_schema READ ONLY=1;
+
+#--------------------------------------------------------------------
+# Verify that all schema operations are disallowed when the schema is read
+# only.
+#--------------------------------------------------------------------
+CREATE SCHEMA S;
+CREATE TABLE S.t1(i INT, j INT, INDEX i1(i));
+ALTER SCHEMA S READ ONLY = 1; 
+
+--echo #--------------------------------------------------------------------
+--echo # Schema operations.
+--echo #--------------------------------------------------------------------
+--let $MYSQLD_DATADIR=`SELECT @@DATADIR;`
+--error ER_DB_CREATE_EXISTS
+eval CREATE SCHEMA S;
+--error ER_SCHEMA_READ_ONLY
+ALTER SCHEMA S COLLATE utf8mb4_bin;
+--error ER_SCHEMA_READ_ONLY
+ALTER SCHEMA S CHARACTER SET ascii;
+--error ER_SCHEMA_READ_ONLY
+DROP SCHEMA S;
+
+# Verify that all table operations are disallowed when the schema is read
+# only.
+--echo #--------------------------------------------------------------------
+--echo # Table operations.
+--echo #--------------------------------------------------------------------
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE S.t2(i INT);
+--error ER_SCHEMA_READ_ONLY
+ALTER TABLE S.t1 ADD COLUMN (k INT), ALGORITHM INSTANT;
+--error ER_SCHEMA_READ_ONLY
+ALTER TABLE S.t1 ADD COLUMN (k INT), ALGORITHM INPLACE;
+--error ER_SCHEMA_READ_ONLY
+ALTER TABLE S.t1 ADD COLUMN (k INT), ALGORITHM COPY;
+--error ER_SCHEMA_READ_ONLY
+CREATE INDEX i2 ON S.t1(j);
+--error ER_SCHEMA_READ_ONLY
+DROP INDEX i1 ON S.t1;
+--error ER_SCHEMA_READ_ONLY
+RENAME TABLE S.t1 TO S.t2;
+CREATE TABLE test.t1 LIKE S.t1;
+--error ER_SCHEMA_READ_ONLY
+RENAME TABLE S.t1 TO S.t2;
+--error ER_SCHEMA_READ_ONLY
+RENAME TABLE test.t1 TO test.t2, S.t1 TO S.t2;
+--error ER_SCHEMA_READ_ONLY
+TRUNCATE TABLE S.t1;
+--error ER_SCHEMA_READ_ONLY
+DROP TABLE S.t1;
+--error ER_SCHEMA_READ_ONLY
+DROP TABLE test.t1, S.t1;
+DROP TABLE test.t1;
+SELECT * FROM S.t1;
+--error ER_SCHEMA_READ_ONLY
+DELETE FROM S.t1;
+--error ER_SCHEMA_READ_ONLY
+INSERT INTO S.t1 VALUES (1, 1);
+--error ER_SCHEMA_READ_ONLY
+REPLACE INTO S.t1 VALUES (1, 1);
+--error ER_SCHEMA_READ_ONLY
+UPDATE S.t1 SET i = j;
+
+
+# Verify that all import operations are disallowed when the schema is read
+# only.
+--echo #--------------------------------------------------------------------
+--echo # Import
+--echo #--------------------------------------------------------------------
+ALTER SCHEMA S READ ONLY=0;
+CREATE TABLE S.t_imp (i INT) ENGINE=MYISAM;
+INSERT INTO S.t_imp VALUES (1), (3), (5);
+SELECT * FROM S.t_imp;
+
+FLUSH TABLES WITH READ LOCK;
+--copy_files_wildcard $MYSQLD_DATADIR/S/ $MYSQL_TMP_DIR t_imp*
+UNLOCK TABLES;
+DROP TABLE S.t_imp;
+
+--copy_files_wildcard $MYSQL_TMP_DIR $MYSQLD_DATADIR/S/ t_imp*
+ALTER SCHEMA S READ ONLY=1;
+USE S;
+--error ER_SCHEMA_READ_ONLY
+IMPORT TABLE FROM 't_imp*.sdi';
+--remove_files_wildcard $MYSQL_TMP_DIR t_imp*
+--remove_files_wildcard $MYSQLD_DATADIR/S/ t_imp*
+
+# Verify that all LOAD DATA operations are disallowed when the schema is read
+# only.
+--echo #--------------------------------------------------------------------
+--echo # LOAD DATA INFILE/XML
+--echo #--------------------------------------------------------------------
+SELECT 1, 1 INTO OUTFILE 't.txt';
+--error ER_SCHEMA_READ_ONLY
+LOAD DATA INFILE 't.txt' INTO TABLE S.t1;
+--remove_file  $MYSQLD_DATADIR/S/t.txt
+
+CREATE TABLE test.t1 LIKE S.t1;
+INSERT INTO test.t1 VALUES (1, 1);
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_DUMP --xml test t1 > "$MYSQLTEST_VARDIR/tmp/t1.xml" 2>&1
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--error ER_SCHEMA_READ_ONLY
+--eval LOAD XML INFILE "$MYSQLTEST_VARDIR/tmp/t1.xml" INTO TABLE S.t1;
+--remove_file $MYSQLTEST_VARDIR/tmp/t1.xml
+
+# Verify that all view operations are disallowed when the schema is read
+# only.
+--echo #--------------------------------------------------------------------
+--echo # View operations.
+--echo #--------------------------------------------------------------------
+--error ER_SCHEMA_READ_ONLY
+CREATE VIEW S.v1 AS SELECT * FROM S.t1;
+ALTER SCHEMA S READ ONLY=0;
+CREATE VIEW S.v1 AS SELECT * FROM test.t1;
+ALTER SCHEMA S READ ONLY=1;
+
+--echo # Operations altering the validity of a view in a read only schema are
+--echo # rejected.
+--error ER_SCHEMA_READ_ONLY
+DROP TABLE test.t1;
+--error ER_SCHEMA_READ_ONLY
+DROP DATABASE test;
+ALTER SCHEMA S READ ONLY=0;
+DROP TABLE test.t1;
+ALTER SCHEMA S READ ONLY=1;
+--error ER_SCHEMA_READ_ONLY
+CREATE TABLE test.t1 LIKE S.t1;
+
+--error ER_SCHEMA_READ_ONLY
+ALTER VIEW S.v1 AS SELECT * FROM S.t1;
+--error ER_SCHEMA_READ_ONLY
+DROP VIEW S.v1;
+ALTER SCHEMA S READ ONLY=0;
+DROP VIEW S.v1;
+ALTER SCHEMA S READ ONLY=1;
+
+--echo # Inserts in updatable view will fail.
+CREATE VIEW test.v AS SELECT * FROM S.t1;
+SELECT * FROM test.v;
+--error ER_SCHEMA_READ_ONLY
+INSERT INTO test.v VALUES(1, 1);
+DROP VIEW test.v;
+
+--echo #--------------------------------------------------------------------
+--echo # Functions. Recursion not allowed, DDL causing implicit commit not
+--echo # allowed.
+--echo #--------------------------------------------------------------------
+--error ER_SCHEMA_READ_ONLY
+CREATE FUNCTION S.f() RETURNS INT RETURN 1;
+
+CREATE TABLE test.t1 LIKE S.t1;
+
+ALTER SCHEMA S READ ONLY=0;
+delimiter |;
+CREATE FUNCTION S.f(stmt VARCHAR(20)) RETURNS INT
+BEGIN
+  CASE stmt
+    WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+    WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+    ELSE BEGIN END;
+  END CASE;
+  RETURN 1;
+END|
+delimiter ;|
+CREATE VIEW S.v_s AS SELECT S.f('INSERT s');
+CREATE VIEW S.v_test AS SELECT S.f('INSERT test');
+ALTER SCHEMA S READ ONLY=1;
+
+delimiter |;
+CREATE FUNCTION test.f(stmt VARCHAR(20)) RETURNS INT
+BEGIN
+  CASE stmt
+    WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+    WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+    ELSE BEGIN END;
+  END CASE;
+  RETURN 1;
+END|
+delimiter ;|
+CREATE VIEW test.v_s AS SELECT test.f('INSERT s');
+CREATE VIEW test.v_test AS SELECT test.f('INSERT test');
+
+--echo # Fails due to prelocking strategy.
+--error ER_SCHEMA_READ_ONLY
+SELECT S.f('INSERT test');
+--error ER_SCHEMA_READ_ONLY
+SELECT S.f('INSERT s');
+--error ER_SCHEMA_READ_ONLY
+SELECT * FROM S.v_test;
+--error ER_SCHEMA_READ_ONLY
+SELECT * FROM S.v_s;
+--error ER_SCHEMA_READ_ONLY
+DROP FUNCTION S.f;
+
+--echo # Fails due to prelocking strategy.
+--error ER_SCHEMA_READ_ONLY
+SELECT test.f('INSERT test');
+--error ER_SCHEMA_READ_ONLY
+SELECT test.f('INSERT s');
+--error ER_SCHEMA_READ_ONLY
+SELECT * FROM test.v_test;
+--error ER_SCHEMA_READ_ONLY
+SELECT * FROM test.v_s;
+
+ALTER SCHEMA S READ ONLY=0;
+SELECT S.f('INSERT test');
+SELECT S.f('INSERT s');
+SELECT * FROM S.v_test;
+SELECT * FROM S.v_s;
+
+SELECT test.f('INSERT test');
+SELECT test.f('INSERT s');
+SELECT * FROM test.v_test;
+SELECT * FROM test.v_s;
+
+DROP VIEW S.v_s;
+DROP VIEW S.v_test;
+DROP FUNCTION S.f;
+ALTER SCHEMA S READ ONLY=1;
+
+DROP VIEW test.v_s;
+DROP VIEW test.v_test;
+DROP FUNCTION test.f;
+DROP TABLE test.t1;
+
+--echo #--------------------------------------------------------------------
+--echo # Procedures.
+--echo #--------------------------------------------------------------------
+--error ER_SCHEMA_READ_ONLY
+CREATE PROCEDURE S.p() BEGIN END;
+
+CREATE TABLE test.t1 LIKE S.t1;
+
+ALTER SCHEMA S READ ONLY=0;
+delimiter |;
+CREATE PROCEDURE S.p(stmt VARCHAR(20))
+BEGIN
+  CASE stmt
+    WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+    WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+    ELSE BEGIN END;
+  END CASE;
+END|
+delimiter ;|
+ALTER SCHEMA S READ ONLY=1;
+
+delimiter |;
+CREATE PROCEDURE test.p(stmt VARCHAR(20))
+BEGIN
+  CASE stmt
+    WHEN 'INSERT s' THEN INSERT INTO S.t1 VALUES(1, 1);
+    WHEN 'INSERT test' THEN INSERT INTO test.t1 VALUES(1, 1);
+    ELSE BEGIN END;
+  END CASE;
+END|
+delimiter ;|
+
+--error ER_SCHEMA_READ_ONLY
+CALL S.p('INSERT s');
+
+--echo # Succeeds due to no prelocking for CALL.
+CALL S.p('INSERT test');
+
+--error ER_SCHEMA_READ_ONLY
+DROP PROCEDURE S.p;
+
+--error ER_SCHEMA_READ_ONLY
+CALL test.p('INSERT s');
+
+--echo # Succeeds due to no prelocking for CALL.
+CALL test.p('INSERT test');
+
+ALTER SCHEMA S READ ONLY=0;
+CALL S.p('INSERT s');
+CALL S.p('INSERT test');
+DROP PROCEDURE S.p;
+
+CALL test.p('INSERT s');
+CALL test.p('INSERT test');
+ALTER SCHEMA S READ ONLY=1;
+
+DROP PROCEDURE test.p;
+DROP TABLE test.t1;
+
+--echo #--------------------------------------------------------------------
+--echo # Triggers.
+--echo #--------------------------------------------------------------------
+CREATE TABLE test.t1 LIKE S.t1;
+
+--error ER_SCHEMA_READ_ONLY
+CREATE TRIGGER S.eq BEFORE INSERT ON S.t1 FOR EACH ROW SET NEW.j = NEW.i;
+
+ALTER SCHEMA S READ ONLY=0;
+CREATE TRIGGER S.ins_upd
+  BEFORE INSERT ON S.t1 FOR EACH ROW UPDATE test.t1 SET i = j;
+ALTER SCHEMA S READ ONLY=1;
+--error ER_SCHEMA_READ_ONLY
+DROP TRIGGER S.ins_upd;
+
+CREATE TRIGGER test.ins_upd
+  BEFORE INSERT ON test.t1 FOR EACH ROW UPDATE S.t1 SET j = i;
+
+--error ER_SCHEMA_READ_ONLY
+INSERT INTO S.t1 VALUES (1, 2);
+--error ER_SCHEMA_READ_ONLY
+INSERT INTO test.t1 VALUES (3, 4);
+
+ALTER SCHEMA S READ ONLY=0;
+INSERT INTO S.t1 VALUES (1, 2);
+INSERT INTO test.t1 VALUES (3, 4);
+DROP TRIGGER S.ins_upd;
+ALTER SCHEMA S READ ONLY=1;
+
+DROP TRIGGER test.ins_upd;
+DROP TABLE test.t1;
+
+--echo #--------------------------------------------------------------------
+--echo # Events.
+--echo #--------------------------------------------------------------------
+
+--connection node_2
+--echo # Restart to get a separate log file.
+--let $MYSQLD_LOG= $MYSQLTEST_VARDIR/log/event_error.log
+--let $wait_counter= 10000
+--let $restart_parameters= "restart: --log-error=$MYSQLD_LOG"
+--replace_result $MYSQLD_LOG MYSQLD_LOG
+--source include/restart_mysqld.inc
+
+CREATE TABLE test.t1 LIKE S.t1;
+CREATE EVENT test.ev
+  ON SCHEDULE EVERY 1 SECOND DO INSERT INTO S.t1 VALUES (1, 2);
+
+--sleep 5
+
+--error ER_SCHEMA_READ_ONLY
+CREATE EVENT S.ev
+  ON SCHEDULE EVERY 1 SECOND DO INSERT INTO test.t1 VALUES (1, 2);
+
+ALTER SCHEMA S READ ONLY=0;
+CREATE EVENT S.ev
+  ON SCHEDULE EVERY 1 SECOND DO INSERT INTO test.t1 VALUES (1, 2);
+ALTER SCHEMA S READ ONLY=1;
+
+--error ER_SCHEMA_READ_ONLY
+ALTER EVENT S.ev DISABLE;
+
+--error ER_SCHEMA_READ_ONLY
+DROP EVENT S.ev;
+
+--sleep 5
+
+--echo # Reject executing events located in a read only schema because
+--echo # last_executed timestamp must be updated.
+--let $grep_file= $MYSQLD_LOG
+let $grep_pattern= Event Scheduler: Unable to schedule event: Schema '.' is in
+ read only mode.;
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+--let $grep_file= $MYSQLD_LOG
+let $grep_pattern= Event Scheduler: Serious error during getting next event
+ to execute. Stopping;
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+--echo #--------------------------------------------------------------------
+--echo # Reject executing events accessing read only entities.
+--echo #--------------------------------------------------------------------
+--let $grep_file= $MYSQLD_LOG
+let $grep_pattern= Event Scheduler: \[root@localhost\]\[test.ev\] Schema '.'
+ is in read only mode.;
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+--let $grep_file= $MYSQLD_LOG
+let $grep_pattern= Event Scheduler: \[root@localhost\].\[test.ev\] event
+ execution failed.;
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+--remove_file $MYSQLD_LOG
+ALTER SCHEMA S READ ONLY=0;
+ALTER EVENT S.ev DISABLE;
+DROP EVENT S.ev;
+DROP EVENT test.ev;
+DROP TABLE test.t1;
+ALTER SCHEMA S READ ONLY=1;
+
+--echo #--------------------------------------------------------------------
+--echo # Non-cascading foreign keys.
+--echo #--------------------------------------------------------------------
+--connection node_1
+CREATE TABLE test.p (
+    id INT NOT NULL,
+    PRIMARY KEY (id)
+);
+INSERT INTO test.p VALUES (1), (2), (3), (4);
+
+ALTER SCHEMA S READ ONLY=0;
+CREATE TABLE S.c (
+    p_id INT,
+    FOREIGN KEY (p_id)
+        REFERENCES test.p(id)
+);
+INSERT INTO S.c VALUES (1), (2);
+ALTER SCHEMA S READ ONLY=1;
+
+--error ER_ROW_IS_REFERENCED_2
+DELETE FROM test.p WHERE id=1;
+DELETE FROM test.p WHERE id=4;
+
+SELECT * FROM test.p;
+SELECT * FROM S.c;
+
+--echo # Parent of non-cascading FK may be locked.
+LOCK TABLE test.p WRITE;
+UNLOCK TABLES;
+
+ALTER SCHEMA S READ ONLY=0;
+DROP TABLE S.c;
+
+--echo #--------------------------------------------------------------------
+--echo # Cascading foreign keys.
+--echo #--------------------------------------------------------------------
+INSERT INTO test.p VALUES (4);
+CREATE TABLE S.c (
+    p_id INT,
+    FOREIGN KEY (p_id)
+        REFERENCES test.p(id)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+);
+INSERT INTO S.c VALUES (1), (2);
+ALTER SCHEMA S READ ONLY=1;
+
+--echo # Prelocking will reject any parent update/delete + LOCK TABLE.
+--error ER_SCHEMA_READ_ONLY
+DELETE FROM test.p WHERE id=1;
+--error ER_SCHEMA_READ_ONLY
+DELETE FROM test.p WHERE id=4;
+--error ER_SCHEMA_READ_ONLY
+UPDATE test.p SET id=5 WHERE id=2;
+--error ER_SCHEMA_READ_ONLY
+UPDATE test.p SET id=5 WHERE id=4;
+--error ER_SCHEMA_READ_ONLY
+LOCK TABLE test.p WRITE;
+
+--echo #--------------------------------------------------------------------
+--echo # Turning off FKC will allow changes and skip updating child, but still
+--echo # reject LOCK TABLE.
+--echo #--------------------------------------------------------------------
+SET @@session.foreign_key_checks=0;
+
+DELETE FROM test.p WHERE id=1;
+DELETE FROM test.p WHERE id=4;
+UPDATE test.p SET id=5 WHERE id=2;
+UPDATE test.p SET id=2 WHERE id=3;
+
+SELECT * FROM test.p;
+SELECT * FROM S.c;
+
+--error ER_SCHEMA_READ_ONLY
+LOCK TABLE test.p WRITE;
+
+SET @@session.foreign_key_checks=1;
+
+--echo #--------------------------------------------------------------------
+--echo # Turning off read only will allow changes and update child + allow
+--echo # LOCK TABLE.
+--echo #--------------------------------------------------------------------
+ALTER SCHEMA S READ ONLY=0;
+UPDATE test.p SET id=6 WHERE id=2;
+
+SELECT * FROM test.p;
+SELECT * FROM S.c;
+
+DELETE FROM test.p WHERE id=6;
+
+SELECT * FROM test.p;
+SELECT * FROM S.c;
+
+LOCK TABLE test.p WRITE;
+--echo #--------------------------------------------------------------------
+--echo # LOCK will block altering schema from same connection.
+--echo #--------------------------------------------------------------------
+--error ER_LOCK_OR_ACTIVE_TRANSACTION
+ALTER SCHEMA S READ ONLY=1;
+UNLOCK TABLES;
+
+ALTER SCHEMA S READ ONLY=1;
+
+--echo #--------------------------------------------------------------------
+--echo # Trigger deleting/updating parent with a cascading FK child in
+--echo # read only schema.
+--echo #--------------------------------------------------------------------
+CREATE TABLE test.t(i INT);
+
+CREATE TRIGGER test.ins_upd
+  BEFORE INSERT ON test.t FOR EACH ROW
+    UPDATE test.p SET id = id + 1 WHERE id = NEW.i;
+CREATE TRIGGER test.ins_del
+  AFTER INSERT ON test.t FOR EACH ROW DELETE FROM test.p WHERE id = NEW.i-1;
+
+SELECT * FROM test.p;
+SELECT * FROM S.c;
+
+--error ER_SCHEMA_READ_ONLY
+INSERT INTO test.t VALUES (4);
+--error ER_SCHEMA_READ_ONLY
+LOCK TABLE test.t WRITE;
+
+ALTER SCHEMA S READ ONLY=0;
+INSERT INTO test.t VALUES (4);
+
+SELECT * FROM test.p;
+SELECT * FROM S.c;
+
+--connection node_2
+--echo # LOCK TABLES of table in read only schema.
+ALTER SCHEMA S READ ONLY=1;
+--error ER_SCHEMA_READ_ONLY
+LOCK TABLE S.c WRITE;
+
+--echo # Restart with default log file.
+--let $wait_counter= 10000
+--let $restart_parameters= "restart:"
+--source include/restart_mysqld.inc
+
+--echo # Intermediate cleanup.
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+DROP TABLE test.t;
+DROP TABLE test.p;
+
+--echo #--------------------------------------------------------------------
+--echo # The option shall not have any affect on temporary tables.
+--echo #--------------------------------------------------------------------
+--connection node_1
+eval CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+CREATE TEMPORARY TABLE S.t(i INT);
+INSERT INTO S.t VALUES(1);
+SELECT * FROM S.t;
+DROP TABLE S.t;
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+
+--echo #--------------------------------------------------------------------
+--echo # Conflicting options.
+--echo #--------------------------------------------------------------------
+eval CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY = 0 READ ONLY = 0;
+--error ER_CONFLICTING_DECLARATIONS
+ALTER SCHEMA S READ ONLY = 0 READ ONLY = 1;
+ALTER SCHEMA S READ ONLY = 0 READ ONLY = DEFAULT;
+
+--error ER_CONFLICTING_DECLARATIONS
+ALTER SCHEMA S READ ONLY = 1 READ ONLY = 0;
+ALTER SCHEMA S READ ONLY = 1 READ ONLY = 1;
+--error ER_CONFLICTING_DECLARATIONS
+ALTER SCHEMA S READ ONLY = 1 READ ONLY = DEFAULT;
+
+ALTER SCHEMA S READ ONLY = DEFAULT READ ONLY = 0;
+--error ER_CONFLICTING_DECLARATIONS
+ALTER SCHEMA S READ ONLY = DEFAULT READ ONLY = 1;
+ALTER SCHEMA S READ ONLY = DEFAULT READ ONLY = DEFAULT;
+DROP SCHEMA S;
+
+--echo #--------------------------------------------------------------------
+--echo # ALTER READ ONLY allowed for read only schema.
+--echo #--------------------------------------------------------------------
+eval CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+SHOW CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=DEFAULT;
+SHOW CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+--echo Repeated READ ONLY = 1 is allowed
+ALTER SCHEMA S READ ONLY=1;
+SHOW CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+
+--echo #--------------------------------------------------------------------
+--echo # ALTER SCHEMA rejected for read only schema.
+--echo #--------------------------------------------------------------------
+eval CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+SHOW CREATE SCHEMA S;
+--error ER_SCHEMA_READ_ONLY
+ALTER SCHEMA S COLLATE utf8mb4_bin;
+SHOW CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+
+--echo #--------------------------------------------------------------------
+--echo # ALTER SCHEMA for a mix of options.
+--echo #--------------------------------------------------------------------
+eval CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY=1;
+--error ER_SCHEMA_READ_ONLY
+ALTER SCHEMA S READ ONLY = 1 COLLATE utf8mb4_bin;
+ALTER SCHEMA S READ ONLY = 0 COLLATE utf8mb4_bin;
+SHOW CREATE SCHEMA S;
+ALTER SCHEMA S READ ONLY = 1 COLLATE utf8mb4_general_ci;
+ALTER SCHEMA S READ ONLY=0;
+DROP SCHEMA S;
+
+# Despite all the above queries, the cluster should still be operational.
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Test suppressions
+CALL mtr.add_suppression("Can't create database 'S'; database exists");
+CALL mtr.add_suppression("Query apply failed");
+CALL mtr.add_suppression("Access to system schema 'mysql' is rejected.");
+CALL mtr.add_suppression("Schema 'S' is in read only mode.");
+
+--connection node_1
+CALL mtr.add_suppression("Schema 'S' is in read only mode.");

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -3685,8 +3685,8 @@ bool Query_log_event::write(Basic_ostream *ostream) {
   }
 
   /*
-    Replicate Q_WSREP_SKIP_READONLY_CHECKS only if it is a
-    replication applier thread.
+    Replicate Q_WSREP_SKIP_READONLY_CHECKS only if it is an async/semisync
+    applier thread, but not a wsrep applier thread.
   */
   if (WSREP(thd) && ((thd->system_thread == SYSTEM_THREAD_SLAVE_SQL) ||
                      (thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER))) {

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -718,6 +718,7 @@ THD::THD(bool enable_plugins)
       wsrep_applier_closing(false),
       wsrep_client_thread(false),
       wsrep_allow_mdl_conflict(false),
+      wsrep_applier_skip_readonly_checks(false),
       wsrep_last_query_id(0),
       wsrep_xid(),
       wsrep_skip_locking(false),

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3147,6 +3147,8 @@ class THD : public MDL_context_owner,
   bool wsrep_applier_closing; /* applier marked to close */
   bool wsrep_client_thread;   /* to identify client threads */
   bool wsrep_allow_mdl_conflict;
+  /* Skips read only checks for wsrep applier threads */
+  bool wsrep_applier_skip_readonly_checks;
   query_id_t wsrep_last_query_id;
   XID wsrep_xid;
 

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -179,6 +179,9 @@ static bool thread_can_ignore_schema_read_only(THD *thd) {
   */
   return (thd->is_bootstrap_system_thread() ||
           thd->is_server_upgrade_thread() || thd->slave_thread ||
+#ifdef WITH_WSREP
+          thd->wsrep_applier_skip_readonly_checks ||
+#endif /* WITH_WSREP */
           thd->is_cmd_skip_readonly());
 }
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4573,6 +4573,10 @@ int mysql_execute_command(THD *thd, bool first_level) {
         break;
 
 #ifdef WITH_WSREP
+      if (thd->locked_tables_mode) {
+        my_error(ER_LOCK_OR_ACTIVE_TRANSACTION, MYF(0));
+        break;
+      }
       WSREP_TO_ISOLATION_BEGIN(lex->name.str, NULL, NULL)
 #endif /* WITH_WSREP */
       /*
@@ -4593,6 +4597,10 @@ int mysql_execute_command(THD *thd, bool first_level) {
                        false))
         break;
 #ifdef WITH_WSREP
+      if (thd->locked_tables_mode) {
+        my_error(ER_LOCK_OR_ACTIVE_TRANSACTION, MYF(0));
+        break;
+      }
       WSREP_TO_ISOLATION_BEGIN(lex->name.str, NULL, NULL)
 #endif /* WITH_WSREP */
       res = mysql_rm_db(thd, to_lex_cstring(lex->name), lex->drop_if_exists);
@@ -4605,6 +4613,10 @@ int mysql_execute_command(THD *thd, bool first_level) {
                        false))
         break;
 #ifdef WITH_WSREP
+      if (thd->locked_tables_mode) {
+        my_error(ER_LOCK_OR_ACTIVE_TRANSACTION, MYF(0));
+        break;
+      }
       WSREP_TO_ISOLATION_BEGIN(lex->name.str, NULL, NULL)
 #endif /* WITH_WSREP */
       /*


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4137

    Problem
    -------
    When a PXC cluster acts as the async replica to a MySQL source, and if
    the cluster has a schema marked as read only in the PXC cluster, then
    updates on the schema from async source server are not handled correctly
    leading to inconsistencies between PXC cluster nodes.
    
    Analysis
    --------
    Consider the scenario where a schema has been marked as read only in the
    PXC Cluster, while the schema on source server is open for writes.
    
    Topology:
    
                   async           PXC
            node1 -------> node2 <-----> node3
    
    1. n1> CREATE DATABASE testdb;
    2. n2> ALTER SCHEMA testdb READ ONLY = 1; -> schema will be read only on all
                                                 nodes of the cluster
    3. n1> CREATE TABLE testdb.t1 ..
    
    In such a case, the CREATE TABLE query in step 3 will be applied on pxc
    replica by the replication applier thread on node2 and the same will
    also be replicated to node3 as TOI.
    
    Since the replication applier threads are allowed to continue even when
    schema is read only, the CREATE TABLE will be successful on node2.
    
    However, the same operation will error out on node3 as wsrep applier
    threads are not allowed to operate on read only schemas, thereby
    resulting in inconsistency voting to kick-in and thereby resulting in
    the cluster shutdown.
    
    NOTE:
    This problem could have been easily fixed by allowing the wsrep applier
    threads to operate on read only schemas. However this resulted in
    inconsistency if the user tries to create database objects directly on
    PXC nodes (node2 and node3) as the the queries are replicated as TOI
    before the checks for read only schemas are carried out.  As a result,
    the query can still succeed on the replicated node while it fails on the
    originating node, thereby again resulting in inconsistency followed by
    cluster shutdown.
    
    node2> create table testdb.t1(i int);
    ERROR 3989 (HY000): Schema 'testdb' is in read only mode.
    
    Solution
    --------
    - A new Query_event flag Q_WSREP_SKIP_READONLY_CHECKS has been added.
    - Server now enables this flag and sends it in the replication
      changestream only when the thread is an async/semisync applier thread.
    - On receiving node, server checks for Q_WSREP_SKIP_READONLY_CHECKS flag
      if enabled it sets thd->wsrep_applier_skip_readonly_checks.
    - Server ignores all readonly checks when
      thd->wsrep_applier_skip_readonly_checks is set.
