### PR TITLE
PXC-4182: Assertion 'active() == false' failed

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -369,6 +369,8 @@ INSERT INTO global_suppressions VALUES
  (" *down context*"),
  (" Failed to send state UUID:*"),
  ("wsrep_sst_receive_address is set to '127.0.0.1"),
+ ("Failed to guess base node address"),
+ ("Guessing address for incoming client connections failed"),
  ("option --wsrep-causal-reads is deprecated"),
  ("--wsrep-sync-wait=.* takes precedence over --wsrep-causal-reads=OFF"),
  ("--wsrep-causal-reads=ON takes precedence over --wsrep-sync-wait=.*"),

--- a/mysql-test/suite/galera/galera_1node_as_slave.cnf
+++ b/mysql-test/suite/galera/galera_1node_as_slave.cnf
@@ -1,0 +1,62 @@
+#
+# This .cnf file creates a setup with 1 standard MySQL server, followed by a 1-node Galera cluster
+#
+
+# Use default setting for mysqld processes
+!include include/default_mysqld.cnf
+
+[mysqld]
+log-slave-updates
+log-bin=mysqld-bin
+binlog-format=row
+default-storage-engine=InnoDB
+mysqlx=0
+
+ssl-ca=@ENV.MYSQLTEST_VARDIR/std_data/cacert.pem
+ssl-cert=@ENV.MYSQLTEST_VARDIR/std_data/server-cert.pem
+ssl-key=@ENV.MYSQLTEST_VARDIR/std_data/server-key.pem
+
+[mysqld.1]
+server-id=1
+
+[mysqld.2]
+server-id=2
+
+wsrep_provider=@ENV.WSREP_PROVIDER
+wsrep_cluster_address='gcomm://'
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;evs.install_timeout = PT15S; evs.max_install_timeouts=1;pc.ignore_sb=true'
+
+# enforce read-committed characteristics across the cluster
+wsrep_causal_reads=ON
+wsrep_sync_wait = 15
+
+wsrep_node_address=127.0.0.1
+wsrep_sst_receive_address=127.0.0.1:@mysqld.2.#sst_port
+wsrep_node_incoming_address=127.0.0.1:@mysqld.2.port
+
+# Required for Galera
+innodb_autoinc_lock_mode=2
+innodb_flush_log_at_trx_commit=2
+
+log_slave_updates=1
+
+[mysqld.1]
+early_plugin_load=keyring_file.so
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.1/keyring.1
+
+[mysqld.2]
+early_plugin_load=keyring_file.so
+keyring_file_data=@ENV.MYSQL_TMP_DIR/mysqld.2/keyring.2
+
+[sst]
+encrypt=4
+
+[ENV]
+NODE_MYPORT_1= @mysqld.1.port
+NODE_MYSOCK_1= @mysqld.1.socket
+
+NODE_MYPORT_2= @mysqld.2.port
+NODE_MYSOCK_2= @mysqld.2.socket
+
+NODE_GALERAPORT_2= @mysqld.2.#galera_port
+NODE_SSTPORT_2= @mysqld.2.#sst_port

--- a/mysql-test/suite/galera/r/pxc_as_replica_transaction_retry.result
+++ b/mysql-test/suite/galera/r/pxc_as_replica_transaction_retry.result
@@ -1,0 +1,50 @@
+#
+# 1. Setup replication
+# connection node_2
+SET @saved_replica_transaction_retries = @@GLOBAL.replica_transaction_retries;
+SET @saved_innodb_lock_wait_timeout = @@GLOBAL.innodb_lock_wait_timeout;
+SET GLOBAL replica_transaction_retries = 4;
+SET GLOBAL innodb_lock_wait_timeout = 2;
+START REPLICA USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+# connection node_1
+#
+# 2. Setup testing environment.
+#    2.1. Create table on source and insert few rows.
+#    2.2. Setup necessary variables on replica server.
+CREATE TABLE t1(i INT PRIMARY KEY) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(1),(2),(3);
+#
+# 3. Sync the PXC node
+# connection node_2
+#
+# 4. Start a local Transaction on replica to block the DELETE statement
+#    coming through the replication channel. This blocks the applier
+#    thread executing "DELETE FROM t1" from source server.
+# connection node_2
+BEGIN;
+SELECT * FROM t1 FOR UPDATE;
+i
+1
+2
+3
+#
+# 5. Execute transactions on source server that would cause lock conflict
+#    on replica server.
+# connection node_1
+DELETE FROM t1;
+# connection node_2
+ROLLBACK;
+#
+# 6. Cleanup
+# connection node_1
+DROP TABLE t1;
+RESET MASTER;
+# connection node_2
+SET GLOBAL innodb_lock_wait_timeout = @saved_innodb_lock_wait_timeout;
+SET GLOBAL replica_transaction_retries = @saved_replica_transaction_retries;
+include/stop_slave.inc
+RESET REPLICA ALL;
+# Add error supressions.
+CALL mtr.add_suppression("Pending to replicate MySQL GTID event");

--- a/mysql-test/suite/galera/t/pxc_as_replica_transaction_retry.cnf
+++ b/mysql-test/suite/galera/t/pxc_as_replica_transaction_retry.cnf
@@ -1,0 +1,1 @@
+!include ../galera_1node_as_slave.cnf

--- a/mysql-test/suite/galera/t/pxc_as_replica_transaction_retry.test
+++ b/mysql-test/suite/galera/t/pxc_as_replica_transaction_retry.test
@@ -1,0 +1,100 @@
+#
+# This test verifies that PXC node operating as a replica to a MySQL source
+# handles the lock conflict properly and replicated transactions are retried
+# honoring the replica_transaction_retries.
+#
+# The galera/galera_1node_as_slave.cnf describes the setup of the nodes
+
+# As node #1 is not a Galera node, we connect to node #2 in order to run
+# include/galera_cluster.inc
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster_master_slave.inc
+--disconnect node_2a
+
+--echo #
+--echo # 1. Setup replication
+--connection node_2
+--echo # connection node_2
+# Set the innnodb_lock_wait_timeout to a smaller value to make the test fast
+SET @saved_replica_transaction_retries = @@GLOBAL.replica_transaction_retries;
+SET @saved_innodb_lock_wait_timeout = @@GLOBAL.innodb_lock_wait_timeout;
+
+SET GLOBAL replica_transaction_retries = 4;
+SET GLOBAL innodb_lock_wait_timeout = 2;
+
+--disable_query_log
+--eval CHANGE REPLICATION SOURCE TO SOURCE_HOST='127.0.0.1', SOURCE_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START REPLICA USER='root';
+
+--echo # connection node_1
+--connection node_1
+--echo #
+--echo # 2. Setup testing environment.
+--echo #    2.1. Create table on source and insert few rows.
+--echo #    2.2. Setup necessary variables on replica server.
+CREATE TABLE t1(i INT PRIMARY KEY) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(1),(2),(3);
+
+--echo #
+--echo # 3. Sync the PXC node
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*)=3 FROM t1;
+--source include/wait_condition.inc
+
+--echo #
+--echo # 4. Start a local Transaction on replica to block the DELETE statement
+--echo #    coming through the replication channel. This blocks the applier
+--echo #    thread executing "DELETE FROM t1" from source server.
+
+--echo # connection node_2
+--connection node_2
+BEGIN;
+SELECT * FROM t1 FOR UPDATE;
+
+--echo #
+--echo # 5. Execute transactions on source server that would cause lock conflict
+--echo #    on replica server.
+--echo # connection node_1
+--connection node_1
+DELETE FROM t1;
+
+# Wait till DELETE statement to start applying
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT count(*) = 1 FROM information_schema.processlist WHERE STATE = "Applying batch of row changes (delete)";
+--source include/wait_condition.inc
+
+# Wait for a little more duration than the innodb_lock_wait_timeout to ensure that
+# transaction retry is performed by the applier thread
+--sleep 4
+
+# Resume the DELETE statement from source by rolling back the local transaction
+ROLLBACK;
+
+# Wait for the DELETE statement to be applied
+--let $wait_condition = SELECT COUNT(*)=0 FROM t1;
+--source include/wait_condition.inc
+
+--echo #
+--echo # 6. Cleanup
+--echo # connection node_1
+--connection node_1
+DROP TABLE t1;
+RESET MASTER;
+
+--echo # connection node_2
+--connection node_2
+
+# Wait for the table to be dropped.
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+SET GLOBAL innodb_lock_wait_timeout = @saved_innodb_lock_wait_timeout;
+SET GLOBAL replica_transaction_retries = @saved_replica_transaction_retries;
+--source include/stop_slave.inc
+RESET REPLICA ALL;
+
+--echo # Add error supressions.
+CALL mtr.add_suppression("Pending to replicate MySQL GTID event");

--- a/sql/rpl_rli_pdb.cc
+++ b/sql/rpl_rli_pdb.cc
@@ -1890,6 +1890,9 @@ bool Slave_worker::retry_transaction(uint start_relay_number,
       reset_commit_order_deadlock();
       cleaned_up = true;
     }
+#ifdef WITH_WSREP
+    wsrep_after_statement(thd);
+#endif
   };
 
   /* Object of sentry class to perform cleanup */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4182

Problem
-------
When PXC node is operating as an async replica of a MySQL server, cleanup of wsrep context of the applier thread was not being done during the transaction retry of the replicated transaction resulted in the below assertion failure.

   Assertion "active() == false" in wsrep::transaction::start_transaction

Solution
--------
The applier threads now perform cleanup of wsrep context before performing a transaction retry.

Testing Done
Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/144/console