### PR TITLE
PXC-667: Crash during BF-abort of active HANDLER <table> OPEN AS <alias>

### DIFF
--- a/mysql-test/suite/galera/r/handler_open_as.result
+++ b/mysql-test/suite/galera/r/handler_open_as.result
@@ -1,0 +1,12 @@
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
+SET DEBUG_SYNC = 'innodb_delay_open_table SIGNAL reached WAIT_FOR continue';
+HANDLER t1 OPEN AS t1;;
+SET DEBUG_SYNC = 'now WAIT_FOR reached';
+DROP TABLE t1;
+ERROR 40001: WSREP detected deadlock/conflict and aborted the transaction. Try restarting the transaction
+HANDLER t1 CLOSE;
+SET GLOBAL pxc_strict_mode = DISABLED;
+SET GLOBAL pxc_strict_mode = DISABLED;
+SET DEBUG_SYNC = reset;

--- a/mysql-test/suite/galera/r/pxc_strict_mode.result
+++ b/mysql-test/suite/galera/r/pxc_strict_mode.result
@@ -27,12 +27,14 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend changing storage engine of a table ");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of INSERT");
+call mtr.add_suppression("Percona-XtraDB-Cluster doesn't recommend use of HANDLER");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of DML command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of TRUNCATE command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ADMIN command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits changing storage engine of a table");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of INSERT");
+call mtr.add_suppression("Percona-XtraDB-Cluster prohibits use of HANDLER");
 call mtr.add_suppression("WSREP doesn't support XA transaction");
 set global pxc_strict_mode='ENFORCING';
 #node-2
@@ -1345,6 +1347,52 @@ DROP VIEW view_w_pk;
 DROP TABLE tbl_wo_pk;
 DROP TABLE tbl_w_pk;
 #node-1
-set global pxc_strict_mode = DISABLED;;
+CREATE TABLE t1(id INT PRIMARY KEY);
+#node-1
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SELECT @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
 #node-2
-set global pxc_strict_mode = DISABLED;;
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SELECT @@pxc_strict_mode;
+@@pxc_strict_mode
+DISABLED
+#node-1
+HANDLER t1 OPEN AS h1;
+HANDLER h1 CLOSE;
+#node-1
+SET GLOBAL pxc_strict_mode = 'PERMISSIVE';
+SELECT @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-2
+SET GLOBAL pxc_strict_mode = 'PERMISSIVE';
+SELECT @@pxc_strict_mode;
+@@pxc_strict_mode
+PERMISSIVE
+#node-1
+HANDLER t1 OPEN AS h1;
+Warnings:
+Warning	1105	Percona-XtraDB-Cluster doesn't recommend use of HANDLER <table> OPEN AS <alias> with pxc_strict_mode = PERMISSIVE
+HANDLER h1 CLOSE;
+include/assert_grep.inc [pxc_strict_mode issued warning about HANDLER OPEN]
+#node-1
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SELECT @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
+#node-2
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SELECT @@pxc_strict_mode;
+@@pxc_strict_mode
+ENFORCING
+#node-1
+HANDLER t1 OPEN AS h1;
+ERROR HY000: Percona-XtraDB-Cluster prohibits use of HANDLER <table> OPEN AS <alias> with pxc_strict_mode = ENFORCING
+include/assert_grep.inc [pxc_strict_mode issued error about HANDLER OPEN]
+DROP TABLE t1;
+#node-1
+set global pxc_strict_mode = DISABLED;
+#node-2
+set global pxc_strict_mode = DISABLED;

--- a/mysql-test/suite/galera/t/handler_open_as.test
+++ b/mysql-test/suite/galera/t/handler_open_as.test
@@ -1,0 +1,45 @@
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+--connection node_1
+--let $pxc_strict_mode_saved1 = `SELECT @@pxc_strict_mode`
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+--connection node_2
+--let $pxc_strict_mode_saved2 = `SELECT @@pxc_strict_mode`
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+
+
+CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE=InnoDB;
+
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--connection node_1
+SET DEBUG_SYNC = 'innodb_delay_open_table SIGNAL reached WAIT_FOR continue';
+--send HANDLER t1 OPEN AS t1;
+
+--connection node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR reached';
+
+--connection node_2
+DROP TABLE t1;
+
+# connection node_1 is BF-aborted. It will be unblocked by abort. No need to signal.
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+HANDLER t1 CLOSE;
+
+--connection node_1
+--eval SET GLOBAL pxc_strict_mode = $pxc_strict_mode_saved1
+--connection node_2
+--eval SET GLOBAL pxc_strict_mode = $pxc_strict_mode_saved2
+SET DEBUG_SYNC = reset;
+--disconnect node_1a
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -60,6 +60,7 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend changing storage engine of a table ");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster doesn't recommend use of INSERT");
+call mtr.add_suppression("Percona-XtraDB-Cluster doesn't recommend use of HANDLER");
 
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of DML command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of TRUNCATE command");
@@ -67,6 +68,7 @@ call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ADMIN c
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of ALTER command");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits changing storage engine of a table");
 call mtr.add_suppression("WSREP: Percona-XtraDB-Cluster prohibits use of INSERT");
+call mtr.add_suppression("Percona-XtraDB-Cluster prohibits use of HANDLER");
 
 
 call mtr.add_suppression("WSREP doesn't support XA transaction");
@@ -1454,6 +1456,90 @@ DROP VIEW view_w_pk;
 DROP TABLE tbl_wo_pk;
 DROP TABLE tbl_w_pk;
 
+#-------------------------------------------------------------------------------
+#
+# Scenario-10: HANDLER <table> OPEN AS <alias>
+#
+
+#
+--connection node_1
+--echo #node-1
+CREATE TABLE t1(id INT PRIMARY KEY);
+
+#----------------------------
+#
+# DISABLED
+--connection node_1
+--echo #node-1
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SELECT @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SELECT @@pxc_strict_mode;
+
+#
+--connection node_1
+--echo #node-1
+HANDLER t1 OPEN AS h1;
+HANDLER h1 CLOSE;
+
+
+#----------------------------
+#
+# PERMISSIVE
+--connection node_1
+--echo #node-1
+SET GLOBAL pxc_strict_mode = 'PERMISSIVE';
+SELECT @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+SET GLOBAL pxc_strict_mode = 'PERMISSIVE';
+SELECT @@pxc_strict_mode;
+
+#
+--connection node_1
+--echo #node-1
+HANDLER t1 OPEN AS h1;
+HANDLER h1 CLOSE;
+
+--let $assert_text = pxc_strict_mode issued warning about HANDLER OPEN
+--let $assert_select = doesn't recommend use of HANDLER <table> OPEN AS <alias> with pxc_strict_mode = PERMISSIVE
+--let $assert_count = 1
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+#----------------------------
+#
+# ENFORCING
+--connection node_1
+--echo #node-1
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SELECT @@pxc_strict_mode;
+#
+--connection node_2
+--echo #node-2
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SELECT @@pxc_strict_mode;
+
+#
+--connection node_1
+--echo #node-1
+--error ER_UNKNOWN_ERROR
+HANDLER t1 OPEN AS h1;
+
+--let $assert_text = pxc_strict_mode issued error about HANDLER OPEN
+--let $assert_select = prohibits use of HANDLER <table> OPEN AS <alias> with pxc_strict_mode = ENFORCING
+--let $assert_count = 1
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST
+--source include/assert_grep.inc
+
+DROP TABLE t1;
+
 
 #-------------------------------------------------------------------------------
 #
@@ -1461,8 +1547,8 @@ DROP TABLE tbl_w_pk;
 #
 --connection node_1
 --echo #node-1
---eval set global pxc_strict_mode = $pxc_strict_mode_saved1;
+--eval set global pxc_strict_mode = $pxc_strict_mode_saved1
 #
 --connection node_2
 --echo #node-2
---eval set global pxc_strict_mode = $pxc_strict_mode_saved2;
+--eval set global pxc_strict_mode = $pxc_strict_mode_saved2

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7987,8 +7987,15 @@ static bool wsrep_should_retry_in_autocommit(const THD* thd)
     So, we avoid retries for such queries that return result set to client,
     but cannot be run in TOI and can be killed by a TOI.
 
-    As of now, we only do this check for CHECK TABLE and SELECT, and if the
-    same symptom is found for other commands, then please add it to the
+    As of now, we only do this check for CHECK TABLE and SELECT.
+
+    We also do not retry for HANDLER OPEN AS statement. This is because
+    Sql_cmd_handler_open::execute() stores table alias in its internal hash
+    even if opening of the table is BF-aborted with the hope of auto-recovering
+    during the next handler access (READ). If we retry, we will end up with
+    the error of duplicate alias.
+
+    If the same symptom is found for other commands, then please add it to the
     below list.
   */
 
@@ -7996,6 +8003,7 @@ static bool wsrep_should_retry_in_autocommit(const THD* thd)
   {
     case SQLCOM_CHECK:
     case SQLCOM_SELECT:
+    case SQLCOM_HA_OPEN:
       return false;
     case SQLCOM_ALTER_TABLE:
     {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7208,6 +7208,10 @@ ha_innobase::open(
 
 	DBUG_ENTER("ha_innobase::open");
 
+#ifdef WITH_WSREP
+	DEBUG_SYNC(ha_thd(), "innodb_delay_open_table");
+#endif
+
 	UT_NOT_USED(mode);
 	UT_NOT_USED(test_if_locked);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-667

Problem:
When HANDLER <table> OPEN AS <alias> query is running and it gets BF-aborted by DELETE TABLE <table>, the server crashes.

Cause:
Original flow:
HANDLER ... OPEN AS ... opens the table, creates MDL explicit lock on it and stores it in its internal hash. The table is not closed  (is not returned to table cache) when the query finishes. When other thread tries to delete the table, it is blocked until HANDLER ... CLOSE is executed and tables are closed and all explicit locks are released.

PXC flow:
session 1: HANDLER ... OPEN AS ... opens the table, creates MDL explicit lock on it and stores it in its internal hash. The table is not closed (is not returned to table cache) when the query finishes. session 2: If DELETE TABLE ... is executed while session 1 is still executing, session 1 detects that it was aborted and executes Wsrep_client_service::bf_rollback() as the part of wsrep_after_statement(). This causes all explicit locks release, which allows session 2 to go on, but does not close handler tables. When Session 1 executes CLOSE HANDLER ... it asserts during closing of handler talbes because it expects tables to be still locked, but they are already unlocked during bf_rollback()

Solution:
1. When HANDLER ... OPEN AS ... does self-rollback, close all handler tables before releasing explicit locks.
2. Unfortunately HANDLER ... OPEN AS ... does not start the transaction, so if it is BF-aborted while not active, there is no way to kick-off background rollbacker. The only way we can learn about BF-abort is to execute the next statement in victim session. Up to this moment, BF session needs to wait on explicit lock. This is similar situation to session explicit locks done by LOCK TABLES ... which is prohibited when pxc_strict_mode=ENFORCING.
As the consequence HANDLER ... OPEN AS ... has been prohibited for pxc_strict_mode=ENFORCING.