### PR TITLE
PXC-4318: long semaphore wait crash due to ha_commit_low does not com…

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2071,6 +2071,29 @@ int ha_commit_low(THD *thd, bool all, bool run_after_commit) {
         Commit_order_manager::wait_and_finish(thd, error);
       }
     }
+  } else {
+      /* This function is common for group commit flow and the flow that skips
+      group commit. We register the thread in wsrep_group_commit_queue always.
+      For group commit it is done during binlog flush stage, for 1-phase commit
+      it is done in wsrep_before_commit().
+      Ideally, for one-phase (with binlog=off) or two-phase (with binlog=on)
+      this step would be executed when transaction commits in InnoDB.
+      If galera node is acting as async slave and replicated action from async
+      master result in empty changes on slave (slave directly applied the said
+      changes and has skipped error through skip-slave-error configuration) it
+      can result in said situation. In this case slave protocol directly commits
+      gtid through gtid_end_transaction that invokes ordered_commit causing
+      thread handler to register in wsrep group commit queue but since storage
+      engine commit is not done it would fail to unregister the said thread
+      handler as part of storage engine commit. Handle unregistration here,
+      because doing it in wsrep_after_commit() is too late. If there is another
+      thread following this thread in currently processed commit queue,
+      current thread is commited (but does not commit in SE, so does not unregister
+      from wsrep_group_commit_queue. Then the following thread calls
+      wsrep_wait_for_turn_in_group_commit() but sees the previous thread at the front
+      and waits infinitely. */
+      wsrep_wait_for_turn_in_group_commit(thd);
+      wsrep_unregister_from_group_commit(thd);
   }
 
 err:

--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -447,12 +447,12 @@ void wsrep_wait_for_turn_in_group_commit(THD *thd) {
 
   }
 
-  MUTEX_LOCK(guard, &LOCK_wsrep_group_commit);
-
   if (!thd->wsrep_enforce_group_commit) {
     /* Said handler was not register for wsrep group commit */
     return;
   }
+
+  MUTEX_LOCK(guard, &LOCK_wsrep_group_commit);
 
   while (true) {
     if (thd == wsrep_group_commit_queue.front()) {
@@ -481,12 +481,12 @@ void wsrep_unregister_from_group_commit(THD *thd) {
     return;
   }
 
-  MUTEX_LOCK(guard, &LOCK_wsrep_group_commit);
-
   if (!thd->wsrep_enforce_group_commit) {
     /* Said handler was not register for wsrep group commit */
     return;
   }
+
+  MUTEX_LOCK(guard, &LOCK_wsrep_group_commit);
 
   thd->wsrep_enforce_group_commit = false;
   assert(wsrep_group_commit_queue.front() == thd);

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -310,7 +310,8 @@ static inline int wsrep_before_commit(THD *thd, bool all) {
       THD in wsrep group commit queue at this stage.
       If the transaction is running as 2-phase then THD is registered
       in ordered_commit to ensure thd registration order is same as
-      mysql group commit queue order. */
+      mysql group commit queue order.
+      It will be unregistered in ha_commit_low() during SE commit. */
       wsrep_register_for_group_commit(thd);
     }
 
@@ -352,7 +353,12 @@ static inline int wsrep_ordered_commit(THD *thd, bool all) {
   /* Register thread handler in wsrep group commit queue.
   Note: thread handler executing 2 phase commit transaction is registered
   as part of ordered_commit (and not part of before_commit) as wsrep group
-  commit sequence should be same as mysql group commit queue sequence. */
+  commit sequence should be same as mysql group commit queue sequence.
+  In most cases it will be unregistered as part of ha_commit_low() during
+  SE commit, however there are rare cases when it will unregistered directly
+  from ha_commit_low() if SE is not involved in the commit (for more detailed
+  explanation of this case see the comment in ha_commit_low())
+  */
   wsrep_register_for_group_commit(thd);
 
   DBUG_RETURN(thd->wsrep_cs().ordered_commit());
@@ -370,21 +376,8 @@ static inline int wsrep_after_commit(THD *thd, bool all) {
               wsrep_has_changes(thd));
   assert(wsrep_run_commit_hook(thd, all));
 
-  if (thd->wsrep_enforce_group_commit) {
-    /* Ideally, for one-phase (with binlog=off) or two-phase (with binlog=on)
-    this step would be executed when transaction commits in InnoDB.
-    If galera node is acting as async slave and replicated action from async
-    master result in empty changes on slave (slave directly applied the said
-    changes and has skipped error through skip-slave-error configuration) it
-    can result in said situation. In this case slave protocol directly commits
-    gtid through gtid_end_transaction that invokes ordered_commit causing
-    thread handler to register in wsrep group commit queue but since storage
-    engine commit is not done it would fail to unregister the said thread
-    handler as part of storage engine commit. Handle unregistration here. */
-    wsrep_wait_for_turn_in_group_commit(thd);
-    wsrep_unregister_from_group_commit(thd);
-  }
-
+  /* It has to already unregistered from wsrep_group_commit_queue either
+  during SE commit or directly in ha_commit_low if SE commit was not done. */
   assert(!thd->wsrep_enforce_group_commit);
 
   int ret = 0;


### PR DESCRIPTION
…mit an empty transaction

https://jira.percona.com/browse/PXC-4318

Problem:
When PXC node acts as the async replica to some master and in parallel
the row is updated on PXC node and via replication the PXC node hangs.

Cause:
If the row is updated in parallel by local session on PXC node and via
replication in the way that both updates result in the same row, and
local transaction updated the row as the first one, the replicated
transaction is not logged into the binlog.
This is because when replicated transaction commits in InooDB,
SE returns HA_ERR_RECORD_IS_THE_SAME and binlogging is skipped
(logic inside handler::ha_update_row()). So the transaction becomes
an empty transaction. In this case slave protocol directly commits
gtid through gtid_end_transaction that invokes ordered_commit causing
thread handler to register in wsrep group commit queue but since storage
engine commit is not done it would fail to unregister the said thread
handler as part of storage engine commit.

Commit 730b82ac tried to solve the above situation by removing
the thread from wsrep group commit queue in wsrep_after_commit() if it
was not removed by committing to SE.
The problem of this solution is when the thread (t1) registers in
wsrep_group_commit_queue, another thread (t2) may register after it
(t1 does not have to be a leader). The queue is processed by the leader
and each thread is supposed to remove itself from
wsrep_group_commit_queue during SE commit. If t1 does not do SE commit
it remains at the front of the queue, and we block during t2 processing
in wsrep_wait_for_turn_in_group_commit().
So unregistering t1 from the queue in wsrep_after_commit() (after the
whole commit queue is done) is too late.

Solution:
If the transaction does not cause commit in SE which would cause
removal of it from wsrep_group_commit_queue, remove it explicitly.
This is a similar approach as implemented in 730b82ac but moved directly
to after processing of the thread during COMMIT stage rather than having
it after the whole stage is finished.