### PR TITLE
PXC-4194: Integrate diff-checker script to Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,23 @@ jobs:
           python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v ${CHANGED_FILES}
       fi
 
+- job: PS Diff Check
+  pool:
+    vmImage: 'ubuntu-20.04'
+
+  steps:
+  - checkout: self
+    fetchDepth: 32
+
+  - script: |
+      CHANGED_FILES=$(git diff -U0 --name-only --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | tr '\n' ' ')
+
+      if [ -z "${CHANGED_FILES}" ]; then
+          echo --- No changed files
+      else
+          bash $(Build.SourcesDirectory)/ps-diff-check.sh
+      fi
+
 - job:
   timeoutInMinutes: 240
   pool:

--- a/check_src/whitelist/rpl_commit_stage_manager.cc
+++ b/check_src/whitelist/rpl_commit_stage_manager.cc
@@ -1,0 +1,3 @@
+< #include "sql/rpl_rli_pdb.h"  // Slave_worker                    // Slave_worker
+< 
+> #include "sql/rpl_rli_pdb.h"                       // Slave_worker

--- a/check_src/whitelist/rpl_replica.cc
+++ b/check_src/whitelist/rpl_replica.cc
@@ -7,6 +7,7 @@
 <           DBUG_PRINT("info",
 <                      ("Resetting retry counter, rli->trans_retries: %lu",
 >         DBUG_PRINT("info", ("Resetting retry counter, rli->trans_retries: %lu",
+<   // Replicas shall not create GIPKs if source tables have no PKs
 <     rli->report(WARNING_LEVEL, 0,
 >       rli->report(
 >           WARNING_LEVEL, 0,

--- a/ps-diff-check.sh
+++ b/ps-diff-check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Create a temporary directory to fetch the PS source tarball.
+PS_80_PATH=`mktemp -d`
+SCRIPT_PATH=${BASH_SOURCE[0]}
+BASE_DIR=$(dirname $SCRIPT_PATH)
+RET=1
+
+# Get the MySQL Version to download to compare the sources.
+source MYSQL_VERSION
+PS_VERSION=$MYSQL_VERSION_MAJOR.$MYSQL_VERSION_MINOR.$MYSQL_VERSION_PATCH$MYSQL_VERSION_EXTRA
+
+echo "Using PS Version: $PS_VERSION"
+
+# Get the source tarball from Percona downloads
+pushd $PS_80_PATH
+curl https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-$PS_VERSION/source/tarball/percona-server-$PS_VERSION.tar.gz -o percona-server-$PS_VERSION.tar.gz
+tar -xf percona-server-$PS_VERSION.tar.gz
+popd
+
+# Run the diff checker tool
+echo "Running Diff Checker..."
+$BASE_DIR/check_src/run.sh $PS_80_PATH/percona-server-$PS_VERSION/ 2>&1 > $PS_80_PATH/diff-check.log
+
+if [[ -s $PS_80_PATH/diff-check.log ]]; then
+  echo "Diff checker failed with below error. Please add them to whitelist if they are expected"
+  echo ""
+  cat $PS_80_PATH/diff-check.log
+  RET=1
+else
+  RET=0
+fi
+
+
+# Cleanup
+rm -rf $PS_80_PATH
+exit $RET


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4194

This commit integrates the diff checker tool added as part of PXC-3026 to Azure Pipelines to detect changes in WITHOUT_WSREP regions to warn the developer.


Output
------
```
Using PS Version: 8.0.32-24
/tmp/tmp.ACwcmbXY8J ~/work/pxc/80
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
 39  452M   39  177M    0     0   951k      0  0:08:06  0:03:11  0:04:55  456k
100  452M  100  452M    0     0   909k      0  0:08:29  0:08:29 --:--:-- 2922k

~/work/pxc/80
Running Diff Checker...
Diff checker failed with below error. Please add them to whitelist if they are expected

============
Error: ./sql/rpl_replica.cc
============
5104,5106c5099,5101
<             then need the cache to be at position 0 (see comments at beginning
<             of init_info()). b) init_relay_log_pos(), because the BEGIN may be
<             an older relay log.
---
>           then need the cache to be at position 0 (see comments at beginning of
>           init_info()).
>           b) init_relay_log_pos(), because the BEGIN may be an older relay log.
5184,5185c5178
<           DBUG_PRINT("info",
<                      ("Resetting retry counter, rli->trans_retries: %lu",
---
>         DBUG_PRINT("info", ("Resetting retry counter, rli->trans_retries: %lu",
7061d7051
<   // Replicas shall not create GIPKs if source tables have no PKs
7138c7128,7129
<     rli->report(WARNING_LEVEL, 0,
---
>       rli->report(
>           WARNING_LEVEL, 0,
7195c7186
<            llstr(rli->get_group_master_log_pos(), llbuff),
---
>              llstr(rli->get_group_master_log_pos_info(), llbuff),
7202c7193
<            llstr(rli->get_group_master_log_pos(), llbuff),
---
>              llstr(rli->get_group_master_log_pos_info(), llbuff),
7315c7303
<            llstr(rli->get_group_master_log_pos(), llbuff));
---
>              llstr(rli->get_group_master_log_pos_info(), llbuff));
7319,7320c7307
<            llstr(rli->get_group_master_log_pos(), llbuff));
< 
---
>              llstr(rli->get_group_master_log_pos_info(), llbuff));
7423,7424c7409
<   DBUG_EXECUTE_IF("simulate_replica_delay_at_terminate_bug38694",
<                   sleep(5););
---
>     DBUG_EXECUTE_IF("simulate_replica_delay_at_terminate_bug38694", sleep(5););
============
Error: ./sql/rpl_commit_stage_manager.cc
============
32,33c32
< #include "sql/rpl_rli_pdb.h"  // Slave_worker                    // Slave_worker
< 
---
> #include "sql/rpl_rli_pdb.h"                       // Slave_worker
```