### PR TITLE
PXC-4211: Server aborts on binary log rotation

### DIFF
--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -430,6 +430,9 @@ void wsrep_register_for_group_commit(THD *thd) {
 }
 
 bool wsrep_implicit_transaction(THD *thd) {
+  if (!thd) {
+    return false;
+  }
   return thd->is_operating_substatement_implicitly ||
          thd->is_operating_gtid_table_implicitly;
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4211

Post push fix:
Commit f07c0c78 is missing validation of thd pointer against nullptr. It can be nullptr if wsrep_implicit_transaction() is called by trx_sys_update_wsrep_checkpoint() during binlog recovery.

wsrep_implicit_transaction