### PR TITLE
PXC-3026: Fix most of WITH_WSREP issues in the 8.0 branch

### DIFF
--- a/check_src/check_file.sh
+++ b/check_src/check_file.sh
@@ -1,0 +1,50 @@
+# Compares a single PS/PXC source file
+# The script will print out an error and a diff if there is any difference
+# after removing the PXC specific code, not counting whitespace and empty lines
+# The script also allows whitelisting expected differences, such as different
+# product names (Percona Server vs Percona Xtradb Cluster)
+
+# Usage: bash check_src/check_file.sh <file_name> <PS 5.6 source directory>
+# The script should be run from the root directory of the PXC source
+# The PS source should be the currently merged PS tag
+
+# Extending/changing the whitelist:
+# The whitelist directory contains files in a single directory (without
+# subdirectories), each file whitelist a single real source file, with the
+# same name.
+# The whitelist file contains the lines starting with > or < of the expected
+# diff: only the change without the actual line/offset numbers, to prevent
+# unrelated changes from breaking the whitelisted change.
+if [ ! -s $2/$1 ] ; then
+  exit 0
+fi
+F=`mktemp`
+gawk -f check_src/rem.awk $1 > $F
+
+D=`mktemp`
+D2=`mktemp`
+diff -wB $F $2/$1 > $D
+
+if [ -s $D ] ; then
+  WHITELIST_NAME=check_src/whitelist/${1##*/}
+  if [ -f $WHITELIST_NAME ] ; then
+    D3=`mktemp`
+    cat $D | grep "^[<>].*" > $D3
+    diff -wB $WHITELIST_NAME $D3 > $D2
+    rm $D3
+    if [ ! -s $D2 ] ; then
+      echo -n "" > $D
+    fi
+  fi
+fi
+
+if [ -s $D ] ; then
+  echo "============"
+  echo "Error: $1"
+  echo "============"
+  cat $D
+fi
+
+rm $F
+rm $D
+rm $D2

--- a/check_src/rem.awk
+++ b/check_src/rem.awk
@@ -1,0 +1,74 @@
+# AWK script to remove PXC specific code from source files
+# Based on common PXC specific ifdefs/macros
+BEGIN {
+	# We are currently checking a WITH_WSREP ifdef line
+	with_wsrep = 0
+	# We encountered an if(n)def WITH_WSREP block before,
+	# and it's scope, or the scope of its else clause is still open
+	had_wsrep = 0
+	# How many ifdefs we have nested?
+	# Used to ensure that we find the correct else/endif
+	nest_level = 0
+	# We encountered an ifndef WITH_WSREP, or the else clause of
+	# the ifdef version
+	ifndef_wsrep = 0
+}
+
+{
+	skip_this = 0
+	if ($0 ~ /WSREP_TO_ISOLATION_BEGIN/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /WSREP_TO_ISOLATION_END/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /WSREP_SYNC_WAIT/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /WAIT_ALLOW_WRITES/) {
+		# Macro defined to nothing without WITH_WSREP
+		skip_this = 1
+	}
+	if ($0 ~ /#if/) {
+		if ($0 ~ /WITH_WSREP/ || $0 ~ /WITH_INNODB_DISALLOW_WRITES/) {
+			if ($0 ~ /ifndef/) {
+				had_wsrep = 1
+				ifndef_wsrep = 1
+				nest_level = 0
+				skip_this = 1
+			} else {
+				with_wsrep = 1
+				had_wsrep = 1
+				nest_level = 0
+			}
+		} else if (had_wsrep == 1) {
+			nest_level = nest_level + 1
+		}
+	}
+	if ($0 ~ /#else/ && (with_wsrep == 1 || ifndef_wsrep == 1) && nest_level == 0) {
+		if (ifndef_wsrep == 1) {
+			with_wsrep = 1
+			ifndef_wsrep = 0
+		} else {
+			with_wsrep = 0
+		}
+		skip_this = 1
+	}
+	if ($0 ~ /#endif/ && nest_level == 0) {
+		if (had_wsrep == 1) {
+			skip_this = 1
+		}
+		had_wsrep = 0
+		with_wsrep = 0
+		ifndef_wsrep = 0
+	}
+	if ($0 ~ /#endif/ && nest_level != 0) {
+		nest_level = nest_level - 1
+	}
+	if (with_wsrep == 0 && skip_this == 0) {
+		print $0
+	}
+}

--- a/check_src/run.sh
+++ b/check_src/run.sh
@@ -1,0 +1,9 @@
+# Compares every source file between PS/PXC for differences without the if WITH_WSREP
+# blocks.
+# Usage:  bash check_src/run.sh <PS_DIRECTORY>
+PS_LOCATION=$1
+find . -type f -name '*.h' -exec bash check_src/check_file.sh '{}' $PS_LOCATION \;
+find . -type f -name '*.cc' -exec bash check_src/check_file.sh '{}' $PS_LOCATION \;
+find . -type f -name '*.c' -exec bash check_src/check_file.sh '{}' $PS_LOCATION \;
+find . -type f -name '*.ic' -exec bash check_src/check_file.sh '{}' $PS_LOCATION \;
+

--- a/check_src/whitelist/bootstrapper.cc
+++ b/check_src/whitelist/bootstrapper.cc
@@ -1,0 +1,4 @@
+<       repopulate_charsets_and_collations(thd) ||
+<       verify_contents(thd) || update_versions(thd, false)) {
+>       repopulate_charsets_and_collations(thd) || verify_contents(thd) ||
+>       update_versions(thd, false)) {

--- a/check_src/whitelist/ha_innodb.cc
+++ b/check_src/whitelist/ha_innodb.cc
@@ -1,0 +1,16 @@
+< #if 0
+<     /* If the increment step of the auto increment column
+<     decreases then it is not affecting the immediate
+<     next value in the series. */
+<     if (m_prebuilt->autoinc_increment > increment) {
+<       current = autoinc - m_prebuilt->autoinc_increment;
+< 
+<       current = innobase_next_autoinc(current, 1, increment, 1, col_max_value);
+< 
+<       dict_table_autoinc_initialize(m_prebuilt->table, current);
+< 
+<       *first_value = current;
+<     }
+< #endif
+< 
+

--- a/check_src/whitelist/handler.cc
+++ b/check_src/whitelist/handler.cc
@@ -1,0 +1,4 @@
+<     auto *ht = ha_info->ht();
+< 
+< 
+>     auto ht = ha_info->ht();

--- a/check_src/whitelist/innochecksum.cc
+++ b/check_src/whitelist/innochecksum.cc
@@ -1,0 +1,3 @@
+>   ulong n;
+<   ulong n;
+

--- a/check_src/whitelist/lock.cc
+++ b/check_src/whitelist/lock.cc
@@ -1,0 +1,7 @@
+<   if (m_mdl_global_shared_lock) {
+>   if (m_mdl_global_shared_lock)
+<   }
+<   if (m_mdl_blocks_commits_lock) {
+>   if (m_mdl_blocks_commits_lock)
+<   }
+

--- a/check_src/whitelist/lock0lock.cc
+++ b/check_src/whitelist/lock0lock.cc
@@ -1,0 +1,13 @@
+< /**
+< Enqueue a lock wait for normal transaction. If it is a high priority transaction
+< then jump the record lock wait queue and if the transaction at the head of the
+< queue is itself waiting roll it back, also do a deadlock check and resolve.
+< @param[in, out] wait_for	The lock that the joining transaction is
+<                                 waiting for
+< @param[in] prdt			Predicate [optional]
+< @return DB_SUCCESS, DB_LOCK_WAIT, DB_DEADLOCK, or
+<         DB_SUCCESS_LOCKED_REC; DB_SUCCESS_LOCKED_REC means that
+<         there was a deadlock, but another transaction was chosen
+<         as a victim, and we got the lock immediately: no need to
+<         wait then */
+<  @param[in] c_lock         conflicting lock

--- a/check_src/whitelist/log_event.cc
+++ b/check_src/whitelist/log_event.cc
@@ -1,0 +1,10 @@
+<   if (ddl_skip_rewrite != print_event_info->ddl_skip_rewrite) {
+<     my_b_printf(file, "/*!80026 SET @@session.binlog_ddl_skip_rewrite=%d*/%s\n",
+<                 ddl_skip_rewrite, print_event_info->delimiter);
+<     print_event_info->ddl_skip_rewrite = ddl_skip_rewrite;
+<   }
+<       here as the present method does not call dispatch_sql_command().
+>       here as the present method does not call mysql_parse().
+<       skipped_event_in_transaction(false),
+<       ddl_skip_rewrite(false) {
+>       skipped_event_in_transaction(false) {

--- a/check_src/whitelist/log_event.h
+++ b/check_src/whitelist/log_event.h
@@ -1,0 +1,1 @@
+<   bool ddl_skip_rewrite;

--- a/check_src/whitelist/mysql.cc
+++ b/check_src/whitelist/mysql.cc
@@ -1,0 +1,3 @@
+<       "Percona XtraDB Cluster manual: "
+<       "http://www.percona.com/doc/percona-xtradb-cluster/8.0/\n"
+>       "Percona Server manual: http://www.percona.com/doc/percona-server/8.0/\n"

--- a/check_src/whitelist/mysqlbinlog.cc
+++ b/check_src/whitelist/mysqlbinlog.cc
@@ -1,0 +1,2 @@
+< #undef WITH_WSREP
+<

--- a/check_src/whitelist/mysqld.cc
+++ b/check_src/whitelist/mysqld.cc
@@ -1,0 +1,77 @@
+<   /* Leave the original location if wsrep is not involved otherwise
+<   we do this before initializing WSREP as wsrep needs access to
+<   gtid_mode which and for accessing gtid_mode gtid_sid_locks has to be
+<   initialized which is done by this function. */
+< 
+<       LogErr(ERROR_LEVEL,
+<              ER_RPL_GTID_MODE_REQUIRES_ENFORCE_GTID_CONSISTENCY_ON);
+>     LogErr(ERROR_LEVEL, ER_RPL_GTID_MODE_REQUIRES_ENFORCE_GTID_CONSISTENCY_ON);
+<     if (opt_bin_log) {
+<       if (binlog_space_limit) mysql_bin_log.purge_logs_by_size(true);
+<     } else {
+>   if (!opt_bin_log) {
+<    "Keyring plugin or component to which the keys are "
+<    "migrated to. This option must be specified along with "
+<    "--keyring-migration-source.",
+>      "Keyring plugin or component to which the keys are migrated to.",
+<   {"keyring-migration-socket", OPT_KEYRING_MIGRATION_SOCKET,
+<    "The socket file to use for connection.", &opt_keyring_migration_socket,
+<    &opt_keyring_migration_socket, nullptr, GET_STR, REQUIRED_ARG, 0, 0, 0,
+<    nullptr, 0, nullptr},
+<   {"keyring-migration-port", OPT_KEYRING_MIGRATION_PORT,
+<    "Port number to use for connection.", &opt_keyring_migration_port,
+<    &opt_keyring_migration_port, nullptr, GET_ULONG, REQUIRED_ARG, 0, 0, 0,
+<    nullptr, 0, nullptr},
+<    &opt_validate_config, &opt_validate_config, nullptr, GET_BOOL, NO_ARG, 0, 0,
+<    0, nullptr, 0, nullptr},
+>      &opt_validate_config, &opt_validate_config, nullptr, GET_BOOL, NO_ARG, 0,
+>      0, 0, nullptr, 0, nullptr},
+<    &opt_libcoredumper_path, &opt_libcoredumper_path, 0, GET_STR, OPT_ARG, 0, 0,
+<    0, 0, 0, 0},
+>      &opt_libcoredumper_path, &opt_libcoredumper_path, 0, GET_STR, OPT_ARG, 0,
+>      0, 0, 0, 0, 0},
+<   {nullptr, 0, nullptr, nullptr, nullptr, nullptr, GET_NO_ARG, NO_ARG, 0, 0, 0,
+<    nullptr, 0, nullptr}
+< };
+>     {nullptr, 0, nullptr, nullptr, nullptr, nullptr, GET_NO_ARG, NO_ARG, 0, 0,
+>      0, nullptr, 0, nullptr}};
+<    &slow_start_timeout, &slow_start_timeout, 0, GET_ULONG, REQUIRED_ARG, 15000,
+<    0, 0, 0, 0, 0},
+>      &slow_start_timeout, &slow_start_timeout, 0, GET_ULONG, REQUIRED_ARG,
+>      15000, 0, 0, 0, 0, 0},
+<   {"standalone", 0, "Dummy option to start as a standalone program (NT).", 0, 0,
+<    0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
+>     {"standalone", 0, "Dummy option to start as a standalone program (NT).", 0,
+>      0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
+<    &my_enable_symlinks, &my_enable_symlinks, nullptr, GET_BOOL, NO_ARG, 0, 0, 0,
+<    nullptr, 0, nullptr},
+>      &my_enable_symlinks, &my_enable_symlinks, nullptr, GET_BOOL, NO_ARG, 0, 0,
+>      0, nullptr, 0, nullptr},
+<    &global_system_variables.sysdate_is_now, nullptr, nullptr, GET_BOOL, NO_ARG,
+<    0, 0, 1, nullptr, 1, nullptr},
+>      &global_system_variables.sysdate_is_now, nullptr, nullptr, GET_BOOL,
+>      NO_ARG, 0, 0, 1, nullptr, 1, nullptr},
+<    &tc_heuristic_recover, &tc_heuristic_recover, &tc_heuristic_recover_typelib,
+<    GET_ENUM, REQUIRED_ARG, TC_HEURISTIC_NOT_USED, 0, 0, nullptr, 0, nullptr},
+>      &tc_heuristic_recover, &tc_heuristic_recover,
+>      &tc_heuristic_recover_typelib, GET_ENUM, REQUIRED_ARG,
+>      TC_HEURISTIC_NOT_USED, 0, 0, nullptr, 0, nullptr},
+<    &opt_debug_sync_timeout, nullptr, nullptr, GET_UINT, OPT_ARG, 0, 0, UINT_MAX,
+<    nullptr, 0, nullptr},
+>      &opt_debug_sync_timeout, nullptr, nullptr, GET_UINT, OPT_ARG, 0, 0,
+>      UINT_MAX, nullptr, 0, nullptr},
+<    nullptr, nullptr, nullptr, GET_BOOL, OPT_ARG, 0, 0, 0, nullptr, 0, nullptr},
+>      nullptr, nullptr, nullptr, GET_BOOL, OPT_ARG, 0, 0, 0, nullptr, 0,
+>      nullptr},
+<    &utility_user_dynamic_privileges, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0,
+<    0},
+>      &utility_user_dynamic_privileges, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0,
+>      0, 0},
+<    &utility_user_schema_access, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+>      &utility_user_schema_access, 0, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0,
+>      0},
+<   {nullptr, 0, nullptr, nullptr, nullptr, nullptr, GET_NO_ARG, NO_ARG, 0, 0, 0,
+<    nullptr, 0, nullptr}
+< };
+>     {nullptr, 0, nullptr, nullptr, nullptr, nullptr, GET_NO_ARG, NO_ARG, 0, 0,
+>      0, nullptr, 0, nullptr}};

--- a/check_src/whitelist/mysqltest.cc
+++ b/check_src/whitelist/mysqltest.cc
@@ -1,0 +1,6 @@
+<         "consist of only alpha-numeric characters, dash (-), "
+<         "underscore (_) or hash (#), but should not start with dash or "
+<         "underscore or hash.",
+>         "consist of only alpha-numeric characters, dash (-) or "
+>         "underscore (_), but should not start with dash or "
+>         "underscore.",

--- a/check_src/whitelist/psi_memory_key.cc
+++ b/check_src/whitelist/psi_memory_key.cc
@@ -1,0 +1,3 @@
+<      "Memory allocated for in-memory sets for persisted variables"}
+< };
+>      "Memory allocated for in-memory sets for persisted variables"}};

--- a/check_src/whitelist/row0ins.cc
+++ b/check_src/whitelist/row0ins.cc
@@ -1,0 +1,5 @@
+>   mtr_commit(mtr);
+> 
+<   {
+<     mtr_commit(mtr);
+<   }

--- a/check_src/whitelist/rpl_group_replication.cc
+++ b/check_src/whitelist/rpl_group_replication.cc
@@ -1,0 +1,4 @@
+< int group_replication_init() {
+<   return initialize_channel_service_interface();
+< }
+> int group_replication_init() { return initialize_channel_service_interface(); }

--- a/check_src/whitelist/rpl_replica.cc
+++ b/check_src/whitelist/rpl_replica.cc
@@ -1,0 +1,24 @@
+<             then need the cache to be at position 0 (see comments at beginning
+<             of init_info()). b) init_relay_log_pos(), because the BEGIN may be
+<             an older relay log.
+>           then need the cache to be at position 0 (see comments at beginning of
+>           init_info()).
+>           b) init_relay_log_pos(), because the BEGIN may be an older relay log.
+<           DBUG_PRINT("info",
+<                      ("Resetting retry counter, rli->trans_retries: %lu",
+>         DBUG_PRINT("info", ("Resetting retry counter, rli->trans_retries: %lu",
+<     rli->report(WARNING_LEVEL, 0,
+>       rli->report(
+>           WARNING_LEVEL, 0,
+<            llstr(rli->get_group_master_log_pos(), llbuff),
+>              llstr(rli->get_group_master_log_pos_info(), llbuff),
+<            llstr(rli->get_group_master_log_pos(), llbuff),
+>              llstr(rli->get_group_master_log_pos_info(), llbuff),
+<            llstr(rli->get_group_master_log_pos(), llbuff));
+>              llstr(rli->get_group_master_log_pos_info(), llbuff));
+<            llstr(rli->get_group_master_log_pos(), llbuff));
+< 
+>              llstr(rli->get_group_master_log_pos_info(), llbuff));
+<   DBUG_EXECUTE_IF("simulate_replica_delay_at_terminate_bug38694",
+<                   sleep(5););
+>     DBUG_EXECUTE_IF("simulate_replica_delay_at_terminate_bug38694", sleep(5););

--- a/check_src/whitelist/signal_handler.cc
+++ b/check_src/whitelist/signal_handler.cc
@@ -1,0 +1,7 @@
+<       "You may download the Percona XtraDB Cluster operations manual by "
+<       "visiting\n"
+<       "http://www.percona.com/software/percona-xtradb-cluster/. You may find "
+>       "Please help us make Percona Server better by reporting any\n"
+>       "bugs at https://bugs.percona.com/\n\n"
+>       "You may download the Percona Server operations manual by visiting\n"
+>       "http://www.percona.com/software/percona-server/. You may find "

--- a/check_src/whitelist/sql_admin.cc
+++ b/check_src/whitelist/sql_admin.cc
@@ -1,0 +1,5 @@
+<   /* table can be nullptr if we failed with wsrep_toi_replication() */
+<   if (table && table->table) table->table->invalidate_dict();
+>   if (table->table) table->table->invalidate_dict();
+<   WSREP_NBO_1ST_PHASE_END;
+< 

--- a/check_src/whitelist/sql_class.cc
+++ b/check_src/whitelist/sql_class.cc
@@ -1,0 +1,1 @@
+<     // TODO: add why this needs to be skipped

--- a/check_src/whitelist/sql_parse.cc
+++ b/check_src/whitelist/sql_parse.cc
@@ -1,0 +1,7 @@
+<     case SQLCOM_UNLOCK_TABLES: {
+< 
+>     case SQLCOM_UNLOCK_TABLES:
+<     }
+<             tmp->awake(only_kill_query ? THD::KILL_QUERY
+<                                        : THD::KILL_CONNECTION);
+>           tmp->awake(only_kill_query ? THD::KILL_QUERY : THD::KILL_CONNECTION);

--- a/check_src/whitelist/sql_parse.h
+++ b/check_src/whitelist/sql_parse.h
@@ -1,0 +1,5 @@
+< 
+<                                               fk_tables_)
+<                                                      fk_tables_)
+< 
+< 

--- a/check_src/whitelist/sql_partition_admin.cc
+++ b/check_src/whitelist/sql_partition_admin.cc
@@ -1,0 +1,14 @@
+<   if (first_table->table->part_info->set_partition_bitmaps(first_table)) {
+<     WSREP_NBO_1ST_PHASE_END;
+>   if (first_table->table->part_info->set_partition_bitmaps(first_table))
+<   }
+<     if (thd->mdl_context.upgrade_shared_lock(ticket, MDL_EXCLUSIVE, timeout)) {
+<       WSREP_NBO_1ST_PHASE_END;
+>     if (thd->mdl_context.upgrade_shared_lock(ticket, MDL_EXCLUSIVE, timeout))
+<     }
+<           first_table->db, first_table->table_name, &table_def)) {
+<     WSREP_NBO_1ST_PHASE_END;
+>           first_table->db, first_table->table_name, &table_def))
+<   }
+< 
+<   WSREP_NBO_1ST_PHASE_END;

--- a/check_src/whitelist/sql_table.cc
+++ b/check_src/whitelist/sql_table.cc
@@ -1,0 +1,11 @@
+<           if (thd->variables.binlog_ddl_skip_rewrite) {
+>           if (thd->variables.binlog_ddl_skip_rewrite ||
+>               thd->system_thread == SYSTEM_THREAD_SLAVE_SQL ||
+>               thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER ||
+>               thd->is_binlog_applier()) {
+<       if (thd->variables.binlog_ddl_skip_rewrite) {
+>       if (thd->variables.binlog_ddl_skip_rewrite ||
+>           thd->system_thread == SYSTEM_THREAD_SLAVE_SQL ||
+>           thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER ||
+>           thd->is_binlog_applier()) {
+<       4. WSREP tables

--- a/check_src/whitelist/sql_user.cc
+++ b/check_src/whitelist/sql_user.cc
@@ -1,0 +1,12 @@
+<     // clang-format off
+<     /* We already started TOI. Below we will acquire ACL lock again.
+<        If we do this leaving critical section, someone else can acquire
+<        ACL lock before us, and then attempt to start TOI which will block.
+<        In such a case when we try to acquire ACL lock below, we will end up
+<        in a deadlock */
+<     // clang-format off
+<     /* We already started TOI. Below we will acquire ACL lock again.
+<        If we do this leaving critical section, someone else can acquire
+<        ACL lock before us, and then attempt to start TOI which will block.
+<        In such a case when we try to acquire ACL lock below, we will end up
+<        in a deadlock */

--- a/check_src/whitelist/transaction.cc
+++ b/check_src/whitelist/transaction.cc
@@ -1,0 +1,14 @@
+<
+< #if 0
+<   /* TODO: (G-4) Krunal
+<   streaming replication transaction flow will regularly append
+<   transactions fragments and persist them in streaming table
+<   (wsrep_streaming_log). Once the main transaction is committed then
+<   the relevant entries from the streaming table needs to be removed.
+<   this removal action is done as part of main transaction commit action.
+<   main transaction commit ha_commit_trans involves 2 commits:
+<   - main commit: to register commit of main transaction.
+<   - sub-commit: to register commit of streaming table entries removal.
+<   This could be avoided by using a new THD for sub-commit purpose. */
+< #endif
+

--- a/include/my_sqlcommand.h
+++ b/include/my_sqlcommand.h
@@ -210,9 +210,11 @@ enum enum_sql_command {
   SQLCOM_LOCK_TABLES_FOR_BACKUP,
   SQLCOM_CREATE_COMPRESSION_DICTIONARY,
   SQLCOM_DROP_COMPRESSION_DICTIONARY,
+#ifdef WITH_WSREP
   /* Placeholder. If you see more command following this
   lines then check if they need handling in PXC.
   PXC has special handling (TOI based) for DDL command. */
+#endif /* WITH_WSREP */
   /* This should be the last !!! */
   SQLCOM_END
 };

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -537,8 +537,8 @@ The following options may be given as the first argument:
  --key-cache-division-limit=# 
  The minimum percentage of warm blocks in key cache
  --keyring-migration-destination=name 
- Keyring plugin to which the keys are migrated to. This
- option must be specified along with
+ Keyring plugin or component to which the keys are
+ migrated to. This option must be specified along with
  --keyring-migration-source.
  --keyring-migration-host=name 
  Connect to host.

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -6105,8 +6105,8 @@ bool check_fk_parent_table_access(THD *thd, HA_CREATE_INFO *create_info,
 #ifdef WITH_WSREP
   if (check_fk_support) {
 #endif
-    handlerton *db_type = create_info->db_type ? create_info->db_type
-                                               : ha_default_handlerton(thd);
+    handlerton *db_type = 
+        create_info->db_type ? create_info->db_type : ha_default_handlerton(thd);
 
     // Return if engine does not support Foreign key Constraint.
     if (!ha_check_storage_engine_flag(db_type, HTON_SUPPORTS_FOREIGN_KEYS))

--- a/sql/auth/sql_user.cc
+++ b/sql/auth/sql_user.cc
@@ -93,7 +93,6 @@
 #include "violite.h"
 /* key_restore */
 
-#include <openssl/rand.h>  // RAND_bytes
 #include "prealloced_array.h"
 #include "sql/auth/auth_internal.h"
 #include "sql/auth/sql_auth_cache.h"
@@ -106,6 +105,7 @@
 #include "sql/mysqld.h"
 #include "sql/sql_rewrite.h"
 
+#include <openssl/rand.h>  // RAND_bytes
 #ifdef WITH_WSREP
 #include "sql/wsrep_trans_observer.h"
 #endif /* WITH_WSREP */
@@ -2044,8 +2044,7 @@ bool change_password(THD *thd, LEX_USER *lex_user, const char *new_password,
     }
 
     /* trying to change the password of the utility user? */
-    if (acl_is_utility_user(acl_user->user, acl_user->host.get_host(),
-                            nullptr)) {
+    if (acl_is_utility_user(acl_user->user, acl_user->host.get_host(), nullptr)) {
       my_error(ER_PASSWORD_NO_MATCH, MYF(0));
       return true;
     }

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -29,9 +29,10 @@
 #include <atomic>
 #include <utility>
 
+#ifdef WITH_WSREP
 #include "sql/log.h"
-
 #include "include/mysql/components/services/log_builtins.h"
+#endif /* WITH_WSREP */
 
 #include "libbinlogevents/include/binlog_event.h"  // enum_binlog_checksum_alg
 #include "m_string.h"                              // llstr

--- a/sql/binlog_ostream.cc
+++ b/sql/binlog_ostream.cc
@@ -40,6 +40,7 @@ bool binlog_cache_is_reset = false;
 IO_CACHE_binlog_cache_storage::IO_CACHE_binlog_cache_storage() = default;
 IO_CACHE_binlog_cache_storage::~IO_CACHE_binlog_cache_storage() { close(); }
 
+#ifdef WITH_WSREP
 bool IO_CACHE_binlog_cache_storage::open(File file,
                                          my_off_t max_cache_size) {
   DBUG_TRACE;
@@ -55,6 +56,7 @@ bool IO_CACHE_binlog_cache_storage::open(File file,
   m_max_cache_size = max_cache_size;
   return false;
 }
+#endif /* WITH_WSREP */
 
 bool IO_CACHE_binlog_cache_storage::open(const char *dir, const char *prefix,
                                          my_off_t cache_size,
@@ -281,12 +283,14 @@ bool IO_CACHE_binlog_cache_storage::setup_ciphers_password() {
   return false;
 }
 
+#ifdef WITH_WSREP
 bool Binlog_cache_storage::open(File file, my_off_t max_cache_size) {
   if (m_file.open(file, max_cache_size))
     return true;
   m_pipeline_head = &m_file;
   return false;
 }
+#endif /* WITH_WSREP */
 
 bool Binlog_cache_storage::open(my_off_t cache_size, my_off_t max_cache_size) {
   const char *LOG_PREFIX = "ML";

--- a/sql/binlog_ostream.h
+++ b/sql/binlog_ostream.h
@@ -73,8 +73,10 @@ class IO_CACHE_binlog_cache_storage : public Truncatable_ostream {
   IO_CACHE_binlog_cache_storage(const IO_CACHE_binlog_cache_storage &) = delete;
   ~IO_CACHE_binlog_cache_storage() override;
 
+#ifdef WITH_WSREP
   bool open(File file, 
             my_off_t max_cache_size);
+#endif /* WITH_WSREP */
   /**
      Opens the binlog cache. It creates a memory buffer as long as cache_size.
      The buffer will be extended up to max_cache_size when writing data. The
@@ -184,8 +186,9 @@ class IO_CACHE_binlog_cache_storage : public Truncatable_ostream {
 class Binlog_cache_storage : public Basic_ostream {
  public:
   ~Binlog_cache_storage() override;
-
+#ifdef WITH_WSREP
   bool open(File file, my_off_t max_cache_size);
+#endif /* WITH_WSREP */
   bool open(my_off_t cache_size, my_off_t max_cache_size);
   void close();
 
@@ -243,9 +246,9 @@ class Binlog_cache_storage : public Basic_ostream {
   */
   bool is_empty() const { return length() == 0; }
 
+#ifdef WITH_WSREP
   bool flush() { return m_file.flush(); }
 
-#ifdef WITH_WSREP
   /* Not a good pratice to expose private member but PXC/wsrep
   function would need re-write for this so temporary fix to
   allow PXC/wsrep orginal function to work for now. */

--- a/sql/conn_handler/connection_handler_per_thread.cc
+++ b/sql/conn_handler/connection_handler_per_thread.cc
@@ -338,7 +338,9 @@ static void *handle_connection(void *arg) {
 #endif /* WITH_WSREP */
 
     delete thd;
+#ifdef WITH_WSREP
     thd = NULL;
+#endif /* WITH_WSREP */
 
 #ifdef HAVE_PSI_THREAD_INTERFACE
     /* Delete the instrumentation for the job that just completed. */

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2499,6 +2499,7 @@ int ha_prepare_low(THD *thd, bool all) {
   SAVEPOINT is *not* transaction-initiating SQL-statement
 */
 int ha_savepoint(THD *thd, SAVEPOINT *sv) {
+#ifdef WITH_WSREP
 #if 0
 /* commenting it out for now.
    it was not present in 5.7. there is no reason explained why
@@ -2507,7 +2508,6 @@ int ha_savepoint(THD *thd, SAVEPOINT *sv) {
    executing rollback to savepoint when it is killed by high priority
    trx.
 */
-#ifdef WITH_WSREP
   /*
     Register binlog hton for savepoint processing if wsrep binlog
     emulation is on.
@@ -2515,8 +2515,8 @@ int ha_savepoint(THD *thd, SAVEPOINT *sv) {
   if (WSREP_EMULATE_BINLOG(thd) && wsrep_thd_is_local(thd)) {
     wsrep_register_binlog_handler(thd, thd->in_multi_stmt_transaction_mode());
   }
-#endif /* WITH_WSREP */
 #endif
+#endif /* WITH_WSREP */
 
   int error = 0;
   Transaction_ctx::enum_trx_scope trx_scope =
@@ -3727,9 +3727,9 @@ bool handler::is_using_full_key(key_part_map keypart_map,
          (keypart_map == ((key_part_map(1) << actual_key_parts) - 1));
 }
 
-bool handler::is_using_full_unique_key(
-    uint index, key_part_map keypart_map,
-    enum ha_rkey_function find_flag) const noexcept {
+bool handler::is_using_full_unique_key(uint index, key_part_map keypart_map,
+                                       enum ha_rkey_function find_flag) const
+    noexcept {
   return (
       is_using_full_key(keypart_map, table->key_info[index].actual_key_parts) &&
       find_flag == HA_READ_KEY_EXACT &&
@@ -8482,7 +8482,8 @@ int handler::ha_write_row(uchar *buf) {
 
   DBUG_TRACE;
   DEBUG_SYNC(ha_thd(), "start_ha_write_row");
-  DBUG_EXECUTE_IF("inject_error_ha_write_row", return HA_ERR_INTERNAL_ERROR;);
+  DBUG_EXECUTE_IF("inject_error_ha_write_row",
+                  return HA_ERR_INTERNAL_ERROR;);
   DBUG_EXECUTE_IF("simulate_storage_engine_out_of_memory",
                   return HA_ERR_SE_OUT_OF_MEMORY;);
   mark_trx_read_write();
@@ -8839,8 +8840,9 @@ static void copy_blob_data(const TABLE *table, const MY_BITMAP *const fields,
   }
 }
 
-bool handler::is_using_prohibited_gap_locks(
-    TABLE *table, bool using_full_primary_key) const noexcept {
+bool handler::is_using_prohibited_gap_locks(TABLE *table,
+                                            bool using_full_primary_key) const
+    noexcept {
   const THD *thd = table->in_use;
   const thr_lock_type lock_type = table->reginfo.lock_type;
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -677,7 +677,9 @@ enum legacy_db_type {
   /** Performance schema engine. */
   DB_TYPE_PERFORMANCE_SCHEMA,
   DB_TYPE_TEMPTABLE,
+#ifdef WITH_WSREP
   DB_TYPE_WSREP,
+#endif /* WITH_WSREP */
   DB_TYPE_TOKUDB = 41,
   DB_TYPE_ROCKSDB = 42,
   DB_TYPE_FIRST_DYNAMIC = 43,

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -147,10 +147,10 @@
 
 #ifdef WITH_WSREP
 #include "wsrep_trans_observer.h"
-#endif /* WITH_WSREP */
 
 class Protocol;
 class sp_rcontext;
+#endif /* WITH_WSREP */
 
 using std::max;
 using std::min;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -4900,10 +4900,12 @@ int Query_log_event::do_apply_event(Relay_log_info const *rli,
         }
       }
 
+#ifdef WITH_WSREP
       thd->variables.binlog_ddl_skip_rewrite =
           (ddl_skip_rewrite != 0) ? true : false;
       thd->wsrep_applier_skip_readonly_checks =
           (wsrep_applier_skip_readonly_checks != 0) ? true : false;
+#endif /* WITH_WSREP */
 
       thd->table_map_for_update = (table_map)table_map_for_update;
 

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -50,7 +50,6 @@
 #include "libbinlogevents/include/statement_events.h"
 #include "libbinlogevents/include/uuid.h"
 #include "m_string.h"  // native_strncasecmp
-#include "my_aes.h"
 #include "my_bitmap.h"    // MY_BITMAP
 #include "my_checksum.h"  // ha_checksum
 #include "my_dbug.h"

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2822,9 +2822,8 @@ static void unireg_abort(int exit_code) {
 void clean_up_mysqld_mutexes() { clean_up_mutexes(); }
 
 static void mysqld_exit(int exit_code) {
-  assert(
-      (exit_code >= MYSQLD_SUCCESS_EXIT && exit_code <= MYSQLD_ABORT_EXIT) ||
-      exit_code == MYSQLD_RESTART_EXIT);
+  assert((exit_code >= MYSQLD_SUCCESS_EXIT && exit_code <= MYSQLD_ABORT_EXIT) ||
+          exit_code == MYSQLD_RESTART_EXIT);
 #ifdef WITH_WSREP
   wsrep_deinit_server();
 #endif /* WITH_WSREP */
@@ -10016,7 +10015,7 @@ struct my_option my_long_early_options[] = {
    &opt_keyring_migration_source, &opt_keyring_migration_source, nullptr,
    GET_STR, REQUIRED_ARG, 0, 0, 0, nullptr, 0, nullptr},
   {"keyring-migration-destination", OPT_KEYRING_MIGRATION_DESTINATION,
-   "Keyring plugin to which the keys are "
+   "Keyring plugin or component to which the keys are "
    "migrated to. This option must be specified along with "
    "--keyring-migration-source.",
    &opt_keyring_migration_destination, &opt_keyring_migration_destination,
@@ -14216,8 +14215,8 @@ PSI_stage_info *all_server_stages[] = {
     &stage_communication_delegation,
     &stage_restoring_secondary_keys};
 
-/* clang-format off */
 #ifdef WITH_WSREP
+/* clang-format off */
 PSI_stage_info *wsrep_server_stages[] = {
     // log_event
     &stage_wsrep_writing_rows,
@@ -14257,8 +14256,8 @@ PSI_stage_info *wsrep_server_stages[] = {
     &stage_wsrep_aborter_idle,
     &stage_wsrep_aborter_active};
 
-#endif /* WITH_WSREP */
 /* clang-format on */
+#endif /* WITH_WSREP */
 
 PSI_socket_key key_socket_tcpip;
 PSI_socket_key key_socket_unix;

--- a/sql/psi_memory_key.cc
+++ b/sql/psi_memory_key.cc
@@ -153,8 +153,8 @@ PSI_memory_key key_memory_userstat_thread_stats;
 PSI_memory_key key_memory_userstat_client_stats;
 PSI_memory_key key_memory_thread_pool_connection;
 
-// Percona XtraDB Cluster (PXC) PSI memory keys
 #ifdef WITH_WSREP
+// Percona XtraDB Cluster (PXC) PSI memory keys
 PSI_memory_key key_memory_wsrep;
 #endif /* WITH_WSREP */
 

--- a/sql/psi_memory_key.h
+++ b/sql/psi_memory_key.h
@@ -180,8 +180,8 @@ extern PSI_memory_key key_memory_userstat_thread_stats;
 extern PSI_memory_key key_memory_userstat_client_stats;
 extern PSI_memory_key key_memory_thread_pool_connection;
 
-// Percona XtradB Cluster (PXC) PSI memory keys
 #ifdef WITH_WSREP
+// Percona XtradB Cluster (PXC) PSI memory keys
 extern PSI_memory_key key_memory_wsrep;
 #endif /* WITH_WSREP */
 

--- a/sql/rpl_commit_stage_manager.cc
+++ b/sql/rpl_commit_stage_manager.cc
@@ -27,8 +27,11 @@
 #include "sql/rpl_commit_stage_manager.h"
 #include "sql/rpl_replica_commit_order_manager.h"  // Commit_order_manager
 #include "sql/rpl_rli_pdb.h"  // Slave_worker                    // Slave_worker
+
+#ifdef WITH_WSREP
 #include "sql/wsrep_applier.h"
 #include "sql/wsrep_trans_observer.h"
+#endif /* WITH_WSREP */
 
 class Slave_worker;
 class Commit_order_manager;

--- a/sql/rpl_gtid_state.cc
+++ b/sql/rpl_gtid_state.cc
@@ -887,7 +887,7 @@ void Gtid_state::update_gtids_impl_own_gtid(THD *thd, bool is_commit) {
     In Group Replication the GTID may additionally be owned by another
     thread, and we won't remove that ownership (it will be rolled back later)
   */
-#ifdef WSREP
+#ifdef WITH_WSREP
   /* Check comment associated with wsrep_replayer for more details. */
   if (WSREP(thd)) {
     assert(owned_gtids.is_owned_by(thd->owned_gtid, thd->thread_id()) ||
@@ -897,7 +897,7 @@ void Gtid_state::update_gtids_impl_own_gtid(THD *thd, bool is_commit) {
   }
 #else
   assert(owned_gtids.is_owned_by(thd->owned_gtid, thd->thread_id()));
-#endif /* WSREP */
+#endif /* WITH_WSREP */
   owned_gtids.remove_gtid(thd->owned_gtid, thd->thread_id());
 
   if (is_commit) {

--- a/sql/rpl_replica.cc
+++ b/sql/rpl_replica.cc
@@ -832,7 +832,8 @@ bool stop_slave_cmd(THD *thd) {
     }
   }
 
-  if (!lex->mi.for_channel) res = stop_slave(thd);
+  if (!lex->mi.for_channel)
+    res = stop_slave(thd);
 #ifdef WITH_WSREP
   // Similar to GR, do not allow operations on the wsrep channel
   else if (lex->mi.channel && wsrep_is_wsrep_channel_name(lex->mi.channel)) {
@@ -3942,7 +3943,8 @@ bool show_slave_status_cmd(THD *thd) {
 
   channel_map.rdlock();
 
-  if (!lex->mi.for_channel) res = show_slave_status(thd);
+  if (!lex->mi.for_channel)
+    res = show_slave_status(thd);
 #ifdef WITH_WSREP
   // Disable the SHOW SLAVE STATUS command with the wsrep channel
   else if (lex->mi.channel && wsrep_is_wsrep_channel_name(lex->mi.channel)) {
@@ -5068,11 +5070,11 @@ static int exec_relay_log_event(THD *thd, Relay_log_info *rli,
 #ifdef WITH_WSREP
       {
         wsrep_after_statement(thd);
-#endif /* WITH_WSREP */
         /*
-          In the case of an error, coord_handle_partial_binlogged_transaction
+          In case of an error, coord_handle_partial_binlogged_transaction
           will not try to get the rli->data_lock again.
         */
+#endif /* WITH_WSREP */
         return 1;
 #ifdef WITH_WSREP
       }
@@ -6416,9 +6418,10 @@ bool mts_recovery_groups(Relay_log_info *rli) {
           continue;
         }
 
-        DBUG_PRINT("mts", ("Event Recoverying relay log info "
-                           "group_mster_log_name %s, event_master_log_pos "
-                           "%llu type code %u.",
+        DBUG_PRINT(
+            "mts",
+            ("Event Recoverying relay log info "
+             "group_mster_log_name %s, event_master_log_pos %llu type code %u.",
                            linfo.log_file_name, ev->common_header->log_pos,
                            ev->get_type_code()));
 
@@ -7230,15 +7233,6 @@ wsrep_restart_point :
       goto err;
     }
 
-  if (rli->update_is_transactional()) {
-    mysql_cond_broadcast(&rli->start_cond);
-    mysql_mutex_unlock(&rli->run_lock);
-    rli->report(ERROR_LEVEL, ER_SLAVE_FATAL_ERROR,
-                ER_THD(thd, ER_SLAVE_FATAL_ERROR),
-                "Error checking if the relay log repository is transactional.");
-    goto err;
-  }
-
   if (!rli->is_transactional())
     rli->report(WARNING_LEVEL, 0,
                 "If a crash happens this configuration does not guarantee that "
@@ -7447,7 +7441,7 @@ err:
 #endif /* WITH_WSREP */
 
   delete rli->current_mts_submode;
-  rli->current_mts_submode = 0;
+  rli->current_mts_submode = nullptr;
   rli->clear_mts_recovery_groups();
 
   /*
@@ -8789,8 +8783,7 @@ int flush_relay_logs(Master_info *mi, THD *thd) {
            !mi->transaction_parser
                 .is_inside_transaction() ||  // not inside a transaction
            !channel_map.is_group_replication_channel_name(
-               mi->get_channel(),
-               true) ||            // channel isn't GR applier channel
+               mi->get_channel(), true) ||  // channel isn't GR applier channel
            !mi->slave_running) &&  // the I/O thread isn't running
           DBUG_EVALUATE_IF("deferred_flush_relay_log",
                            !channel_map.is_group_replication_channel_name(
@@ -9578,7 +9571,8 @@ bool reset_slave_cmd(THD *thd) {
     return res = true;
   }
 
-  if (!lex->mi.for_channel) res = reset_slave(thd);
+  if (!lex->mi.for_channel)
+    res = reset_slave(thd);
 #ifdef WITH_WSREP
   // Similar to GR, do not allow operations on the wsrep channel
   else if (lex->mi.channel && wsrep_is_wsrep_channel_name(lex->mi.channel)) {

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -236,11 +236,11 @@ extern "C" void handle_fatal_signal(int sig) {
 
   s_handler_being_processed = true;
 
+#ifdef WITH_WSREP
 /*
   The wsrep subsystem has their its own actions
   which need be performed before exiting:
 */
-#ifdef WITH_WSREP
   wsrep_handle_fatal_signal(sig);
 #endif /* WITH_WSREP */
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -446,8 +446,7 @@ size_t get_table_def_key(const TABLE_LIST *table_list, const char **key) {
     strcase is converted to strcasecmp because information_schema tables
     can be accessed with lower case and upper case table names.
   */
-  assert(
-      !my_strcasecmp(system_charset_info, table_list->get_db_name(),
+  assert( !my_strcasecmp(system_charset_info, table_list->get_db_name(),
                      table_list->mdl_request.key.db_name()) &&
 #ifdef WITH_WSREP
       (!my_strcasecmp(system_charset_info, table_list->get_table_name(),
@@ -10485,8 +10484,9 @@ void tdc_remove_table(THD *thd, enum_tdc_remove_table_type remove_type,
     /* if thd was BF aborted, exclusive locks are cancelled */
 #else
   assert(remove_type == TDC_RT_REMOVE_UNUSED ||
-              thd->mdl_context.owns_equal_or_stronger_lock(
-                  MDL_key::TABLE, db, table_name, MDL_EXCLUSIVE));
+         remove_type == TDC_RT_MARK_FOR_REOPEN ||
+         thd->mdl_context.owns_equal_or_stronger_lock(
+             MDL_key::TABLE, db, table_name, MDL_EXCLUSIVE));
 #endif /* WITH_WSREP */
 
   key_length = create_table_def_key(db, table_name, key);

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -914,8 +914,7 @@ class Global_read_lock {
         provider_paused(false),
 #endif /* WITH_WSREP */
         m_mdl_global_shared_lock(nullptr),
-        m_mdl_blocks_commits_lock(nullptr) {
-  }
+        m_mdl_blocks_commits_lock(nullptr) {}
 
 #ifdef WITH_WSREP
   bool lock_global_read_lock(THD *thd, bool *own_lock);

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2685,7 +2685,7 @@ void Query_result_insert::abort_result_set(THD *thd) {
     changed = (info.stats.copied || info.stats.deleted || info.stats.updated);
     transactional_table = table->file->has_transactions();
     if (thd->get_transaction()->cannot_safely_rollback(Transaction_ctx::STMT)) {
-#ifdef WIT_WSREP
+#ifdef WITH_WSREP
       if (WSREP_EMULATE_BINLOG(thd) || mysql_bin_log.is_open()) {
 #else
       if (mysql_bin_log.is_open()) {

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -564,8 +564,6 @@ bool set_default_collation(HA_CREATE_INFO *create_info,
   Do not check that wsrep snapshot is ready before allowing this command
 */
 #define CF_SKIP_WSREP_CHECK (1U << 2)
-#else
-#define CF_SKIP_WSREP_CHECK 0
 #endif /* WITH_WSREP */
 
 /**

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -179,7 +179,10 @@ When one supplies long data for a placeholder:
 #include "sql/window.h"
 #include "sql_string.h"
 #include "violite.h"
+
+#ifdef WITH_WSREP
 #include "wsrep_trans_observer.h"
+#endif /* WITH_WSREP */
 
 namespace resourcegroups {
 class Resource_group;
@@ -3172,16 +3175,17 @@ reexecute:
       }
     }
 
-    if (!error) { /* Success */
 #ifdef WITH_WSREP
+    if (!error) { /* Success */
       // We are going to retry the statement, so clean up first.
       wsrep_after_statement(thd);
-#endif
       goto reexecute;
     }
-#ifdef WITH_WSREP
-  }
+#else
+    if (!error) /* Success */
+      goto reexecute;
 #endif
+  }
   reset_stmt_parameters(this);
 
   // Re-enable the general log if it was temporarily disabled while repreparing

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -4488,8 +4488,7 @@ static int fill_temporary_tables(THD *thd, TABLE_LIST *tables, Item *cond) {
 
   for (tmp = thd->temporary_tables; tmp; tmp = tmp->next) {
     if (store_temporary_table_record(thd, tables->table, tmp,
-                                     thd->lex->query_block->db,
-                                     thd->mem_root)) {
+                                     thd->lex->query_block->db, thd->mem_root)) {
       DBUG_RETURN(1);
     }
   }

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -87,7 +87,6 @@
 #include "pfs_table_provider.h"
 #include "prealloced_array.h"
 #include "scope_guard.h"
-#include "service_wsrep.h"
 #include "sql/auth/auth_acls.h"
 #include "sql/auth/auth_common.h"  // check_fk_parent_table_access
 #include "sql/binlog.h"            // mysql_bin_log
@@ -192,6 +191,10 @@
 #include "template_utils.h"
 #include "thr_lock.h"
 #include "typelib.h"
+
+#ifdef WITH_WSREP
+#include "service_wsrep.h"
+#endif /* WITH_WSREP */
 
 namespace dd {
 class View;
@@ -13714,13 +13717,13 @@ static bool mysql_inplace_alter_table(
       }
     }
 
+#ifdef WITH_WSREP
     DBUG_EXECUTE_IF("halt_alter_table_after_lock_downgrade", {
       const char act[] =
           "now SIGNAL alter_table_inplace_after_downgrade "
           "WAIT_FOR continue_inplace_alter";
       assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
     };);
-#ifdef WITH_WSREP
 
     WSREP_NBO_1ST_PHASE_END;
 
@@ -17659,7 +17662,9 @@ bool mysql_alter_table(THD *thd, const char *new_db, const char *new_name,
     trans_rollback_stmt(thd);
     trans_rollback(thd);
 
+#ifdef WITH_WSREP
     WSREP_NBO_1ST_PHASE_END;
+#endif /* WITH_WSREP */
 
     return true;
   }

--- a/sql/sql_thd_internal_api.h
+++ b/sql/sql_thd_internal_api.h
@@ -309,8 +309,10 @@ void thd_get_fragmentation_stats(const THD *thd,
 void thd_add_fragmentation_stats(THD *thd,
                                  const fragmentation_stats_t &stats) noexcept;
 
+#ifdef WITH_WSREP
 /** Mark for complete transaction rollback
 @param[in] thd   the calling thread */
 void thd_mark_for_rollback(THD *thd);
+#endif /* WITH_WSREP */
 
 #endif  // SQL_THD_INTERNAL_API_INCLUDED

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -1188,12 +1188,14 @@ bool Sql_cmd_update::update_single_table(THD *thd) {
 
   assert(CountHiddenFields(*update_value_list) == 0);
 
+#ifdef WITH_WSREP
   DBUG_EXECUTE_IF("pause_commit_after_update_single_table", {
     const char act[] =
         "innobase_commit_low_begin "
         "SIGNAL update_commit_waiting WAIT_FOR continue";
     assert(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));
   };);
+#endif /* WITH_WSREP */
 
   // Following test is disabled, as we get RQG errors that are hard to debug
   // assert((error >= 0) == thd->is_error());

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5889,17 +5889,19 @@ static bool pre_autocommit(sys_var *self, THD *thd, set_var *var) {
       (thd->variables.option_bits & OPTION_NOT_AUTOCOMMIT) &&
       var->save_result.ulonglong_value) {
     // Autocommit mode is about to be activated.
-    if (trans_commit_stmt(thd) || trans_commit(thd)) {
 #ifdef WITH_WSREP
+    if (trans_commit_stmt(thd) || trans_commit(thd)) {
       // TODO: check if this release is needed ?
       thd->mdl_context.release_transactional_locks();
       WSREP_DEBUG(
           "Transaction commit failed while toggling autocommit."
           " Release MDL trx lock for thread: %u",
           thd->thread_id());
-#endif /* WITH_WSREP */
       return true;
     }
+#else
+    if (trans_commit_stmt(thd) || trans_commit(thd)) return true;
+#endif /* WITH_WSREP */
   }
   return false;
 }

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -5838,8 +5838,7 @@ void TABLE::mark_columns_per_binlog_row_image(THD *thd) {
        thd->is_current_stmt_binlog_format_row() &&
        !ha_check_storage_engine_flag(s->db_type(), HTON_NO_BINLOG_ROW_OPT))) {
 #else
-  if ((mysql_bin_log.is_open() &&
-       thd->is_current_stmt_binlog_format_row() &&
+  if ((mysql_bin_log.is_open() && thd->is_current_stmt_binlog_format_row() &&
        !ha_check_storage_engine_flag(s->db_type(), HTON_NO_BINLOG_ROW_OPT))) {
 #endif /* WITH_WSREP */
     /* if there is no PK, then mark all columns for the BI. */
@@ -7702,12 +7701,12 @@ bool TABLE::setup_partial_update() {
       log_bin_use_v1_row_events == 0 &&
       thd->is_current_stmt_binlog_format_row();
 #else
-  bool logical_diffs = (thd->variables.binlog_row_value_options &
-                        PARTIAL_JSON_UPDATES) != 0 &&
-                       mysql_bin_log.is_open() &&
-                       (thd->variables.option_bits & OPTION_BIN_LOG) != 0 &&
-                       log_bin_use_v1_row_events == 0 &&
-                       thd->is_current_stmt_binlog_format_row();
+  bool logical_diffs = 
+      (thd->variables.binlog_row_value_options & PARTIAL_JSON_UPDATES) != 0 &&
+      mysql_bin_log.is_open() &&
+      (thd->variables.option_bits & OPTION_BIN_LOG) != 0 &&
+      log_bin_use_v1_row_events == 0 &&
+      thd->is_current_stmt_binlog_format_row();
 #endif /* WITH_WSREP */
 
   DBUG_PRINT(

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6266,9 +6266,9 @@ void innobase_commit_low(trx_t *trx) /*!< in: transaction handle */
     wsrep_set_thd_proc_info(thd, info);
     thd_proc_info(thd, wsrep_get_thd_proc_info(thd));
   }
-#endif /* WITH_WSREP */
 
   DEBUG_SYNC_C("innobase_commit_low_begin");
+#endif /* WITH_WSREP */
 
   if (trx_is_started(trx)) {
     const dberr_t error [[maybe_unused]] = trx_commit_for_mysql(trx);
@@ -21682,47 +21682,6 @@ void ha_innobase::get_auto_increment(
     ulonglong next_value;
 
     current = *first_value > col_max_value ? autoinc : *first_value;
-
-#if 0
-    /* If the increment step of the auto increment column
-    decreases then it is not affecting the immediate
-    next value in the series. */
-    if (m_prebuilt->autoinc_increment > increment) {
-#ifdef WITH_WSREP
-      WSREP_DEBUG(
-          "Refresh change in auto-inc configuration"
-          " from (off: %llu -> %llu)"
-          " and (inc: %llu -> %llu)."
-          " Re-align auto increment"
-          " value for table (%s)"
-          " THD: %u, current: %llu, autoinc: %llu",
-          m_prebuilt->autoinc_offset, offset, m_prebuilt->autoinc_increment,
-          increment, m_prebuilt->table->name.m_name,
-          wsrep_thd_thread_id(ha_thd()), current, autoinc);
-      /* MySQL flow will construct last_inserted_id but PXC
-      can't do so because any values in that range are
-      potentially unsafe as they were reserved for other node
-      and if other node has used them it will result in
-      conflict. So PXC skip this readjustment logic
-      and re-calibration too as there is no change in
-      current autoinc value. */
-      if (!wsrep_on(ha_thd())) {
-        current = autoinc - m_prebuilt->autoinc_increment;
-
-        current =
-            innobase_next_autoinc(current, 1, increment, 1, col_max_value);
-      }
-#else
-      current = autoinc - m_prebuilt->autoinc_increment;
-
-      current = innobase_next_autoinc(current, 1, increment, 1, col_max_value);
-#endif /* WITH_WSREP */
-
-      dict_table_autoinc_initialize(m_prebuilt->table, current);
-
-      *first_value = current;
-    }
-#endif
 
     /* Compute the last value in the interval */
     next_value = innobase_next_autoinc(current, *nb_reserved_values, increment,

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -3132,7 +3132,7 @@ func_exit:
                          record under the cursor */
     que_thr_t *thr,      /*!< in: query thread */
     bool referenced,
-    /*!< in: TRUE if index may be referenced in
+    /*!< in: true if index may be referenced in
     a foreign key constraint */
 #ifdef WITH_WSREP
     bool foreign, /*!< in: TRUE if index is foreign key index */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2080,12 +2080,11 @@ loop:
 
   if (sync_array_print_long_waits(&waiter, &sema) && sema == old_sema &&
       waiter == old_waiter) {
-    fatal_cnt++;
-#if defined(WITH_WSREP)
+#ifdef WITH_WSREP
     if (os_event_is_set(srv_allow_writes_event)) {
 #endif /* WITH_WSREP */
       fatal_cnt++;
-#if defined(WITH_WSREP)
+#ifdef WITH_WSREP
     } else {
       ib::warn() << "WSREP: avoiding InnoDB self crash due to long "
                     "semaphore wait of > "

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2840,12 +2840,12 @@ void srv_start_threads(bool bootstrap) {
 void srv_start_threads_after_ddl_recovery() {
   /* Start the buffer pool dump/load thread, which will access spaces thus
         must wait for DDL recovery */
-#ifdef WTIH_WSREP
+#ifdef WITH_WSREP
   if (!get_wsrep_recovery()) {
     /* Skip creating buffer pool dump thread during wsrep
     co-ordinate recovery (triggered using --wsrep-recover option). */
     srv_threads.m_buf_dump =
-        os_thread_create(buf_dump_thread_key, buf_dump_thread);
+        os_thread_create(buf_dump_thread_key, 0, buf_dump_thread);
 
     srv_threads.m_buf_dump.start();
   } else {

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -67,14 +67,13 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "ut0pool.h"
 #include "ut0vec.h"
 
-#include "debug_sync.h"
 #include "my_dbug.h"
 #include "mysql/plugin.h"
 #include "sql/clone_handler.h"
-#include "sql/wsrep_mysqld.h"
 
 #ifdef WITH_WSREP
-#include <wsrep_mysqld.h>
+#include "debug_sync.h"
+#include "sql/wsrep_mysqld.h"
 #endif /* WITH_WSREP */
 
 static const ulint MAX_DETAILED_ERROR_LEN = 256;
@@ -1356,18 +1355,6 @@ static void trx_start_low(
                           std::memory_order_relaxed);
   }
 
-#if 0
-#ifdef WITH_WSREP
-  /* Avoid resetting the trx xid if the ddl is metadata only changing.
-  In this case transaction is started as part of prepare phase and not
-  before prepare it would normally happen since there is nothing
-  to change during execution phase. */
-  if (!trx->ddl_md_only) {
-    trx->xid->reset();
-  }
-#endif /* WITH_WSREP */
-#endif
-
   /* The initial value for trx->no: TRX_ID_MAX is used in
   read_view_open_now: */
 
@@ -2323,19 +2310,6 @@ void trx_commit(trx_t *trx) /*!< in/out: transaction */
 
   trx_commit_low(trx, mtr);
 
-#if 0
-  -- G4_CHANGE
-  /* PXC original flow does this as part of trx_commit_complete_for_mysql */
-#ifdef WITH_WSREP
-  /* Serialization history has been written and the
-     transaction is committed in memory, which makes
-     this commit ordered. Release commit order critical
-     section. */
-  if (wsrep_on(trx->mysql_thd)) {
-    wsrep_commit_ordered(trx->mysql_thd);
-  }
-#endif /* WITH_WSREP */
-#endif
 }
 
 /** Cleans up a transaction at database startup. The cleanup is needed if
@@ -3761,6 +3735,7 @@ void trx_set_rw_mode(trx_t *trx) /*!< in/out: transaction that is RW */
   trx_sys_rw_trx_add(trx);
 }
 
+#ifdef WITH_WSREP
 /*
   This function is needed only for canceling thread, which are inside replicator
   processing commit, when high priority transaction aborts the victim
@@ -3817,16 +3792,19 @@ int wsrep_signal_replicator(trx_t *victim_trx, trx_t *bf_trx) {
 
   DBUG_RETURN(0);
 }
+#endif /* WITH_WSREP */
 
 void trx_kill_blocking(trx_t *trx) {
-  DBUG_ENTER("trx_kill_blocking");
+#ifdef WITH_WSREP
+  DBUG_TRACE;
+#endif /* WITH_WSREP */
   if (!trx_is_high_priority(trx)) {
-    DBUG_VOID_RETURN;
+    return;
   }
   hit_list_t hit_list;
   lock_make_trx_hit_list(trx, hit_list);
   if (hit_list.empty()) {
-    DBUG_VOID_RETURN;
+    return;
   }
 #ifdef WITH_WSREP
   if (wsrep_debug) ib::info() << "trx_kill_blocking";
@@ -3994,8 +3972,6 @@ void trx_kill_blocking(trx_t *trx) {
   if (had_dict_lock) {
     row_mysql_freeze_data_dictionary(trx, UT_LOCATION_HERE);
   }
-
-  DBUG_VOID_RETURN;
 }
 
 /* To get current session thread default THD */

--- a/storage/perfschema/unittest/pfs_account-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_account-oom-t.cc
@@ -34,9 +34,12 @@
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/pfs_user.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 PFS_thread pfs_thread;
 

--- a/storage/perfschema/unittest/pfs_host-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_host-oom-t.cc
@@ -31,9 +31,12 @@
 #include "storage/perfschema/pfs_instr.h"
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 extern struct PSI_bootstrap PFS_bootstrap;
 

--- a/storage/perfschema/unittest/pfs_instr-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_instr-oom-t.cc
@@ -36,9 +36,12 @@
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/pfs_user.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 PSI_thread_key thread_key_1;
 PSI_thread_info all_thread[] = {{&thread_key_1, "T-1", "T-1", 0, 0, ""}};

--- a/storage/perfschema/unittest/pfs_instr-t.cc
+++ b/storage/perfschema/unittest/pfs_instr-t.cc
@@ -30,8 +30,11 @@
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 static void test_no_instruments() {
   int rc;

--- a/storage/perfschema/unittest/pfs_instr_class-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_instr_class-oom-t.cc
@@ -30,9 +30,12 @@
 #include "storage/perfschema/pfs_instr.h"
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 static void test_oom() {
   int rc;

--- a/storage/perfschema/unittest/pfs_instr_class-t.cc
+++ b/storage/perfschema/unittest/pfs_instr_class-t.cc
@@ -27,8 +27,11 @@
 #include "storage/perfschema/pfs_instr.h"
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 static void test_no_registration() {
   int rc;

--- a/storage/perfschema/unittest/pfs_misc-t.cc
+++ b/storage/perfschema/unittest/pfs_misc-t.cc
@@ -29,8 +29,11 @@
 #include "storage/perfschema/pfs_instr_class.h"
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 static void test_digest_length_overflow() {
   if (sizeof(size_t) != 4) {

--- a/storage/perfschema/unittest/pfs_user-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_user-oom-t.cc
@@ -31,9 +31,12 @@
 #include "storage/perfschema/pfs_stat.h"
 #include "storage/perfschema/pfs_user.h"
 #include "storage/perfschema/unittest/stub_pfs_global.h"
-#include "storage/perfschema/unittest/stub_pfs_defaults.h"
 #include "storage/perfschema/unittest/stub_pfs_plugin_table.h"
 #include "unittest/mytap/tap.h"
+
+#ifdef WITH_WSREP
+#include "storage/perfschema/unittest/stub_pfs_defaults.h"
+#endif /* WITH_WSREP */
 
 static void test_oom() {
   int rc;

--- a/storage/perfschema/unittest/stub_pfs_defaults.h
+++ b/storage/perfschema/unittest/stub_pfs_defaults.h
@@ -22,14 +22,16 @@
 
 #include "storage/perfschema/pfs.h"
 #include "storage/perfschema/pfs_defaults.h"
+#ifdef WITH_WSREP
 #include "wsrep-lib/wsrep-API/v26/wsrep_api.h"
+#endif /* WITH_WSREP */
 
 void install_default_setup(PSI_thread_bootstrap *) {}
 
+#ifdef WITH_WSREP
 void wsrep_sst_cancel(bool) { }
 
 void wsrep_pfs_instr_cb(wsrep_pfs_instr_type_t, wsrep_pfs_instr_ops_t,
                         wsrep_pfs_instr_tag_t, void **, void **,
                         const void *) {}
-
-
+#endif /* WITH_WSREP */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3026

* Introduces scripts under the check_src directory, which detect differences between the pxc WITH_WSREP=OFF source and PS. For the same upstream versions, there shouldn't be any changes except for the existing whitelists.

  The script also disables WITH_INNODB_DISALLOW_WRITES, as that's another 3rd party path not present in PS.

* Whitelisted product name changes, as PXC should be called PXC even without WITH_WSREP.

* Added WITH_WSREP if(n)defs everywhere where PXC added/deleted logic.

* Removed cosmetic differences compared to PS.

* Some of the clang-format changes were reverted. 

Developed-by: Zsolt Parragi <zsolt.parragi@percona.com>


Note:
The script currently produces the following output
```
============
Error: ./unittest/gunit/log_event_status_size-t.cc
============
116d115
<     qe.thd->variables.binlog_ddl_skip_rewrite = 1;
============
Error: ./sql/auth/sql_authentication.cc
============
4039,4045c4039
<       std::vector<std::string> external_roles;
<       if (strlen(mpvio.auth_info.external_roles) > 0) {
<         boost::algorithm::split(external_roles, mpvio.auth_info.external_roles,
<                                 boost::is_any_of(","));
<       }
< 
<       if (acl_user->user != nullptr && !external_roles.empty()) {
---
>       if (acl_user->user != nullptr) {
4054c4048,4051
<         for (const auto &role : external_roles) {
---
>         std::vector<std::string> roles;
>         boost::algorithm::split(roles, mpvio.auth_info.external_roles,
>                                 boost::is_any_of(","));
>         for (const auto &role : roles) {

```
1. ./unittest/gunit/log_event_status_size-t.cc - has been fixed in 8.0.32 by [commit](https://github.com/percona/percona-xtradb-cluster/commit/9fdcad17f4816c988a1a92a876974c56101f3af8)
2. ./sql/auth/sql_authentication.cc - has been fixed in 8.0.32 by [commit ](https://github.com/percona/percona-xtradb-cluster/commit/fcf47657ccf76516d5edf5f3bafd215e29fddb30)