### PR TITLE
(5.7) PXC-679: Undetected state gap discovery causes server hung on shutdown

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -207,7 +207,7 @@ my $DEFAULT_SUITES= "main,sys_vars,binlog,binlog_encryption,rpl_encryption,encry
   ."tokudb.rpl,tokudb.perfschema,"
   ."rocksdb,rocksdb_rpl,rocksdb_sys_vars,rocksdb_stress,"
   ."audit_null,percona-pam-for-mysql,data_masking,"
-  ."galera,galera_3nodes";
+  ."galera,galera_3nodes,wsrep";
 
 my $opt_suites;
 

--- a/mysql-test/suite/sys_vars/t/disabled.def
+++ b/mysql-test/suite/sys_vars/t/disabled.def
@@ -12,7 +12,6 @@
 query_cache_size_basic_32           : Bug#13535584
 query_cache_size_basic_64           : Bug#11748572
 #thread_cache_size_func             : Bug#11750172: 2008-11-07 joro main.thread_cache_size_func fails in pushbuild when run with pool of threads
-wsrep_start_position_basic          : This needs server to start in cluster mode with wsrep initialized.
 wsrep_preordered_basic              : TC pending.
 wsrep_reject_queries_basic          : TC pending.
 sql_mode_func                       : Differences in result likely due to configuration. Need more investigation.

--- a/mysql-test/suite/wsrep/r/wsrep_start_position_basic.result
+++ b/mysql-test/suite/wsrep/r/wsrep_start_position_basic.result
@@ -1,0 +1,57 @@
+#
+# wsrep_start_position
+#
+# save the initial value
+SET @wsrep_start_position_global_saved = @@global.wsrep_start_position;
+# default
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-1
+
+# scope
+SELECT @@session.wsrep_start_position;
+ERROR HY000: Variable 'wsrep_start_position' is a GLOBAL variable
+SET @@global.wsrep_start_position='00000000-0000-0000-0000-000000000000:-1';
+ERROR HY000: wsrep_start_position can be set during server boot or before loading wsrep_provider
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-1
+# restart: --wsrep_provider=none --log-bin
+
+# valid values
+SET @@global.wsrep_start_position='00000000-0000-0000-0000-000000000000:-2';
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-2
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:100';
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+12345678-1234-1234-1234-123456789012:100
+SET @@global.wsrep_start_position=default;
+SELECT @@global.wsrep_start_position;
+@@global.wsrep_start_position
+00000000-0000-0000-0000-000000000000:-1
+
+# invalid values
+SET @@global.wsrep_start_position='000000000000000-0000-0000-0000-000000000000:-1';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '000000000000000-0000-0000-0000-000000000000:-1'
+SET @@global.wsrep_start_position='12345678-1234-1234-12345-123456789012:100';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-1234-12345-123456789012:100'
+SET @@global.wsrep_start_position='12345678-1234-123-12345-123456789012:0';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-123-12345-123456789012:0'
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:_99999';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-1234-1234-123456789012:_99999'
+SET @@global.wsrep_start_position='12345678-1234-1234-1234-123456789012:a';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of '12345678-1234-1234-1234-123456789012:a'
+SET @@global.wsrep_start_position='OFF';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'OFF'
+SET @@global.wsrep_start_position=ON;
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'ON'
+SET @@global.wsrep_start_position='';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of ''
+SET @@global.wsrep_start_position=NULL;
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'NULL'
+SET @@global.wsrep_start_position='junk';
+ERROR 42000: Variable 'wsrep_start_position' can't be set to the value of 'junk'
+# restart:
+# End of test

--- a/mysql-test/suite/wsrep/t/wsrep_start_position_basic.test
+++ b/mysql-test/suite/wsrep/t/wsrep_start_position_basic.test
@@ -14,8 +14,16 @@ SELECT @@global.wsrep_start_position;
 --echo # scope
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SELECT @@session.wsrep_start_position;
+
+# Setting wsrep_start_position when wsrep provider is loaded is prohibited 
+--error ER_UNKNOWN_ERROR
 SET @@global.wsrep_start_position='00000000-0000-0000-0000-000000000000:-1';
 SELECT @@global.wsrep_start_position;
+
+# Restart the server without wsrep provider loaded
+--let $do_not_echo_parameters = 1
+--let $restart_parameters = "restart: --wsrep_provider=none --log-bin"
+--source include/restart_mysqld.inc
 
 --echo
 --echo # valid values
@@ -49,8 +57,8 @@ SET @@global.wsrep_start_position=NULL;
 --error ER_WRONG_VALUE_FOR_VAR
 SET @@global.wsrep_start_position='junk';
 
---echo
---echo # restore the initial value
-SET @@global.wsrep_start_position = @wsrep_start_position_global_saved;
+--let $do_not_echo_parameters = 1
+--let $restart_parameters = "restart:"
+--source include/restart_mysqld.inc
 
 --echo # End of test

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6586,7 +6586,7 @@ static Sys_var_charptr Sys_wsrep_start_position (
        "wsrep_start_position", "global transaction position to start from ",
        PREALLOCATED GLOBAL_VAR(wsrep_start_position), 
        CMD_LINE(REQUIRED_ARG, OPT_WSREP_START_POSITION),
-       IN_FS_CHARSET, DEFAULT(wsrep_start_position),
+       IN_FS_CHARSET, DEFAULT(WSREP_START_POSITION_ZERO),
        NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(wsrep_start_position_check), 
        ON_UPDATE(wsrep_start_position_update));

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -734,7 +734,7 @@ wsrep_view_handler_cb (void*                    app_ctx,
   default:
       WSREP_ERROR("Unsupported application protocol version: %d",
                   view->proto_ver);
-      unireg_abort(1);
+      return WSREP_CB_FAILURE;
   }
 
   if (view->state_gap)
@@ -808,7 +808,7 @@ wsrep_view_handler_cb (void*                    app_ctx,
       WSREP_ERROR("Undetected state gap. Can't continue.");
       wsrep_log_states(WSREP_LOG_FATAL, &cluster_uuid, view->state_id.seqno,
                        &local_uuid, -1);
-      unireg_abort(1);
+      return WSREP_CB_FAILURE;
     }
   }
 

--- a/sql/wsrep_priv.h
+++ b/sql/wsrep_priv.h
@@ -40,6 +40,8 @@ void wsrep_abort_cb (void);
 extern wsrep_uuid_t  local_uuid;
 extern wsrep_seqno_t local_seqno;
 
+bool wsrep_sst_in_progress();
+
 // a helper function
 void wsrep_sst_received(wsrep_t*, const wsrep_uuid_t&, wsrep_seqno_t,
                         const void*, size_t);

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -450,6 +450,14 @@ void wsrep_sst_complete (const wsrep_uuid_t* sst_uuid,
 
 static bool sst_awaiting_callback= false;
 
+bool wsrep_sst_in_progress()
+{
+    if (mysql_mutex_lock (&LOCK_wsrep_sst)) abort();
+    bool in_progress = sst_awaiting_callback;
+    mysql_mutex_unlock (&LOCK_wsrep_sst);
+    return in_progress;
+}
+
 void wsrep_sst_received (wsrep_t*            const wsrep,
                          const wsrep_uuid_t& uuid,
                          wsrep_seqno_t       const seqno,

--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -104,6 +104,8 @@ void wsrep_set_SE_checkpoint(XID& xid)
 
 void wsrep_set_SE_checkpoint(const wsrep_uuid_t& uuid, wsrep_seqno_t seqno)
 {
+  if (!WSREP_ON) return;
+
   XID xid;
   wsrep_xid_init(&xid, uuid, seqno);
   wsrep_set_SE_checkpoint(xid);


### PR DESCRIPTION
PXC-679: Undetected state gap discovery causes server to hang on shutdown

https://jira.percona.com/browse/PXC-679

Problem:
When the server detects a state gap which was not detected at galera
level it aborts itself. It is OK however, during the shutdown the server
hangs.

Cause:
This is because we call unireg_abort() from wsrep_view_handler_cb
(view_cb_), which is done from wsrep applier context. The process is
waiting for wsrep applier thread to be finished and never exits.

Solution:
1. Return WSREP_CB_FAILURE from view callback instead of calling
unireg_abort(). The failure will be detected by galera and abort will
be called.
2. Prohibit setting wsrep_start_position when wsrep provider is loaded
and server is not starting.
Backported 8.0 commit a11616faa1b8781dd6d36e3c0d25097d2c5d52a0 idea.
However, note that the original logic implemented in this commit is
wrong and is in contradiction to the warning message displayed.
wsrep_start_position variable's purpose is to tell the Joiner its start
position after SST. It is used by mysqldump SST.
The condition which prohibits setting wsrep_start_position has been
fixed.
3. Fixed wsrep_start_position default value
(SET GLOBAL wsrep_start_position=default didn't work as nullptr was
the default value instead of 00000000-0000-0000-0000-000000000000:-1
4. wsrep_start_position_basic MTR test moved to wsrep suite and fixed.
5. Added wsrep suite to the list of default suites