### PR TITLE
PXC-4221: Merge PS-8.0.33 (Fixed ASAN failures)

### DIFF
--- a/mysql-test/suite/galera/t/galera_fc_auto_evict.test
+++ b/mysql-test/suite/galera/t/galera_fc_auto_evict.test
@@ -11,6 +11,7 @@
 # It's just a smoke test of the feature, because it's problematic to achieve required
 # time characteristics. For more granular testing a unit test is used.
 
+--source include/force_restart.inc
 --source include/galera_cluster.inc
 
 --connection node_2

--- a/mysql-test/suite/galera/t/pxc_information_schema.test
+++ b/mysql-test/suite/galera/t/pxc_information_schema.test
@@ -1,7 +1,8 @@
 #
 # Test that INFORMATION_SCHEMA.PROCESSLIST shows proper information about wsrep threads
 #
-
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
 --source include/galera_cluster.inc
 
 #

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -785,6 +785,7 @@ IF(WITH_WSREP)
    wsrep_sst.cc
    wsrep_storage_service.cc
    wsrep_thd.cc
+   wsrep_thd_context.cc
    wsrep_utils.cc
    wsrep_var.cc
    wsrep_xid.cc

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -717,6 +717,7 @@ THD::THD(bool enable_plugins)
       wsrep_last_query_id(0),
       wsrep_xid(),
       wsrep_skip_locking(false),
+      wsrep_thd_context(),
       wsrep_rand(0),
       wsrep_rli(NULL),
       wsrep_retry_counter(0),
@@ -2205,6 +2206,7 @@ void THD::cleanup_after_query() {
 
 #ifdef WITH_WSREP
   if (!in_active_multi_stmt_transaction()) wsrep_affected_rows = 0;
+  wsrep_thd_context.clear();
 #endif /* WITH_WSREP */
 }
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -164,6 +164,7 @@ struct LOG_INFO;
 #include "wsrep_condition_variable.h"
 #include "wsrep_mutex.h"
 #include "wsrep_mysqld.h"
+#include "wsrep_thd_context.h"
 
 class Wsrep_applier_service;
 #endif /* WITH_WSREP */
@@ -3188,6 +3189,7 @@ class THD : public MDL_context_owner,
   };
 
   nbo_context wsrep_nbo;
+  Wsrep_thd_context wsrep_thd_context;
 
   mysql_mutex_t LOCK_wsrep_thd;
   mysql_cond_t COND_wsrep_thd;

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -879,6 +879,7 @@ int Wsrep_applier_service::apply_nbo_begin(const wsrep::ws_meta &ws_meta,
     thd->wsrep_cs().close();
     thd->wsrep_cs().cleanup();
 
+    thd->get_protocol_classic()->end_net();
     thd->release_resources();
     thd_manager->remove_thd(thd);
 #ifdef HAVE_PSI_THREAD_INTERFACE

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1859,14 +1859,24 @@ static bool wsrep_do_action_for_tables(THD *thd, Table_ref *tables,
  */
 bool wsrep_append_child_tables(THD *thd, Table_ref *tables,
                                wsrep::key_array *keys) {
-  return wsrep_do_action_for_tables(
-      thd, tables, [keys](const dd::Table *table_def) {
-        for (const auto fk : table_def->foreign_key_parents()) {
-          keys->push_back(wsrep_prepare_key_for_toi(
-              fk->child_schema_name().c_str(), fk->child_table_name().c_str(),
-              wsrep::key::shared));
-        }
-      });
+  auto populate_child_tables = [thd](const dd::Table *table_def) {
+    for (const auto fk : table_def->foreign_key_parents()) {
+      std::pair<std::string, std::string> table = std::make_pair(
+          fk->child_schema_name().c_str(), fk->child_table_name().c_str());
+
+      thd->wsrep_thd_context.get_fk_child_tables().push_back(table);
+    }
+  };
+
+  if (wsrep_do_action_for_tables(thd, tables, populate_child_tables))
+    return true;
+
+  for (const auto &table_obj : thd->wsrep_thd_context.get_fk_child_tables()) {
+    keys->push_back(wsrep_prepare_key_for_toi(
+        table_obj.first.c_str(), table_obj.second.c_str(), wsrep::key::shared));
+  }
+
+  return false;
 }
 
 /*
@@ -1874,14 +1884,25 @@ bool wsrep_append_child_tables(THD *thd, Table_ref *tables,
  */
 bool wsrep_append_fk_parent_table(THD *thd, Table_ref *tables,
                                   wsrep::key_array *keys) {
-  return wsrep_do_action_for_tables(
-      thd, tables, [keys](const dd::Table *table_def) {
-        for (const auto fk : table_def->foreign_keys()) {
-          keys->push_back(wsrep_prepare_key_for_toi(
-              fk->referenced_table_schema_name().c_str(),
-              fk->referenced_table_name().c_str(), wsrep::key::shared));
-        }
-      });
+  auto populate_parent_tables = [thd](const dd::Table *table_def) {
+    for (const auto fk : table_def->foreign_keys()) {
+      std::pair<std::string, std::string> table =
+          std::make_pair(fk->referenced_table_schema_name().c_str(),
+                         fk->referenced_table_name().c_str());
+      thd->wsrep_thd_context.get_fk_parent_tables().push_back(table);
+    }
+  };
+
+  if (wsrep_do_action_for_tables(thd, tables, populate_parent_tables))
+    return true;
+
+
+  for (const auto &table_obj : thd->wsrep_thd_context.get_fk_parent_tables()) {
+    keys->push_back(wsrep_prepare_key_for_toi(
+        table_obj.first.c_str(), table_obj.second.c_str(), wsrep::key::shared));
+  }
+
+  return false;
 }
 
 /*

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1889,13 +1889,13 @@ bool wsrep_append_fk_parent_table(THD *thd, Table_ref *tables,
       std::pair<std::string, std::string> table =
           std::make_pair(fk->referenced_table_schema_name().c_str(),
                          fk->referenced_table_name().c_str());
+
       thd->wsrep_thd_context.get_fk_parent_tables().push_back(table);
     }
   };
 
   if (wsrep_do_action_for_tables(thd, tables, populate_parent_tables))
     return true;
-
 
   for (const auto &table_obj : thd->wsrep_thd_context.get_fk_parent_tables()) {
     keys->push_back(wsrep_prepare_key_for_toi(

--- a/sql/wsrep_thd_context.cc
+++ b/sql/wsrep_thd_context.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2023 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "sql/wsrep_thd_context.h"  // Wsrep_thd_context
+
+std::vector<wsrep_table_t>& Wsrep_thd_context::get_fk_parent_tables() {
+  return fk_parent_tables;
+}
+
+std::vector<wsrep_table_t>& Wsrep_thd_context::get_fk_child_tables() {
+  return fk_child_tables;
+}
+
+void Wsrep_thd_context::clear() {
+  fk_parent_tables.clear();
+  fk_child_tables.clear();
+}

--- a/sql/wsrep_thd_context.cc
+++ b/sql/wsrep_thd_context.cc
@@ -17,11 +17,11 @@
 
 #include "sql/wsrep_thd_context.h"  // Wsrep_thd_context
 
-std::vector<wsrep_table_t>& Wsrep_thd_context::get_fk_parent_tables() {
+std::vector<wsrep_table_t> &Wsrep_thd_context::get_fk_parent_tables() {
   return fk_parent_tables;
 }
 
-std::vector<wsrep_table_t>& Wsrep_thd_context::get_fk_child_tables() {
+std::vector<wsrep_table_t> &Wsrep_thd_context::get_fk_child_tables() {
   return fk_child_tables;
 }
 

--- a/sql/wsrep_thd_context.h
+++ b/sql/wsrep_thd_context.h
@@ -1,0 +1,49 @@
+/* Copyright (c) 2023 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef WSREP_THD_CONTEXT_H
+#define WSREP_THD_CONTEXT_H
+
+#include <string>
+#include <vector>
+
+using wsrep_table_t = std::pair<std::string, std::string>;
+
+/*
+  This class encapsulates the wsrep context associated with the THD
+  object.
+ */
+class Wsrep_thd_context {
+ private:
+  std::vector<wsrep_table_t> fk_parent_tables;
+  std::vector<wsrep_table_t> fk_child_tables;
+
+  Wsrep_thd_context(const Wsrep_thd_context &) = delete;  // copy constructor
+  Wsrep_thd_context operator=(Wsrep_thd_context &&) =
+      delete;  // move assignment
+  Wsrep_thd_context operator=(const Wsrep_thd_context &) =
+      delete;  // copy assignment
+
+ public:
+  Wsrep_thd_context() {}
+  void clear();
+
+  std::vector<wsrep_table_t>& get_fk_parent_tables();
+  std::vector<wsrep_table_t>& get_fk_child_tables();
+};
+
+#endif /* WSREP_THD_CONTEXT_H */

--- a/sql/wsrep_thd_context.h
+++ b/sql/wsrep_thd_context.h
@@ -42,8 +42,8 @@ class Wsrep_thd_context {
   Wsrep_thd_context() {}
   void clear();
 
-  std::vector<wsrep_table_t>& get_fk_parent_tables();
-  std::vector<wsrep_table_t>& get_fk_child_tables();
+  std::vector<wsrep_table_t> &get_fk_parent_tables();
+  std::vector<wsrep_table_t> &get_fk_child_tables();
 };
 
 #endif /* WSREP_THD_CONTEXT_H */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4221

***
During the execution of ALTER TABLE in NBO mode on a table in a Foreign Key relationship, the query accessed the memory that already freed resulting in heap-use-after-free.

Stack is as follows:

==214817==ERROR: AddressSanitizer: heap-use-after-free on address 0x60b0000bbb50 at pc 0x7f330e694495 bp 0x7f32d74914a0 sp 0x7f32d7490c48

    READ of size 4 at 0x60b0000bbb50 thread T53
 #0 0x7f330e694494 in MemcmpInterceptorCommon
__interceptor_memcmp
__interceptor_memcmp
galera::KeySetOut::KeyPart::match
galera::KeySetOut::append
galera::WriteSetOut::append_key
galera::TrxHandleMaster::append_key
galera_to_execute_start
wsrep::wsrep_provider_v26::enter_toi
wsrep::client_state::poll_enter_toi
wsrep::client_state::begin_nbo_phase_two
wsrep_NBO_begin_phase_two
mysql_execute_command

    freed by thread T53 here:

operator delete
delete_container_pointers
dd::Table_impl::~Table_impl()
dd::Table_impl::~Table_impl()
dd::cache::Shared_multi_map
dd::cache::Shared_multi_map
void dd::cache::Shared_dictionary_cache::drop
void dd::cache::Dictionary_client::invalidate
bool dd::cache::Dictionary_client::drop
mysql_inplace_alter_table
mysql_alter_table
Sql_cmd_alter_table::execute
mysql_execute_command

    previously allocated by thread T53 here:

operator new
dd::Table_impl::add_foreign_key_parent
dd::Table_impl::load_foreign_key_parents
dd::Table_impl::restore_children
n dd::Entity_object_table_impl::restore_object_from_record n bool dd::cache::Storage_adapter::get
n bool dd::cache::Shared_dictionary_cache::get_uncached n bool dd::cache::Shared_dictionary_cache::get
n bool dd::cache::Dictionary_client::acquire
bool dd::cache::Dictionary_client::acquire
wsrep_do_action_for_tables
wsrep_append_fk_parent_table
Sql_cmd_alter_table::execute
mysql_execute_command

***
Fixed the memory leak in apply_NBO_begin()

Direct leak of 32846 byte(s) in 2 object(s) allocated from: __interceptor_malloc
redirecting_allocator
my_raw_malloc
my_internal_malloc
my_malloc
my_net_init
Protocol_classic::init_net
Wsrep_applier_service::apply_nbo_begin

SUMMARY: AddressSanitizer: 32846 byte(s) leaked in 2 allocation(s).