### PR TITLE
PXC-4278: Renaming table crashes with NBO

### DIFF
--- a/mysql-test/suite/galera/r/pxc_alter_table_rename.result
+++ b/mysql-test/suite/galera/r/pxc_alter_table_rename.result
@@ -1,0 +1,2987 @@
+CREATE TABLE t1(i INT PRIMARY KEY);
+SET SESSION WSREP_OSU_METHOD=NBO;
+ALTER TABLE t1 RENAME TO t2;
+ALTER TABLE t2 RENAME TO t1;
+ALTER TABLE t1 DISABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't1' doesn't have this option
+ALTER TABLE t1 ENABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't1' doesn't have this option
+ALTER TABLE t1 RENAME TO t2, DISABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't1' doesn't have this option
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't2' doesn't have this option
+ALTER TABLE t1 RENAME TO t2, ENGINE=INNODB;
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS, ENGINE=INNODB;
+Warnings:
+Note	1031	Table storage engine for '#sql-XXXXX
+SET SESSION WSREP_OSU_METHOD=default;
+ALTER TABLE t1 RENAME TO t2;
+ALTER TABLE t2 RENAME TO t1;
+ALTER TABLE t1 DISABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't1' doesn't have this option
+ALTER TABLE t1 ENABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't1' doesn't have this option
+ALTER TABLE t1 RENAME TO t2, DISABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't1' doesn't have this option
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS;
+Warnings:
+Note	1031	Table storage engine for 't2' doesn't have this option
+ALTER TABLE t1 RENAME TO t2, ENGINE=INNODB;
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS, ENGINE=INNODB;
+Warnings:
+Note	1031	Table storage engine for '#sql-XXXXX
+DROP TABLE t1;
+# Scenario 1 : Rename a column
+SET SESSION wsrep_OSU_method=TOI;
+CREATE TABLE t1 (c1 INT, c2 INT, c3 INT AS (c1 + 10) VIRTUAL);
+INSERT INTO t1(c1, c2) VALUES (1,11);
+INSERT INTO t1(c1, c2) VALUES (2,22);
+INSERT INTO t1(c1, c2) VALUES (3,33);
+INSERT INTO t1(c1, c2) VALUES (4,44);
+INSERT INTO t1(c1, c2) VALUES (5,55);
+SELECT * FROM t1;
+c1	c2	c3
+1	11	11
+2	22	12
+3	33	13
+4	44	14
+5	55	15
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t1 RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+SELECT * FROM t1;
+c1	c22	c3
+1	11	11
+2	22	12
+3	33	13
+4	44	14
+5	55	15
+SET SESSION wsrep_OSU_method=TOI;
+CREATE TABLE tpart (c1 INT, c2 INT, c3 INT AS (c1 + 10) VIRTUAL)
+PARTITION BY RANGE (c1) (
+PARTITION tpart1 VALUES LESS THAN (10),
+PARTITION tpart2 VALUES LESS THAN (100));
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE tpart RENAME COLUMN c1 TO c22, ALGORITHM=INSTANT;
+ERROR HY000: Column 'c1' has a generated column dependency.
+ALTER TABLE tpart RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+# Scenario 2 : Rename an INSTANT ADD column
+ALTER TABLE t1 ADD COLUMN c4 INT, ALGORITHM=INSTANT;
+ALTER TABLE t1 RENAME COLUMN c4 to c44, ALGORITHM=INSTANT;
+SELECT * FROM t1;
+c1	c22	c3	c44
+1	11	11	NULL
+2	22	12	NULL
+3	33	13	NULL
+4	44	14	NULL
+5	55	15	NULL
+ALTER TABLE tpart ADD COLUMN c4 INT, ALGORITHM=INSTANT;
+ALTER TABLE tpart RENAME COLUMN c4 TO c44, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c3	c44
+# Scenario 3 : Rename a VIRTUAL column
+ALTER TABLE t1 CHANGE c3 c33 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, algorithm=instant;
+SELECT * FROM t1;
+c1	c22	c33	c44
+1	11	11	NULL
+2	22	12	NULL
+3	33	13	NULL
+4	44	14	NULL
+5	55	15	NULL
+ALTER TABLE tpart CHANGE c3 c33 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c33	c44
+# Scenario 4 : Rename an INSTANT ADD VIRTUAL column
+ALTER TABLE t1 add COLUMN (c5 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL), ALGORITHM=INSTANT;
+SELECT * FROM t1;
+c1	c22	c33	c44	c5
+1	11	11	NULL	11
+2	22	12	NULL	12
+3	33	13	NULL	13
+4	44	14	NULL	14
+5	55	15	NULL	15
+ALTER TABLE t1 change c5 c55 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, algorithm=instant;
+SELECT * FROM t1;
+c1	c22	c33	c44	c55
+1	11	11	NULL	11
+2	22	12	NULL	12
+3	33	13	NULL	13
+4	44	14	NULL	14
+5	55	15	NULL	15
+ALTER TABLE tpart ADD COLUMN (c5 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL), ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c33	c44	c5
+ALTER TABLE tpart CHANGE c5 c55 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c33	c44	c55
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1;
+DROP TABLE tpart;
+# Scenario 5 : Try to rename a column which is referenced in other table
+CREATE TABLE t1 (c1 INT PRIMARY KEY, c2 INT, c3 INT,  INDEX(c2));
+CREATE TABLE t1c (c1 INT PRIMARY KEY, c2 INT,
+CONSTRAINT t1c1 FOREIGN KEY (c2) REFERENCES t1(c2));
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t1 CHANGE c2 c22 INT, algorithm=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Columns participating in a foreign key are renamed. Try ALGORITHM=INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1c;
+DROP TABLE t1;
+# Scenario 6: Try to change the column name in a table with discarded tablespace
+CREATE TABLE t1 (c1 int, c2 INT as (c1+1) VIRTUAL);
+SELECT TABLE_ID INTO @old_tid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%t1%";
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t1 DISCARD TABLESPACE;
+SELECT TABLE_ID INTO @new_tid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%t1%";
+SELECT (@old_tid != @new_tid) as Table_Id_Changed;
+Table_Id_Changed
+1
+ALTER TABLE t1 RENAME COLUMN c2 to c3, algorithm=instant;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't1'
+ALTER TABLE t1 RENAME COLUMN c3 to c2, algorithm=instant;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't1'
+SET SESSION wsrep_OSU_method=TOI;
+Drop TABLE t1;
+CREATE TABLE tpart (c1 INT, c2 INT AS (c1 + 1) VIRTUAL)
+PARTITION BY RANGE(c1) (
+PARTITION p1 VALUES LESS THAN (10),
+PARTITION p2 VALUES LESS THAN (100));
+SELECT max(TABLE_ID) INTO @old_tpid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%tpart%";
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE tpart DISCARD TABLESPACE;
+SELECT max(TABLE_ID) INTO @new_tpid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%tpart%";
+SELECT (@old_tpid != @new_tpid) AS Table_Id_Changed;
+Table_Id_Changed
+1
+ALTER TABLE tpart RENAME COLUMN c2 TO c3, ALGORITHM=INSTANT;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+ALTER TABLE tpart RENAME COLUMN c3 TO c2, ALGORITHM=INSTANT;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tpart;
+# Scenario 7: Try to rename a column to an internal column name
+CREATE TABLE t1 (c1 INT, c2 INT);
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_ROW_ID;
+ERROR 42000: Incorrect column name 'DB_ROW_ID'
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_TRX_ID;
+ERROR 42000: Incorrect column name 'DB_TRX_ID'
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_ROLL_PTR;
+ERROR 42000: Incorrect column name 'DB_ROLL_PTR'
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1;
+# Scenario 8: Rename SET and ENUM type columns
+CREATE TABLE tenum (c1 INT, c2 ENUM('a','b'));
+INSERT INTO tenum VALUES (1, 'a');
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE tenum RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+ALTER TABLE tenum CHANGE c22 c2 ENUM ('a','b','c'), ALGORITHM=INSTANT;
+ALTER TABLE tenum CHANGE c2 c22 ENUM ('a','b'), ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tenum;
+CREATE TABLE tset (c1 INT, c2 SET('a','b'));
+INSERT INTO tset VALUES (1, 'a');
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE tset RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+ALTER TABLE tset CHANGE c22 c2 SET ('a','b','c'), ALGORITHM=INSTANT;
+ALTER TABLE tset CHANGE c2 c22 SET ('a','b'), ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tset;
+# Scenario 9: CHANGE column cannot use INSTANT algorithm if
+# it involves definition change
+CREATE TABLE tchange (c1 INT, c2 INT);
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE tchange CHANGE c2 c2 DOUBLE, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE tchange CHANGE c2 c2 DOUBLE, ALGORITHM=INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+ALTER TABLE tchange CHANGE c2 c22 DOUBLE, ALGORITHM=COPY;
+SHOW CREATE TABLE tchange;
+Table	Create Table
+tchange	CREATE TABLE `tchange` (
+  `c1` int DEFAULT NULL,
+  `c22` double DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE tchange CHANGE c22 c2 DOUBLE, ALGORITHM=INSTANT;
+SHOW CREATE TABLE tchange;
+Table	Create Table
+tchange	CREATE TABLE `tchange` (
+  `c1` int DEFAULT NULL,
+  `c2` double DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tchange;
+# Scenario 10: INSTANT RENAME WITH INSTANT ADD
+Create table t1 (c1 int KEY, c2 int, c3 int, c4 int);
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c2	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+SET SESSION wsrep_OSU_method=NBO;
+alter table t1 add column c5 int , rename column c2 to c22, algorithm=instant;
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c22	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+c5	int	YES		NULL	
+alter table t1 add column v1 int as (c1+1), add column v2 int as (c1+2) virtual, rename column c3 to c33, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: INPLACE ADD or DROP of virtual columns cannot be combined with other ALTER TABLE actions. Try ALGORITHM=COPY/INPLACE.
+alter table t1 add column v1 int as (c1+1), add column v2 int as (c1+2) virtual, algorithm=instant;
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c22	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+c5	int	YES		NULL	
+v1	int	YES		NULL	VIRTUAL GENERATED
+v2	int	YES		NULL	VIRTUAL GENERATED
+alter table t1 drop column v1, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+alter table t1 drop column v2, algorithm=instant;
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c22	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+c5	int	YES		NULL	
+v1	int	YES		NULL	VIRTUAL GENERATED
+alter table t1 drop column v1, rename column c22 to c222, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: INPLACE ADD or DROP of virtual columns cannot be combined with other ALTER TABLE actions. Try ALGORITHM=COPY/INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1;
+SET SESSION wsrep_OSU_method=TOI;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t RENAME INDEX i1 TO GEN_CLUST_INDEX;
+ERROR 42000: Incorrect index name 'GEN_CLUST_INDEX'
+ALTER TABLE t RENAME INDEX i1 TO i1;
+ALTER TABLE t RENAME INDEX aa TO aa;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+# combination: aaaa
+ALTER TABLE t ADD INDEX i4(f), DROP INDEX i4, RENAME INDEX i4 TO i4;
+ERROR 42000: Key 'i4' doesn't exist in table 't'
+# combination: aabb
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX i2 TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX bb TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX bb TO bb;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i2 TO i2;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	f
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	f
+i1	f,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abcc
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX cc TO cc;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX i3 TO i3;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO cc;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO i3;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `aa` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	aa	f
+test/t	i1	b
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+aa	f
+aa	f,a
+i1	b
+i1	b,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abaa
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i1, RENAME INDEX aa TO aa;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i1 TO i1;
+ERROR 42000: Duplicate key name 'i1'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX i1 TO i1;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX aa TO aa;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+# combination: baaa
+ALTER TABLE t ADD INDEX i2(f), DROP INDEX i1, RENAME INDEX i1 TO i1;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX bb(f), DROP INDEX i1, RENAME INDEX i1 TO i1;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i2(f), DROP INDEX aa, RENAME INDEX aa TO aa;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX bb(f), DROP INDEX aa, RENAME INDEX aa TO aa;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX aa TO bb;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX bb TO aa;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX i2 TO aa;
+ERROR 42000: Duplicate key name 'aa'
+ALTER TABLE t ADD INDEX i1(f), RENAME INDEX i1 TO bb;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `bb` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	bb	b
+test/t	i1	f
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+bb	b
+bb	b,a
+i1	f
+i1	f,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abba
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i2 TO i1;
+ERROR 42000: Key 'i2' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i2 TO aa;
+ERROR 42000: Key 'i2' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX bb TO i1;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX bb TO aa;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+# combination: cabc
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i2 TO i3;
+ERROR 42000: Duplicate key name 'i3'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i2 TO i3;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX bb TO i3;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX bb TO i3;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX i2 TO cc;
+ERROR 42000: Duplicate key name 'cc'
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX i2 TO cc;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX bb TO cc;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX bb TO cc;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t DROP INDEX i1, RENAME INDEX i1 TO bb;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t DROP INDEX aa, RENAME INDEX i2 TO aa;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t DROP INDEX aa, RENAME INDEX aa TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t DROP INDEX i1, RENAME INDEX i4 TO i1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i1` (`e`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	e
+test/t	i2	c
+test/t	i3	d
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	e
+i1	e,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: accb
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i3 TO i2;
+ERROR 42000: Key 'i3' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i3 TO bb;
+ERROR 42000: Key 'i3' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX cc TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX cc TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX cc TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX cc TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+# combination: aaab
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO i2;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO bb;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO i2;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+# combination: abcd
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX cc TO i4;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX cc TO dd;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO i4;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO dd;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i3 TO i4;
+ERROR 42000: Duplicate key name 'i4'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i3 TO dd;
+ERROR 42000: Duplicate key name 'i1'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO i4;
+ERROR 42000: Duplicate key name 'i4'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO dd;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `dd` (`d`),
+  KEY `i4` (`e`),
+  KEY `aa` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	aa	f
+test/t	dd	d
+test/t	i1	b
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+aa	f
+aa	f,a
+dd	d
+dd	d,a
+i1	b
+i1	b,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abab
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i1 TO i2;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`b`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	f
+test/t	i2	b
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	f
+i1	f,a
+i2	b
+i2	b,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX i1 TO bb;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX aa TO i2;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+# combination: acbc
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX i2 TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX i2 TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX bb TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX bb TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX bb TO i3;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i3, RENAME INDEX bb TO i3;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i2 TO i3;
+ERROR 42000: Duplicate key name 'i1'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i3, RENAME INDEX i2 TO i3;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `i3` (`c`),
+  KEY `i4` (`e`),
+  KEY `aa` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	aa	f
+test/t	i1	b
+test/t	i3	c
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+aa	f
+aa	f,a
+i1	b
+i1	b,a
+i3	c
+i3	c,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: cacb
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX cc TO i2;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX cc TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX cc TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX cc TO bb;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i3 TO i2;
+ERROR 42000: Duplicate key name 'i2'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i3 TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i3 TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i3 TO bb;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`c`),
+  KEY `bb` (`d`),
+  KEY `i4` (`e`),
+  KEY `i3` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	bb	d
+test/t	i2	c
+test/t	i3	f
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+bb	d
+bb	d,a
+i2	c
+i2	c,a
+i3	f
+i3	f,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: ccab
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX i1 TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX i1 TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX aa TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX cc, RENAME INDEX aa TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX cc, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i3, RENAME INDEX i1 TO i2;
+ERROR 42000: Duplicate key name 'i2'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i3, RENAME INDEX i1 TO bb;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `bb` (`b`),
+  KEY `i2` (`c`),
+  KEY `i4` (`e`),
+  KEY `i3` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	bb	b
+test/t	i2	c
+test/t	i3	f
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+bb	b
+bb	b,a
+i2	c
+i2	c,a
+i3	f
+i3	f,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t RENAME INDEX i1 TO x;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `x` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+test/t	x	b
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+x	b
+x	b,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t RENAME INDEX i1 TO i2;
+ERROR 42000: Duplicate key name 'i2'
+ALTER TABLE t RENAME INDEX foo TO i1;
+ERROR 42000: Key 'foo' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i9 (f), RENAME INDEX i1 TO i8;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i8` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i9` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	i8	b
+test/t	i9	f
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+i8	b
+i8	b,a
+i9	f
+i9	f,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO i9;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i9` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	f
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	i9	b
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	f
+i1	f,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+i9	b
+i9	b,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD INDEX foo (f), RENAME INDEX i1 TO foo;
+ERROR 42000: Duplicate key name 'foo'
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO foo, DROP INDEX i1;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO foo, DROP INDEX foo;
+ERROR 42000: Can't DROP 'foo'; check that column/key exists
+ALTER TABLE t ADD INDEX foo (f), RENAME INDEX foo TO bar, DROP INDEX foo;
+ERROR 42000: Can't DROP 'foo'; check that column/key exists
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i2 TO x;
+ERROR 42000: Duplicate key name 'x'
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i1 TO y;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i1 TO x;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	b
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	b
+i1	b,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+c1 INT NOT NULL,
+c2 INT NOT NULL,
+c3 INT,
+c4 INT,
+PRIMARY KEY (c1),
+INDEX i1 (c3),
+INDEX i2 (c4)
+) ENGINE=INNODB;
+INSERT INTO t SET c1=1, c2=2;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t DROP PRIMARY KEY, ADD PRIMARY KEY (c2), RENAME INDEX i1 TO x;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` int DEFAULT NULL,
+  `c4` int DEFAULT NULL,
+  PRIMARY KEY (`c2`),
+  KEY `x` (`c3`),
+  KEY `i2` (`c4`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c4
+test/t	PRIMARY	c2
+test/t	x	c3
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	c2
+i2	c4
+i2	c4,c2
+x	c3
+x	c3,c2
+ALTER TABLE t RENAME INDEX i2 TO y, ROW_FORMAT=REDUNDANT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` int DEFAULT NULL,
+  `c4` int DEFAULT NULL,
+  PRIMARY KEY (`c2`),
+  KEY `x` (`c3`),
+  KEY `y` (`c4`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=REDUNDANT
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	PRIMARY	c2
+test/t	x	c3
+test/t	y	c4
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	c2
+x	c3
+x	c3,c2
+y	c4
+y	c4,c2
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+c1 INT NOT NULL,
+c2 INT,
+c3 INT,
+INDEX i1 (c2),
+INDEX i2 (c3)
+) ENGINE=INNODB;
+INSERT INTO t SET c1=1;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t ADD PRIMARY KEY (c1), RENAME INDEX i1 TO x;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `c1` int NOT NULL,
+  `c2` int DEFAULT NULL,
+  `c3` int DEFAULT NULL,
+  PRIMARY KEY (`c1`),
+  KEY `x` (`c2`),
+  KEY `i2` (`c3`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c3
+test/t	PRIMARY	c1
+test/t	x	c2
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	c1
+i2	c3
+i2	c3,c1
+x	c2
+x	c2,c1
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (a INT, INDEX iiiii (a)) ENGINE=INNODB;
+INSERT INTO t SET a=NULL;
+SET SESSION wsrep_OSU_method=NBO;
+ALTER TABLE t RENAME INDEX iiiii TO i;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t RENAME INDEX i TO iiiii;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t RENAME INDEX iiiii TO i;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t RENAME INDEX i TO iiiii;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+# Scenario 1 : Rename a column
+SET SESSION wsrep_OSU_method=TOI;
+CREATE TABLE t1 (c1 INT, c2 INT, c3 INT AS (c1 + 10) VIRTUAL);
+INSERT INTO t1(c1, c2) VALUES (1,11);
+INSERT INTO t1(c1, c2) VALUES (2,22);
+INSERT INTO t1(c1, c2) VALUES (3,33);
+INSERT INTO t1(c1, c2) VALUES (4,44);
+INSERT INTO t1(c1, c2) VALUES (5,55);
+SELECT * FROM t1;
+c1	c2	c3
+1	11	11
+2	22	12
+3	33	13
+4	44	14
+5	55	15
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t1 RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+SELECT * FROM t1;
+c1	c22	c3
+1	11	11
+2	22	12
+3	33	13
+4	44	14
+5	55	15
+SET SESSION wsrep_OSU_method=TOI;
+CREATE TABLE tpart (c1 INT, c2 INT, c3 INT AS (c1 + 10) VIRTUAL)
+PARTITION BY RANGE (c1) (
+PARTITION tpart1 VALUES LESS THAN (10),
+PARTITION tpart2 VALUES LESS THAN (100));
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE tpart RENAME COLUMN c1 TO c22, ALGORITHM=INSTANT;
+ERROR HY000: Column 'c1' has a generated column dependency.
+ALTER TABLE tpart RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+# Scenario 2 : Rename an INSTANT ADD column
+ALTER TABLE t1 ADD COLUMN c4 INT, ALGORITHM=INSTANT;
+ALTER TABLE t1 RENAME COLUMN c4 to c44, ALGORITHM=INSTANT;
+SELECT * FROM t1;
+c1	c22	c3	c44
+1	11	11	NULL
+2	22	12	NULL
+3	33	13	NULL
+4	44	14	NULL
+5	55	15	NULL
+ALTER TABLE tpart ADD COLUMN c4 INT, ALGORITHM=INSTANT;
+ALTER TABLE tpart RENAME COLUMN c4 TO c44, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c3	c44
+# Scenario 3 : Rename a VIRTUAL column
+ALTER TABLE t1 CHANGE c3 c33 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, algorithm=instant;
+SELECT * FROM t1;
+c1	c22	c33	c44
+1	11	11	NULL
+2	22	12	NULL
+3	33	13	NULL
+4	44	14	NULL
+5	55	15	NULL
+ALTER TABLE tpart CHANGE c3 c33 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c33	c44
+# Scenario 4 : Rename an INSTANT ADD VIRTUAL column
+ALTER TABLE t1 add COLUMN (c5 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL), ALGORITHM=INSTANT;
+SELECT * FROM t1;
+c1	c22	c33	c44	c5
+1	11	11	NULL	11
+2	22	12	NULL	12
+3	33	13	NULL	13
+4	44	14	NULL	14
+5	55	15	NULL	15
+ALTER TABLE t1 change c5 c55 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, algorithm=instant;
+SELECT * FROM t1;
+c1	c22	c33	c44	c55
+1	11	11	NULL	11
+2	22	12	NULL	12
+3	33	13	NULL	13
+4	44	14	NULL	14
+5	55	15	NULL	15
+ALTER TABLE tpart ADD COLUMN (c5 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL), ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c33	c44	c5
+ALTER TABLE tpart CHANGE c5 c55 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+c1	c22	c33	c44	c55
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1;
+DROP TABLE tpart;
+# Scenario 5 : Try to rename a column which is referenced in other table
+CREATE TABLE t1 (c1 INT PRIMARY KEY, c2 INT, c3 INT,  INDEX(c2));
+CREATE TABLE t1c (c1 INT PRIMARY KEY, c2 INT,
+CONSTRAINT t1c1 FOREIGN KEY (c2) REFERENCES t1(c2));
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t1 CHANGE c2 c22 INT, algorithm=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Columns participating in a foreign key are renamed. Try ALGORITHM=INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1c;
+DROP TABLE t1;
+# Scenario 6: Try to change the column name in a table with discarded tablespace
+CREATE TABLE t1 (c1 int, c2 INT as (c1+1) VIRTUAL);
+SELECT TABLE_ID INTO @old_tid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%t1%";
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t1 DISCARD TABLESPACE;
+SELECT TABLE_ID INTO @new_tid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%t1%";
+SELECT (@old_tid != @new_tid) as Table_Id_Changed;
+Table_Id_Changed
+1
+ALTER TABLE t1 RENAME COLUMN c2 to c3, algorithm=instant;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't1'
+ALTER TABLE t1 RENAME COLUMN c3 to c2, algorithm=instant;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't1'
+SET SESSION wsrep_OSU_method=TOI;
+Drop TABLE t1;
+CREATE TABLE tpart (c1 INT, c2 INT AS (c1 + 1) VIRTUAL)
+PARTITION BY RANGE(c1) (
+PARTITION p1 VALUES LESS THAN (10),
+PARTITION p2 VALUES LESS THAN (100));
+SELECT max(TABLE_ID) INTO @old_tpid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%tpart%";
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE tpart DISCARD TABLESPACE;
+SELECT max(TABLE_ID) INTO @new_tpid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%tpart%";
+SELECT (@old_tpid != @new_tpid) AS Table_Id_Changed;
+Table_Id_Changed
+1
+ALTER TABLE tpart RENAME COLUMN c2 TO c3, ALGORITHM=INSTANT;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+ALTER TABLE tpart RENAME COLUMN c3 TO c2, ALGORITHM=INSTANT;
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+Warning	1814	InnoDB: Tablespace has been discarded for table 'tpart'
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tpart;
+# Scenario 7: Try to rename a column to an internal column name
+CREATE TABLE t1 (c1 INT, c2 INT);
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_ROW_ID;
+ERROR 42000: Incorrect column name 'DB_ROW_ID'
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_TRX_ID;
+ERROR 42000: Incorrect column name 'DB_TRX_ID'
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_ROLL_PTR;
+ERROR 42000: Incorrect column name 'DB_ROLL_PTR'
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1;
+# Scenario 8: Rename SET and ENUM type columns
+CREATE TABLE tenum (c1 INT, c2 ENUM('a','b'));
+INSERT INTO tenum VALUES (1, 'a');
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE tenum RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+ALTER TABLE tenum CHANGE c22 c2 ENUM ('a','b','c'), ALGORITHM=INSTANT;
+ALTER TABLE tenum CHANGE c2 c22 ENUM ('a','b'), ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tenum;
+CREATE TABLE tset (c1 INT, c2 SET('a','b'));
+INSERT INTO tset VALUES (1, 'a');
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE tset RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+ALTER TABLE tset CHANGE c22 c2 SET ('a','b','c'), ALGORITHM=INSTANT;
+ALTER TABLE tset CHANGE c2 c22 SET ('a','b'), ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tset;
+# Scenario 9: CHANGE column cannot use INSTANT algorithm if
+# it involves definition change
+CREATE TABLE tchange (c1 INT, c2 INT);
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE tchange CHANGE c2 c2 DOUBLE, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE tchange CHANGE c2 c2 DOUBLE, ALGORITHM=INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.
+ALTER TABLE tchange CHANGE c2 c22 DOUBLE, ALGORITHM=COPY;
+SHOW CREATE TABLE tchange;
+Table	Create Table
+tchange	CREATE TABLE `tchange` (
+  `c1` int DEFAULT NULL,
+  `c22` double DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE tchange CHANGE c22 c2 DOUBLE, ALGORITHM=INSTANT;
+SHOW CREATE TABLE tchange;
+Table	Create Table
+tchange	CREATE TABLE `tchange` (
+  `c1` int DEFAULT NULL,
+  `c2` double DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE tchange;
+# Scenario 10: INSTANT RENAME WITH INSTANT ADD
+Create table t1 (c1 int KEY, c2 int, c3 int, c4 int);
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c2	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+SET SESSION wsrep_OSU_method=TOI;
+alter table t1 add column c5 int , rename column c2 to c22, algorithm=instant;
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c22	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+c5	int	YES		NULL	
+alter table t1 add column v1 int as (c1+1), add column v2 int as (c1+2) virtual, rename column c3 to c33, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: INPLACE ADD or DROP of virtual columns cannot be combined with other ALTER TABLE actions. Try ALGORITHM=COPY/INPLACE.
+alter table t1 add column v1 int as (c1+1), add column v2 int as (c1+2) virtual, algorithm=instant;
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c22	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+c5	int	YES		NULL	
+v1	int	YES		NULL	VIRTUAL GENERATED
+v2	int	YES		NULL	VIRTUAL GENERATED
+alter table t1 drop column v1, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=COPY/INPLACE.
+alter table t1 drop column v2, algorithm=instant;
+desc t1;
+Field	Type	Null	Key	Default	Extra
+c1	int	NO	PRI	NULL	
+c22	int	YES		NULL	
+c3	int	YES		NULL	
+c4	int	YES		NULL	
+c5	int	YES		NULL	
+v1	int	YES		NULL	VIRTUAL GENERATED
+alter table t1 drop column v1, rename column c22 to c222, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: INPLACE ADD or DROP of virtual columns cannot be combined with other ALTER TABLE actions. Try ALGORITHM=COPY/INPLACE.
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t1;
+SET SESSION wsrep_OSU_method=TOI;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t RENAME INDEX i1 TO GEN_CLUST_INDEX;
+ERROR 42000: Incorrect index name 'GEN_CLUST_INDEX'
+ALTER TABLE t RENAME INDEX i1 TO i1;
+ALTER TABLE t RENAME INDEX aa TO aa;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+# combination: aaaa
+ALTER TABLE t ADD INDEX i4(f), DROP INDEX i4, RENAME INDEX i4 TO i4;
+ERROR 42000: Key 'i4' doesn't exist in table 't'
+# combination: aabb
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX i2 TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX bb TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX bb TO bb;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i2 TO i2;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	f
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	f
+i1	f,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abcc
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX cc TO cc;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX i3 TO i3;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO cc;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO i3;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `aa` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	aa	f
+test/t	i1	b
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+aa	f
+aa	f,a
+i1	b
+i1	b,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abaa
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i1, RENAME INDEX aa TO aa;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i1 TO i1;
+ERROR 42000: Duplicate key name 'i1'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX i1 TO i1;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX aa TO aa;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+# combination: baaa
+ALTER TABLE t ADD INDEX i2(f), DROP INDEX i1, RENAME INDEX i1 TO i1;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX bb(f), DROP INDEX i1, RENAME INDEX i1 TO i1;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i2(f), DROP INDEX aa, RENAME INDEX aa TO aa;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX bb(f), DROP INDEX aa, RENAME INDEX aa TO aa;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX aa TO bb;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX bb TO aa;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX i2 TO aa;
+ERROR 42000: Duplicate key name 'aa'
+ALTER TABLE t ADD INDEX i1(f), RENAME INDEX i1 TO bb;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `bb` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	bb	b
+test/t	i1	f
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+bb	b
+bb	b,a
+i1	f
+i1	f,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abba
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i2 TO i1;
+ERROR 42000: Key 'i2' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i2 TO aa;
+ERROR 42000: Key 'i2' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX bb TO i1;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX bb TO aa;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+# combination: cabc
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i2 TO i3;
+ERROR 42000: Duplicate key name 'i3'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i2 TO i3;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX bb TO i3;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX bb TO i3;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX i2 TO cc;
+ERROR 42000: Duplicate key name 'cc'
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX i2 TO cc;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX bb TO cc;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX bb TO cc;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t DROP INDEX i1, RENAME INDEX i1 TO bb;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t DROP INDEX aa, RENAME INDEX i2 TO aa;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t DROP INDEX aa, RENAME INDEX aa TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t DROP INDEX i1, RENAME INDEX i4 TO i1;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i1` (`e`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	e
+test/t	i2	c
+test/t	i3	d
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	e
+i1	e,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: accb
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i3 TO i2;
+ERROR 42000: Key 'i3' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i3 TO bb;
+ERROR 42000: Key 'i3' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX cc TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX cc TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX cc TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX cc TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+# combination: aaab
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO i2;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO bb;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO i2;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+# combination: abcd
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX cc TO i4;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX cc TO dd;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO i4;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO dd;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i3 TO i4;
+ERROR 42000: Duplicate key name 'i4'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i3 TO dd;
+ERROR 42000: Duplicate key name 'i1'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO i4;
+ERROR 42000: Duplicate key name 'i4'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO dd;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `dd` (`d`),
+  KEY `i4` (`e`),
+  KEY `aa` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	aa	f
+test/t	dd	d
+test/t	i1	b
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+aa	f
+aa	f,a
+dd	d
+dd	d,a
+i1	b
+i1	b,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: abab
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i1 TO i2;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`b`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	f
+test/t	i2	b
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	f
+i1	f,a
+i2	b
+i2	b,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX i1 TO bb;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX aa TO i2;
+ERROR 42000: Key 'aa' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'bb'; check that column/key exists
+# combination: acbc
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX i2 TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX i2 TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX bb TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX bb TO cc;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX bb TO i3;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i3, RENAME INDEX bb TO i3;
+ERROR 42000: Key 'bb' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i2 TO i3;
+ERROR 42000: Duplicate key name 'i1'
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i3, RENAME INDEX i2 TO i3;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `i3` (`c`),
+  KEY `i4` (`e`),
+  KEY `aa` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	aa	f
+test/t	i1	b
+test/t	i3	c
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+aa	f
+aa	f,a
+i1	b
+i1	b,a
+i3	c
+i3	c,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: cacb
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX cc TO i2;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX cc TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX cc TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX cc TO bb;
+ERROR 42000: Key 'cc' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i3 TO i2;
+ERROR 42000: Duplicate key name 'i2'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i3 TO i2;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i3 TO bb;
+ERROR 42000: Can't DROP 'aa'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i3 TO bb;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i2` (`c`),
+  KEY `bb` (`d`),
+  KEY `i4` (`e`),
+  KEY `i3` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	bb	d
+test/t	i2	c
+test/t	i3	f
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+bb	d
+bb	d,a
+i2	c
+i2	c,a
+i3	f
+i3	f,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+# combination: ccab
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX i1 TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX i1 TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX aa TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX cc, RENAME INDEX aa TO i2;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX cc, RENAME INDEX aa TO bb;
+ERROR 42000: Can't DROP 'cc'; check that column/key exists
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i3, RENAME INDEX i1 TO i2;
+ERROR 42000: Duplicate key name 'i2'
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i3, RENAME INDEX i1 TO bb;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `bb` (`b`),
+  KEY `i2` (`c`),
+  KEY `i4` (`e`),
+  KEY `i3` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	bb	b
+test/t	i2	c
+test/t	i3	f
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+bb	b
+bb	b,a
+i2	c
+i2	c,a
+i3	f
+i3	f,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t RENAME INDEX i1 TO x;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `x` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+test/t	x	b
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+x	b
+x	b,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t RENAME INDEX i1 TO i2;
+ERROR 42000: Duplicate key name 'i2'
+ALTER TABLE t RENAME INDEX foo TO i1;
+ERROR 42000: Key 'foo' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i9 (f), RENAME INDEX i1 TO i8;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i8` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i9` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	i8	b
+test/t	i9	f
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+i8	b
+i8	b,a
+i9	f
+i9	f,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO i9;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i9` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`),
+  KEY `i1` (`f`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	f
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	i9	b
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	f
+i1	f,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+i9	b
+i9	b,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT,
+d INT,
+e INT,
+f INT,
+PRIMARY KEY (a),
+INDEX i1 (b),
+INDEX i2 (c),
+INDEX i3 (d),
+INDEX i4 (e)
+) ENGINE=INNODB;
+INSERT INTO t SET a = 1;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD INDEX foo (f), RENAME INDEX i1 TO foo;
+ERROR 42000: Duplicate key name 'foo'
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO foo, DROP INDEX i1;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO foo, DROP INDEX foo;
+ERROR 42000: Can't DROP 'foo'; check that column/key exists
+ALTER TABLE t ADD INDEX foo (f), RENAME INDEX foo TO bar, DROP INDEX foo;
+ERROR 42000: Can't DROP 'foo'; check that column/key exists
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i2 TO x;
+ERROR 42000: Duplicate key name 'x'
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i1 TO y;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i1 TO x;
+ERROR 42000: Key 'i1' doesn't exist in table 't'
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
+  `c` int DEFAULT NULL,
+  `d` int DEFAULT NULL,
+  `e` int DEFAULT NULL,
+  `f` int DEFAULT NULL,
+  PRIMARY KEY (`a`),
+  KEY `i1` (`b`),
+  KEY `i2` (`c`),
+  KEY `i3` (`d`),
+  KEY `i4` (`e`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i1	b
+test/t	i2	c
+test/t	i3	d
+test/t	i4	e
+test/t	PRIMARY	a
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	a
+i1	b
+i1	b,a
+i2	c
+i2	c,a
+i3	d
+i3	d,a
+i4	e
+i4	e,a
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+c1 INT NOT NULL,
+c2 INT NOT NULL,
+c3 INT,
+c4 INT,
+PRIMARY KEY (c1),
+INDEX i1 (c3),
+INDEX i2 (c4)
+) ENGINE=INNODB;
+INSERT INTO t SET c1=1, c2=2;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t DROP PRIMARY KEY, ADD PRIMARY KEY (c2), RENAME INDEX i1 TO x;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` int DEFAULT NULL,
+  `c4` int DEFAULT NULL,
+  PRIMARY KEY (`c2`),
+  KEY `x` (`c3`),
+  KEY `i2` (`c4`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c4
+test/t	PRIMARY	c2
+test/t	x	c3
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	c2
+i2	c4
+i2	c4,c2
+x	c3
+x	c3,c2
+ALTER TABLE t RENAME INDEX i2 TO y, ROW_FORMAT=REDUNDANT;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `c1` int NOT NULL,
+  `c2` int NOT NULL,
+  `c3` int DEFAULT NULL,
+  `c4` int DEFAULT NULL,
+  PRIMARY KEY (`c2`),
+  KEY `x` (`c3`),
+  KEY `y` (`c4`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=REDUNDANT
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	PRIMARY	c2
+test/t	x	c3
+test/t	y	c4
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	c2
+x	c3
+x	c3,c2
+y	c4
+y	c4,c2
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (
+c1 INT NOT NULL,
+c2 INT,
+c3 INT,
+INDEX i1 (c2),
+INDEX i2 (c3)
+) ENGINE=INNODB;
+INSERT INTO t SET c1=1;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t ADD PRIMARY KEY (c1), RENAME INDEX i1 TO x;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `c1` int NOT NULL,
+  `c2` int DEFAULT NULL,
+  `c3` int DEFAULT NULL,
+  PRIMARY KEY (`c1`),
+  KEY `x` (`c2`),
+  KEY `i2` (`c3`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+table_name	index_name	column_name
+test/t	i2	c3
+test/t	PRIMARY	c1
+test/t	x	c2
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+index_name	stat_description
+PRIMARY	c1
+i2	c3
+i2	c3,c1
+x	c2
+x	c2,c1
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CREATE TABLE t (a INT, INDEX iiiii (a)) ENGINE=INNODB;
+INSERT INTO t SET a=NULL;
+SET SESSION wsrep_OSU_method=TOI;
+ALTER TABLE t RENAME INDEX iiiii TO i;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t RENAME INDEX i TO iiiii;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t RENAME INDEX iiiii TO i;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+ALTER TABLE t RENAME INDEX i TO iiiii;
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+SET SESSION wsrep_OSU_method=TOI;
+DROP TABLE t;
+CALL mtr.add_suppression("While running PXC node in cluster mode it will skip binlogging of non-replicating DDL statement");
+CALL mtr.add_suppression("Column 'c1' has a generated column dependency.");
+CALL mtr.add_suppression("Incorrect column name");
+CALL mtr.add_suppression("ALGORITHM=INSTANT is not supported");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported");
+CALL mtr.add_suppression("Query apply failed");
+CALL mtr.add_suppression("Incorrect index name");
+CALL mtr.add_suppression("Key .* doesn't exist in table");
+CALL mtr.add_suppression("Can't DROP '.*'; check that column/key exists");
+CALL mtr.add_suppression("Duplicate key name");
+SET SESSION WSREP_OSU_METHOD=default;

--- a/mysql-test/suite/galera/t/pxc_alter_table_rename.test
+++ b/mysql-test/suite/galera/t/pxc_alter_table_rename.test
@@ -1,0 +1,78 @@
+--source include/galera_cluster.inc
+
+# Test the basic table rename
+CREATE TABLE t1(i INT PRIMARY KEY);
+
+SET SESSION WSREP_OSU_METHOD=NBO;
+ALTER TABLE t1 RENAME TO t2;
+ALTER TABLE t2 RENAME TO t1;
+ALTER TABLE t1 DISABLE KEYS;
+ALTER TABLE t1 ENABLE KEYS;
+
+ALTER TABLE t1 RENAME TO t2, DISABLE KEYS;
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS;
+ALTER TABLE t1 RENAME TO t2, ENGINE=INNODB;
+--replace_regex /#sql.*$/#sql-XXXXX/
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS, ENGINE=INNODB;
+
+SET SESSION WSREP_OSU_METHOD=default;
+ALTER TABLE t1 RENAME TO t2;
+ALTER TABLE t2 RENAME TO t1;
+ALTER TABLE t1 DISABLE KEYS;
+ALTER TABLE t1 ENABLE KEYS;
+
+ALTER TABLE t1 RENAME TO t2, DISABLE KEYS;
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS;
+ALTER TABLE t1 RENAME TO t2, ENGINE=INNODB;
+--replace_regex /#sql.*$/#sql-XXXXX/
+ALTER TABLE t2 RENAME TO t1, ENABLE KEYS, ENGINE=INNODB;
+DROP TABLE t1;
+
+--write_file $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+  if ($ddl_method == 'TOI') 
+  {
+    SET SESSION wsrep_OSU_method=TOI;
+  }
+  if ($ddl_method == 'NBO') 
+  {
+    SET SESSION wsrep_OSU_method=NBO;
+  }
+EOF
+
+--write_file $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+  SET SESSION wsrep_OSU_method=TOI;
+EOF
+
+# Let's source some innodb tests for better coverage
+--let $ddl_method=NBO
+--source pxc_instant_rename_column.inc
+--source pxc_rename_index.inc
+
+# Let's source some innodb tests for better coverage
+--let $ddl_method=TOI
+--source pxc_instant_rename_column.inc
+--source pxc_rename_index.inc
+
+# Test suppressions
+# Suppressions from pxc_instant_rename_column.inc
+CALL mtr.add_suppression("While running PXC node in cluster mode it will skip binlogging of non-replicating DDL statement");
+
+--connection node_2
+# Suppressions from pxc_instant_rename_column.inc
+CALL mtr.add_suppression("Column 'c1' has a generated column dependency.");
+CALL mtr.add_suppression("Incorrect column name");
+CALL mtr.add_suppression("ALGORITHM=INSTANT is not supported");
+CALL mtr.add_suppression("ALGORITHM=INPLACE is not supported");
+CALL mtr.add_suppression("Query apply failed");
+
+# Suppressions from pxc_rename_index.inc
+CALL mtr.add_suppression("Incorrect index name");
+CALL mtr.add_suppression("Key .* doesn't exist in table");
+CALL mtr.add_suppression("Can't DROP '.*'; check that column/key exists");
+CALL mtr.add_suppression("Duplicate key name");
+
+# Cleanup
+--connection node_1
+SET SESSION WSREP_OSU_METHOD=default;
+--remove_file $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc

--- a/mysql-test/suite/galera/t/pxc_instant_rename_column.inc
+++ b/mysql-test/suite/galera/t/pxc_instant_rename_column.inc
@@ -1,0 +1,217 @@
+#
+# This test has been taken from innodb/t/instant_rename_column.test
+# and modified as per PXC.
+#
+
+
+#############################################
+# Test script to test INSTANT RENAME COLUMN #
+#############################################
+
+--disable_query_log
+call mtr.add_suppression("\\[Warning\\].* Tablespace for table `.*`\\.`.*` is set as discarded");
+call mtr.add_suppression("\\[Warning\\].* Tablespace for table `.*`\\.`.*` /\\* Partition `.*` \\*/ is set as discarded");
+--enable_query_log
+
+--echo # Scenario 1 : Rename a column
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+CREATE TABLE t1 (c1 INT, c2 INT, c3 INT AS (c1 + 10) VIRTUAL);
+INSERT INTO t1(c1, c2) VALUES (1,11);
+INSERT INTO t1(c1, c2) VALUES (2,22);
+INSERT INTO t1(c1, c2) VALUES (3,33);
+INSERT INTO t1(c1, c2) VALUES (4,44);
+INSERT INTO t1(c1, c2) VALUES (5,55);
+SELECT * FROM t1;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+ALTER TABLE t1 RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+SELECT * FROM t1;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+CREATE TABLE tpart (c1 INT, c2 INT, c3 INT AS (c1 + 10) VIRTUAL)
+  PARTITION BY RANGE (c1) (
+    PARTITION tpart1 VALUES LESS THAN (10),
+    PARTITION tpart2 VALUES LESS THAN (100));
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+--error ER_DEPENDENT_BY_GENERATED_COLUMN
+ALTER TABLE tpart RENAME COLUMN c1 TO c22, ALGORITHM=INSTANT;
+
+ALTER TABLE tpart RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+
+--echo # Scenario 2 : Rename an INSTANT ADD column
+ALTER TABLE t1 ADD COLUMN c4 INT, ALGORITHM=INSTANT;
+ALTER TABLE t1 RENAME COLUMN c4 to c44, ALGORITHM=INSTANT;
+SELECT * FROM t1;
+
+ALTER TABLE tpart ADD COLUMN c4 INT, ALGORITHM=INSTANT;
+ALTER TABLE tpart RENAME COLUMN c4 TO c44, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+
+--echo # Scenario 3 : Rename a VIRTUAL column
+ALTER TABLE t1 CHANGE c3 c33 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, algorithm=instant;
+SELECT * FROM t1;
+
+ALTER TABLE tpart CHANGE c3 c33 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+
+--echo # Scenario 4 : Rename an INSTANT ADD VIRTUAL column
+ALTER TABLE t1 add COLUMN (c5 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL), ALGORITHM=INSTANT;
+SELECT * FROM t1;
+ALTER TABLE t1 change c5 c55 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, algorithm=instant;
+SELECT * FROM t1;
+
+ALTER TABLE tpart ADD COLUMN (c5 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL), ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+ALTER TABLE tpart CHANGE c5 c55 INT GENERATED ALWAYS AS (c1 + 10) VIRTUAL, ALGORITHM=INSTANT;
+SELECT * FROM tpart;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t1;
+DROP TABLE tpart;
+
+--echo # Scenario 5 : Try to rename a column which is referenced in other table
+CREATE TABLE t1 (c1 INT PRIMARY KEY, c2 INT, c3 INT,  INDEX(c2));
+CREATE TABLE t1c (c1 INT PRIMARY KEY, c2 INT,
+                  CONSTRAINT t1c1 FOREIGN KEY (c2) REFERENCES t1(c2));
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 CHANGE c2 c22 INT, algorithm=INSTANT;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t1c;
+DROP TABLE t1;
+
+--echo # Scenario 6: Try to change the column name in a table with discarded tablespace
+CREATE TABLE t1 (c1 int, c2 INT as (c1+1) VIRTUAL);
+SELECT TABLE_ID INTO @old_tid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%t1%";
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+ALTER TABLE t1 DISCARD TABLESPACE;
+SELECT TABLE_ID INTO @new_tid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%t1%";
+
+SELECT (@old_tid != @new_tid) as Table_Id_Changed;
+
+ALTER TABLE t1 RENAME COLUMN c2 to c3, algorithm=instant;
+ALTER TABLE t1 RENAME COLUMN c3 to c2, algorithm=instant;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+Drop TABLE t1;
+
+CREATE TABLE tpart (c1 INT, c2 INT AS (c1 + 1) VIRTUAL)
+  PARTITION BY RANGE(c1) (
+    PARTITION p1 VALUES LESS THAN (10),
+    PARTITION p2 VALUES LESS THAN (100));
+
+SELECT max(TABLE_ID) INTO @old_tpid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%tpart%";
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+ALTER TABLE tpart DISCARD TABLESPACE;
+SELECT max(TABLE_ID) INTO @new_tpid FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE NAME LIKE "%tpart%";
+
+SELECT (@old_tpid != @new_tpid) AS Table_Id_Changed;
+
+ALTER TABLE tpart RENAME COLUMN c2 TO c3, ALGORITHM=INSTANT;
+ALTER TABLE tpart RENAME COLUMN c3 TO c2, ALGORITHM=INSTANT;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE tpart;
+
+--echo # Scenario 7: Try to rename a column to an internal column name
+CREATE TABLE t1 (c1 INT, c2 INT);
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+--error ER_WRONG_COLUMN_NAME
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_ROW_ID;
+
+--error ER_WRONG_COLUMN_NAME
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_TRX_ID;
+
+--error ER_WRONG_COLUMN_NAME
+ALTER TABLE t1 RENAME COLUMN c1 TO DB_ROLL_PTR;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t1;
+
+--echo # Scenario 8: Rename SET and ENUM type columns
+CREATE TABLE tenum (c1 INT, c2 ENUM('a','b'));
+INSERT INTO tenum VALUES (1, 'a');
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+ALTER TABLE tenum RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+ALTER TABLE tenum CHANGE c22 c2 ENUM ('a','b','c'), ALGORITHM=INSTANT;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE tenum CHANGE c2 c22 ENUM ('a','b'), ALGORITHM=INSTANT;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE tenum;
+
+CREATE TABLE tset (c1 INT, c2 SET('a','b'));
+INSERT INTO tset VALUES (1, 'a');
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+ALTER TABLE tset RENAME COLUMN c2 TO c22, ALGORITHM=INSTANT;
+ALTER TABLE tset CHANGE c22 c2 SET ('a','b','c'), ALGORITHM=INSTANT;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE tset CHANGE c2 c22 SET ('a','b'), ALGORITHM=INSTANT;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE tset;
+
+--echo # Scenario 9: CHANGE column cannot use INSTANT algorithm if
+--echo # it involves definition change
+CREATE TABLE tchange (c1 INT, c2 INT);
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE tchange CHANGE c2 c2 DOUBLE, ALGORITHM=INSTANT;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE tchange CHANGE c2 c2 DOUBLE, ALGORITHM=INPLACE;
+ALTER TABLE tchange CHANGE c2 c22 DOUBLE, ALGORITHM=COPY;
+SHOW CREATE TABLE tchange;
+ALTER TABLE tchange CHANGE c22 c2 DOUBLE, ALGORITHM=INSTANT;
+SHOW CREATE TABLE tchange;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE tchange;
+
+--echo # Scenario 10: INSTANT RENAME WITH INSTANT ADD
+# [c1, c2, c3, c4]
+Create table t1 (c1 int KEY, c2 int, c3 int, c4 int);
+desc t1;
+# INSTANT ADD column with rename
+# [c1, c2, c3, c4] => [c1, c22, c3, c4, c5]
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+alter table t1 add column c5 int , rename column c2 to c22, algorithm=instant;
+desc t1;
+
+# INSTANT ADD virtual column with rename
+# Not allowed yet.
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t1 add column v1 int as (c1+1), add column v2 int as (c1+2) virtual, rename column c3 to c33, algorithm=instant;
+
+# INSTANT ADD virtual column
+# [c1, c22, c3, c4, c5] => [c1, c22, c3, c4, c5, v1, v2]
+alter table t1 add column v1 int as (c1+1), add column v2 int as (c1+2) virtual, algorithm=instant;
+desc t1;
+
+# INSTANT DROP virtual column
+# Drop virtual column in between. This will change the order of virtual column.
+# Not allowed.
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+alter table t1 drop column v1, algorithm=instant;
+
+# INSTANT DROP virtual column
+# [c1, c22, c3, c4, c5, v1, v2] => [c1, c22, c3, c4, c5, v1]
+alter table t1 drop column v2, algorithm=instant;
+desc t1;
+
+# INSTANT DROP virtual column with rename
+# Not allowed.
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t1 drop column v1, rename column c22 to c222, algorithm=instant;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t1;
+

--- a/mysql-test/suite/galera/t/pxc_rename_index.inc
+++ b/mysql-test/suite/galera/t/pxc_rename_index.inc
@@ -1,0 +1,595 @@
+#
+# This test has been taken from innodb/t/innodb_rename_index.test and modified
+# as per PXC.
+#
+
+#
+# Test "ALTER TABLE ... RENAME INDEX" in InnoDB
+#
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+let create =
+CREATE TABLE t (
+	a INT,
+	b INT,
+	c INT,
+	d INT,
+	e INT,
+	f INT,
+	PRIMARY KEY (a),
+	INDEX i1 (b),
+	INDEX i2 (c),
+	INDEX i3 (d),
+	INDEX i4 (e)
+) ENGINE=INNODB;
+
+let insert = INSERT INTO t SET a = 1;
+
+let show_table =
+SHOW CREATE TABLE t;
+
+let show_sys =
+SELECT
+t.name AS table_name,
+i.name AS index_name,
+f.name AS column_name
+FROM
+information_schema.innodb_tables t,
+information_schema.innodb_indexes i,
+information_schema.innodb_fields f
+WHERE
+t.name LIKE '%/t' AND
+t.table_id = i.table_id AND
+i.index_id = f.index_id
+ORDER BY 1, 2, 3;
+
+let show_stats =
+SELECT index_name, stat_description
+FROM mysql.innodb_index_stats
+WHERE table_name = 't' AND stat_name LIKE 'n_diff%'
+ORDER BY 1, 2;
+
+-- eval $create
+
+# Add a row, so that affected rows would be nonzero for ALGORITHM=COPY.
+# ALGORITHM=INPLACE will report 0 affected row in the result file.
+# We will have enable_info/disable_info around every successful ALTER
+# to enable the affected rows: output in the result file.
+-- eval $insert
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_WRONG_NAME_FOR_INDEX
+ALTER TABLE t RENAME INDEX i1 TO GEN_CLUST_INDEX;
+
+# Test all combinations of ADD w, DROP x, RENAME y TO z.
+#
+# Use the following names for wxyz (with 1 to 4 of wxyz being the same):
+# aaaa abcd aabb abab abba abcc acbc accb cacb cabc ccab aaab aaba abaa baaa
+#
+# Some cases should trivially succeed or fail. Test them in isolation:
+# no-op: y=z (RENAME y TO y)
+# rules out the combinations ..\(.\)\1
+# a.k.a. aaaa aabb abcc abaa baaa
+
+# We use the index names i1 to i4 for existing indexes abcd.
+# Non-existing index names will be aa,bb,cc,dd.
+# Index creation on non-existing columns will not be tested.
+
+ALTER TABLE t RENAME INDEX i1 TO i1;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t RENAME INDEX aa TO aa;
+
+-- echo # combination: aaaa
+# drop/add existing, null rename and drop the same
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i4(f), DROP INDEX i4, RENAME INDEX i4 TO i4;
+
+-- echo # combination: aabb
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX i2 TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX bb TO bb;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX bb TO bb;
+
+-- enable_info
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i2 TO i2;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+-- echo # combination: abcc
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX cc TO cc;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX i3 TO i3;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO cc;
+
+# rename existing (succeeds)
+-- enable_info
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO i3;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+-- echo # combination: abaa
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i1, RENAME INDEX aa TO aa;
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i1 TO i1;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX i1 TO i1;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX aa TO aa;
+
+-- echo # combination: baaa
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i2(f), DROP INDEX i1, RENAME INDEX i1 TO i1;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX bb(f), DROP INDEX i1, RENAME INDEX i1 TO i1;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i2(f), DROP INDEX aa, RENAME INDEX aa TO aa;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX bb(f), DROP INDEX aa, RENAME INDEX aa TO aa;
+
+# refuse: w=z (ADD w, RENAME y TO w)
+# rules out the combinations \(.\)..\1
+# a.k.a. aaaa abba cabc aaba abaa
+# the case w=y (ADD w, RENAME w to z) may succeed, as seen below
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX aa TO bb;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX bb TO aa;
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX aa(f), RENAME INDEX i2 TO aa;
+
+# rename existing, add one with the same name
+-- enable_info
+ALTER TABLE t ADD INDEX i1(f), RENAME INDEX i1 TO bb;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+-- echo # combination: abba
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i2 TO i1;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i2 TO aa;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX bb TO i1;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX bb TO aa;
+
+-- echo # combination: cabc
+
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i2 TO i3;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i2 TO i3;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX bb TO i3;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX bb TO i3;
+
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX i2 TO cc;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX i2 TO cc;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX bb TO cc;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX bb TO cc;
+
+# refuse: x=y (DROP x, RENAME x TO z)
+# rules out the combinations .\(.\)\1.
+# a.k.a. aaaa abba accb aaab baaa
+
+# rename and drop the same
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t DROP INDEX i1, RENAME INDEX i1 TO bb;
+# drop non-existing
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t DROP INDEX aa, RENAME INDEX i2 TO aa;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t DROP INDEX aa, RENAME INDEX aa TO i2;
+
+# this one will succeed (drop, replace with an existing one)
+-- enable_info
+ALTER TABLE t DROP INDEX i1, RENAME INDEX i4 TO i1;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+-- echo # combination: accb
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i3 TO i2;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i3 TO bb;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX cc TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX cc TO bb;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX cc TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX cc TO bb;
+
+-- echo # combination: aaab
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO i2;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO bb;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i1, RENAME INDEX i1 TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX aa, RENAME INDEX aa TO bb;
+
+# Remaining combinations: abcd abab acbc cacb ccab
+
+-- echo # combination: abcd
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX cc TO i4;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX cc TO dd;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO i4;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX cc TO dd;
+
+# add existing, rename to existing
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i3 TO i4;
+# add existing
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i3 TO dd;
+# rename to existing
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO i4;
+
+-- enable_info
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX i3 TO dd;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+-- echo # combination: abab
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- enable_info
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i2, RENAME INDEX i1 TO i2;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX bb, RENAME INDEX i1 TO bb;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i2, RENAME INDEX aa TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX bb, RENAME INDEX aa TO bb;
+
+-- echo # combination: acbc
+
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX i2 TO cc;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX i2 TO cc;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX cc, RENAME INDEX bb TO cc;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX cc, RENAME INDEX bb TO cc;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX bb TO i3;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i3, RENAME INDEX bb TO i3;
+
+# add existing
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX i1(f), DROP INDEX i3, RENAME INDEX i2 TO i3;
+
+-- enable_info
+ALTER TABLE t ADD INDEX aa(f), DROP INDEX i3, RENAME INDEX i2 TO i3;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+-- echo # combination: cacb
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX cc TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX cc TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX aa, RENAME INDEX cc TO bb;
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX i1, RENAME INDEX cc TO bb;
+
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i3 TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i3 TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX aa, RENAME INDEX i3 TO bb;
+
+-- enable_info
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i1, RENAME INDEX i3 TO bb;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+-- echo # combination: ccab
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX i1 TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX i1 TO bb;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX aa TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX cc(f), DROP INDEX cc, RENAME INDEX aa TO bb;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX cc, RENAME INDEX aa TO i2;
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX cc, RENAME INDEX aa TO bb;
+
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i3, RENAME INDEX i1 TO i2;
+
+-- enable_info
+ALTER TABLE t ADD INDEX i3(f), DROP INDEX i3, RENAME INDEX i1 TO bb;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+# A simple successful ALTER
+-- enable_info
+ALTER TABLE t RENAME INDEX i1 TO x;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_DUP_KEYNAME
+ALTER TABLE t RENAME INDEX i1 TO i2;
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t RENAME INDEX foo TO i1;
+
+# Test ADD INDEX, RENAME INDEX
+
+-- enable_info
+ALTER TABLE t ADD INDEX i9 (f), RENAME INDEX i1 TO i8;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- enable_info
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO i9;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+-- eval $create
+-- eval $insert
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- error ER_DUP_KEYNAME
+ALTER TABLE t ADD INDEX foo (f), RENAME INDEX i1 TO foo;
+
+# Test ADD INDEX, RENAME INDEX, DROP INDEX
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO foo, DROP INDEX i1;
+
+-- error ER_CANT_DROP_FIELD_OR_KEY
+ALTER TABLE t ADD INDEX i1 (f), RENAME INDEX i1 TO foo, DROP INDEX foo;
+
+-- error ER_CANT_DROP_FIELD_OR_KEY
+# "ALTER TABLE t ADD INDEX foo (d), DROP INDEX foo;" alone fails with the
+# same error code, but we have that test here anyway
+ALTER TABLE t ADD INDEX foo (f), RENAME INDEX foo TO bar, DROP INDEX foo;
+
+# Test RENAME INDEX, RENAME INDEX
+
+-- error ER_DUP_KEYNAME
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i2 TO x;
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i1 TO y;
+
+-- error ER_KEY_DOES_NOT_EXITS
+ALTER TABLE t RENAME INDEX i1 TO x, RENAME INDEX i1 TO x;
+
+# show that the table did not change after all the erroneous ALTERs
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+
+# now test the rebuild case (new clustered index)
+
+CREATE TABLE t (
+	c1 INT NOT NULL,
+	c2 INT NOT NULL,
+	c3 INT,
+	c4 INT,
+	PRIMARY KEY (c1),
+	INDEX i1 (c3),
+	INDEX i2 (c4)
+) ENGINE=INNODB;
+
+INSERT INTO t SET c1=1, c2=2;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- enable_info
+ALTER TABLE t DROP PRIMARY KEY, ADD PRIMARY KEY (c2), RENAME INDEX i1 TO x;
+-- disable_info
+
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+
+-- enable_info
+ALTER TABLE t RENAME INDEX i2 TO y, ROW_FORMAT=REDUNDANT;
+-- disable_info
+
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+
+# a case where the PK does not exist prior to the ALTER TABLE command
+
+CREATE TABLE t (
+	c1 INT NOT NULL,
+	c2 INT,
+	c3 INT,
+	INDEX i1 (c2),
+	INDEX i2 (c3)
+) ENGINE=INNODB;
+
+INSERT INTO t SET c1=1;
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- enable_info
+ALTER TABLE t ADD PRIMARY KEY (c1), RENAME INDEX i1 TO x;
+-- disable_info
+-- eval $show_table
+-- eval $show_sys
+-- eval $show_stats
+
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+
+# Test repeated RENAMEs with alternating names
+
+CREATE TABLE t (a INT, INDEX iiiii (a)) ENGINE=INNODB;
+INSERT INTO t SET a=NULL;
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_alter.inc
+-- enable_info
+ALTER TABLE t RENAME INDEX iiiii TO i;
+ALTER TABLE t RENAME INDEX i TO iiiii;
+ALTER TABLE t RENAME INDEX iiiii TO i;
+ALTER TABLE t RENAME INDEX i TO iiiii;
+-- disable_info
+--source $MYSQLTEST_VARDIR/tmp/set_osu_method_for_other_ddls.inc
+DROP TABLE t;
+
+# Below is a shell script to generate the full set of ALTER TABLE
+# DROP/ADD/RENAME combinations. The generated .sql file is 3.3MB and
+# executes in about 7 minutes.
+#
+##!/bin/sh
+#
+#create="
+#CREATE TABLE t (
+#        a INT,
+#        b INT,
+#        c INT,
+#        d INT,
+#        PRIMARY KEY (a),
+#        INDEX i1 (b),
+#        INDEX i2 (c)
+#) ENGINE=INNODB;
+#"
+#
+#echo "DROP TABLE IF EXISTS t;"
+#for r in "" ", DROP PRIMARY KEY, ADD PRIMARY KEY (a)" ", ROW_FORMAT=REDUNDANT" ; do
+#    for i1 in i1 i1noexist; do
+#        for i2 in i2 i2noexist; do
+#            for i3 in i3 i3noexist; do
+#                for i4 in i4 i4noexist; do
+#                    for a in $i1 $i2 $i3 $i4; do
+#                        for b in $i1 $i2 $i3 $i4; do
+#                            for c in $i1 $i2 $i3 $i4; do
+#                                for d in $i1 $i2 $i3 $i4; do
+#                                    echo "$create"
+#                                    echo "ALTER TABLE t ADD INDEX $a (d), RENAME INDEX $b TO $c, DROP INDEX $d $r;"
+#                                    echo "DROP TABLE t;"
+#                                done
+#                            done
+#                        done
+#                    done
+#                done
+#            done
+#        done
+#    done
+#done

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -16012,6 +16012,14 @@ static bool simple_rename_or_index_change(
     // It's now safe to take the table level lock.
     if (lock_tables(thd, table_list, alter_ctx->tables_opened, 0)) return true;
 
+#ifdef WITH_WSREP
+    /*
+      Locks are acquired for ALTER TABLE .. ENABLE | DISABLE KEYS
+      It is time to call nbo_phase_one_end().
+    */
+    WSREP_NBO_1ST_PHASE_END;
+#endif /* WITH_WSREP */
+
     if (keys_onoff == Alter_info::ENABLE) {
       DEBUG_SYNC(thd, "alter_table_enable_indexes");
       DBUG_EXECUTE_IF("sleep_alter_enable_indexes", my_sleep(6000000););
@@ -16132,6 +16140,14 @@ static bool simple_rename_or_index_change(
             thd, table_list->db, table_list->table_name, alter_ctx->new_db,
             alter_ctx->new_alias, old_db_type))
       error = -1;
+
+#ifdef WITH_WSREP
+    /*
+      Locks are acquired for ALTER TABLE .. RENAME TO
+      It is time to call nbo_phase_one_end().
+    */
+    WSREP_NBO_1ST_PHASE_END;
+#endif /* WITH_WSREP */
 
     if (!error) {
       if (mysql_rename_table(thd, old_db_type, alter_ctx->db,


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4278

Problem: ALTER TABLE RENAME command asserts with

  In wsrep::client_state::begin_nbo_phase_two()
  Assertion 'toi_mode_ == m_undefined' failed

Solution: Fixed the missing call to end_nbo_phase_one() during the ALTER TABLE RENAME command.