### PR TITLE
PXC-3211 REPLACES GALERA VERSION NUMBERS WITH ENUM VALUES

### DIFF
--- a/unittest/gunit/group_replication/group_replication_gcs_mysql_network_provider-t.cc
+++ b/unittest/gunit/group_replication/group_replication_gcs_mysql_network_provider-t.cc
@@ -430,7 +430,7 @@ TEST_F(MySQLNetworkProviderTest, NewServerConnectionTest) {
 #ifdef WITH_WSREP
   wsrep::gtid gtid;
   Wsrep_server_state::init_once(std::string(), std::string(), std::string(),
-                                std::string(), gtid, 0);
+                                std::string(), gtid, WsrepVersion::UNSPECIFIED);
 #endif
 
   THD fake_thd(false);

--- a/unittest/gunit/innodb/log0log-t.cc
+++ b/unittest/gunit/innodb/log0log-t.cc
@@ -724,7 +724,7 @@ TEST(log0log, log_random_disturb) {
 #ifdef WITH_WSREP
   wsrep::gtid gtid;
   Wsrep_server_state::init_once(std::string(), std::string(), std::string(),
-                                std::string(), gtid, 0);
+                                std::string(), gtid, WsrepVersion::UNSPECIFIED);
 #endif
 
   disturber.reset(new Log_buf_resizer{256 * 1024, 1024 * 1024});

--- a/unittest/gunit/test_utils.cc
+++ b/unittest/gunit/test_utils.cc
@@ -151,7 +151,7 @@ void Server_initializer::SetUp() {
 #ifdef WITH_WSREP
   wsrep::gtid gtid;
   Wsrep_server_state::init_once(std::string(), std::string(), std::string(),
-                                std::string(), gtid, 0);
+                                std::string(), gtid, WsrepVersion::UNSPECIFIED);
 #endif
 
   m_thd = new THD(false);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3211

Post-push fix to rectify compilation errors regarding casting ‘int’ to ‘WsrepVersion’.