### PR TITLE
PXC-4284: GRANT without existing user leads to disconnected PXC node

### DIFF
--- a/mysql-test/include/galera_connect.inc
+++ b/mysql-test/include/galera_connect.inc
@@ -17,6 +17,9 @@
 # $galera_debug
 #   Print debug information.
 #
+# $galera_use_socket_client_connection
+#   Use socket connection instead of TCP/IP
+#
 
 if (!$galera_connection_name)
 {
@@ -28,18 +31,37 @@ if (!$galera_server_number)
   --die ERROR IN TEST: $galera_server_number must be set before sourcing include/galera_connect.inc
 }
 
---let $_galera_port= \$NODE_MYPORT_$galera_server_number
-if (!$_galera_port)
+
+--let $_galera_port=
+--let $_host=
+if (!$galera_use_socket_client_connection)
 {
-  --echo Bug in test case: '\$NODE_MYPORT_$galera_server_number' not initialized. Check the test's .cfg file.
-  --die Not all NODE_MYPORT_* environment variables are setup correctly.
+  --let $_galera_port= \$NODE_MYPORT_$galera_server_number
+  --let $_host= 127.0.0.1
+  if (!$_galera_port)
+  {
+    --echo Bug in test case: '\$NODE_MYPORT_$galera_server_number' not initialized. Check the test's .cfg file.
+    --die Not all NODE_MYPORT_* environment variables are setup correctly.
+  }
+}
+
+--let $_galera_sock=
+if ($galera_use_socket_client_connection)
+{
+  --let $_galera_sock= \$NODE_MYSOCK_$galera_server_number
+  --let $_host= localhost
+  if (!$_galera_sock)
+  {
+    --echo Bug in test case: '\$NODE_MYSOCK_$galera_server_number' not initialized. Check the test's .cfg file.
+    --die Not all NODE_MYSOCK_* environment variables are setup correctly.
+  }
 }
 
 if ($galera_debug)
 {
-  --echo connect($galera_connection_name,127.0.0.1,root,,test,$_galera_port,)
+  --echo connect($galera_connection_name,$_host,root,,test,$_galera_port,$_galera_sock)
 }
 
 # Open a connection
---connect($galera_connection_name,127.0.0.1,root,,test,$_galera_port,)
+--connect($galera_connection_name,$_host,root,,test,$_galera_port,$_galera_sock)
 

--- a/mysql-test/suite/galera/r/galera_account_management2.result
+++ b/mysql-test/suite/galera/r/galera_account_management2.result
@@ -1,0 +1,26 @@
+CALL mtr.add_suppression("Operation .* failed");
+CALL mtr.add_suppression("You are not allowed to create a user with GRANT");
+CALL mtr.add_suppression("Can't revoke all privileges for one or more of the requested users");
+CALL mtr.add_suppression("There is no such grant defined for user");
+CALL mtr.add_suppression("Operation .* failed");
+CALL mtr.add_suppression("You are not allowed to create a user with GRANT");
+CALL mtr.add_suppression("Can't revoke all privileges for one or more of the requested users");
+CALL mtr.add_suppression("There is no such grant defined for user");
+ALTER USER user1@localhost PASSWORD EXPIRE;
+ERROR HY000: Operation ALTER USER failed for 'user1'@'localhost'
+ALTER USER 'user10@localhost' IDENTIFIED BY 'new_password';
+ERROR HY000: Operation ALTER USER failed for 'user10@localhost'@'%'
+RENAME USER user2@localhost TO user3@localhost;
+ERROR HY000: Operation RENAME USER failed for 'user2'@'localhost'
+SET PASSWORD FOR user3@localhost = 'foo';
+ERROR 42000: Can't find any matching row in the user table
+DROP USER user1@localhost, user3@localhost;
+ERROR HY000: Operation DROP USER failed for 'user1'@'localhost','user3'@'localhost'
+GRANT ALL ON *.* TO user4@localhost;
+ERROR 42000: You are not allowed to create a user with GRANT
+GRANT PROXY ON user4@localhost TO user5@localhost;
+ERROR 42000: You are not allowed to create a user with GRANT
+REVOKE ALL PRIVILEGES ON *.* FROM user4@localhost;
+ERROR HY000: Can't revoke all privileges for one or more of the requested users
+REVOKE PROXY ON user4@localhost FROM user5@localhost;
+ERROR 42000: There is no such grant defined for user 'user5' on host 'localhost'

--- a/mysql-test/suite/galera/t/galera_account_management2-master.opt
+++ b/mysql-test/suite/galera/t/galera_account_management2-master.opt
@@ -1,0 +1,1 @@
+--skip-name-resolve

--- a/mysql-test/suite/galera/t/galera_account_management2.test
+++ b/mysql-test/suite/galera/t/galera_account_management2.test
@@ -1,0 +1,88 @@
+#
+# Test the account management statements - GRANT, REVOKE, etc.
+# when cluster servers are started with --skip-name-resolve option
+# and nonexistent user is used within the query
+#
+
+--let $galera_use_socket_client_connection = 1
+--source include/galera_cluster.inc
+
+--connection node_1
+CALL mtr.add_suppression("Operation .* failed");
+CALL mtr.add_suppression("You are not allowed to create a user with GRANT");
+CALL mtr.add_suppression("Can't revoke all privileges for one or more of the requested users");
+CALL mtr.add_suppression("There is no such grant defined for user");
+
+--connection node_2
+CALL mtr.add_suppression("Operation .* failed");
+CALL mtr.add_suppression("You are not allowed to create a user with GRANT");
+CALL mtr.add_suppression("Can't revoke all privileges for one or more of the requested users");
+CALL mtr.add_suppression("There is no such grant defined for user");
+
+--connection node_1
+
+#
+# ALTER USER
+#
+
+--connection node_1
+--error ER_CANNOT_USER
+ALTER USER user1@localhost PASSWORD EXPIRE;
+
+#
+# ALTER USER IDENTIFIED BY 
+#
+
+--error ER_CANNOT_USER
+ALTER USER 'user10@localhost' IDENTIFIED BY 'new_password';
+
+#
+# RENAME USER
+#
+
+--error ER_CANNOT_USER
+RENAME USER user2@localhost TO user3@localhost;
+
+
+#
+# SET PASSWORD
+#
+
+--error ER_PASSWORD_NO_MATCH
+SET PASSWORD FOR user3@localhost = 'foo';
+
+#
+# DROP USER
+#
+--error ER_CANNOT_USER
+DROP USER user1@localhost, user3@localhost;
+
+#
+# GRANT
+#
+
+--error ER_CANT_CREATE_USER_WITH_GRANT
+GRANT ALL ON *.* TO user4@localhost;
+
+#
+# GRANT PROXY ON
+#
+--error ER_CANT_CREATE_USER_WITH_GRANT
+GRANT PROXY ON user4@localhost TO user5@localhost;
+
+#
+# REVOKE
+#
+
+--error ER_REVOKE_GRANTS
+REVOKE ALL PRIVILEGES ON *.* FROM user4@localhost;
+
+#
+# REVOKE PROXY
+#
+
+--error ER_NONEXISTING_GRANT
+REVOKE PROXY ON user4@localhost FROM user5@localhost;
+
+# Assert that the cluster is still up and running
+--assert(`SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'`)

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -5721,7 +5721,11 @@ bool acl_check_proxy_grant_access(THD *thd, const char *host, const char *user,
              ("user=%s host=%s with_grant=%d", user, host, (int)with_grant));
   assert(initialized);
   /* replication slave thread can do anything */
+#if WITH_WSREP
+  if (thd->slave_thread || thd->wsrep_applier) {
+#else
   if (thd->slave_thread) {
+#endif
     DBUG_PRINT("info", ("replication slave"));
     return false;
   }

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4886,7 +4886,14 @@ int mysql_execute_command(THD *thd, bool first_level) {
       /* Replicate current user as grantor */
       thd->binlog_invoker();
 
+#ifdef WITH_WSREP
+      /* If not replication or wsrep applier thread.
+         We need the below warning for consistency voting protocol
+         to work properly as it may have been issued on source node. */
+      if (thd->security_context()->user().str || thd->wsrep_applier)
+#else
       if (thd->security_context()->user().str)  // If not replication
+#endif
       {
         LEX_USER *user, *tmp_user;
         bool first_user = true;


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4284

Problem:
When GRANT statement related to nonexisting user was executed on server started with --skip-name-resolve option, the node was kicked-off from the cluster by inconsistency voting algorithm.

Cause:
Inconsistency voting uses hashed error messages for voting. In case of --skip-name-resolve additional warning message is added however, it was skipped for applier thread.

Solution:
1. Do not skip --skip-name-resolve part of message for of applier thread
2. Improved MTR scripts. Now it is possible to use socket connections.