### PR TITLE
Fix possible dereference of nullptr.

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -3192,8 +3192,10 @@ static bool wsrep_init_master_key() {
 }
 
 static void wsrep_deinit_master_key() {
-  masterKeyManager->DeInit();
-  masterKeyManager.reset();
+  if (masterKeyManager) {
+    masterKeyManager->DeInit();
+    masterKeyManager.reset();
+  }
 }
 
 std::string wsrep_get_master_key(const std::string &keyId) {


### PR DESCRIPTION
The problem was discovered by galera.galera_restart_on_unknown_option mtr test. wsrep_deinit() which calls wsrep_deinit_master_key() can be called twice in a case when the server is started with an unknown option. This causes 1st call to unireg_abort and wsrep_deinit(). As the SST is still being processed, breaking it may result in unireg_abort() call, which calls wsrep_deinit() for the 2nd time causing nullptr dereference in wsrep_deinit_master_key().

The problem seems to be hard to reproduce when the test is executed under the high load (parallel=12, together with other tests), but is easy reproducible if the test is executed alone.

Fixing this issue, uncovers yet another problem which existed since some time, but visible only in debug build. Global_THD_manager::remove_thd() is called twice for (probably) SST thread, causing assertion. This will be handled as a separate Jira issue for the next release.