### PR TITLE
PXC-4312: DROP EVENT IF EXISTS generates local GTID event

### DIFF
--- a/mysql-test/suite/galera/r/galera_drop_if_exists.result
+++ b/mysql-test/suite/galera/r/galera_drop_if_exists.result
@@ -1,0 +1,16 @@
+include/gtid_utils.inc
+include/gtid_step_reset.inc
+DROP DATABASE IF EXISTS db1;
+Warnings:
+Note	1008	Can't drop database 'db1'; database doesn't exist
+DROP TABLE IF EXISTS t1;
+Warnings:
+Note	1051	Unknown table 'test.t1'
+DROP VIEW IF EXISTS v1;
+Warnings:
+Note	1051	Unknown table 'test.v1'
+DROP EVENT IF EXISTS ev1;
+Warnings:
+Note	1305	Event ev1 does not exist
+include/gtid_step_assert.inc [count=4, only_count=0]
+include/gtid_utils_end.inc

--- a/mysql-test/suite/galera/t/galera_drop_if_exists-master.opt
+++ b/mysql-test/suite/galera/t/galera_drop_if_exists-master.opt
@@ -1,0 +1,1 @@
+--gtid-mode=ON --enforce-gtid-consistency

--- a/mysql-test/suite/galera/t/galera_drop_if_exists.test
+++ b/mysql-test/suite/galera/t/galera_drop_if_exists.test
@@ -1,0 +1,30 @@
+# Check that the following requirement is fulfiled
+# The DROP DATABASE IF EXISTS, DROP TABLE IF EXISTS, DROP VIEW IF EXISTS and DROP EVENT IF EXISTS statements are always replicated,
+# even if the database, table, or view to be dropped does not exist on the source.
+# This is to ensure that the object to be dropped no longer exists on either the source or the replica,
+# once the replica has caught up with the source.
+#
+# Additionally check that such statements generate cluster gtid instead of local gtid.
+
+--source include/galera_cluster.inc
+--source include/gtid_utils.inc
+
+--connection node_1
+--source include/gtid_step_reset.inc
+DROP DATABASE IF EXISTS db1;
+DROP TABLE IF EXISTS t1;
+DROP VIEW IF EXISTS v1;
+DROP EVENT IF EXISTS ev1;
+
+# check that GTID is advanced by 4
+--let $gtid_step_count = 4
+--let $gtid_step_uuid = `SELECT Variable_value FROM performance_schema.global_status WHERE Variable_name='wsrep_cluster_state_uuid'`
+--source include/gtid_step_assert.inc
+
+--let $gtid_executed_node_1_end = `SELECT @@global.gtid_executed;`
+
+--connection node_2
+--let $gtid_executed_node_2_end = `SELECT @@global.gtid_executed;`
+--assert($gtid_executed_node_1_end == $gtid_executed_node_2_end)
+
+--source include/gtid_utils_end.inc

--- a/sql/event_db_repository.cc
+++ b/sql/event_db_repository.cc
@@ -244,6 +244,12 @@ bool Event_db_repository::drop_event(THD *thd, LEX_CSTRING db, LEX_CSTRING name,
 
     push_warning_printf(thd, Sql_condition::SL_NOTE, ER_SP_DOES_NOT_EXIST,
                         ER_THD(thd, ER_SP_DOES_NOT_EXIST), "Event", name.str);
+#ifdef WITH_WSREP
+    /* If 'IF EXISTS' clause is present, we replicate always. */
+    if (WSREP(thd) && wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL)) {
+      return true;
+    }
+#endif
     return false;
   }
   /*


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4312

Problem:
When DROP EVENT IF EXISTS is executed for non existing event, the event is binlogged with the GTID containing UUID of local server instead of global, cluster-wide UUID.

Cause:
As per MySql documentation, DROP DATABASE IF EXISTS, DROP TABLE IF EXISTS, and DROP VIEW IF EXISTS have to be replicated always. Code analysis lead to the conclusion that DROP EVENT IF EXISTS is in this group as well.
We did TOI for all besides DROP EVENT IF EXISTS. If the query is not replicated, wsrep logic generates GTID using local server UUID instead of cluster-wide UUID.

Solution:
Replicate DROP EVENT IF EXISTS always. This is enough for GTID to be properly generated.