### PR TITLE
PXC-4268: ALTER DEFINER VIEW makes PXC node Disconnected and Inconsistent

### DIFF
--- a/mysql-test/suite/galera/r/pxc_create_alter_view.result
+++ b/mysql-test/suite/galera/r/pxc_create_alter_view.result
@@ -1,0 +1,27 @@
+CREATE USER u1@localhost IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON test.* TO u1@localhost;
+GRANT SYSTEM_USER ON *.* TO u1@localhost;
+CREATE USER u2@localhost IDENTIFIED BY '';
+GRANT SELECT, CREATE VIEW, SHOW VIEW, DROP ON test.* to u2@localhost;
+CREATE TABLE t1(i INT PRIMARY KEY, n VARCHAR(9));
+CREATE OR REPLACE VIEW v AS SELECT * FROM t1;
+ALTER DEFINER=u1@`localhost` VIEW v AS SELECT * FROM t1;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SET_USER_ID privilege(s) for this operation
+DROP VIEW v;
+DROP TABLE t1;
+DROP USER u1@localhost;
+DROP USER u2@localhost;
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+CREATE TABLE db1.t1(c1 INT PRIMARY KEY);
+CREATE TABLE db1.t2(c2 INT PRIMARY KEY);
+CREATE USER u1@localhost IDENTIFIED BY '';
+GRANT SELECT ON db1.t1 TO u1@localhost;
+GRANT INSERT ON db1.t2 TO u1@localhost;
+GRANT ALL PRIVILEGES ON db2.* TO u1@localhost;
+FLUSH PRIVILEGES;
+CREATE VIEW v AS SELECT c1, c2 FROM db1.t1, db1.t2;
+ERROR 42000: create view command denied to user 'u1'@'localhost' for column 'c2' in table 'v'
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP USER u1@localhost;

--- a/mysql-test/suite/galera/t/pxc_create_alter_view.test
+++ b/mysql-test/suite/galera/t/pxc_create_alter_view.test
@@ -1,0 +1,54 @@
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+
+CREATE USER u1@localhost IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON test.* TO u1@localhost;
+GRANT SYSTEM_USER ON *.* TO u1@localhost;
+
+CREATE USER u2@localhost IDENTIFIED BY '';
+GRANT SELECT, CREATE VIEW, SHOW VIEW, DROP ON test.* to u2@localhost;
+
+--connect (u1_connection,localhost,u1,,test, $NODE_MYPORT_1)
+CREATE TABLE t1(i INT PRIMARY KEY, n VARCHAR(9));
+CREATE OR REPLACE VIEW v AS SELECT * FROM t1;
+
+--connect (u2_connection,localhost,u2,,test, $NODE_MYPORT_1)
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+ALTER DEFINER=u1@`localhost` VIEW v AS SELECT * FROM t1;
+
+--connection u1_connection
+DROP VIEW v;
+DROP TABLE t1;
+
+--disconnect u1_connection
+--disconnect u2_connection
+
+--connection node_1
+DROP USER u1@localhost;
+DROP USER u2@localhost;
+
+
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+CREATE TABLE db1.t1(c1 INT PRIMARY KEY);
+CREATE TABLE db1.t2(c2 INT PRIMARY KEY);
+
+CREATE USER u1@localhost IDENTIFIED BY '';
+GRANT SELECT ON db1.t1 TO u1@localhost;
+GRANT INSERT ON db1.t2 TO u1@localhost;
+GRANT ALL PRIVILEGES ON db2.* TO u1@localhost;
+FLUSH PRIVILEGES;
+
+--connect (u1_connection,127.0.0.1,u1,,db2, $NODE_MYPORT_1)
+--error ER_COLUMNACCESS_DENIED_ERROR
+CREATE VIEW v AS SELECT c1, c2 FROM db1.t1, db1.t2;
+--disconnect u1_connection
+
+--connection node_1
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP USER u1@localhost;
+
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -473,13 +473,6 @@ bool mysql_create_view(THD *thd, Table_ref *views, enum_view_create_mode mode) {
   lex->link_first_table_back(view, link_to_local);
   view->open_type = OT_BASE_ONLY;
 
-#ifdef WITH_WSREP
-  if (WSREP(thd) && wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL)) {
-    res = true;
-    goto err;
-  }
-#endif /* WITH_WSREP */
-
   /*
     No pre-opening of temporary tables is possible since must
     wait until Table_ref::open_type is set. So we have to open
@@ -692,6 +685,21 @@ bool mysql_create_view(THD *thd, Table_ref *views, enum_view_create_mode mode) {
       goto err;
     }
   }
+
+#ifdef WITH_WSREP
+  if (WSREP(thd)) {
+    // We need the view to be the 1st table because of
+    // how create_view_query() is implemented.
+    lex->link_first_table_back(view, link_to_local);
+    int toi_begin_res =
+        wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL);
+    view = lex->unlink_first_table(&link_to_local);
+    if (toi_begin_res) {
+      res = true;
+      goto err;
+    }
+  }
+#endif /* WITH_WSREP */
 
   if ((res = mysql_register_view(thd, view, mode))) goto err_with_rollback;
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4268

Problem:
When ALTER DEFINER VIEW is executed by the user with insufficient privileges the query fails and the node self-leaves the cluster.

Cause:
This is yet another case when replicated TOI is allowed to proceed on the remote node, because it is executed in context of wsrep applier thread (root user), while it fails on local node. This is caused because TOI is replicated before checking privileges locally.

Solution:
Postponed TOI replication up to the point when privileges of the user executing query are validated.