### PR TITLE
PXC-4258: Failed to add foreign key results in Inconsistency

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -426,6 +426,7 @@ INSERT INTO global_suppressions VALUES
  ("Toggling wsrep_on to OFF will affect sql_log_bin"),
  ("Toggling wsrep_on to ON will affect sql_log_bin"),
  ("InnoDB High Priority being used"),
+ ("Query apply failed"),
 
  /* MySQL supression needed by Galera */
  ("Slave I/O.*: Get master clock failed with error:.*"),

--- a/mysql-test/suite/galera/r/pxc_fk_inconsistency_voting.result
+++ b/mysql-test/suite/galera/r/pxc_fk_inconsistency_voting.result
@@ -1,0 +1,14 @@
+CREATE TABLE parent (i INT PRIMARY KEY) ENGINE = InnoDB;
+CREATE TABLE child (j INT PRIMARY KEY) ENGINE = InnoDB;
+INSERT INTO child VALUES (10);
+ALTER TABLE child ADD CONSTRAINT idx17 FOREIGN KEY (j) REFERENCES parent(i);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`temp_table`, CONSTRAINT `idx17` FOREIGN KEY (`j`) REFERENCES `parent` (`i`))
+include/assert_grep.inc [Verify that the intermediate temporary table name has been replaced with temp_table]
+SET SESSION wsrep_on=OFF;
+ALTER TABLE child ADD CONSTRAINT idx17 FOREIGN KEY (j) REFERENCES parent(i), ALGORITHM=COPY;
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`#sql-XXXXX
+SET SESSION wsrep_on=ON;
+CALL mtr.add_suppression("Cannot add or update a child row: a foreign key constraint fails");
+CALL mtr.add_suppression("Cannot add or update a child row: a foreign key constraint fails");
+DROP TABLE child;
+DROP TABLE parent;

--- a/mysql-test/suite/galera/t/pxc_fk_inconsistency_voting.test
+++ b/mysql-test/suite/galera/t/pxc_fk_inconsistency_voting.test
@@ -1,0 +1,40 @@
+#
+# This test ensures that server rewrites the name of the intermediate temporary
+# table in the error messages.
+#
+--source include/galera_cluster.inc
+
+CREATE TABLE parent (i INT PRIMARY KEY) ENGINE = InnoDB;
+CREATE TABLE child (j INT PRIMARY KEY) ENGINE = InnoDB;
+INSERT INTO child VALUES (10);
+
+--error ER_NO_REFERENCED_ROW_2
+ALTER TABLE child ADD CONSTRAINT idx17 FOREIGN KEY (j) REFERENCES parent(i);
+
+# Assert that the message has 'temp_table'. Note that count is 2 because it
+# prints messages from both the nodes.
+--let $assert_text= Verify that the intermediate temporary table name has been replaced with temp_table
+--let $assert_select= a foreign key constraint fails \(`temp_table`, CONSTRAINT `idx17`
+--let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_count=2
+--source include/assert_grep.inc
+
+# Test with wsrep_on=OFF
+SET SESSION wsrep_on=OFF;
+--replace_regex /#sql.*$/#sql-XXXXX/
+--error ER_NO_REFERENCED_ROW_2
+ALTER TABLE child ADD CONSTRAINT idx17 FOREIGN KEY (j) REFERENCES parent(i), ALGORITHM=COPY;
+SET SESSION wsrep_on=ON;
+
+# Assert that the cluster is still up and running
+--assert(`SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'`)
+
+# Test suppressions
+CALL mtr.add_suppression("Cannot add or update a child row: a foreign key constraint fails");
+
+--connection node_2
+CALL mtr.add_suppression("Cannot add or update a child row: a foreign key constraint fails");
+
+--connection node_1
+DROP TABLE child;
+DROP TABLE parent;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4258

Problem
-------
ALTER TABLE on a table involving a FK relationship can sometimes result in cluster inconsistency due to different error messages.

Different messages are possible when the error message includes the name of the intermediate temporary table that gets created during the execution of the ALTER TABLE.

  Example:

  node-1: foreign key constraint fails (`test`.`#sql-25528d_2`, CONSTRAINT `child_ibfk_1`
  node-2: foreign key constraint fails (`test`.`#sql-22ed07_9`, CONSTRAINT `child_ibfk_1`

Solution
--------
Avoid printing the temporary table name and instead print "temp_table" to the error message for TOI and NBO operations.


Testing Done
----
Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-pipeline-parallel-mtr/1916/console

Failing tests
| Sl.No | Test | Remarks |
|--------|--------|--------|
| 1 | main.derived_condition_pushdown | Fixed in 8.0.33 |
| 2 | galera.galera_fc_auto_evict | Fixed in 8.0.33 |
| 3 | galera.galera_performance_schema | Fixed in 8.0.33 |
| 4 | galera.pxc_information_schema | Fixed in 8.0.33 |
| 5 | galera_sr.GCF-1043A | Fixed in 8.0.33 |
| 6 | galera_sr.gakera_sr_wsrep_error_handling | Test removed in 8.0.33 |
| 7 | galera_encryption.gcache_mk_rotation_enc_off | Sporadic |
| 7 | galera.galera_gcache_recover_manytrx | Sporadic |