### PR TITLE
PXC-4211: Server aborts on binary log rotation

### DIFF
--- a/mysql-test/suite/wsrep/r/binlog_rotation.result
+++ b/mysql-test/suite/wsrep/r/binlog_rotation.result
@@ -1,0 +1,4 @@
+CREATE TABLE t1(a INT PRIMARY KEY, c1 varchar(8192));
+INSERT INTO t1 VALUES (0, repeat('a', 8192));
+DROP TABLE t1;
+include/assert.inc [Binlog rotation should have occured]

--- a/mysql-test/suite/wsrep/t/binlog_rotation-master.opt
+++ b/mysql-test/suite/wsrep/t/binlog_rotation-master.opt
@@ -1,0 +1,1 @@
+--max-binlog-size=4096 --gtid-mode=ON --enforce-gtid-consistency=ON

--- a/mysql-test/suite/wsrep/t/binlog_rotation.test
+++ b/mysql-test/suite/wsrep/t/binlog_rotation.test
@@ -1,0 +1,23 @@
+# The purpose of this test is to check of binlog rotation works
+# when WSREP is enabled.
+
+--source include/have_wsrep_provider.inc
+
+--let $statement = SHOW BINARY LOGS
+--let $column = Log_name
+--source include/get_row_count.inc
+--let $binlogs_count_start = $row_count
+
+CREATE TABLE t1(a INT PRIMARY KEY, c1 varchar(8192));
+INSERT INTO t1 VALUES (0, repeat('a', 8192));
+DROP TABLE t1;
+
+# Check that binlog rotation occured
+--let $statement = SHOW BINARY LOGS
+--let $column = Log_name
+--source include/get_row_count.inc
+--let $binlogs_count_end = $row_count
+
+--let $assert_text = Binlog rotation should have occured
+--let $assert_cond = "[SELECT $binlogs_count_start = $binlogs_count_end]" = 0
+--source include/assert.inc

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1867,9 +1867,12 @@ end:
   /*
     New galera flow now start transaction even for read-only transaction.
     This read-only transaction will not change any row so will get committed
-    as an empty transaction
+    as an empty transaction.
+    But we need to skip this for implicit, internal transactions.
   */
-  if (wsrep_is_active(thd) && is_real_trans && !error && (rw_ha_count == 0) &&
+  if (!thd->is_operating_substatement_implicitly &&
+      !thd->is_operating_gtid_table_implicitly && wsrep_is_active(thd) &&
+      is_real_trans && !error && (rw_ha_count == 0) &&
       wsrep_not_committed(thd)) {
     wsrep_commit_empty(thd, all);
   }

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -170,8 +170,10 @@ static inline bool wsrep_run_commit_hook(THD *thd, bool all) {
                        wsrep_is_ordered(thd),
                        thd->is_operating_substatement_implicitly));
   /* Avoid running commit hooks if a sub-statement is being operated implicitly
+     or gtid table is being accessed implicitly
    * within current transaction (if it is an internal transaction) */
-  if (thd->is_operating_substatement_implicitly) {
+  if (thd->is_operating_substatement_implicitly ||
+      thd->is_operating_gtid_table_implicitly) {
     return false;
   }
   /* Is MST commit or autocommit? */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4211

Problem:
When the binlog is rotated because of reaching its maximum size the server aborts with assertion.

Cause:
Upstream commit 9b4809f2fc3bcdfb90c77a463912e133d36acc53 introduced the optimization which skips blocking operation of compressing GTID sets during storing them into GTIDs table during binlog rotation. Now GTIDs are stored as well, but compression is delegated to compress_gtid_table thread.
Before the upstream fix, compression and store were triggered by connection context, but actual work was done in context of clone_gtid_thread which is not wsrep_thread so wsrep commit hooks were not executed.
After the upstream fix GTIDs are stored in table from connection context. When this implicit transaction commits, commit hooks are executed causing assertion.

Solution:
Skip wsrep commit hooks execution for implicit internal transaction of storing GTIDS.