### PR TITLE
PXC-4228: NBO generates corrupted binlogs

### DIFF
--- a/mysql-test/suite/galera_nbo/r/galera_nbo_gtid.result
+++ b/mysql-test/suite/galera_nbo/r/galera_nbo_gtid.result
@@ -1,0 +1,39 @@
+CREATE TABLE t1(i INT PRIMARY KEY);
+#
+# Run ALTER TABLE in NBO mode and verify that it is logged with a proper GTID.
+#
+SET SESSION wsrep_OSU_method="NBO";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method=default;
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+#	#	Gtid	#	#	SET @@SESSION.GTID_NEXT= 'Gtid_set'
+#	#	Query	#	#	use `test`; ALTER TABLE t1 ENGINE=InnoDB
+include/assert_binlog_events.inc [Gtid/.*CLUSTER_UUID.* # Query/.*ALTER TABLE.*]
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+#	#	Gtid	#	#	SET @@SESSION.GTID_NEXT= 'Gtid_set'
+#	#	Query	#	#	use `test`; ALTER TABLE t1 ENGINE=InnoDB
+include/assert_binlog_events.inc [Gtid/.*CLUSTER_UUID.* # Query/.*ALTER TABLE.*]
+#
+# Assert that Incremental State Transfer succeeds when the binary log has a DDL logged in NBO.
+#
+INSERT INTO t1 VALUES(1),(2),(3),(4);
+CREATE TABLE t2 (j INT PRIMARY KEY);
+INSERT INTO t2 VALUES(1),(2),(3),(4);
+# restart
+#
+# Assert that binlog rotation will be successful on both nodes.
+#
+SET SESSION wsrep_OSU_method="NBO";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method=default;
+SET SESSION wsrep_OSU_method="NBO";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method=default;
+FLUSH BINARY LOGS;
+FLUSH BINARY LOGS;
+CALL mtr.add_suppression("no corresponding NBO begin found for NBO end");
+CALL mtr.add_suppression("no corresponding NBO begin found for NBO end");
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera_nbo/t/galera_nbo_gtid.cnf
+++ b/mysql-test/suite/galera_nbo/t/galera_nbo_gtid.cnf
@@ -1,0 +1,11 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+gtid-mode=on
+enforce-gtid-consistency=on
+log-slave-updates
+
+[mysqld.2]
+gtid-mode=on
+enforce-gtid-consistency=on
+log-slave-updates

--- a/mysql-test/suite/galera_nbo/t/galera_nbo_gtid.test
+++ b/mysql-test/suite/galera_nbo/t/galera_nbo_gtid.test
@@ -1,0 +1,128 @@
+# === Purpose ===
+# This test verifies that both local and remote DDLs running in NBO mode are
+# binlogged 
+#
+# 1. Like any other DDL, with a proper XID
+# 2. With a valid GTID using the cluster uuid when GTID mode is enabled
+#
+# === Reference ===
+#
+# PXC-4228: NBO generates corrupted binary logs
+
+--source include/galera_cluster.inc
+CREATE TABLE t1(i INT PRIMARY KEY);
+
+# Save binlog positions
+--let $node1_file= query_get_value(SHOW MASTER STATUS,File,1)
+--let $node1_pos= query_get_value(SHOW MASTER STATUS,Position,1)
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $node2_file= query_get_value(SHOW MASTER STATUS,File,1)
+--let $node2_pos= query_get_value(SHOW MASTER STATUS,Position,1)
+
+--echo #
+--echo # Run ALTER TABLE in NBO mode and verify that it is logged with a proper GTID.
+--echo #
+--connection node_1
+SET SESSION wsrep_OSU_method="NBO";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method=default;
+
+--let $binlog_file=$node1_file
+--let $binlog_start=$node1_pos
+--let $keep_gtid_events=1
+--let $show_binlog_events_mask_columns=1,2,4,5
+--source include/show_binlog_events.inc
+
+--let $cluster_uuid=`SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME='wsrep_cluster_state_uuid'`
+
+# Assert that NBO query is logged as normal DDLs with cluster_uuid gtid on the local node
+--let $event_sequence= Gtid/.*$cluster_uuid.* # Query/.*ALTER TABLE.*
+--let $binlog_position=$node1_pos
+--let $include_silent=1
+--source include/assert_binlog_events.inc
+--echo include/assert_binlog_events.inc [Gtid/.*CLUSTER_UUID.* # Query/.*ALTER TABLE.*]
+--let $include_silent=0
+
+--connection node_2
+--let $binlog_file=$node2_file
+--let $binlog_start=$node2_pos
+--let $keep_gtid_events=1
+--source include/show_binlog_events.inc
+
+# Assert that NBO query is logged as normal DDLs with cluster_uuid gtid on the remote node
+--let $event_sequence= Gtid/.*$cluster_uuid.* # Query/.*ALTER TABLE.*
+--let $binlog_position=$node2_pos
+--let $include_silent=1
+--source include/assert_binlog_events.inc
+--echo include/assert_binlog_events.inc [Gtid/.*CLUSTER_UUID.* # Query/.*ALTER TABLE.*]
+--let $include_silent=0
+
+--echo #
+--echo # Assert that Incremental State Transfer succeeds when the binary log has a DDL logged in NBO.
+--echo #
+
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+INSERT INTO t1 VALUES(1),(2),(3),(4);
+CREATE TABLE t2 (j INT PRIMARY KEY);
+INSERT INTO t2 VALUES(1),(2),(3),(4);
+
+--connection node_2
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+# Assert that IST was successful
+--assert(`SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.TABLES WHERE table_schema="test"`)
+--assert(`SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t1" AND table_schema="test"`)
+--assert(`SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t2" AND table_schema="test"`)
+--assert(`SELECT COUNT(*) = 4 FROM test.t1`)
+--assert(`SELECT COUNT(*) = 4 FROM test.t1`)
+
+--echo #
+--echo # Assert that binlog rotation will be successful on both nodes.
+--echo #
+
+# Run a DDL in NBO mode on both nodes
+--connection node_1
+SET SESSION wsrep_OSU_method="NBO";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method=default;
+
+--connection node_2
+SET SESSION wsrep_OSU_method="NBO";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method=default;
+
+# Assert that binlog rotation was successful
+--connection node_1
+--let $node1_file_before= query_get_value(SHOW MASTER STATUS,File,1)
+FLUSH BINARY LOGS;
+--let $node1_file_after= query_get_value(SHOW MASTER STATUS,File,1)
+--assert(`SELECT '$node1_file_before' <> '$node1_file_after'`)
+
+--connection node_2
+--let $node2_file_before= query_get_value(SHOW MASTER STATUS,File,1)
+FLUSH BINARY LOGS;
+--let $node2_file_after= query_get_value(SHOW MASTER STATUS,File,1)
+--assert(`SELECT '$node2_file_before' <> '$node2_file_after'`)
+
+# Add test suppressions
+--connection node_1
+CALL mtr.add_suppression("no corresponding NBO begin found for NBO end");
+
+--connection node_2
+CALL mtr.add_suppression("no corresponding NBO begin found for NBO end");
+
+# Cleanup
+--let $binlog_file=
+--let $binlog_start=
+--let $binlog_position=
+--let $keep_gtid_events=
+--let $show_binlog_events_mask_columns=
+DROP TABLE t1;
+DROP TABLE t2;

--- a/sql/rpl_gtid_state.cc
+++ b/sql/rpl_gtid_state.cc
@@ -512,9 +512,12 @@ enum_return_status Gtid_state::generate_automatic_gtid(
 #ifdef WITH_WSREP
     /* If node is running in cluster mode then get wsrep_sidno */
     bool seqno_undefined = false;
-    seqno_undefined = (wsrep_thd_is_toi(thd)
-                           ? thd->wsrep_cs().toi_meta().seqno().is_undefined()
-                           : thd->wsrep_trx().ws_meta().seqno().is_undefined());
+    seqno_undefined =
+        (wsrep_thd_is_toi(thd)
+             ? thd->wsrep_cs().toi_meta().seqno().is_undefined()
+             : wsrep_thd_is_in_nbo(thd)
+                   ? thd->wsrep_cs().nbo_meta().seqno().is_undefined()
+                   : thd->wsrep_trx().ws_meta().seqno().is_undefined());
 
     if (WSREP(thd) && !seqno_undefined && !thd->wsrep_skip_wsrep_GTID)
       automatic_gtid.sidno = wsrep_sidno;
@@ -891,7 +894,7 @@ void Gtid_state::update_gtids_impl_own_gtid(THD *thd, bool is_commit) {
   /* Check comment associated with wsrep_replayer for more details. */
   if (WSREP(thd)) {
     assert(owned_gtids.is_owned_by(thd->owned_gtid, thd->thread_id()) ||
-                thd->wsrep_replayer);
+           thd->wsrep_replayer);
   } else {
     assert(owned_gtids.is_owned_by(thd->owned_gtid, thd->thread_id()));
   }

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -180,9 +180,12 @@ int wsrep_apply_events(THD *thd, Relay_log_info *rli __attribute__((unused)),
     thd->unmasked_server_id = ev->common_header->unmasked_server_id;
     thd->set_time();  // time the query
 
-    if (wsrep_thd_is_toi(thd) || wsrep_thd_is_in_nbo(thd)) {
+    if (wsrep_thd_is_toi(thd)) {
       wsrep_xid_init(thd->get_transaction()->xid_state()->get_xid(),
                      thd->wsrep_cs().toi_meta().gtid());
+    } else if (wsrep_thd_is_in_nbo(thd)) {
+      wsrep_xid_init(thd->get_transaction()->xid_state()->get_xid(),
+                     thd->wsrep_cs().nbo_meta().gtid());
     } else {
       wsrep_xid_init(thd->get_transaction()->xid_state()->get_xid(),
                      thd->wsrep_trx().ws_meta().gtid());


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4228

Problem
-------
1. Incorrect usage of toi_meta_ for DDLs running as NBO resulted in binlogging of the DDL with invalid XID.

2. Local and Remote DDLs logged as NBO were wrapped inside BEGIN and COMMIT in the binlog, thereby breaking the async replication.

3. Failure during binlog recovery.

4. The node with the NBO event in its last binary log failed to provide SST.

5. IST failed with bogus GTID error.

6. DDL binlogging used node's server_uuid instead of cluster_uuid.

7. Unable to rotate the binary log that has just executed a remote NBO.

Analysis & Solution
-------------------

Problem 1,2,3,4,5:

  Server was using the incorrect meta instance to persist the XID/seqno
  generated from galera.

  In order to fix this, the initialization of `toi_meta_` and `nbo_meta_` has
  been moved to the phase one of NBO.  With this, the DDLs will now use the
  seqno from galera to persist the XID in storage engine.

Problem 6:

  There was no proper handling for NBO in
  `Gtid_state::generate_automatic_gtid()`, that resulted in the sidno and gno
  being generated from the server's uuid for binlogging, instead of using the
  cluster UUID and seqno generated from galera.

Problem 7:

  There was a mistake in the logic in calculating the number of active TOI/NBO
  transactions that resulted in the counter being set to -1 for remote NBO,
  that prohibited binlog rotation request from FLUSH BINARY LOGS.

  In normal cases, we increment `wsrep_to_isolation` (the variable to track the
  ongoing DDL) in `wsrep_TOI_begin()` and `wsrep_NBO_begin_phase_one()` and we
  decrement the count in `wsrep_TOI_end()` and `wsrep_NBO_end_phase_two()`.

  Since `wsrep_NBO_end_phase_two()` is called in case of both local or remote
  NBO, we ended up decrementing the count for remote NBO without having it
  incremented in the `wsrep_NBO_begin_phase_one()`.

  The current fix ensures that we dont decrement the count for NBO applier
  threads.

In addition to tha above fix, the following changes have been done:

- Used proper variable names to increase the readability of the code.
- Reduced the redundant call to `wsrep_thd_trx_seqno()` by caching the value in a local variable and reusing it for reporting and logging.

Testing Done
----
Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/127/
Failing tests: 
1. [galera_sr.GCF-1043A](https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/127/CMAKE_BUILD_TYPE=Debug,DOCKER_OS=oraclelinux%3A9/testReport/oraclelinux-9.Debug.galera_sr/galera_sr/GCF_1043A_enc_off/) - Will be fixed in 8.0.33
2. [galera_sr.gakera_sr_wsrep_error_handling.enc_on](https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/127/CMAKE_BUILD_TYPE=RelWithDebInfo,DOCKER_OS=ubuntu%3Ajammy/testReport/ubuntu-jammy.RelWithDebInfo.galera_sr/galera_sr/gakera_sr_wsrep_error_handling_enc_on/) - Will be fixed in 8.0.33
3. [galera.galera#505](https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/127/CMAKE_BUILD_TYPE=Debug,DOCKER_OS=oraclelinux%3A9/testReport/oraclelinux-9.Debug.galera/galera/galera_505_enc_off/)
4. [galera.galera_fc_auto_evict](https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/127/CMAKE_BUILD_TYPE=RelWithDebInfo,DOCKER_OS=ubuntu%3Ajammy/testReport/ubuntu-jammy.RelWithDebInfo.galera/galera/galera_fc_auto_evict_enc_on/) - Sporadic failure