### PR TITLE
PXC-4225: Incorrect COMMAND value in I_S.PROCESSLIST for wsrep applie…

### DIFF
--- a/mysql-test/suite/galera/r/pxc_information_schema.result
+++ b/mysql-test/suite/galera/r/pxc_information_schema.result
@@ -11,3 +11,23 @@ include/assert.inc [All wsrep threads COMMAND should be Sleep after DML]
 DROP TABLE t1;
 include/assert.inc [All wsrep threads COMMAND should be Sleep after DDL]
 include/assert.inc [All wsrep threads COMMAND should be Sleep after DDL]
+CREATE TABLE t1 (a INT PRIMARY KEY AUTO_INCREMENT, b INT);
+INSERT INTO t1(b) (SELECT * FROM SEQUENCE_TABLE(4) AS tt);
+SET SESSION wsrep_OSU_method='NBO';
+SET @debug_saved = @@global.debug;
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL debug = "+d,wsrep_signal_applier_thread";
+SET GLOBAL debug = "+d,wsrep_signal_nbo_applier_thread";
+CREATE INDEX b_idx ON t1 (b);
+SET DEBUG_SYNC="now WAIT_FOR apply_nbo_begin_entered_nbo_mode.reached";
+SET DEBUG_SYNC="now WAIT_FOR nbo_applier_started";
+include/assert.inc [Wsrep applier and nbo applier should be in Query state]
+SET DEBUG_SYNC="now SIGNAL apply_nbo_begin_entered_nbo_mode.continue";
+SET DEBUG_SYNC="now WAIT_FOR apply_nbo_begin_nbo_applier_created.reached";
+include/assert.inc [Only nbo applier should be in Query state]
+SET DEBUG_SYNC="now SIGNAL nbo_applier_continue";
+SET DEBUG_SYNC="now WAIT_FOR nbo_applier_finished";
+include/assert.inc [There should be no thread in Query state after NBO execution]
+SET @@global.debug = @debug_saved;
+SET SESSION wsrep_OSU_method='TOI';
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/pxc_information_schema.result
+++ b/mysql-test/suite/galera/r/pxc_information_schema.result
@@ -1,0 +1,13 @@
+Killing server ...
+# restart
+include/assert.inc [All wsrep threads COMMAND should be Sleep after node startup]
+include/assert.inc [All wsrep threads COMMAND should be Sleep after node startup]
+CREATE TABLE t1 (a INT PRIMARY KEY);
+include/assert.inc [All wsrep threads COMMAND should be Sleep after DDL]
+include/assert.inc [All wsrep threads COMMAND should be Sleep after DDL]
+INSERT INTO t1 VALUES (0);
+include/assert.inc [All wsrep threads COMMAND should be Sleep after DML]
+include/assert.inc [All wsrep threads COMMAND should be Sleep after DML]
+DROP TABLE t1;
+include/assert.inc [All wsrep threads COMMAND should be Sleep after DDL]
+include/assert.inc [All wsrep threads COMMAND should be Sleep after DDL]

--- a/mysql-test/suite/galera/t/pxc_information_schema.test
+++ b/mysql-test/suite/galera/t/pxc_information_schema.test
@@ -82,3 +82,59 @@ DROP TABLE t1;
 --let $assert_cond = [ SELECT $sleep_wsrep_thd_cnt = $sleep_wsrep_thd_cnt_start ]
 --source include/assert.inc
 
+
+#
+# Test the status reported during the NBO
+#
+
+--connection node_1
+CREATE TABLE t1 (a INT PRIMARY KEY AUTO_INCREMENT, b INT);
+INSERT INTO t1(b) (SELECT * FROM SEQUENCE_TABLE(4) AS tt);
+SET SESSION wsrep_OSU_method='NBO';
+
+--connection node_2
+SET @debug_saved = @@global.debug;
+SET SESSION wsrep_sync_wait = 0;
+
+# stop wsrep applier thread after NBO applier creation
+SET GLOBAL debug = "+d,wsrep_signal_applier_thread";
+
+# stop nbo applier after entering into NBO mode
+SET GLOBAL debug = "+d,wsrep_signal_nbo_applier_thread";
+
+--connection node_1
+--send CREATE INDEX b_idx ON t1 (b)
+
+--connection node_2
+SET DEBUG_SYNC="now WAIT_FOR apply_nbo_begin_entered_nbo_mode.reached";
+SET DEBUG_SYNC="now WAIT_FOR nbo_applier_started";
+
+# wsrep applier and nbo thread both should report their states as 'Query'
+--let $nbo_thds = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND COMMAND LIKE 'Query'`
+--let $assert_text = Wsrep applier and nbo applier should be in Query state
+--let $assert_cond = [ SELECT $nbo_thds = 2 ]
+--source include/assert.inc
+
+# unblock wsrep applier thread and wait until it is done with creation of NBO applier
+SET DEBUG_SYNC="now SIGNAL apply_nbo_begin_entered_nbo_mode.continue";
+SET DEBUG_SYNC="now WAIT_FOR apply_nbo_begin_nbo_applier_created.reached";
+--let $nbo_thds = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND COMMAND LIKE 'Query'`
+--let $assert_text = Only nbo applier should be in Query state
+--let $assert_cond = [ SELECT $nbo_thds = 1 ]
+--source include/assert.inc
+
+# unblock NBO applier thread and wait until it is done
+SET DEBUG_SYNC="now SIGNAL nbo_applier_continue";
+SET DEBUG_SYNC="now WAIT_FOR nbo_applier_finished";
+
+--let $nbo_thds = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND COMMAND LIKE 'Query'`
+--let $assert_text = There should be no thread in Query state after NBO execution
+--let $assert_cond = [ SELECT $nbo_thds = 0 ]
+--source include/assert.inc
+
+SET @@global.debug = @debug_saved;
+
+--connection node_1
+--reap
+SET SESSION wsrep_OSU_method='TOI';
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_information_schema.test
+++ b/mysql-test/suite/galera/t/pxc_information_schema.test
@@ -1,0 +1,84 @@
+#
+# Test that INFORMATION_SCHEMA.PROCESSLIST shows proper information about wsrep threads
+#
+
+--source include/galera_cluster.inc
+
+#
+# Restart node_2 and check that all wsrep threads related command is 'Sleep'
+#
+--connection node_2
+--source include/kill_galera.inc
+--source include/wait_until_disconnected.inc
+--source include/start_mysqld.inc
+
+--let $sleep_wsrep_thd_cnt_start = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND LIKE 'Sleep'`
+--let $not_sleep_wsrep_thd_cnt = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND NOT LIKE 'Sleep'`
+
+--let $assert_text = All wsrep threads COMMAND should be Sleep after node startup
+--let $assert_cond = [ SELECT $not_sleep_wsrep_thd_cnt = 0 ]
+--source include/assert.inc
+--let $assert_text = All wsrep threads COMMAND should be Sleep after node startup
+--let $assert_cond = [ SELECT $sleep_wsrep_thd_cnt_start != 0 ]
+--source include/assert.inc
+
+#
+# execute DDL on node_1 and check that after applying on node_2 wsrep applier goes to 'Sleep'
+#
+--connection node_1
+CREATE TABLE t1 (a INT PRIMARY KEY);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1'
+--source include/wait_condition.inc
+
+--let $sleep_wsrep_thd_cnt = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND LIKE 'Sleep'`
+--let $not_sleep_wsrep_thd_cnt = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND NOT LIKE 'Sleep'`
+
+--let $assert_text = All wsrep threads COMMAND should be Sleep after DDL
+--let $assert_cond = [ SELECT $not_sleep_wsrep_thd_cnt = 0 ]
+--source include/assert.inc
+--let $assert_text = All wsrep threads COMMAND should be Sleep after DDL
+--let $assert_cond = [ SELECT $sleep_wsrep_thd_cnt = $sleep_wsrep_thd_cnt_start ]
+--source include/assert.inc
+
+#
+# execute DML on node_1 and check that after applying on node_2 wsrep applier goes to 'Sleep'
+#
+--connection node_1
+INSERT INTO t1 VALUES (0);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
+--let $sleep_wsrep_thd_cnt = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND LIKE 'Sleep'`
+--let $not_sleep_wsrep_thd_cnt = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND NOT LIKE 'Sleep'`
+
+--let $assert_text = All wsrep threads COMMAND should be Sleep after DML
+--let $assert_cond = [ SELECT $not_sleep_wsrep_thd_cnt = 0 ]
+--source include/assert.inc
+--let $assert_text = All wsrep threads COMMAND should be Sleep after DML
+--let $assert_cond = [ SELECT $sleep_wsrep_thd_cnt = $sleep_wsrep_thd_cnt_start ]
+--source include/assert.inc
+
+#
+# execute DDL once again on node_1 and check that after applying on node_2 wsrep applier goes to 'Sleep'
+#
+--connection node_1
+DROP TABLE t1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1'
+--source include/wait_condition.inc
+
+--let $sleep_wsrep_thd_cnt = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND LIKE 'Sleep'`
+--let $not_sleep_wsrep_thd_cnt = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE 'wsrep%' AND COMMAND NOT LIKE 'Sleep'`
+
+--let $assert_text = All wsrep threads COMMAND should be Sleep after DDL
+--let $assert_cond = [ SELECT $not_sleep_wsrep_thd_cnt = 0 ]
+--source include/assert.inc
+--let $assert_text = All wsrep threads COMMAND should be Sleep after DDL
+--let $assert_cond = [ SELECT $sleep_wsrep_thd_cnt = $sleep_wsrep_thd_cnt_start ]
+--source include/assert.inc
+

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -448,6 +448,7 @@ int Wsrep_high_priority_service::apply_toi(const wsrep::ws_meta &ws_meta,
            (long long)wsrep_thd_trx_seqno(m_thd));
   WSREP_DEBUG("%s", m_thd->wsrep_info);
   thd_proc_info(thd, m_thd->wsrep_info);
+  thd->set_command(COM_QUERY);
 
   WSREP_DEBUG("Wsrep_high_priority_service::apply_toi: %lld",
               client_state.toi_meta().seqno().get());
@@ -483,6 +484,7 @@ int Wsrep_high_priority_service::apply_toi(const wsrep::ws_meta &ws_meta,
            (long long)wsrep_thd_trx_seqno(m_thd));
   WSREP_DEBUG("%s", m_thd->wsrep_info);
   thd_proc_info(thd, m_thd->wsrep_info);
+  thd->set_command(COM_SLEEP);
 
   wsrep_wait_rollback_complete_and_acquire_ownership(m_thd);
   wsrep_set_SE_checkpoint(client_state.toi_meta().gtid());
@@ -630,6 +632,10 @@ int Wsrep_applier_service::apply_write_set(const wsrep::ws_meta &ws_meta,
            "wsrep: applying write-set (%lld)", ws_meta.seqno().get());
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
+  /* Note that COM_QUERY is set in Rows_log_event::do_apply_event() anyway,
+     but let's set it here for sanity.
+   */
+  thd->set_command(COM_QUERY);
 
   /* moved dbug sync point here, after possible THD switch for SR transactions
      has ben done
@@ -666,6 +672,7 @@ int Wsrep_applier_service::apply_write_set(const wsrep::ws_meta &ws_meta,
            ws_meta.seqno().get());
   WSREP_DEBUG("%s", thd->wsrep_info);
   thd_proc_info(thd, thd->wsrep_info);
+  thd->set_command(COM_SLEEP);
 
   return ret;
 }

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -702,9 +702,13 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
   const char *category = "sql";
   mysql_thread_register(category, nbo_threads, 1);
 
+  /* The job of wsrep applier thread is only to create a background thread
+      which job is to apply NBO.
+  */
   snprintf(m_thd->wsrep_info, sizeof(m_thd->wsrep_info),
-           "wsrep: applying NBO write-set (%lld)",
+           "wsrep: creating NBO applier for write-set (%lld)",
            (long long)wsrep_thd_trx_seqno(m_thd));
+  m_thd->set_command(COM_QUERY);
 
   std::thread th([&] {
     wsp::thd wthd(true);
@@ -783,12 +787,21 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
 
     assert(ret == 0);
 
+    /* The background thread which executes NBO will be visible in
+       I_S.PROCESSLIST table for the time of its job. */
     snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
              "wsrep: applying NBO write-set (%lld)",
              (long long)wsrep_thd_trx_seqno(thd));
     WSREP_DEBUG("%s", thd->wsrep_info);
     thd_proc_info(thd, thd->wsrep_info);
-
+    thd->set_command(COM_QUERY);
+    DBUG_EXECUTE_IF("wsrep_signal_nbo_applier_thread", {
+      const char act[] =
+          "now "
+          "SIGNAL nbo_applier_started "
+          "WAIT_FOR nbo_applier_continue";
+      assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+    };);
     WSREP_DEBUG("Wsrep_high_priority_service::apply_nbo_begin: %lld",
                 client_state.nbo_meta().seqno().get());
 
@@ -817,6 +830,8 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
 
     ret = trans_commit(thd);
 
+    /* This thread is going to be removed soon and will be not visible in
+       I_S.PROCESSLIST anymore, but set proper info for sanity. */
     THD_STAGE_INFO(thd, stage_wsrep_committed);
     snprintf(thd->wsrep_info, sizeof(thd->wsrep_info),
              "wsrep: %s NBO write set (%lld)",
@@ -824,6 +839,14 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
              (long long)wsrep_thd_trx_seqno(thd));
     WSREP_DEBUG("%s", thd->wsrep_info);
     thd_proc_info(thd, thd->wsrep_info);
+    thd->set_command(COM_SLEEP);
+
+    DBUG_EXECUTE_IF("wsrep_signal_nbo_applier_thread", {
+      const char act[] =
+          "now "
+          "SIGNAL nbo_applier_finished";
+      assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+    };);
 
     if (ret == 0) {
       thd->wsrep_rli->cleanup_context(thd, 0);
@@ -866,6 +889,28 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
   cv.wait(lk, [&] { return entered_nbo_mode; });
 
   th.detach();
+
+  DBUG_EXECUTE_IF("wsrep_signal_applier_thread", {
+    const char act[] =
+        "now "
+        "SIGNAL apply_nbo_begin_entered_nbo_mode.reached "
+        "WAIT_FOR apply_nbo_begin_entered_nbo_mode.continue";
+    assert(!debug_sync_set_action(m_thd, STRING_WITH_LEN(act)));
+  };);
+
+  /* WSREP applier thread created NBO background worker
+     and is ready for processing next writesets. */
+  snprintf(m_thd->wsrep_info, sizeof(m_thd->wsrep_info),
+           "wsrep: created NBO applier for write-set (%lld)",
+           (long long)wsrep_thd_trx_seqno(m_thd));
+  m_thd->set_command(COM_SLEEP);
+
+  DBUG_EXECUTE_IF("wsrep_signal_applier_thread", {
+    const char act[] =
+        "now "
+        "SIGNAL apply_nbo_begin_nbo_applier_created.reached";
+    assert(!debug_sync_set_action(m_thd, STRING_WITH_LEN(act)));
+  };);
 
   return 0;
 }


### PR DESCRIPTION
…r threads

https://jira.percona.com/browse/PXC-4225

Problem:
After DML executon or DDL execution after previouw DML, the COMMAND column in I_S.PROCESSLIST shows incorrect value
(Query, instead of Sleep)

Cause:
In normal flow thread's command state is maintained in sql_parse.cc::dispatch_command() functions. PXC flow for replicated events do not use this function, however command state is set to Query in Rows_log_event::do_apply_event() and it remains so.

Solution:
Set proper state of thread's command in Wsrep_applier_service methods called by Galera provider when DDL and DML events are applied.