### PR TITLE
PXC-4302: GRANT statement may be replicated in a wrong way if partial…

### DIFF
--- a/mysql-test/suite/galera/r/galera_account_management3.result
+++ b/mysql-test/suite/galera/r/galera_account_management3.result
@@ -1,0 +1,18 @@
+CREATE ROLE 'reader', 'writer';
+GRANT SELECT ON *.* TO 'reader';
+GRANT INSERT, UPDATE, DELETE ON *.* TO 'writer';
+CREATE USER 'user1'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';
+CREATE USER 'user2'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';
+GRANT ALL PRIVILEGES ON *.* TO 'user1'@'%' WITH GRANT OPTION ;
+GRANT 'reader', 'writer' TO 'user2'@'%';
+GRANT USAGE ON *.* TO 'user2'@'%' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON *.* TO 'user2'@'%' WITH GRANT OPTION ;
+SET ROLE 'writer';
+GRANT ALL PRIVILEGES ON *.* TO 'user1'@'%' WITH GRANT OPTION;
+include/assert_binlog_events.inc [.*GRANT ALL PRIVILEGES ON.*TO 'user2'.* WITH GRANT OPTION AS 'user1'.* WITH ROLE NONE.*]
+include/assert_binlog_events.inc [.*GRANT ALL PRIVILEGES ON.*TO 'user1'.* WITH GRANT OPTION AS 'user2'.* WITH ROLE 'writer'.*]
+include/assert_binlog_events.inc [.*GRANT ALL PRIVILEGES ON.*TO 'user2'.* WITH GRANT OPTION AS 'user1'.* WITH ROLE NONE.*]
+include/assert_binlog_events.inc [.*GRANT ALL PRIVILEGES ON.*TO 'user1'.* WITH GRANT OPTION AS 'user2'.* WITH ROLE 'writer'.*]
+DROP USER 'user1'@'%';
+DROP USER 'user2'@'%';
+DROP ROLE 'reader', 'writer';

--- a/mysql-test/suite/galera/t/galera_account_management3-master.opt
+++ b/mysql-test/suite/galera/t/galera_account_management3-master.opt
@@ -1,0 +1,1 @@
+--partial-revokes=1

--- a/mysql-test/suite/galera/t/galera_account_management3.test
+++ b/mysql-test/suite/galera/t/galera_account_management3.test
@@ -1,0 +1,66 @@
+#
+# Test the account management statements - GRANT, REVOKE with partial_revokes enabled
+#
+
+
+--source include/galera_cluster.inc
+--source include/have_log_bin.inc
+--source include/count_sessions.inc
+
+#
+# CREATE USER
+#
+--connection node_1
+CREATE ROLE 'reader', 'writer';
+GRANT SELECT ON *.* TO 'reader';
+GRANT INSERT, UPDATE, DELETE ON *.* TO 'writer';
+
+CREATE USER 'user1'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';
+CREATE USER 'user2'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';
+
+GRANT ALL PRIVILEGES ON *.* TO 'user1'@'%' WITH GRANT OPTION ;
+GRANT 'reader', 'writer' TO 'user2'@'%';
+GRANT USAGE ON *.* TO 'user2'@'%' WITH GRANT OPTION;
+
+--connect node_1a, 127.0.0.1, user1, passwd, test, $NODE_MYPORT_1
+--connection node_1a
+GRANT ALL PRIVILEGES ON *.* TO 'user2'@'%' WITH GRANT OPTION ;
+--disconnect node_1a
+
+--connect node_1b, 127.0.0.1, user2, passwd, test, $NODE_MYPORT_1
+--connection node_1b
+SET ROLE 'writer';
+GRANT ALL PRIVILEGES ON *.* TO 'user1'@'%' WITH GRANT OPTION;
+
+--let $binlog_file = mysqld-bin.000002
+--let $binlog_position = 2282
+--let $limit = 1
+--let $event_sequence = .*GRANT ALL PRIVILEGES ON.*TO 'user2'.* WITH GRANT OPTION AS 'user1'.* WITH ROLE NONE.*
+--source include/assert_binlog_events.inc
+
+--let $binlog_file = mysqld-bin.000002
+--let $binlog_position = 2547
+--let $limit = 1
+--let $event_sequence = .*GRANT ALL PRIVILEGES ON.*TO 'user1'.* WITH GRANT OPTION AS 'user2'.* WITH ROLE 'writer'.*
+--source include/assert_binlog_events.inc
+
+--disconnect node_1b
+
+--connection node_2
+--let $binlog_file = mysqld-bin.000004
+--let $binlog_position = 2298
+--let $limit = 1
+--let $event_sequence = .*GRANT ALL PRIVILEGES ON.*TO 'user2'.* WITH GRANT OPTION AS 'user1'.* WITH ROLE NONE.*
+--source include/assert_binlog_events.inc
+
+--let $binlog_file = mysqld-bin.000004
+--let $binlog_position = 2565
+--let $limit = 1
+--let $event_sequence = .*GRANT ALL PRIVILEGES ON.*TO 'user1'.* WITH GRANT OPTION AS 'user2'.* WITH ROLE 'writer'.*
+--source include/assert_binlog_events.inc
+
+--connection node_1
+DROP USER 'user1'@'%';
+DROP USER 'user2'@'%';
+DROP ROLE 'reader', 'writer';
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
…_revokes=1

https://jira.percona.com/browse/PXC-4302

Problem:
If partial_revokes is enabled and the user executes on node_1 GRANT statement without explicit AS clause, the binlog on node_2 contains wrong event having "AS 'skip-grants user'@'skip-grants host'" which may break async replication if node_2 is a source node for such a chain.

Cause:
If partial_revokes is enabled, AS clause is not explicitly specified and the GRANT is on global (*.*) level, node_1 rewrites the query just before writing the event into the binlog, adding AS clause with the current user. This causes async replica node to explicitly see AS clause and not doing any rewrite (replica thread works in root user context)

However, we replicate TOI with the query being "as is" before local execution. It triggers the rewrite path on replica node, causing event with wrong AS clause being stored in its binlog.

Solution:
Rewrite query on source node for TOI replication in the same way as it is rewritten before storing into the binlog.