### PR TITLE
PXC-4041: Rotating InnoDB MK from a read_only node breaks the cluster

### DIFF
--- a/mysql-test/suite/galera/r/galera_kill_ddl_query.result
+++ b/mysql-test/suite/galera/r/galera_kill_ddl_query.result
@@ -1,25 +1,5 @@
 CALL mtr.add_suppression("WSREP: TO isolation failed");
-################ Test 1 ################
-[connection node_1]
-FLUSH TABLES WITH READ LOCK;
-[connection node_1a]
-SET DEBUG_SYNC = 'wsrep_TOI_begin_after_wsrep_skip_wsrep_hton SIGNAL reached';
-CREATE TABLE t1 (ID INT PRIMARY KEY);;
-[connection node_1b]
-SET DEBUG_SYNC = "now WAIT_FOR reached";
-# Killing query on node1a
-ERROR HY000: The query is in TOI/NBO and cannot be killed
-[connection node_1]
-UNLOCK TABLES;
-[connection node_1a]
-[connection node_1]
-include/assert.inc [Table t1 should exist on node1]
-[connection node_2]
-include/assert.inc [Table t1 should exist on node2]
-[connection node_1]
-DROP TABLE t1;
-SET DEBUG_SYNC='RESET';
-################ Test 2a ################
+################ Test 1a ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_TOI_begin_before_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;
@@ -35,7 +15,7 @@ include/assert.inc [Table t1 should not exist on node1]
 include/assert.inc [Table t1 should not exist on node2]
 [connection node_1]
 SET DEBUG_SYNC='RESET';
-################ Test 2b ################
+################ Test 1b ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_TOI_begin_after_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;
@@ -52,7 +32,7 @@ include/assert.inc [Table t1 should exist on node2]
 [connection node_1]
 DROP TABLE t1;
 SET DEBUG_SYNC='RESET';
-################ Test 2c ################
+################ Test 1c ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_to_isolation_end_before_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;
@@ -69,7 +49,7 @@ include/assert.inc [Table t1 should exist on node2]
 [connection node_1]
 DROP TABLE t1;
 SET DEBUG_SYNC='RESET';
-################ Test 2d ################
+################ Test 1d ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;
@@ -85,7 +65,7 @@ include/assert.inc [Table t1 should exist on node2]
 [connection node_1]
 DROP TABLE t1;
 SET DEBUG_SYNC='RESET';
-################ Test 3 ################
+################ Test 2 ################
 [connection node_1]
 CREATE TABLE t2(id INT PRIMARY KEY);
 SET DEBUG_SYNC = 'ha_innobase_write_row SIGNAL write_reached WAIT_FOR write_continue';
@@ -112,7 +92,7 @@ include/assert.inc [Table t2 should be empty on node2]
 DROP TABLE t1;
 DROP TABLE t2;
 SET DEBUG_SYNC='RESET';
-################ Test 4a ################
+################ Test 3a ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_TOI_begin_before_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;
@@ -128,7 +108,7 @@ include/assert.inc [Table t1 should not exist on node1]
 include/assert.inc [Table t1 should not exist on node2]
 [connection node_1]
 SET DEBUG_SYNC='RESET';
-################ Test 4b ################
+################ Test 3b ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_TOI_begin_after_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;
@@ -145,7 +125,7 @@ include/assert.inc [Table t1 should exist on node2]
 [connection node_1]
 DROP TABLE t1;
 SET DEBUG_SYNC='RESET';
-################ Test 4c ################
+################ Test 3c ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_to_isolation_end_before_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;
@@ -162,7 +142,7 @@ include/assert.inc [Table t1 should exist on node2]
 [connection node_1]
 DROP TABLE t1;
 SET DEBUG_SYNC='RESET';
-################ Test 4d ################
+################ Test 3d ################
 [connection node_1a]
 SET DEBUG_SYNC = 'wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton SIGNAL reached WAIT_FOR continue';
 CREATE TABLE t1 (ID INT PRIMARY KEY);;

--- a/mysql-test/suite/galera/r/galera_read_only.result
+++ b/mysql-test/suite/galera/r/galera_read_only.result
@@ -20,3 +20,16 @@ t1
 SET GLOBAL super_read_only=FALSE;
 SET GLOBAL read_only=FALSE;
 DROP TABLE t1;
+SET GLOBAL super_read_only=1;
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+SET GLOBAL super_read_only=0;
+SET GLOBAL read_only=1;
+CREATE USER 'testuser'@'%' IDENTIFIED WITH 'mysql_native_password' BY 'testuser';
+GRANT ENCRYPTION_KEY_ADMIN ON *.* to 'testuser'@'%';
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+SET global read_only = 0;
+SET global super_read_only = 0;
+DROP USER 'testuser'@'%';
+CALL mtr.add_suppression("Failed to replicate .* in cluster mode");

--- a/mysql-test/suite/galera/r/galera_toi_read_only_server.result
+++ b/mysql-test/suite/galera/r/galera_toi_read_only_server.result
@@ -1,0 +1,56 @@
+[connection node_1]
+CREATE TABLE t1 (ID INT PRIMARY KEY) ENCRYPTION='Y';
+SET GLOBAL super_read_only=1;
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+ERROR HY000: The MySQL server is running with the --super-read-only option so it cannot execute this statement
+[connection node_2]
+[connection node_1a]
+SET GLOBAL super_read_only=0;
+SET DEBUG_SYNC = 'wsrep_to_isolation_begin_before_replication SIGNAL reached WAIT_FOR continue';
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+[connection node_1b]
+SET SESSION wsrep_sync_wait=0;
+SET DEBUG_SYNC = "now WAIT_FOR reached";
+# Setting super_read_only=1
+SET GLOBAL super_read_only=1;
+[connection node_1]
+SET SESSION wsrep_sync_wait=0;
+include/assert.inc [Verify that SET GLOBAL super_read_only=1 is waiting for Global Read Lock.]
+SET DEBUG_SYNC= 'now SIGNAL continue';
+[connection node_1]
+[connection node_2]
+[connection node_1]
+SET DEBUG_SYNC='RESET';
+FLUSH HOSTS;
+Warnings:
+Warning	1287	'FLUSH HOSTS' is deprecated and will be removed in a future release. Please use TRUNCATE TABLE performance_schema.host_cache instead
+SET GLOBAL super_read_only=0;
+CREATE USER 'user1'@'localhost' IDENTIFIED BY 'pass1';
+SET GLOBAL super_read_only=1;
+FLUSH PRIVILEGES;
+SET GLOBAL super_read_only=0;
+DELETE FROM mysql.user WHERE user = 'user1';
+SET GLOBAL super_read_only=1;
+FLUSH PRIVILEGES;
+FLUSH STATUS;
+FLUSH USER_RESOURCES;
+FLUSH TABLES;
+SET GLOBAL super_read_only=0;
+CREATE TABLE t2 (f1 INTEGER);
+SET GLOBAL super_read_only=1;
+FLUSH TABLES t2;
+FLUSH ERROR LOGS;
+FLUSH SLOW LOGS;
+FLUSH GENERAL LOGS;
+FLUSH ENGINE LOGS;
+FLUSH RELAY LOGS;
+FLUSH CLIENT_STATISTICS;
+FLUSH INDEX_STATISTICS;
+FLUSH TABLE_STATISTICS;
+FLUSH USER_STATISTICS;
+FLUSH THREAD_STATISTICS;
+SET global read_only = 0;
+SET global super_read_only = 0;
+DROP TABLE t1;
+DROP TABLE t2;
+CALL mtr.add_suppression("Failed to replicate .* in cluster mode");

--- a/mysql-test/suite/galera/t/galera_kill_ddl_query.test
+++ b/mysql-test/suite/galera/t/galera_kill_ddl_query.test
@@ -18,73 +18,12 @@ CALL mtr.add_suppression("WSREP: TO isolation failed");
 --connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
 
 #
-# Test 1: Block with FTWRL, then KILL
-# (The command will succeed)
+# Test 1: Test killing of the DDL query using KILL QUERY
 #
---echo ################ Test 1 ################
---connection node_1
---echo [connection node_1]
-FLUSH TABLES WITH READ LOCK;
-
-# Do the CREATE TABLE, this will block due to the FTWRL
---connection node_1a
---echo [connection node_1a]
-SET DEBUG_SYNC = 'wsrep_TOI_begin_after_wsrep_skip_wsrep_hton SIGNAL reached';
---send CREATE TABLE t1 (ID INT PRIMARY KEY);
-
-# Kill the CREATE TABLE query
---connection node_1b
---echo [connection node_1b]
-
-# Ensure that we have entered TOI (at least)
-SET DEBUG_SYNC = "now WAIT_FOR reached";
-
-# The KILL will fail because we are already in TOI
---disable_query_log
---echo # Killing query on node1a
---error ER_KILL_DENIED_ERROR
---eval KILL QUERY $node1a_connection_id
---enable_query_log
-
-# Unblock the CREATE TABLE
---connection node_1
---echo [connection node_1]
-UNLOCK TABLES;
-
-# The CREATE TABLE should succeed
---connection node_1a
---echo [connection node_1a]
---reap
-
-# Verify the cluster contents
---connection node_1
---echo [connection node_1]
---let $assert_text= Table t1 should exist on node1
---let $assert_cond= COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
---let $assert_debug= SELECT * FROM INFORMATION_SCHEMA.TABLES
---source include/assert.inc
-
---connection node_2
---echo [connection node_2]
---let $assert_text= Table t1 should exist on node2
---let $assert_cond= COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = "t1"
---let $assert_debug= SELECT * FROM INFORMATION_SCHEMA.TABLES
---source include/assert.inc
-
-# Cleanup
---connection node_1
---echo [connection node_1]
-DROP TABLE t1;
-SET DEBUG_SYNC='RESET';
-
-
-#
-# Test 2: Test killing of the DDL query using KILL QUERY
-#
-# Test 2a: Block in wsrep_TOI_begin_before_wsrep_skip_wsrep_hton, then KILL
+# Test 1a: Block in wsrep_TOI_begin_before_wsrep_skip_wsrep_hton, then KILL
 # (The command will be aborted)
 #
---echo ################ Test 2a ################
+--echo ################ Test 1a ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a
@@ -135,10 +74,10 @@ SET DEBUG_SYNC='RESET';
 
 
 #
-# Test 2b: Block in wsrep_TOI_begin_after_wsrep_skip_wsrep_hton, then KILL
+# Test 1b: Block in wsrep_TOI_begin_after_wsrep_skip_wsrep_hton, then KILL
 # (The command will succeed)
 #
---echo ################ Test 2b ################
+--echo ################ Test 1b ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a
@@ -189,10 +128,10 @@ DROP TABLE t1;
 SET DEBUG_SYNC='RESET';
 
 #
-# Test 2c: Block in wsrep_to_isolation_end_before_wsrep_skip_wsrep_hton, then KILL
+# Test 1c: Block in wsrep_to_isolation_end_before_wsrep_skip_wsrep_hton, then KILL
 # (The command will succeed)
 #
---echo ################ Test 2c ################
+--echo ################ Test 1c ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a
@@ -244,9 +183,9 @@ SET DEBUG_SYNC='RESET';
 
 
 #
-# Test 2d: Block in wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton, then KILL
+# Test 1d: Block in wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton, then KILL
 # (The command will succeed)
---echo ################ Test 2d ################
+--echo ################ Test 1d ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a
@@ -298,9 +237,9 @@ SET DEBUG_SYNC='RESET';
 
 
 #
-# Test 3: Check that other (DML) queries (while running a DDL) can still
+# Test 2: Check that other (DML) queries (while running a DDL) can still
 # be killed.
---echo ################ Test 3 ################
+--echo ################ Test 2 ################
 
 # Setup the test
 --connection node_1
@@ -379,12 +318,12 @@ DROP TABLE t2;
 SET DEBUG_SYNC='RESET';
 
 #
-# Test 4: Test killing of the DDL using KILL CONNECTION
+# Test 3: Test killing of the DDL using KILL CONNECTION
 #
-# Test 4a: Block in wsrep_TOI_begin_before_wsrep_skip_wsrep_hton, then KILL the connection
+# Test 3a: Block in wsrep_TOI_begin_before_wsrep_skip_wsrep_hton, then KILL the connection
 # (The command will be aborted)
 #
---echo ################ Test 4a ################
+--echo ################ Test 3a ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a
@@ -439,10 +378,10 @@ SET DEBUG_SYNC='RESET';
 --let $node1a_connection_id=`SELECT CONNECTION_ID()`
 
 #
-# Test 4b: Block in wsrep_TOI_begin_after_wsrep_skip_wsrep_hton, then KILL the connection
+# Test 3b: Block in wsrep_TOI_begin_after_wsrep_skip_wsrep_hton, then KILL the connection
 # (The command will succeed)
 #
---echo ################ Test 4b ################
+--echo ################ Test 3b ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a
@@ -494,10 +433,10 @@ SET DEBUG_SYNC='RESET';
 
 
 #
-# Test 4c: Block in wsrep_to_isolation_end_before_wsrep_skip_wsrep_hton, then KILL the connection
+# Test 3c: Block in wsrep_to_isolation_end_before_wsrep_skip_wsrep_hton, then KILL the connection
 # (The command will succeed)
 #
---echo ################ Test 4c ################
+--echo ################ Test 3c ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a
@@ -549,9 +488,9 @@ SET DEBUG_SYNC='RESET';
 
 
 #
-# Test 4d: Block in wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton, then KILL the connection
+# Test 3d: Block in wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton, then KILL the connection
 # (The command will succeed)
---echo ################ Test 4d ################
+--echo ################ Test 3d ################
 
 # Do the CREATE TABLE, this will block due to the DEBUG_SYNC
 --connection node_1a

--- a/mysql-test/suite/galera/t/galera_read_only.test
+++ b/mysql-test/suite/galera/t/galera_read_only.test
@@ -44,3 +44,33 @@ SET GLOBAL super_read_only=FALSE;
 SET GLOBAL read_only=FALSE;
 
 DROP TABLE t1;
+#
+# PXC-4041: Rotating InnoDB MK from a read_only node breaks the cluster
+#
+
+--connection node_1
+--let super_read_only_saved = `SELECT @@super_read_only`
+--let read_only_saved = `SELECT @@read_only`
+
+# super_read_only
+SET GLOBAL super_read_only=1;
+--error ER_OPTION_PREVENTS_STATEMENT
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+# read_only
+SET GLOBAL super_read_only=0;
+SET GLOBAL read_only=1;
+
+CREATE USER 'testuser'@'%' IDENTIFIED WITH 'mysql_native_password' BY 'testuser';
+GRANT ENCRYPTION_KEY_ADMIN ON *.* to 'testuser'@'%';
+--connect node_1a, 127.0.0.1, testuser, testuser, test, $NODE_MYPORT_1
+--connection node_1a
+--error ER_OPTION_PREVENTS_STATEMENT
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+--connection node_1
+--eval SET global read_only = $read_only_saved
+--eval SET global super_read_only = $super_read_only_saved
+DROP USER 'testuser'@'%';
+
+CALL mtr.add_suppression("Failed to replicate .* in cluster mode");

--- a/mysql-test/suite/galera/t/galera_toi_read_only_server.test
+++ b/mysql-test/suite/galera/t/galera_toi_read_only_server.test
@@ -1,0 +1,346 @@
+# === Purpose ===
+#
+# This test verifies that DDLs replicating as TOI fail before replication when
+# server is set to super_read_only.
+#
+# === References ===
+# PXC-4041: Rotating InnoDB MK from a read_only node breaks the cluster
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+###############################################################################
+# Test-1: Setting super_read_only=1 before running DDL. DDL must fail with
+# ER_OPTION_PREVENTS_STATEMENT.
+###############################################################################
+--connection node_1
+--echo [connection node_1]
+--let super_read_only_saved = `SELECT @@super_read_only`
+--let read_only_saved = `SELECT @@read_only`
+
+CREATE TABLE t1 (ID INT PRIMARY KEY) ENCRYPTION='Y';
+
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+SET GLOBAL super_read_only=1;
+
+--error ER_OPTION_PREVENTS_STATEMENT
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+# Verify that there was no replication
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+--connection node_2
+--echo [connection node_2]
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+###############################################################################
+# Test-2: Setting super_read_only before query is replicated to other nodes.
+# i.e, Make the query block in wsrep_to_isolation_begin_before_replication, then
+# set super_read_only from the other session.
+###############################################################################
+
+# Execute ALTER INSTANCE, this will block due to the DEBUG_SYNC
+--connection node_1a
+--echo [connection node_1a]
+SET GLOBAL super_read_only=0;
+SET DEBUG_SYNC = 'wsrep_to_isolation_begin_before_replication SIGNAL reached WAIT_FOR continue';
+
+--send ALTER INSTANCE ROTATE INNODB MASTER KEY
+
+--connection node_1b
+--echo [connection node_1b]
+SET SESSION wsrep_sync_wait=0;
+--let $conn_id=`SELECT CONNECTION_ID()`
+SET DEBUG_SYNC = "now WAIT_FOR reached";
+
+--echo # Setting super_read_only=1
+--send SET GLOBAL super_read_only=1
+
+# Verify that SET GLBOAL super_read_only=1 waits for Global Read Lock.
+--connection node_1
+--echo [connection node_1]
+SET SESSION wsrep_sync_wait=0;
+--let $wait_condition= SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State='Waiting for global read lock';
+--source include/wait_condition.inc
+
+--let $assert_text= Verify that SET GLOBAL super_read_only=1 is waiting for Global Read Lock.
+--let $assert_cond= [ SELECT State="Waiting for global read lock" FROM INFORMATION_SCHEMA.PROCESSLIST WHERE Id = $conn_id ] = 1
+--source include/assert.inc
+
+# Unblock ALTER INSTANCE
+SET DEBUG_SYNC= 'now SIGNAL continue';
+
+--connection node_1a
+--reap
+
+--connection node_1b
+--reap
+
+# Assert that super_read_only has been set.
+--assert(`SELECT @@GLOBAL.super_read_only = 1`)
+
+# Verify that the query was replicated
+--connection node_1
+--echo [connection node_1]
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+--connection node_2
+--echo [connection node_2]
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+# Cleanup
+--connection node_1
+--echo [connection node_1]
+SET DEBUG_SYNC='RESET';
+
+###############################################################################
+# Test-3: Verify that FLUSH commands are not affected when server has
+# super_read_only=1
+###############################################################################
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH HOSTS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH HOSTS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH PRIVILEGES
+#-------------------------------------------------------------------------------
+--connection node_1
+SET GLOBAL super_read_only=0;
+CREATE USER 'user1'@'localhost' IDENTIFIED BY 'pass1';
+SET GLOBAL super_read_only=1;
+FLUSH PRIVILEGES;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE User = "user1"
+--source include/wait_condition.inc
+
+--connect node_2a, 127.0.0.1, user1, pass1, test, $NODE_MYPORT_2
+
+--connection node_1
+SET GLOBAL super_read_only=0;
+DELETE FROM mysql.user WHERE user = 'user1';
+SET GLOBAL super_read_only=1;
+FLUSH PRIVILEGES;
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH STATUS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH STATUS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH USER_RESOURCES
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH USER_RESOURCES;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH TABLES
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH TABLES;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH TABLES
+#-------------------------------------------------------------------------------
+--connection node_1
+SET GLOBAL super_read_only=0;
+CREATE TABLE t2 (f1 INTEGER);
+SET GLOBAL super_read_only=1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH TABLES t2;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH ERROR_LOGS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH ERROR LOGS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH SLOW_LOGS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH SLOW LOGS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH GENERAL_LOGS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH GENERAL LOGS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH ENGINE_LOGS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH ENGINE LOGS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH RELAY_LOGS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH RELAY LOGS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH CLIENT_STATISTICS
+#       FLUSH INDEX_STATISTICS
+#       FLUSH TABLE_STATISTICS
+#       FLUSH USER_STATISTICS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH CLIENT_STATISTICS;
+FLUSH INDEX_STATISTICS;
+FLUSH TABLE_STATISTICS;
+FLUSH USER_STATISTICS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 4 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 4 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+--source include/wait_condition.inc
+
+
+#-------------------------------------------------------------------------------
+# Test: FLUSH THREAD_STATISTICS
+#-------------------------------------------------------------------------------
+--connection node_2
+--let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_1
+FLUSH THREAD_STATISTICS;
+
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = $wsrep_last_committed_before + 1 FROM performance_schema.session_status WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition_on_error_output = SELECT VARIABLE_NAME, VARIABLE_VALUE, $wsrep_last_committed_before + 1 as EXPECTED_VALUE FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('wsrep_last_committed')
+--source include/wait_condition_with_debug.inc
+
+
+
+# Test cleanup
+
+--disconnect node_1b
+--disconnect node_1a
+
+--connection node_1
+--eval SET global read_only = $read_only_saved
+--eval SET global super_read_only = $super_read_only_saved
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+CALL mtr.add_suppression("Failed to replicate .* in cluster mode");
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/mysql-wsrep#198.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#198.test
@@ -81,7 +81,7 @@ FLUSH TABLE WITH READ LOCK;
 --connection node_2
 SET SESSION wsrep_sync_wait = 0;
 --echo #node-2 (check ddl are waiting)
---let $wait_condition = SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'wsrep: initiating TOI for write set (-1)';
+--let $wait_condition = SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for global read lock';
 --source include/wait_condition.inc
 
 --connection node_1

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1734,22 +1734,6 @@ static bool deny_updates_if_read_only_option(THD *thd, TABLE_LIST *all_tables) {
 }
 
 #ifdef WITH_WSREP
-static bool wsrep_read_only_option(THD *thd, TABLE_LIST *all_tables) {
-  int opt_readonly_saved = opt_readonly;
-
-  ulong master_access = thd->security_context()->master_access();
-  ulong flag_saved = (ulong)(master_access & SUPER_ACL);
-
-  opt_readonly = 0;
-  thd->security_context()->set_master_access(master_access & ~SUPER_ACL);
-
-  bool ret = !deny_updates_if_read_only_option(thd, all_tables);
-
-  opt_readonly = opt_readonly_saved;
-  thd->security_context()->set_master_access(master_access | flag_saved);
-
-  return ret;
-}
 
 static void wsrep_copy_query(THD *thd) {
   thd->wsrep_retry_command = thd->get_command();
@@ -7734,8 +7718,7 @@ static bool wsrep_dispatch_sql_command(THD *thd, const char *rawbuf,
                                        uint length, Parser_state *parser_state,
                                        bool update_userstat) {
   DBUG_TRACE;
-  bool is_autocommit = !thd->in_multi_stmt_transaction_mode() &&
-                       wsrep_read_only_option(thd, thd->lex->query_tables);
+  bool is_autocommit = !thd->in_multi_stmt_transaction_mode();
   bool retry_autocommit;
 
   do {


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4041

Problem
-------
When super_read_only or read_only is set, ALTER INSTANCE fails (as expected) which triggers consistency voting mechanism and causes node to leave the cluster

Analysis
--------
In original flow, the validation happens inside Sql_cmd_alter_instance::execute

Eg: For ALTER INSTACE ROTATE INNODB MASTER KEY, it happens at

Sql_cmd_alter_instance::execute
 -> Rotate_innodb_master_key::execute
  -> acquire_shared_global_read_lock
   -> check_readonly
    -> err_readonly

As the statement is replicated as TOI before validation, this causes the query to fail on originating node and succeed on the replicating nodes.

In addition to the above problem, the following problems were also discovered during investigation.

1. It was also found that server allows read_only variable to be updated while a TOI is in progress thereby causing cluster inconsistency when the read_only variable was changed after the TOI was replicated.

2. Discovered the code in wsrep_read_only_option() that silently modified the global opt_readonly variable and always evaluated to true. This function has been removed in 5.7 by commit f481ce88437, but was not removed in 8.0

Solution
--------
1. In the beginning of TOI, the server now takes an intention-exclusive lock on the global read lock to have protection against concurrent change of read_only option. If the server is already in read only mode, we error out with ER_OPTION_PREVENTS_STATEMENT.

2. The function wsrep_read_only_option() has been removed.