### PR TITLE
PXC-3421 IMPROVES ERROR HANDLING IN WSREP_SCHEMA.CC

### DIFF
--- a/mysql-test/suite/galera_sr/r/gakera_sr_wsrep_error_handling.result
+++ b/mysql-test/suite/galera_sr/r/gakera_sr_wsrep_error_handling.result
@@ -1,0 +1,7 @@
+#node-1
+SET SESSION DEBUG='+d,fail_at_update_fragment';
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+INSERT INTO t1 VALUES (1);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/gakera_sr_wsrep_error_handling.test
+++ b/mysql-test/suite/galera_sr/t/gakera_sr_wsrep_error_handling.test
@@ -1,0 +1,18 @@
+# Test to verify the error paths of wsrep_schema.cc 
+# (More scenarios can be added in the future)
+#
+
+# Failing to update fragment results in a deadlock
+--source include/galera_cluster.inc
+
+--connection node_1
+--echo #node-1
+SET SESSION DEBUG='+d,fail_at_update_fragment';
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+SET SESSION wsrep_trx_fragment_size=1;
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES (1);
+
+# cleanup
+DROP TABLE t1;

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -860,6 +860,8 @@ int Wsrep_schema::update_fragment_meta(THD *thd,
   Wsrep_schema_impl::init_stmt(thd);
   if (Wsrep_schema_impl::open_for_write(thd, sr_table_str.c_str(),
                                         &frag_table)) {
+    trans_rollback_stmt(thd);
+    close_thread_tables(thd);
     DBUG_RETURN(1);
   }
 
@@ -870,12 +872,15 @@ int Wsrep_schema::update_fragment_meta(THD *thd,
   Wsrep_schema_impl::make_key(frag_table, key, &key_map, 3);
 
   if ((error =
-           Wsrep_schema_impl::init_for_index_scan(frag_table, key, key_map))) {
+           Wsrep_schema_impl::init_for_index_scan(frag_table, key, key_map)) ||
+           DBUG_EVALUATE_IF("fail_at_update_fragment", true, false)) {
     if (error == HA_ERR_END_OF_FILE || error == HA_ERR_KEY_NOT_FOUND) {
       WSREP_WARN("Record not found in %s.%s: %d", frag_table->s->db.str,
                  frag_table->s->table_name.str, error);
     }
-    Wsrep_schema_impl::finish_stmt(thd);
+    Wsrep_schema_impl::end_index_scan(frag_table);
+    trans_rollback_stmt(thd);
+    close_thread_tables(thd);
     DBUG_RETURN(1);
   }
 
@@ -889,7 +894,8 @@ int Wsrep_schema::update_fragment_meta(THD *thd,
     WSREP_ERROR("Error updating record in %s.%s: %d", frag_table->s->db.str,
                 frag_table->s->table_name.str, error);
     Wsrep_schema_impl::end_index_scan(frag_table);
-    Wsrep_schema_impl::finish_stmt(thd);
+    trans_rollback_stmt(thd);
+    close_thread_tables(thd);
     DBUG_RETURN(1);
   }
 
@@ -1043,8 +1049,9 @@ int Wsrep_schema::replay_transaction(
     if ((error = Wsrep_schema_impl::open_for_read(&thd, sr_table_str.c_str(),
                                                   &frag_table))) {
       WSREP_WARN("Could not open SR table for read: %d", error);
-      Wsrep_schema_impl::finish_stmt(&thd);
-      DBUG_RETURN(1);
+      trans_rollback_stmt(&thd);
+      ret = 1;
+      break;
     }
 
     Wsrep_schema_impl::store(frag_table, 0, ws_meta.server_id());
@@ -1057,7 +1064,8 @@ int Wsrep_schema::replay_transaction(
     if (error2) {
       WSREP_WARN("Failed to init streaming log table for index scan: %d",
                  error);
-      Wsrep_schema_impl::finish_stmt(&thd);
+      Wsrep_schema_impl::end_index_scan(frag_table);
+      trans_rollback_stmt(&thd);
       ret = 1;
       break;
     }
@@ -1077,7 +1085,7 @@ int Wsrep_schema::replay_transaction(
         WSREP_WARN(
             "Wsrep_schema::replay_transaction: failed to apply fragments");
         Wsrep_schema_impl::end_index_scan(frag_table);
-        Wsrep_schema_impl::finish_stmt(&thd);
+        trans_rollback_stmt(&thd);
         break;
       }
     }
@@ -1090,14 +1098,16 @@ int Wsrep_schema::replay_transaction(
     if ((error = Wsrep_schema_impl::open_for_write(&thd, sr_table_str.c_str(),
                                                    &frag_table))) {
       WSREP_WARN("Could not open SR table for write: %d", error);
-      Wsrep_schema_impl::finish_stmt(&thd);
-      DBUG_RETURN(1);
+      trans_rollback_stmt(&thd);
+      ret = 1;
+      break;
     }
     error = Wsrep_schema_impl::init_for_index_scan(frag_table, key, key_map);
     if (error) {
       WSREP_WARN("Failed to init streaming log table for index scan: %d",
                  error);
-      Wsrep_schema_impl::finish_stmt(&thd);
+      Wsrep_schema_impl::end_index_scan(frag_table);
+      trans_rollback_stmt(&thd);
       ret = 1;
       break;
     }
@@ -1106,14 +1116,16 @@ int Wsrep_schema::replay_transaction(
     if (error) {
       WSREP_WARN("Could not delete row from streaming log table: %d", error);
       Wsrep_schema_impl::end_index_scan(frag_table);
-      Wsrep_schema_impl::finish_stmt(&thd);
+      trans_rollback_stmt(&thd);
       ret = 1;
       break;
     }
     Wsrep_schema_impl::end_index_scan(frag_table);
     Wsrep_schema_impl::finish_stmt(&thd);
+    DBUG_RETURN(ret);
   }
 
+  close_thread_tables(&thd);
   DBUG_RETURN(ret);
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-3421

All the failure scenarios in wsrep_schema.cc are suffixed with a call to finish_stmt() method at the end before erroring out. But, internally it invokes trans_commit_stmt() which actually commits the transaction which is unnecessary.

So, the transaction is properly rollbacked and followed by closing of the tables.

Notes:-
- Codership's version was also referred before making this change.
- All the init_for_index_scan for index scan method calls should be paired with end_index_scan method calls regardless of the success or failure scenarios so that the value of **_inited_** is set appropriately when cleanup stage is reached.
- To induce the error scenarios, debug simulations can be used like the following diff

```
diff --git a/mysql-test/suite/galera_sr/t/galera_sr_transaction_replay.test b/mysql-test/suite/galera_sr/t/galera_sr_transaction_replay.test
index 245f9c17a0a..05ebe36fc25 100644
--- a/mysql-test/suite/galera_sr/t/galera_sr_transaction_replay.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_transaction_replay.test
@@ -74,6 +74,7 @@ UPDATE t1 SET f2 = 'c' WHERE f1 = 2;
 # Send the commit on node_1
 #
 --connection node_1
+SET SESSION DEBUG='+d,fail_at_replay_transaction';
 --echo #node-1
 --send COMMIT
 
diff --git a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#96.test b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#96.test
index 5c7717f54cb..bbf4d753cd1 100644
--- a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#96.test
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#96.test
@@ -4,6 +4,7 @@
 --source include/galera_cluster.inc
 
 --connection node_1
+SET SESSION DEBUG='+d,fail_at_update_fragment';
 --echo #node-1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
 CREATE TABLE t2 (f2 VARCHAR(32));
diff --git a/sql/wsrep_schema.cc b/sql/wsrep_schema.cc
index f86fc701566..37ee18413b6 100644
--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -872,7 +872,8 @@ int Wsrep_schema::update_fragment_meta(THD *thd,
   Wsrep_schema_impl::make_key(frag_table, key, &key_map, 3);
 
   if ((error =
-           Wsrep_schema_impl::init_for_index_scan(frag_table, key, key_map))) {
+           Wsrep_schema_impl::init_for_index_scan(frag_table, key, key_map)) ||
+           DBUG_EVALUATE_IF("fail_at_update_fragment", true, false)) {
     if (error == HA_ERR_END_OF_FILE || error == HA_ERR_KEY_NOT_FOUND) {
       WSREP_WARN("Record not found in %s.%s: %d", frag_table->s->db.str,
                  frag_table->s->table_name.str, error);
@@ -1113,7 +1114,7 @@ int Wsrep_schema::replay_transaction(
     }
 
     error = Wsrep_schema_impl::delete_row(frag_table);
-    if (error) {
+    if (error || DBUG_EVALUATE_IF("fail_at_replay_transaction", true, false)) {
       WSREP_WARN("Could not delete row from streaming log table: %d", error);
       Wsrep_schema_impl::end_index_scan(frag_table);
       trans_rollback_stmt(&thd);

```

With the above patch, the MTR test, _galera_sr_transaction_replay.test_ hits an assert at 
_$REPO/wsrep-lib/src/transaction.cpp:2086: void wsrep::transaction::cleanup(): Assertion `is_streaming() == false' failed._

This is because the applied fragment count hasn't been updated in the streaming_context_ object and fragments_certified_ would have the 0 value since the error/failure has been introduced artificially by us. 

```
Thread 1 (Thread 0x7fa4142fb640 (LWP 347147)):
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140342690035264) at ./nptl/pthread_kill.c:44
#1  __pthread_kill_internal (signo=6, threadid=140342690035264) at ./nptl/pthread_kill.c:78
#2  __GI___pthread_kill (threadid=140342690035264, signo=6) at ./nptl/pthread_kill.c:89
#3  0x00005643a6c5424b in my_write_core (sig=6) at /home/varun/pxc-3421/repo/mysys/stacktrace.cc:396
#4  0x00005643a58d3ae2 in handle_fatal_signal (sig=6) at /home/varun/pxc-3421/repo/sql/signal_handler.cc:267
#5  <signal handler called>
#6  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140342690035264) at ./nptl/pthread_kill.c:44
#7  __pthread_kill_internal (signo=6, threadid=140342690035264) at ./nptl/pthread_kill.c:78
#8  __GI___pthread_kill (threadid=140342690035264, signo=signo@entry=6) at ./nptl/pthread_kill.c:89
#9  0x00007fa43ee42476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#10 0x00007fa43ee287f3 in __GI_abort () at ./stdlib/abort.c:79
#11 0x00007fa43ee2871b in __assert_fail_base (fmt=0x7fa43efdd150 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x5643a9b7916d "is_streaming() == false", file=0x5643a9b780e8 "/home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp", line=2086, function=<optimized out>) at ./assert/assert.c:92
#12 0x00007fa43ee39e96 in __GI___assert_fail (assertion=0x5643a9b7916d "is_streaming() == false", file=0x5643a9b780e8 "/home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp", line=2086, function=0x5643a9b7a070 "void wsrep::transaction::cleanup()") at ./assert/assert.c:101
#13 0x00005643a7c93789 in wsrep::transaction::cleanup (this=0x7fa3641b3290) at /home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp:2086
#14 0x00005643a7c8efa1 in wsrep::transaction::after_applying (this=0x7fa3641b3290) at /home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp:972
#15 0x00005643a58f4baa in wsrep::client_state::after_applying (this=0x7fa3641b3228) at /home/varun/pxc-3421/repo/wsrep-lib/include/wsrep/client_state.hpp:304
#16 0x00005643a58eda7a in wsrep_after_apply (thd=0x7fa3641b04e0) at /home/varun/pxc-3421/repo/sql/wsrep_trans_observer.h:468
#17 0x00005643a58f3930 in Wsrep_replayer_service::~Wsrep_replayer_service (this=0x7fa4142f9020, __in_chrg=<optimized out>) at /home/varun/pxc-3421/repo/sql/wsrep_high_priority_service.cc:947
#18 0x00005643a58ebb36 in Wsrep_client_service::replay (this=0x7fa3640096b0) at /home/varun/pxc-3421/repo/sql/wsrep_client_service.cc:300
#19 0x00005643a7c93497 in wsrep::transaction::replay (this=0x7fa364009730, lock=...) at /home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp:2039
#20 0x00005643a7c8ea52 in wsrep::transaction::after_statement (this=0x7fa364009730) at /home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp:884
#21 0x00005643a7c72b2b in wsrep::client_state::after_statement (this=0x7fa3640096c8) at /home/varun/pxc-3421/repo/wsrep-lib/src/client_state.cpp:282
#22 0x00005643a5640fe0 in wsrep_after_statement (thd=0x7fa364006980) at /home/varun/pxc-3421/repo/sql/wsrep_trans_observer.h:460
#23 0x00005643a565b3bc in wsrep_dispatch_sql_command (thd=0x7fa364006980, rawbuf=0x7fa3642d7ea0 "COMMIT", length=6, parser_state=0x7fa4142f9890, update_userstat=false) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:7756
#24 0x00005643a5648f1e in dispatch_command (thd=0x7fa364006980, com_data=0x7fa4142fa280, command=COM_QUERY) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:2433
#25 0x00005643a5646263 in do_command (thd=0x7fa364006980) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:1645
#26 0x00005643a58ba6ef in handle_connection (arg=0x5643ae2b0270) at /home/varun/pxc-3421/repo/sql/conn_handler/connection_handler_per_thread.cc:312
#27 0x00005643a75911d4 in pfs_spawn_thread (arg=0x5643ae30bec0) at /home/varun/pxc-3421/repo/storage/perfschema/pfs.cc:2987
#28 0x00007fa43ee94b43 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#29 0x00007fa43ef26a00 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

With the above patch, the MTR test, mysql-wsrep-features#96.test fails with an expected deadlock error.
```
[ 33%] galera_sr.mysql-wsrep-features#96 'enc_off' w1  [ fail ]
        Test ended at 2023-04-18 13:55:16

CURRENT_TEST: galera_sr.mysql-wsrep-features#96
mysqltest: At line 15: Query 'INSERT INTO t1 VALUES (1)' failed.
ERROR 1213 (40001): Deadlock found when trying to get lock; try restarting transaction

The result from queries just before the failure was:
SET SESSION DEBUG='+d,fail_at_update_fragment';
#node-1
CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
CREATE TABLE t2 (f2 VARCHAR(32));
SET SESSION wsrep_trx_fragment_size=1;
SET AUTOCOMMIT=OFF;
START TRANSACTION;
INSERT INTO t1 VALUES (1);

Warnings from just before the error:
Error 1030 Got error 1213 - 'Unknown error 1213' from storage engine 
safe_process[424301]: Child process: 424302, exit: 1
```

The above can be verified with an assert at wsrep-lib/src/transaction.cpp.
```
diff --git a/src/transaction.cpp b/src/transaction.cpp
index f7e98e4..dab52da 100644
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1610,6 +1610,7 @@ int wsrep::transaction::certify_fragment(
                                              wsrep::ws_meta());
                     ret = 1;
                     error = wsrep::e_deadlock_error;
+                    assert(0);
                     break;
                 }
                 if (storage_service.commit(ws_handle_, sr_ws_meta))
```
```
#11 0x00007f56cf82871b in __assert_fail_base (fmt=0x7f56cf9dd150 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x5653a17b61a2 "0", file=0x5653a17b6108 "/home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp", line=1613, function=<optimized out>) at ./assert/assert.c:92
#12 0x00007f56cf839e96 in __GI___assert_fail (assertion=0x5653a17b61a2 "0", file=0x5653a17b6108 "/home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp", line=1613, function=0x5653a17b7bd8 "int wsrep::transaction::certify_fragment(wsrep::unique_lock<wsrep::mutex>&)") at ./assert/assert.c:101
#13 0x000056539f8cfc3b in wsrep::transaction::certify_fragment (this=0x7f55f0009730, lock=...) at /home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp:1613
#14 0x000056539f8cf1d2 in wsrep::transaction::streaming_step (this=0x7f55f0009730, lock=..., force=false) at /home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp:1459
#15 0x000056539f8ca695 in wsrep::transaction::after_row (this=0x7f55f0009730) at /home/varun/pxc-3421/repo/wsrep-lib/src/transaction.cpp:271
#16 0x000056539cdb20ab in wsrep::client_state::after_row (this=0x7f55f00096c8) at /home/varun/pxc-3421/repo/wsrep-lib/include/wsrep/client_state.hpp:399
#17 0x000056539cd8c75e in wsrep_after_row (thd=0x7f55f0006980) at /home/varun/pxc-3421/repo/sql/wsrep_trans_observer.h:148
#18 0x000056539cda8363 in wsrep_after_row (thd=0x7f55f0006980) at /home/varun/pxc-3421/repo/sql/handler.cc:8471
#19 0x000056539cda8902 in handler::ha_write_row (this=0x7f55f04adcf0, buf=0x7f55f04a1f20 "\377\001") at /home/varun/pxc-3421/repo/sql/handler.cc:8512
#20 0x000056539d22ac63 in write_record (thd=0x7f55f0006980, table=0x7f55f0187930, info=0x7f56904efc00, update=0x7f56904efc80) at /home/varun/pxc-3421/repo/sql/sql_insert.cc:2238
#21 0x000056539d2260ae in Sql_cmd_insert_values::execute_inner (this=0x7f55f0246a98, thd=0x7f55f0006980) at /home/varun/pxc-3421/repo/sql/sql_insert.cc:699
#22 0x000056539d32214d in Sql_cmd_dml::execute (this=0x7f55f0246a98, thd=0x7f55f0006980) at /home/varun/pxc-3421/repo/sql/sql_select.cc:605
#23 0x000056539d28ce39 in mysql_execute_command (thd=0x7f55f0006980, first_level=true) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:4286
#24 0x000056539d294ea5 in dispatch_sql_command (thd=0x7f55f0006980, parser_state=0x7f56904f1890, update_userstat=false) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:6466
#25 0x000056539d2991c8 in wsrep_dispatch_sql_command (thd=0x7f55f0006980, rawbuf=0x7f55f0245110 "INSERT INTO t1 VALUES (1)", length=25, parser_state=0x7f56904f1890, update_userstat=false) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:7732
#26 0x000056539d286f1e in dispatch_command (thd=0x7f55f0006980, com_data=0x7f56904f2280, command=COM_QUERY) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:2433
#27 0x000056539d284263 in do_command (thd=0x7f55f0006980) at /home/varun/pxc-3421/repo/sql/sql_parse.cc:1645
#28 0x000056539d4f86ef in handle_connection (arg=0x5653a69e25d0) at /home/varun/pxc-3421/repo/sql/conn_handler/connection_handler_per_thread.cc:312
#29 0x000056539f1cf248 in pfs_spawn_thread (arg=0x5653a6a361b0) at /home/varun/pxc-3421/repo/storage/perfschema/pfs.cc:2987
#30 0x00007f56cf894b43 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#31 0x00007f56cf926a00 in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```