### PR TITLE
PXC-4146: Option to fail startup if IST is unavailable

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_ist_only.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_ist_only.result
@@ -1,0 +1,37 @@
+CALL mtr.add_suppression(".*State transfer to .* failed: -125.*");
+CALL mtr.add_suppression(".*SST request is null, SST canceled.*");
+CALL mtr.add_suppression(".*State transfer to .* failed: -125.*");
+CALL mtr.add_suppression(".*SST request is null, SST canceled.*");
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+# restart:<hidden args>
+include/assert.inc [Table t1 should have 4 rows]
+include/assert_grep.inc [Assert that node_2 joined without SST]
+INSERT INTO t1 VALUES (5);
+INSERT INTO t1 VALUES (6);
+INSERT INTO t1 VALUES (7);
+# restart:<hidden args>
+include/wait_for_removed_expect_file.inc
+# restart:<hidden args>
+include/assert.inc [Table t1 still should have 4 rows]
+# restart:<hidden args>
+include/assert.inc [Table t1 should have 7 rows]
+include/assert_grep.inc [Assert that node_2 failed to join without SST]
+INSERT INTO t1 VALUES (8);
+INSERT INTO t1 VALUES (9);
+INSERT INTO t1 VALUES (10);
+# restart:<hidden args>
+SET GLOBAL wsrep_desync=1;
+# restart:<hidden args>
+include/wait_for_removed_expect_file.inc
+# restart:<hidden args>
+include/assert_grep.inc [Assert that node_2 failed to join without SST]
+include/assert.inc [Table t1 should have 10 rows]
+include/assert.inc [test2 DB should have 200 tables]
+SET GLOBAL wsrep_desync=0;
+# restart:<hidden args>
+DROP TABLE t1;
+DROP DATABASE test2;

--- a/mysql-test/suite/galera_3nodes/t/galera_ist_only.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_ist_only.test
@@ -1,0 +1,175 @@
+# This test checks the case when the node is joining the cluster
+# and it specifies that it is interested only in receiving IST,
+# and no full SST should be done.
+
+--source include/big_test.inc
+--source include/galera_cluster_3nodes.inc
+
+--let $ofile= $MYSQLTEST_VARDIR/tmp/node.2.err
+
+--connection node_1
+CALL mtr.add_suppression(".*State transfer to .* failed: -125.*");
+CALL mtr.add_suppression(".*SST request is null, SST canceled.*");
+
+--connection node_3
+CALL mtr.add_suppression(".*State transfer to .* failed: -125.*");
+CALL mtr.add_suppression(".*SST request is null, SST canceled.*");
+
+--connection node_1
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
+# Case 1:
+# node_2 should catch up with the cluster after the restart
+# because both possible donors have all IST-needed information
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+INSERT INTO t1 VALUES (2);
+INSERT INTO t1 VALUES (3);
+INSERT INTO t1 VALUES (4);
+
+--connection node_2
+--let $restart_parameters = "restart: --wsrep_provider_options='base_port=$NODE_GALERAPORT_2' --wsrep_sst_method=ist_only --log-error=$ofile"
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld.inc
+--source include/galera_wait_ready.inc
+--let $assert_text = Table t1 should have 4 rows
+--let $assert_cond = COUNT(*) = 4 FROM t1;
+--source include/assert.inc
+
+--let $assert_text = Assert that node_2 joined without SST
+--let $assert_file = $ofile
+--let $assert_select = The node will try to join the cluster using only IST.
+--let $assert_count = 1
+--source include/assert_grep.inc
+
+# Case 2:
+# node_2 should fail joining the cluster, because it doesn't have
+# grastate.dat file (cluster uuid is missing)
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+--connection node_1
+INSERT INTO t1 VALUES (5);
+INSERT INTO t1 VALUES (6);
+INSERT INTO t1 VALUES (7);
+
+--connection node_2
+--let $restart_parameters = "restart: --wsrep_provider_options='base_port=$NODE_GALERAPORT_2' --wsrep_sst_method=ist_only --log-error=$ofile"
+--let $expect_crash_on_start = 1
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld.inc
+
+# Now start node_2 as standalone. t1 still should have 4 rows.
+--let $restart_parameters = "restart: --wsrep_provider=none"
+--let $expect_crash_on_start = 0
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld.inc
+--let $assert_text = Table t1 still should have 4 rows
+--let $assert_cond = COUNT(*) = 4 FROM t1;
+--source include/assert.inc
+
+# node_2 can recover only via full SST
+--let $restart_parameters = "restart: --wsrep_provider_options='base_port=$NODE_GALERAPORT_2'"
+--let $expect_crash_on_start = 0
+--let $do_not_echo_parameters = 1
+--source include/restart_mysqld.inc
+--source include/galera_wait_ready.inc
+--let $assert_text = Table t1 should have 7 rows
+--let $assert_cond = COUNT(*) = 7 FROM t1;
+--source include/assert.inc
+
+--let $assert_text = Assert that node_2 failed to join without SST
+--let $assert_file = $ofile
+--let $assert_select = Local state UUID 00000000-0000-0000-0000-000000000000 is different from group state
+--let $assert_count = 1
+--source include/assert_grep.inc
+
+# Case 3:
+# node_2 should fail joining the cluster, because the requested donor
+# cannot serve IST
+
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+INSERT INTO t1 VALUES (8);
+INSERT INTO t1 VALUES (9);
+INSERT INTO t1 VALUES (10);
+
+# prepare the donor with empty GCache
+--connection node_3
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.3/data/galera.cache
+--let $restart_parameters = "restart: --wsrep_provider_options='base_port=$NODE_GALERAPORT_3;gcache.size=0;gcache.page_size=16k'"
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld.inc
+--source include/galera_wait_ready.inc
+
+# Overflow GCache to disable IST possibility
+--let $cnt = 200
+--disable_query_log
+CREATE DATABASE test2;
+USE test2;
+while ($cnt)
+{
+  --eval CREATE TABLE tt_$cnt(a int primary key);
+  --dec $cnt
+}
+USE test;
+--enable_query_log
+
+# Desync node_1. Galera will not elect it as IST donor.
+--connection node_1
+SET GLOBAL wsrep_desync=1;
+
+# now start node_2, but pointing to node_3 as the donor
+--connection node_2
+--let $restart_parameters = "restart: --wsrep_provider_options='base_port=$NODE_GALERAPORT_2' --wsrep_sst_method=ist_only --log-error=$ofile"
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--let $expect_crash_on_start = 1
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld.inc
+
+# node_2 can recover only via full SST if donor is node_3
+--let $restart_parameters = "restart: --wsrep_provider_options='base_port=$NODE_GALERAPORT_2'"
+--let $expect_crash_on_start = 0
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld.inc
+--source include/galera_wait_ready.inc
+
+--let $assert_text = Assert that node_2 failed to join without SST
+--let $assert_file = $ofile
+--let $assert_select = Will never receive state. Need to abort.
+--let $assert_count = 1
+--source include/assert_grep.inc
+
+--let $assert_text = Table t1 should have 10 rows
+--let $assert_cond = COUNT(*) = 10 FROM t1;
+--source include/assert.inc
+
+--let $assert_text = test2 DB should have 200 tables
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME LIKE "tt_%"] = 200;
+--source include/assert.inc
+
+--connection node_1
+SET GLOBAL wsrep_desync=0;
+
+# restart node_3 with default parameters
+--connection node_3
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.3/data/galera.cache
+--let $restart_parameters = "restart: --wsrep_provider_options='base_port=$NODE_GALERAPORT_3'"
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld.inc
+--source include/galera_wait_ready.inc
+
+# cleanup
+DROP TABLE t1;
+DROP DATABASE test2;
+--remove_file $ofile


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4146

Problem:
When we want to join the new node to the cluster, it is possible to avoid time consuming SST process by manually restoring the backup to the new node, manually editing grastate.dat file and start the node. In such a scenario, only IST is expected to be performed. However, it appeared to be a common case when creation/edition of grastate.dat file is forgotten. In such a case the joiner node will receive the full SST which causes unnecessary load on donor and joiner side.

Cause:
The joiner node always sends State Transfer request which consists of:
1. SST method + receiver endpoint
2. IST receiver endpoint + minimum seqno to satisfy IST to the donor node.
It is the donor node who decides (basing on passed IST seqno) if SST is to be sent, or if it is bypassed and only IST is sent. In the case of grastate.dat absence on the joiner node, IST information sent to donor (empty cluster UUID, invalid seqno) makes it to conclude that the full SST is needed.

Solution:
Introduce new possible value, 'ist_only' of 'wsrep_sst_method'. When wsrep_sst_method=ist_only, the joiner sends State Transfer request to the donor which consists empty SST request part and only IST part. If the request cannot be satisfied by the donor, the joiner will fail to join leaving data directory unmodified.