### PR TITLE
PXC-4168: Assertion 'wsrep_get_SE_checkpoint().id() == view.state_id().id()' failed

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1755,7 +1755,11 @@ bool binlog_expire_logs_seconds_supplied = false;
 /* Static variables */
 
 static bool opt_myisam_log;
+#ifdef WITH_WSREP
+static std::atomic_int cleanup_done;
+#else
 static int cleanup_done;
+#endif /* WITH_WSREP */
 static ulong opt_specialflag;
 char *opt_binlog_index_name;
 char *mysql_home_ptr, *pidfile_name_ptr;

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -286,7 +286,8 @@ void Wsrep_server_service::log_view(
       if (checkpoint_was_reset || last_committed != view.state_id().seqno()) {
         wsrep_set_SE_checkpoint(view.state_id());
       }
-      assert(wsrep_get_SE_checkpoint().id() == view.state_id().id());
+      assert(wsrep_get_SE_checkpoint().id() == view.state_id().id() ||
+             wsrep_unireg_abort);
     } else {
       WSREP_DEBUG(
           "No applier in Wsrep_server_service::log_view(), "


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4168

In debug builds, server could sometimes assert with
  Assertion 'wsrep_get_SE_checkpoint().id() == view.state_id().id()
while running post installation scripts.

The root cause is below

1. The init file used for post installation steps has a SHUTDOWN command in it. Since this gets run when mysqld is not fullt started, the server sets mysqld_process_must_end_at_startup flag inside kill_mysql() function.

2. Once the server bootstrap is over, the server checks that mysqld_process_must_end_at_startup is set and thus calls unireg_abort(), which in turn sets wsrep_unireg_abort flag.

3. On the other side, we have the galera replication thread that is trying to update the XID in InnoDB after storing the view in stable storage. This is done by calling wsrep_set_SE_checkpoint() function in Wsrep_server_service::log_view().

4. Since wsrep_unireg_abort flag is already set by the bootstrap thread, the call to wsrep_set_SE_checkpoint() will perform an early return with invalid gtid resulting in the above error.

The below patch fixed the assertion failure on debug builds.

In addition to the above, this patch also avoids multiple concurrent executions of `cleanup()` when multiple threads are calling `unireg_abort()`.