### PR TITLE
PXC-4280: Add support for pxb 8.0.34 (ZSTD compression by default)

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2-options.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2-options.cnf
@@ -7,9 +7,10 @@ wsrep_debug=1
 [xtrabackup]
 close-files
 # compact
-# compression requires qpress from the Percona repositories
-# compress
-# compress-threads=2
+# < PXB 8.0.34 compression requires qpress from the Percona repositories
+# >= PXB 8.0.34 zstd is the default compression mechanism
+compress
+compress-threads=2
 galera-info
 history=backup
 parallel=1


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4280

PXB 8.0.34 removed qpress compression and added ZSTD as the default way of compression.

SST script already supports qpress decompression. It is implemented externally to PXB (probably historical reason).
On the other hand, PXB is is able to automatically detect decompression method if called with --decompress option, but next versions of PXB will remove quicklz support.
Having said above, to be compatible with old donors, we need to leave the existing qpress decompression implementation.
New methods of compression will be handled by additional PXB call for automatic decompression. This step is executed always, because in case of not compressed backup, PXB just does nothing.