### PR TITLE
PXC-4221: Merge PS-8.0.33 (MTR tests fixed)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2223,10 +2223,6 @@ ADD_SUBDIRECTORY(mysys)
 ADD_SUBDIRECTORY(libmysql)
 ADD_SUBDIRECTORY(libbinlogevents)
 ADD_SUBDIRECTORY(libbinlogstandalone)
-IF(WITH_WSREP)
-   ADD_SUBDIRECTORY(percona-xtradb-cluster-galera)
-   ADD_SUBDIRECTORY(wsrep-lib)
-ENDIF()
 ADD_SUBDIRECTORY(libchangestreams)
 ADD_SUBDIRECTORY(sql-common/oci)
 
@@ -2276,6 +2272,10 @@ IF(NOT WITHOUT_SERVER)
   ADD_SUBDIRECTORY(sql)
 ENDIF()
 
+IF(WITH_WSREP)
+   ADD_SUBDIRECTORY(percona-xtradb-cluster-galera)
+   ADD_SUBDIRECTORY(wsrep-lib)
+ENDIF()
 # Some unit tests need to link with the entire server, use this library:
 IF(NOT WITHOUT_SERVER AND WITH_UNIT_TESTS)
 

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -6246,37 +6246,23 @@ sub check_expected_crash_and_restart($$) {
         }
 
         # Ignore any partial or unknown command
-        next unless $last_line =~ /^(restart|try)/;
+        next unless $last_line =~ /^(restart)/;
 
         # If the last line begins with 'restart:' or 'restart_abort:' (with
         # a colon), rest of the line is read as additional command line options
         # to be provided to the mysql server during restart.
         # Anything other than 'wait', 'restart:' or'restart_abort:' will result
         # in a restart with the original mysqld options.
-        my $try = 0;
         my $follow_up_wait = 0;
         if ($last_line =~ /restart:(.+)/) {
           my @rest_opt = split(' ', $1);
           $mysqld->{'restart_opts'} = \@rest_opt;
-       } elsif ($last_line =~ /try:(.+)/) {
-         my @rest_opt= split(' ', $1);
-         $mysqld->{'restart_opts'}= \@rest_opt;
-         $try=1;
         } elsif ($last_line =~ /restart_abort:(.+)/) {
           my @rest_opt = split(' ', $1);
           $mysqld->{'restart_opts'} = \@rest_opt;
           $follow_up_wait = 1;
         } else {
           delete $mysqld->{'restart_opts'};
-        }
-
-        if ($try == 1) {
-           my $handle;
-           open ($handle,'>',$expect_file) or die("Cant open expect file for write");
-           print $handle "wait";
-           close ($handle);
-        } else {
-           unlink($expect_file);
         }
 
         # Attempt to remove the .expect file. If it fails in

--- a/mysql-test/suite/galera/r/galera_as_slave_restart.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_restart.result
@@ -1,9 +1,9 @@
 #node-3 (async slave)
-call mtr.add_suppression("Recovery from master pos");
+call mtr.add_suppression("Recovery from source pos");
 call mtr.add_suppression("when attempting to connect");
 Warnings:
 Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
-Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Note	1760	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
 START REPLICA;
 #node-1 (source)
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;

--- a/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_get_lock.result
@@ -25,11 +25,11 @@ insert into t1 values ('a');
 ERROR 23000: Duplicate entry '0' for key 't1.c1'
 set @@session.sql_log_bin = 1;
 set @@sql_mode = default;
-call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query");
+call mtr.add_suppression("Replica SQL: Error 'Unknown table 'test.t1'' on query");
 call mtr.add_suppression("Ignoring error 'Unknown table 'test.t1'' on query");
 call mtr.add_suppression("Query apply failed");
 call mtr.add_suppression("Inconsistency detected");
-call mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query");
+call mtr.add_suppression("Replica SQL: Error 'Unknown table 'test.t1'' on query");
 call mtr.add_suppression("Ignoring error 'Unknown table 'test.t1'' on query");
 call mtr.add_suppression("Query apply failed");
 call mtr.add_suppression("Inconsistency detected");

--- a/mysql-test/suite/galera/r/galera_vote_rejoin_dml.result
+++ b/mysql-test/suite/galera/r/galera_vote_rejoin_dml.result
@@ -23,7 +23,7 @@ COUNT(*) = 1
 SELECT COUNT(*) = 0 FROM t1 WHERE f2 = 'B';
 COUNT(*) = 0
 1
-CALL mtr.add_suppression("Slave SQL: Could not execute Delete_rows");
+CALL mtr.add_suppression("Replica SQL: Could not execute Delete_rows");
 CALL mtr.add_suppression("Event 3 Delete_rows apply failed: 120, seqno [0-9]*");
 SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'A';
 COUNT(*) = 1
@@ -32,7 +32,7 @@ SELECT COUNT(*) = 0 FROM t1 WHERE f2 = 'B';
 COUNT(*) = 0
 1
 CALL mtr.add_suppression("mysqld: Can't find record in 't1'");
-CALL mtr.add_suppression("Slave SQL: Could not execute Delete_rows");
+CALL mtr.add_suppression("Replica SQL: Could not execute Delete_rows");
 CALL mtr.add_suppression("Event 3 Delete_rows apply failed: 120, seqno [0-9]*");
 SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'A';
 COUNT(*) = 1

--- a/mysql-test/suite/galera/t/galera_as_slave_restart.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_restart.test
@@ -19,7 +19,7 @@
 
 --connection node_3
 --echo #node-3 (async slave)
-call mtr.add_suppression("Recovery from master pos");
+call mtr.add_suppression("Recovery from source pos");
 call mtr.add_suppression("when attempting to connect");
 --disable_query_log
 --eval CHANGE REPLICATION SOURCE TO SOURCE_HOST='127.0.0.1',SOURCE_USER='root',SOURCE_PORT=$NODE_MYPORT_1;

--- a/mysql-test/suite/galera/t/galera_restart_on_unknown_option.test
+++ b/mysql-test/suite/galera/t/galera_restart_on_unknown_option.test
@@ -60,7 +60,7 @@ SELECT * FROM t1;
 --let $start_mysqld_params=--galera-unknown-option
 
 --echo Starting server ...
---exec echo "try:$start_mysqld_params" > $_expect_file_name
+--exec echo "restart_abort:$start_mysqld_params" > $_expect_file_name
 
 # Sleep to ensure that server exited...
 
@@ -105,7 +105,7 @@ SELECT * FROM t1;
 --let $start_mysqld_params=--galera-unknown-option
 
 --echo Starting server ...
---exec echo "try:$start_mysqld_params" > $_expect_file_name
+--exec echo "restart_abort:$start_mysqld_params" > $_expect_file_name
 
 # Sleep to ensure that server exited...
 

--- a/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
@@ -72,7 +72,7 @@ call mtr.add_suppression("Aborting");
 
 --echo "Restart with wsrep_desync=1"
 --let $start_mysqld_params="--wsrep_desync=1"
---exec echo "try:$start_mysqld_params" > $_expect_file_name
+--exec echo "restart_abort:$start_mysqld_params" > $_expect_file_name
 # Sleep to ensure that server exited...
 --sleep 30
 #

--- a/mysql-test/suite/galera/t/pxc_strict_mode.test
+++ b/mysql-test/suite/galera/t/pxc_strict_mode.test
@@ -1333,7 +1333,7 @@ drop table t;
 #
 --let $start_mysqld_params="--innodb_autoinc_lock_mode=1 --pxc_strict_mode=ENFORCING --log-error=$restartdir/restart.log"
 --echo "Try restarting node-2 with --innodb_autoinc_lock_mode=1"
---exec echo "try:$start_mysqld_params" > $_expect_file_name
+--exec echo "restart_abort:$start_mysqld_params" > $_expect_file_name
 --sleep 30
 #
 --echo "grep --count \"Percona-XtraDB-Cluster prohibits setting innodb_autoinc_lock_mode to"

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -672,8 +672,7 @@ static void *sst_joiner_thread(void *a) {
     thd->variables.transaction_isolation = ISO_READ_COMMITTED;
 
     if (wsrep_sst_complete(thd, -err)) {
-      WSREP_ERROR("Failure while signalling the completion of SST. Aborting.");
-      unireg_abort(1);
+      WSREP_WARN("Failure while signalling the completion of SST.");
     }
 
     WSREP_SYSTEM("SST completed");


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4221

Fixed MTR testcases
    ***
    Reverted our implementation of handling expected server abort on mysqld
    restart in MTR testcases
    
    in favor of upstream's implementation by
    
    Bug#35005463 MTR: IMPLEMENT A WAY TO HANDLE SERVER ABORT ON MYSQLD RESTART
    (commit 3437378a6e)
    
    While our implementation used "try:" for the expected server aborts,
    upstream implementation used "restart_abort:". As per this change, all
    the dependent testcases were modified to use "restart_abort:".
    
    ***
    galera_performance_schema test failed when used with the
    libgalera_smm.so library built using cmake command. This is because of
    the uninitialized WITH_PERFSCHEMA_STORAGE_ENGINE variable resulted in
    galera to be built without perfschema instrumentation.
    
    In order to fix this, galera build order has been modified.
    
    ***
    Some tests failing due to master-source changes have been re-recorded.
    
    ***
    SST Joiner thread code has been modified to avoid calling
    unireg_abort(), as it was observed that it could result in both mysqld
    main thread and sst joiner thread simultaneously calling mysqld_exit()
    resulting in double free of some memory structures.
    (commit 06bfad84918 has been partially reverted.

