### PR TITLE
PXC-4233: Cluster state interruption during NBO may lead to permanent cluster lock

### DIFF
--- a/mysql-test/suite/galera_nbo/r/galera_nbo_alter_bf3.result
+++ b/mysql-test/suite/galera_nbo/r/galera_nbo_alter_bf3.result
@@ -1,0 +1,26 @@
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT);
+INSERT INTO t1 VALUES (0, 0), (1, 0);
+CREATE TABLE aux (a INT PRIMARY KEY);
+SET GLOBAL DEBUG="+d,nbo_stop_before_apply_events";
+SET SESSION wsrep_osu_method = NBO;
+CREATE INDEX b_idx ON t1(b);
+SET DEBUG_SYNC = 'now WAIT_FOR nbo_before_apply_events_reached';
+INSERT INTO aux VALUES (0);
+INSERT INTO t1 VALUES (2, 2);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+CALL mtr.add_suppression(".*TO isolation failed.*");
+ALTER TABLE t1 ADD COLUMN (c INT);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET SESSION wsrep_trx_fragment_size=1;
+SET SESSION wsrep_trx_fragment_unit="STATEMENTS";
+BEGIN;
+INSERT INTO t1 VALUES (2, 2);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ROLLBACK;
+SET SESSION wsrep_trx_fragment_size=default;
+SET SESSION wsrep_trx_fragment_unit=default;
+SET DEBUG_SYNC = 'now SIGNAL nbo_before_apply_events_continue';
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;
+DROP TABLE aux;
+SET GLOBAL DEBUG="-d,nbo_stop_before_apply_events";

--- a/mysql-test/suite/galera_nbo/t/galera_nbo_alter_bf3.test
+++ b/mysql-test/suite/galera_nbo/t/galera_nbo_alter_bf3.test
@@ -1,0 +1,56 @@
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+--source include/galera_cluster.inc
+
+--connection node_1
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT);
+INSERT INTO t1 VALUES (0, 0), (1, 0);
+CREATE TABLE aux (a INT PRIMARY KEY);
+
+# Setup node_2 to stop NBO applier thread just before apply_events()
+--connection node_2
+SET GLOBAL DEBUG="+d,nbo_stop_before_apply_events";
+
+--connection node_1
+SET SESSION wsrep_osu_method = NBO;
+--send CREATE INDEX b_idx ON t1(b)
+
+--connection node_2
+SET DEBUG_SYNC = 'now WAIT_FOR nbo_before_apply_events_reached';
+
+# make sure NBO phase 1 finished
+INSERT INTO aux VALUES (0);
+
+# There is nothing which blocks the following transaction:
+# 1. Apply and Commit Monitors are released (NBO phase 1 finished)
+# 2. No MDL locks acquired by NBO applier thread yet
+# It should be be rejected at the certification stage. If not, it would replicate and cause BF-BF conflict on node 1
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES (2, 2);
+
+# Try with TOI
+CALL mtr.add_suppression(".*TO isolation failed.*");
+--error ER_LOCK_DEADLOCK
+ALTER TABLE t1 ADD COLUMN (c INT);
+
+# Try with SR
+SET SESSION wsrep_trx_fragment_size=1;
+SET SESSION wsrep_trx_fragment_unit="STATEMENTS";
+BEGIN;
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES (2, 2);
+ROLLBACK;
+SET SESSION wsrep_trx_fragment_size=default;
+SET SESSION wsrep_trx_fragment_unit=default;
+
+# Let NBO applier thread to continue
+SET DEBUG_SYNC = 'now SIGNAL nbo_before_apply_events_continue';
+
+--connection node_1
+--reap
+SET SESSION wsrep_osu_method=TOI;
+DROP TABLE t1;
+DROP TABLE aux;
+
+--connection node_2
+SET GLOBAL DEBUG="-d,nbo_stop_before_apply_events";

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -2540,7 +2540,7 @@ bool MDL_lock::can_grant_lock(enum_mdl_type type_arg,
           other context.
 
           If we are trying to acquire "unobtrusive" type of lock then the
-          confliciting lock must be from "obtrusive" set, therefore it should
+          conflicting lock must be from "obtrusive" set, therefore it should
           have been acquired using "slow path" and should be present in
           m_granted list.
 
@@ -3073,7 +3073,7 @@ bool MDL_context::try_acquire_lock_impl(MDL_request *mdl_request,
   */
 #ifdef WITH_WSREP
   /* WSREP preempt lock if thread is applier or TOTAL_ORDER and so
-  we avoid using fast path as fast path locks needs to be materalize
+  we avoid using fast path as fast path locks needs to be materialized
   before conflict checks can be done which causes issue with preempt
   approach WSREP uses.
   TODO: Check if this preempt approach can be relaxed. */

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -112,7 +112,7 @@ extern "C" bool wsrep_thd_is_BF(const THD *thd, bool sync) {
     if (sync)
       mysql_mutex_lock(const_cast<mysql_mutex_t *>(&thd->LOCK_wsrep_thd));
     status = (wsrep_thd_is_applying(thd) || wsrep_thd_is_toi(thd) ||
-              wsrep_thd_is_in_rsu(thd));
+              wsrep_thd_is_in_rsu(thd)) || wsrep_thd_is_in_nbo(thd);
     if (sync)
       mysql_mutex_unlock(const_cast<mysql_mutex_t *>(&thd->LOCK_wsrep_thd));
   }

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -30,6 +30,7 @@
 #include "transaction.h"
 
 #include <condition_variable>
+#include "my_dbug.h"
 #include "sql_base.h"  // close_temporary_table()
 
 extern handlerton *binlog_hton;
@@ -808,6 +809,13 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
     /* DDL are atomic so flow (in wsrep_apply_events) will assign XID.
     Avoid over-writting of this XID by MySQL XID */
     thd->get_transaction()->xid_state()->get_xid()->set_keep_wsrep_xid(true);
+
+    DBUG_EXECUTE_IF("nbo_stop_before_apply_events", {
+      const char act[] =
+          "now signal nbo_before_apply_events_reached wait_for "
+          "nbo_before_apply_events_continue";
+      assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+    });
 
     wsrep::mutable_buffer err2;
     ret = apply_events(thd, m_rli, our_buffer, err2);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4233

Problem:
DDL transaction (ALTER TABLE) executed in NBO mode can cause BF-BF
conflict with other DML transaction (INSERT) which tries to modify data
in the same table.
This is a known limitation that both cannot be executed at the same time
but the problem is that BF-BF causes all cluster nodes abort and cluster
outage.

Cause:
When NBO transaction is replicated two things happen:
1. On local node TOI transaction indicating start of NBO ends, releasing
Commit and Apply Monitors in Galera. This is end of NBO phase 1. Then
the DDL goes as normal transaction. At the end we wait for NBO to
finish (NBO phase 2 begin). At this moment we wait for all cluster nodes
to confirm completion of NBO execution. We still hold all MDL locks
related to the transaction
2. On remote node, applier thread just spawns NBO thread which is
responsible for applying all DDL changes. Then applier thread finishes
processing TOI transaction related to local node's NBO phase 1.
At this moment no MDL locks related to NBO are acquired.
Commit and Apply Order Monitors are released as well.

At the moment, when on remote node NBO applier didn't acuire any MDL
locks yet, but the NBO-triggering TOI finished, another DML transaction
modifying the same table is free to go (no MDL conflicts).
Certification flow was implemented in the way that it considered only
other TOI and NBO transactions, ignoring normal and streaming
replication transactions. So the DML transaction was replicated.

Back to local node. It waits for NBO confirmation from remote node.
Replicated DML transaction arrives and is being applied. Applier thread
is attempting to lock MDL lock, which is already held by local NBO
transaction which ends up with BF-BF abort.

Solution:
Modify certification flow in the way that it checks for conflicts
against ongoing NBO transactions also for regular and streaming
replication transactions. If the transaction conflicts with ongoing NBO
transaction, it fails with deadlock error (the original behavior for
TOI)
