### PR TITLE
PXC-4211: Server aborts on binary log rotation

### DIFF
--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -429,6 +429,11 @@ void wsrep_register_for_group_commit(THD *thd) {
   return;
 }
 
+bool wsrep_implicit_transaction(THD *thd) {
+  return thd->is_operating_substatement_implicitly ||
+         thd->is_operating_gtid_table_implicitly;
+}
+
 void wsrep_wait_for_turn_in_group_commit(THD *thd) {
   DBUG_TRACE;
   if (wsrep_emulate_bin_log || thd == NULL) {

--- a/sql/wsrep_binlog.h
+++ b/sql/wsrep_binlog.h
@@ -89,4 +89,6 @@ void wsrep_register_for_group_commit(THD *thd);
 void wsrep_wait_for_turn_in_group_commit(THD *thd);
 void wsrep_unregister_from_group_commit(THD *thd);
 
+bool wsrep_implicit_transaction(THD *thd);
+
 #endif /* WSREP_BINLOG_H */

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -419,6 +419,8 @@ void trx_sys_update_wsrep_checkpoint(
 #endif /* !UNIV_DEBUG */
 #endif
   {
+    if (wsrep_implicit_transaction(current_thd)) return;
+
     /* Check that seqno is monotonically increasing */
     unsigned char xid_uuid[16];
     long long xid_seqno = read_wsrep_xid_seqno(xid);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4211

Post push fix. It appeared that in debug build we hit the assertion trx0sys.cc:473:xid_seqno >= trx_sys_cur_xid_seqno
This is related to internal transaction commit which tries to update wsrep checkpoint:
rotate() -> MYSQL_BIN_LOG::commit() -> innobase_commit_low() -> trx_sys_update_wsrep_checkpoint()

The assertion was reproduced by running sysbench multithreaded workload.