### PR TITLE
PXC-4183 FIXES THE PATH PICKED FOR INSTALLING LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,13 @@ MESSAGE(STATUS "SIZEOF_VOIDP ${SIZEOF_VOIDP}")
 # even if we have configured for 64bit build....
 SET(CMAKE_SIZEOF_VOID_P ${SIZEOF_VOIDP})
 
+IF(WITH_DEFAULT_COMPILER_OPTIONS)
+  INCLUDE(${CMAKE_SOURCE_DIR}/cmake/build_configurations/compiler_options.cmake)
+ENDIF()
+IF(WITH_DEFAULT_FEATURE_SET)
+  INCLUDE(${CMAKE_SOURCE_DIR}/cmake/build_configurations/feature_set.cmake)
+ENDIF()
+
 INCLUDE(compile_flags)
 INCLUDE(install_layout)
 
@@ -334,13 +341,6 @@ IF(WITH_PACKAGE_FLAGS AND NOT CMAKE_C_FLAGS AND NOT CMAKE_CXX_FLAGS)
       MESSAGE(WARNING "Please do 'apt install dpkg-dev'")
     ENDIF()
   ENDIF()
-ENDIF()
-
-IF(WITH_DEFAULT_COMPILER_OPTIONS)
-  INCLUDE(${CMAKE_SOURCE_DIR}/cmake/build_configurations/compiler_options.cmake)
-ENDIF()
-IF(WITH_DEFAULT_FEATURE_SET)
-  INCLUDE(${CMAKE_SOURCE_DIR}/cmake/build_configurations/feature_set.cmake)
 ENDIF()
 
 INCLUDE(CMakePushCheckState)


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4183

Problem
-------
/usr/lib is being picked as path to install the libraries instead of /usr/lib64.

Analysis
--------
install_layout.cmake is responsible for INSTALL_LIBDIR_RPM which is used to select the path to install the libraries. It is dependent on the variable 64BIT which is set in compiler_options.cmake. Due to the recent changes in CMakeLists.txt, install_layout.cmake is invoked before compiler_options.cmake which resulted in 64BIT being unset.

Solution
--------
The invoking of compiler_options.cmake is moved above the usage of install_layout.