### PR TITLE
PXC-4255: Running ALTER USER/ SET PASSWORD and FLUSH PRIVILEGES stall…

### DIFF
--- a/mysql-test/suite/galera/r/pxc_drop_user.result
+++ b/mysql-test/suite/galera/r/pxc_drop_user.result
@@ -45,13 +45,6 @@ CALL mtr.add_suppression(".*Operation DROP USER failed.*");
 CALL mtr.add_suppression(".*Fail to replicate: DROP USER.*");
 CALL mtr.add_suppression(".*Operation DROP USER failed.*");
 CALL mtr.add_suppression(".*Query apply failed.*");
-CREATE USER 'z'@'localhost' IDENTIFIED BY 'z';
-GRANT ALL ON *.* TO 'z'@'localhost' WITH GRANT OPTION;
-SET DEBUG_SYNC = 'wl14084_after_table_locks SIGNAL after_table_locks.reached WAIT_FOR after_table_locks.continue';
-DROP USER 'z'@'localhost';;
-SET DEBUG_SYNC = 'now WAIT_FOR after_table_locks.reached';
-DROP USER 'z'@'localhost';
-ERROR HY000: Operation DROP USER failed for 'z'@'localhost'
 DROP TABLE t1;
 DROP USER 'x'@'localhost';
 DROP USER 'y'@'localhost';

--- a/mysql-test/suite/galera/r/pxc_drop_user_sr.result
+++ b/mysql-test/suite/galera/r/pxc_drop_user_sr.result
@@ -45,13 +45,6 @@ CALL mtr.add_suppression(".*Operation DROP USER failed.*");
 CALL mtr.add_suppression(".*Fail to replicate: DROP USER.*");
 CALL mtr.add_suppression(".*Operation DROP USER failed.*");
 CALL mtr.add_suppression(".*Query apply failed.*");
-CREATE USER 'z'@'localhost' IDENTIFIED BY 'z';
-GRANT ALL ON *.* TO 'z'@'localhost' WITH GRANT OPTION;
-SET DEBUG_SYNC = 'wl14084_after_table_locks SIGNAL after_table_locks.reached WAIT_FOR after_table_locks.continue';
-DROP USER 'z'@'localhost';;
-SET DEBUG_SYNC = 'now WAIT_FOR after_table_locks.reached';
-DROP USER 'z'@'localhost';
-ERROR HY000: Operation DROP USER failed for 'z'@'localhost'
 DROP TABLE t1;
 DROP USER 'x'@'localhost';
 DROP USER 'y'@'localhost';

--- a/mysql-test/suite/galera/t/mysql-wsrep#216.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#216.test
@@ -47,7 +47,7 @@ call mtr.add_suppression("Query apply failed.*");
 # Five times for the first node, in the various wsrep_debug messages
 --let $assert_text = <secret>
 --let $assert_select = <secret>
---let $assert_count = 11
+--let $assert_count = 9
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_only_after = CURRENT_TEST
 --source include/assert_grep.inc

--- a/mysql-test/suite/galera/t/pxc_drop_user.inc
+++ b/mysql-test/suite/galera/t/pxc_drop_user.inc
@@ -76,35 +76,12 @@ SET PASSWORD FOR 'y'@'localhost' TO RANDOM;
 DROP USER 'utilityuser'@'localhost';
 
 
-#
-# Two nodes interaction
-#
---connection node_1
 CALL mtr.add_suppression(".*Operation DROP USER failed.*");
 CALL mtr.add_suppression(".*Fail to replicate: DROP USER.*");
 
 --connection node_2
 CALL mtr.add_suppression(".*Operation DROP USER failed.*");
 CALL mtr.add_suppression(".*Query apply failed.*");
-
---connection node_1
-CREATE USER 'z'@'localhost' IDENTIFIED BY 'z';
-GRANT ALL ON *.* TO 'z'@'localhost' WITH GRANT OPTION;
-
-# It will be BF aborted so will continue automatically after abortion, but we need to wait anyway
-SET DEBUG_SYNC = 'wl14084_after_table_locks SIGNAL after_table_locks.reached WAIT_FOR after_table_locks.continue';
---send DROP USER 'z'@'localhost';
-
---connection node_1a
-SET DEBUG_SYNC = 'now WAIT_FOR after_table_locks.reached';
-
---connection node_2
-DROP USER 'z'@'localhost';
-
---connection node_1
---error ER_CANNOT_USER
---reap
-
 
 --connection node_1
 

--- a/sql/auth/auth_internal.h
+++ b/sql/auth/auth_internal.h
@@ -93,38 +93,8 @@ class Table_access_map {
 typedef std::unordered_set<std::string> Grant_acl_set;
 
 #ifdef WITH_WSREP
-/**
-  Fix for PXC-3872 (commit 487328e781d5acd44cd94e526969874372080b51) moved
-  starting TOI after open_grant_tables(). Before the fix, TOI was started at the
-  beginning of open_grant_tables() (so effectively, 'before'
-  open_grant_tables()). open_grant_tables() calls decide_logging_format(), where
-  we make a check if we are in local mode and doing streaming replication (SR).
-  wsrep_thd_is_local() is used as a part of the decision input. If we are in TOI
-  mode, wsrep_thd_is_local() returns 'false' (before above mentioned commit),
-  but if we didn't start TOI yet, it returns 'true', so the error is returned,
-  as local + STMT + SR is not allowed.
-  We need to inform decide_logging_format() logic that our intention is to
-  start TOI soon.
-
-  Another working solution would be disabling SR for the time of
-  query execution, but this way does not follow the conception, that TOI can be
-  executed while SR is enabled (these are two separate things).
-*/
-class Enable_TOI_preparation_guard {
- public:
-  Enable_TOI_preparation_guard(THD *thd) : m_thd(thd) {
-    m_thd->wsrep_TOI_preparation = true;
-  }
-
-  ~Enable_TOI_preparation_guard() {
-    m_thd->wsrep_TOI_preparation = false;
-  }
-
-  bool start_toi(const char *db = WSREP_MYSQL_DB, const char *table = nullptr);
-
- private:
-  THD *m_thd;
-};
+bool wsrep_check_system_user_privilege(THD *thd,
+                                       const List<LEX_USER> &user_list);
 #endif /* WITH_WSREP */
 
 std::string create_authid_str_from(const LEX_USER *user);
@@ -239,7 +209,13 @@ int replace_routine_table(THD *thd, GRANT_NAME *grant_name, TABLE *table,
                           const LEX_USER &combo, const char *db,
                           const char *routine_name, bool is_proc, ulong rights,
                           bool revoke_grant);
-int open_grant_tables(THD *thd, Table_ref *tables, bool *transactional_tables);
+#ifdef WITH_WSREP
+int open_grant_tables(THD *thd, Table_ref *tables, bool *transactional_tables,
+                      const char *db = WSREP_MYSQL_DB,
+                      const char *table = nullptr);
+#else
+int open_grant_tables(THD *thd, TABLE_LIST *tables, bool *transactional_tables);
+#endif /* WITH_WSREP */
 void acl_tables_setup_for_read(Table_ref *tables);
 
 void acl_print_ha_error(int handler_error);

--- a/sql/auth/sql_user_table.cc
+++ b/sql/auth/sql_user_table.cc
@@ -1971,7 +1971,14 @@ static bool acl_tables_setup_for_write_and_acquire_mdl(THD *thd,
          this function.
 */
 
-int open_grant_tables(THD *thd, Table_ref *tables, bool *transactional_tables) {
+#ifdef WITH_WSREP
+int open_grant_tables(THD *thd, Table_ref *tables, bool *transactional_tables,
+                      const char *db [[maybe_unused]],
+                      const char *table [[maybe_unused]]) {
+#else
+int open_grant_tables(THD *thd, TABLE_LIST *tables,
+                      bool *transactional_tables) {
+#endif /* WITH_WSREP */
   DBUG_TRACE;
 
   if (!initialized) {
@@ -1982,6 +1989,26 @@ int open_grant_tables(THD *thd, Table_ref *tables, bool *transactional_tables) {
   *transactional_tables = false;
 
   DEBUG_SYNC(thd, "wl14084_acl_ddl_before_mdl_acquisition");
+
+#ifdef WITH_WSREP
+  /* CREATE/DROP function/procedure implicitly grant priviliges.
+  Check for detail comment in respected switch handler in sql_parse.cc
+  Since the original statement is already replicated using TOI
+  sub-action of grant/revoke privilges doesn't need to get replicated. */
+  bool skip_toi = (thd->lex->sql_command == SQLCOM_CREATE_SPFUNCTION ||
+                   thd->lex->sql_command == SQLCOM_CREATE_PROCEDURE ||
+                   thd->lex->sql_command == SQLCOM_DROP_FUNCTION ||
+                   thd->lex->sql_command == SQLCOM_DROP_PROCEDURE);
+  /*
+    Perform the TOI after the replication filter check to avoid
+    replicating commands that won't be applied locally (due to a filter).
+  */
+  if (WSREP(thd) && !skip_toi &&
+      wsrep_to_isolation_begin(thd, db, table, nullptr)) {
+    WSREP_ERROR("Fail to replicate: %s", thd->query().str);
+    return -1;
+  }
+#endif /* WITH_WSREP */
 
   if (acl_tables_setup_for_write_and_acquire_mdl(thd, tables)) return -1;
 
@@ -2031,27 +2058,20 @@ int open_grant_tables(THD *thd, Table_ref *tables, bool *transactional_tables) {
 }
 
 #ifdef WITH_WSREP
-bool Enable_TOI_preparation_guard::start_toi(const char *db,
-                                                        const char *table) {
-  /* CREATE/DROP function/procedure implicitly grant privileges.
-  Check for detail comment in respected switch handler in sql_parse.cc
-  Since the original statement is already replicated using TOI
-  sub-action of grant/revoke privileges doesn't need to get replicated. */
-  bool skip_toi = (m_thd->lex->sql_command == SQLCOM_CREATE_SPFUNCTION ||
-                   m_thd->lex->sql_command == SQLCOM_CREATE_PROCEDURE ||
-                   m_thd->lex->sql_command == SQLCOM_DROP_FUNCTION ||
-                   m_thd->lex->sql_command == SQLCOM_DROP_PROCEDURE);
-  /*
-    Perform the TOI after the replication filter check to avoid
-    replicating commands that won't be applied locally (due to a filter).
-  */
-  if (WSREP(m_thd) && !skip_toi &&
-      wsrep_to_isolation_begin(m_thd, db, table, NULL)) {
-    WSREP_ERROR("Fail to replicate: %s", m_thd->query().str);
-    return true;
-  }
+bool wsrep_check_system_user_privilege(THD *thd,
+                                       const List<LEX_USER> &user_list) {
 
-  m_thd->wsrep_TOI_preparation = false;
+  if (WSREP(thd) && !thd->wsrep_applier) {
+    Acl_cache_lock_guard acl_cache_lock(thd, Acl_cache_lock_mode::READ_MODE);
+
+    if (!acl_cache_lock.lock()) {
+      return true;
+    }
+
+    if (check_system_user_privilege(thd, user_list)) {
+      return true;
+    }
+  }
   return false;
 }
 #endif

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -10614,7 +10614,7 @@ int THD::decide_logging_format(Table_ref *tables) {
   */
 #ifdef WITH_WSREP
   // Note that wsrep_thd_is_local() returns false for TOI
-  if (WSREP(this) && wsrep_thd_is_local(this) && !wsrep_TOI_preparation &&
+  if (WSREP(this) && wsrep_thd_is_local(this) &&
       variables.wsrep_trx_fragment_size > 0) {
     if (!is_current_stmt_binlog_format_row()) {
       my_message(ER_NOT_SUPPORTED_YET,

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3340,14 +3340,6 @@ class THD : public MDL_context_owner,
     rollback. */
   bool wsrep_force_savept_rollback;
 
-  /**
-    Set to true if TOI is going to be started, but first user privileges
-    for particular actions need to be checked. In such a case, some tables
-    may be opened, and wsrep logic relies on the information if the transaction
-    is TOI or not.
-  */
-  bool wsrep_TOI_preparation;
-
   /*
     Transaction id:
     * m_next_wsrep_trx_id is assigned on the first query after


### PR DESCRIPTION
… the PXC cluster

https://jira.percona.com/browse/PXC-4255

Problem:
During execution of SET PASSWORD / ALTER USER  on node_1 and simultanous execution of FLUSH PRIVILEGES on node_2 the whole cluster stuck in deadlock.

Cause:
Commits 487328e7 (PXC-3872) and a40b33f8 (PXC-3999) postponed starting TOI after open_grant_tables() call. In such a case some MDL locks are already acquired when TOI is being started.
Node_1:
1. Acquire MDLs
2. Replicate TOI
3. Acquire CommitOrder monitor in Galera

If just before 2. node_2 executes FLUSH PRIVILEGES (another TOI), it will be ordered before node_1's TOI, so node_1 will wait in 3 for replicated TOI to finish. If replicated TOI conflicts with local TOI it will try to abort local TOI, however Galera does not have a concept of aborting TOI, so node_1 still waits for CommitOrder monitor to enter.

Solution:
Avoid acquiring MDL locks before starting TOI. This is in contradiction to what we fixed in the above-mentioned commits, because we need to acquire ACL cache lock to validate query before TOI. On the other hand even original code (before above-mentioned fixes suffered the same problem, because MDL locks were acquired before TOI inside open_grant_tables() when
acl_tables_setup_for_write_and_acquire_mdl() was called.

1. Revoke fixes from 487328e7 and a40b33f8.
2. Move query validation before starting TOI, release all locks before TOI. This is kind of trade-off, because in the time without lock things can potentially change, but I don't know if we could do any better.
3. Start TOI before acl_tables_setup_for_write_and_acquire_mdl().
4. Revoke fix from faad2e23 as it is not needed anymore.