### PR TITLE
PXC-4238: UDF execution adds Errant GTID (Fixed MTR tests)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_acf_add_delete_managed.result
+++ b/mysql-test/suite/galera/r/pxc_acf_add_delete_managed.result
@@ -1,7 +1,7 @@
 include/group_replication.inc [rpl_server_count=5]
 Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
-Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
 [connection server1]
 
 # 1. Deploy a 1 member group A in single primary mode.
@@ -35,7 +35,7 @@ include/assert.inc ['There is one row in performance_schema.replication_asynchro
 CHANGE REPLICATION SOURCE TO SOURCE_HOST='127.0.0.1', SOURCE_USER='root', SOURCE_AUTO_POSITION=1, SOURCE_CONNECTION_AUTO_FAILOVER=1, SOURCE_PORT=SERVER_1_PORT, SOURCE_CONNECT_RETRY=1, SOURCE_RETRY_COUNT=1 FOR CHANNEL 'ch1';
 Warnings:
 Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
-Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Note	1760	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
 include/start_slave.inc [FOR CHANNEL 'ch1']
 include/assert.inc [Verify channel ch1 IO_THREAD is ON and connected to server1]
 

--- a/mysql-test/suite/galera/r/pxc_async_conn_failover.result
+++ b/mysql-test/suite/galera/r/pxc_async_conn_failover.result
@@ -4,13 +4,13 @@
 include/rpl_init.inc [topology=1->2->3->4]
 Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
-Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
 Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
-Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
 Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
-Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Note	####	Storing MySQL user name or password information in the connection metadata repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START REPLICA; see the 'START REPLICA Syntax' in the MySQL Manual for more information.
 #
 # 2. Insert data on server1 and verify that its synced to the end of
 #    chain i.e. server4

--- a/mysql-test/suite/galera/t/pxc_async_conn_failover.test
+++ b/mysql-test/suite/galera/t/pxc_async_conn_failover.test
@@ -146,8 +146,8 @@ CHANGE REPLICATION SOURCE TO SOURCE_CONNECT_RETRY=1, SOURCE_RETRY_COUNT=2, SOURC
 
 --let $assert_text= Assert that the IO thread tried two times connecting to server_3
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.4.err
---let $assert_select= .*error reconnecting to master 'root@127.0.0.1:$SERVER_MYPORT_3' - retry-time: 1 retries:.*
---let $assert_only_after= CURRENT_TEST: rpl_gtid.rpl_async_conn_failover
+--let $assert_select= .*Error reconnecting to source 'root@127.0.0.1:$SERVER_MYPORT_3'
+--let $assert_only_after= CURRENT_TEST: galera.pxc_async_conn_failover
 --let $assert_count= 2
 --source include/assert_grep.inc
 
@@ -188,8 +188,8 @@ CHANGE REPLICATION SOURCE TO SOURCE_CONNECT_RETRY=1, SOURCE_RETRY_COUNT=2, SOURC
 # Verify that it tried connecting to server_3 two (retry_count=2) times.
 --let $assert_text= Assert that the IO thread tried two times connecting to server_3
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.4.err
---let $assert_select= .*error connecting to master 'root@127.0.0.1:$SERVER_MYPORT_3' - retry-time: 1 retries:.*
---let $assert_only_after= CURRENT_TEST: rpl_gtid.rpl_async_conn_failover
+--let $assert_select= .*Error connecting to source 'root@127.0.0.1:$SERVER_MYPORT_3'
+--let $assert_only_after= CURRENT_TEST: galera.pxc_async_conn_failover
 --let $assert_count= 4
 --source include/assert_grep.inc
 
@@ -234,8 +234,8 @@ INSERT INTO t1 VALUES (2);
 # Verify that it tried connecting to server_2 two (retry_count=2) times.
 --let $assert_text= Assert that the IO thread tried two times connecting to server_2
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.4.err
---let $assert_select= .*error reconnecting to master 'root@127.0.0.1:$SERVER_MYPORT_2' - retry-time: 1 retries:.*
---let $assert_only_after= CURRENT_TEST: rpl_gtid.rpl_async_conn_failover
+--let $assert_select= .*Error reconnecting to source 'root@127.0.0.1:$SERVER_MYPORT_2'
+--let $assert_only_after= CURRENT_TEST: galera.pxc_async_conn_failover
 --let $assert_count= 2
 --source include/assert_grep.inc
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4238

Fixed the test failures of galera.pxc_async_conn_failover and galera.pxc_acf_add_delete_managed.