### PR TITLE
PXC-4290: Merge PS-8.0.34 - Q3 2023 (Fix memory leak)

### DIFF
--- a/sql/rpl_replica.cc
+++ b/sql/rpl_replica.cc
@@ -7580,6 +7580,8 @@ err:
   // report error
 
 #ifdef WITH_WSREP
+  /* Free the GTID buffer associated with the thread. */
+  free_gtid_event_buf(thd);
   if (main_loop_error == true && WSREP_ON) {
     mysql_mutex_lock(&thd->LOCK_wsrep_thd);
     if (thd->wsrep_cs().current_error()) {

--- a/sql/rpl_rli_pdb.cc
+++ b/sql/rpl_rli_pdb.cc
@@ -2632,6 +2632,10 @@ int slave_worker_exec_job_group(Slave_worker *worker, Relay_log_info *rli) {
 
   return 0;
 err:
+#ifdef WITH_WSREP
+  /* Free the GTID buffer associated with the thread. */
+  free_gtid_event_buf(thd);
+#endif /* WITH_WSREP */
   if (error) {
     Commit_stage_manager::get_instance().finish_session_ticket(thd);
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2352,7 +2352,7 @@ fail:
   unireg_abort(1);
 }
 
-static void free_gtid_event_buf(THD *thd) {
+void free_gtid_event_buf(THD *thd) {
   if (thd->wsrep_gtid_event_buf) my_free(thd->wsrep_gtid_event_buf);
   thd->wsrep_gtid_event_buf_len = 0;
   thd->wsrep_gtid_event_buf = NULL;

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -468,6 +468,7 @@ void wsrep_init_sidno(const wsrep_uuid_t &);
 bool wsrep_node_is_donor();
 bool wsrep_node_is_synced();
 bool wsrep_replicate_GTID(THD *thd);
+void free_gtid_event_buf(THD *thd);
 
 void wsrep_init_SR();
 void wsrep_verify_SE_checkpoint(const wsrep_uuid_t &uuid, wsrep_seqno_t seqno);


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4290

Fixed the memory leak of the gtid event buffer that happened when the replica applier thread exits due to applier error.

Leak 1:
```
Direct leak of 109 byte(s) in 1 object(s) allocated from:
    #0 0x7f9a33adefdf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x564ff27432a4 in redirecting_allocator /home/venki/work/pxc/merge/80/mysys/my_malloc.cc:279
    #2 0x564ff2743796 in my_raw_malloc<redirecting_allocator> /home/venki/work/pxc/merge/80/mysys/my_malloc.cc:322
    #3 0x564ff27438e4 in my_internal_malloc<redirecting_allocator> /home/venki/work/pxc/merge/80/mysys/my_malloc.cc:372
    #4 0x564ff2743c91 in my_internal_realloc<redirecting_allocator, redirecting_deallocator> /home/venki/work/pxc/merge/80/mysys/my_malloc.cc:417
    #5 0x564ff2743d88 in my_realloc(unsigned int, void*, unsigned long, int) /home/venki/work/pxc/merge/80/mysys/my_malloc.cc:449
    #6 0x564ff1ef2e07 in wsrep_capture_gtid_event /home/venki/work/pxc/merge/80/sql/log_event.cc:13571
    #7 0x564ff1f246bd in Gtid_log_event::do_apply_event(Relay_log_info const*) /home/venki/work/pxc/merge/80/sql/log_event.cc:13670
    #8 0x564ff1f56fe9 in Log_event::do_apply_event_worker(Slave_worker*) /home/venki/work/pxc/merge/80/sql/log_event.cc:1048
    #9 0x564ff20bedca in Slave_worker::slave_worker_exec_event(Log_event*) /home/venki/work/pxc/merge/80/sql/rpl_rli_pdb.cc:1748
    #10 0x564ff20c6b01 in slave_worker_exec_job_group(Slave_worker*, Relay_log_info*) /home/venki/work/pxc/merge/80/sql/rpl_rli_pdb.cc:2519
    #11 0x564ff20f21d1 in handle_slave_worker /home/venki/work/pxc/merge/80/sql/rpl_replica.cc:6288
    #12 0x564ff3446c2c in pfs_spawn_thread /home/venki/work/pxc/merge/80/storage/perfschema/pfs.cc:3043
    #13 0x7f9a32a94ac2 in start_thread nptl/pthread_create.c:442
```
Leak 2:
````
Direct leak of 111 byte(s) in 1 object(s) allocated from:
    #0 0x7fa9c693a9cf in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x55f1e2c34894 in my_raw_malloc<redirecting_allocator> mysys/my_malloc.cc:322
    #2 0x55f1e2c3495e in my_internal_malloc<redirecting_allocator> mysys/my_malloc.cc:372
    #3 0x55f1e24e4668 in wsrep_capture_gtid_event sql/log_event.cc:13571
    #4 0x55f1e24ff4ba in Gtid_log_event::do_apply_event(Relay_log_info const*) sql/log_event.cc:13670
    #5 0x55f1e2678f7b in Slave_worker::read_and_apply_events(unsigned int, unsigned long long, unsigned int, unsigned long long) sql/rpl_rli_pdb.cc:2031
    #6 0x55f1e26799c6 in Slave_worker::retry_transaction(unsigned int, unsigned long long, unsigned int, unsigned long long) sql/rpl_rli_pdb.cc:1954
    #7 0x55f1e267a24c in slave_worker_exec_job_group(Slave_worker*, Relay_log_info*) sql/rpl_rli_pdb.cc:2526
    #8 0x55f1e269ae02 in handle_slave_worker sql/rpl_replica.cc:6288
    #9 0x55f1e36613e5 in pfs_spawn_thread storage/perfschema/pfs.cc:3043
    #10 0x7fa9c5d30043 in start_thread nptl/pthread_create.c:442
```