### PR TITLE
PXC-4219: Deadlock with concurrent START SLAVE and backup using PXB

### DIFF
--- a/mysql-test/suite/galera/r/pxc_start_replica_during_sst_donate.result
+++ b/mysql-test/suite/galera/r/pxc_start_replica_during_sst_donate.result
@@ -1,0 +1,39 @@
+#
+# 1. Create a two node cluster.
+#
+# 2. Shutdown node2 and remove the grastate.dat file.
+[connection node_2]
+[connection node_1]
+#
+# 3. Execute some transactions on node1 so that node2 forces an SST when it
+#    joins next time.
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+#
+# 4. Add a debug point on node1 to halt just before donating state transfer.
+# Adding debug point 'halt_before_sst_donate' to @@GLOBAL.debug
+#
+# 5. Start node2 in background and wait till node1 stops before donating SST
+#
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC='now wait_for stopped_before_sst_donate';
+# Removing debug point 'halt_before_sst_donate' from @@GLOBAL.debug
+#
+# 6. Configure replication parameters and execute START REPLICA.
+START REPLICA USER='root';
+[connection node_1]
+SET DEBUG_SYNC = "now SIGNAL continue";
+#
+# 7. Shutdown node2 started as a background process and restart
+[connection node_2]
+# restart
+SET SESSION wsrep_sync_wait = 0;
+[connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+#
+# 8. Cleanup
+DROP TABLE t1;
+RESET MASTER;
+RESET REPLICA ALL;

--- a/mysql-test/suite/galera/t/pxc_start_replica_during_sst_donate.test
+++ b/mysql-test/suite/galera/t/pxc_start_replica_during_sst_donate.test
@@ -1,0 +1,112 @@
+# ==== Purpose ====
+#
+# This test verifies that starting async replication while proccessing SST
+# request are handled properly by the server.
+#
+# ==== Implementation ====
+#
+# 1. Create a two node cluster.
+# 2. Shutdown node2 and remove the grastate.dat file.
+# 3. Execute some transactions on node1 so that node2 forces an SST when it
+#    joins next time.
+# 4. Add a debug point on node1 to halt just before donating state transfer.
+# 5. Start node2 in background and wait till node1 stops before donating SST
+# 6. Configure replication parameters and execute START REPLICA.
+# 7. Shutdown node2 started as a background process and restart
+# 8. Cleanup
+#
+# ==== References ====
+#
+# PXC-4219: Deadlock with concurrent START SLAVE and backup using PXB
+#
+
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+--echo #
+--echo # 1. Create a two node cluster.
+--source include/galera_cluster.inc
+
+--echo #
+--echo # 2. Shutdown node2 and remove the grastate.dat file.
+--connection node_2
+--echo [connection node_2]
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# Wait until the cluster size is updated on node1.
+--connection node_1
+--echo [connection node_1]
+--let $wait_condition= SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--echo #
+--echo # 3. Execute some transactions on node1 so that node2 forces an SST when it
+--echo #    joins next time.
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+INSERT INTO t1 VALUES(2);
+
+--echo #
+--echo # 4. Add a debug point on node1 to halt just before donating state transfer.
+--let $debug_point= halt_before_sst_donate
+--source include/add_debug_point.inc
+
+--echo #
+--echo # 5. Start node2 in background and wait till node1 stops before donating SST
+--echo #
+
+--let $PID_FILE= $MYSQLTEST_VARDIR/tmp/node2.pid
+--let $ERROR_LOG_FILE= $MYSQLTEST_VARDIR/tmp/node2.err
+
+--let $command= $MYSQLD
+--let $command_opt=  --defaults-group-suffix=.2 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --log-error=$ERROR_LOG_FILE
+--let $pid_file= $PID_FILE
+--source include/start_proc_in_background.inc
+
+--connection node_1
+--echo [connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC='now wait_for stopped_before_sst_donate';
+--source include/remove_debug_point.inc
+
+--echo #
+--echo # 6. Configure replication parameters and execute START REPLICA.
+--disable_query_log
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+CHANGE REPLICATION SOURCE TO SOURCE_PORT = 1;
+--enable_query_log
+--send START REPLICA USER='root'
+
+--connection node_1
+--echo [connection node_1]
+SET DEBUG_SYNC = "now SIGNAL continue";
+
+--echo #
+--echo # 7. Shutdown node2 started as a background process and restart
+--connection node_2
+--echo [connection node_2]
+--enable_reconnect
+--source include/wait_until_connected_again.inc
+--disable_reconnect
+--source include/restart_mysqld.inc
+--source include/wait_proc_to_finish.inc
+
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition= SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1
+--echo [connection node_1]
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition= SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--echo #
+--echo # 8. Cleanup
+--remove_file $PID_FILE
+--remove_file $ERROR_LOG_FILE
+DROP TABLE t1;
+RESET MASTER;
+RESET REPLICA ALL;

--- a/sql/rpl_replica.cc
+++ b/sql/rpl_replica.cc
@@ -7242,20 +7242,6 @@ wsrep_restart_point :
     goto err;
   }
 
-#ifdef WITH_WSREP
-  /* Initialization of Galera/WSREP and async replication happens in parallel.
-     Allow async replication infrastructure to init up to this point, but
-     wait with applying async-replicated events until WSREP infrastructure
-     is fully initialized (wsrep_ready == true). wsrep_ready is set when
-     server state shifts to s_synced.
-     Before this state, events are rejected with error
-     'WSREP has not yet prepared node for application use' */
-  if (WSREP(thd)) {
-    Wsrep_server_state::instance().wait_until_state(
-        Wsrep_server_state::s_synced);
-  }
-#endif /* WITH_WSREP */
-
   /* MTS: starting the worker pool */
   if (slave_start_workers(rli, rli->opt_replica_parallel_workers,
                           &mts_inited) != 0) {
@@ -7311,6 +7297,20 @@ wsrep_restart_point :
 
   mysql_cond_broadcast(&rli->start_cond);
   mysql_mutex_unlock(&rli->run_lock);
+
+#ifdef WITH_WSREP
+  /* Initialization of Galera/WSREP and async replication happens in parallel.
+     Allow async replication infrastructure to init up to this point, but
+     wait with applying async-replicated events until WSREP infrastructure
+     is fully initialized (wsrep_ready == true). wsrep_ready is set when
+     server state shifts to s_synced.
+     Before this state, events are rejected with error
+     'WSREP has not yet prepared node for application use' */
+  if (WSREP(thd)) {
+    Wsrep_server_state::instance().wait_until_state(
+        Wsrep_server_state::s_synced);
+  }
+#endif /* WITH_WSREP */
 
   DEBUG_SYNC(thd, "after_start_replica");
 

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1591,6 +1591,11 @@ int wsrep_sst_donate(const std::string &msg, const wsrep::gtid &current_gtid,
     if (applier_thd->killed == THD::KILL_CONNECTION) return WSREP_CB_FAILURE;
   }
 #endif
+  DBUG_EXECUTE_IF("halt_before_sst_donate", {
+    const char action[] =
+        "now SIGNAL stopped_before_sst_donate WAIT_FOR continue";
+    assert(!debug_sync_set_action(current_thd, STRING_WITH_LEN(action)));
+  };);
 
   int ret;
   ret = sst_donate_other(method, data, current_gtid, bypass, env());


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4219

Problem
-------
Server could enter into a deadlock when START SLAVE is issued immediately when PXB process starts to take a backup of the server.

Deadlock Summary
----------------
This is a 3 way deadlock

1. SQL thread holding rli->run_lock and is waiting for s_synced inside wait_until_state(). This will return only on successful SST.

   But SST is stuck at waiting for results from log_status query.

2. START SLAVE thread waiting for rli->run_lock(lock_cond_sql) in start_slave_thread() which is held by SQL thread.

3. A query on performance_schema.log_status which triggered by SST is waiting for channel_map_lock->wrlock() but it is held by START SLAVE thread.

i.e,
1. SQL thread

        holds: rli->run_lock acquired at line no 7128 in rpl_replica.cc

        waits for: SST/PXB

2. START SLAVE: holds: 1. mi->run_lock, this was reacquired after starting IO thread, usually released in unlock_slave_threads() in the end of start_slave(). 2. channel_map_lock held in start_slave_cmd() line no 747 in rpl_replica.cc

        waits for: rli->run_lock, held by SQL thread

3. SST/PXB:

        holds: nothing

        waits for: channel_map_lock, held by START SLAVE

Solution
--------
The server now performs galera synchronization (i.e, waits for the server to reach 'Synced' state before applying) after worker threads are started and before the events are read from the relay logs, to ensure that other threads get the required locks necessary for SST.

Testing Done
----
Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/145/console