### PR TITLE
PXC-4271: Upgrade errors from 5.7.42 to 5.7.43

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -2090,7 +2090,7 @@ then
                 wsrep_log_warning "This node's PXC version is $local_version_str. The donor's PXC version is $donor_version_str."
                 wsrep_log_warning "Run mysql_upgrade in non-cluster (standalone mode) to upgrade."
                 wsrep_log_warning "Check the upgrade process here:"
-                wsrep_log_warning "    https://www.percona.com/doc/percona-xtradb-cluster/LATEST/howtos/upgrade_guide.html"
+                wsrep_log_warning "    https://www.percona.com/doc/percona-xtradb-cluster/5.7/howtos/upgrade_guide.html"
             fi
         fi
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4271

Updated web link in the SST message informing of the necessity of additional manual post-upgrade steps to point directly to 5.7 instructions.