### PR TITLE
PXC-4336: PXC node eviction due to CHECK CONSTRAINT

### DIFF
--- a/mysql-test/suite/galera/r/galera_alter_add_constraint.result
+++ b/mysql-test/suite/galera/r/galera_alter_add_constraint.result
@@ -1,0 +1,14 @@
+CALL mtr.add_suppression("Replica SQL: Error .Check constraint .CHK_i. is violated");
+CALL mtr.add_suppression("Replica SQL: Error 'Duplicate check constraint name .CHK_i.* on query");
+CALL mtr.add_suppression("Replica SQL: Error 'Constraint .CHK_i2. does not exist");
+CREATE TABLE t (id INT PRIMARY KEY, i INT NOT NULL);
+INSERT INTO t VALUES(1, 100);
+ALTER TABLE t ADD CONSTRAINT CHK_i CHECK (i <=75);
+ERROR HY000: Check constraint 'CHK_i' is violated.
+ALTER TABLE t ADD CONSTRAINT CHK_i CHECK (i <=200);
+ALTER TABLE t ADD CONSTRAINT CHK_i CHECK (i <=200);
+ERROR HY000: Duplicate check constraint name 'CHK_i'.
+ALTER TABLE t DROP CONSTRAINT CHK_i2;
+ERROR HY000: Constraint 'CHK_i2' does not exist.
+ALTER TABLE t DROP CONSTRAINT CHK_i;
+DROP TABLE t;

--- a/mysql-test/suite/galera/t/galera_alter_add_constraint.test
+++ b/mysql-test/suite/galera/t/galera_alter_add_constraint.test
@@ -1,0 +1,38 @@
+
+# Test that contraint check is done on source and replicated node
+# and produces the same error, which leaves the cluster in consistent
+# state after consistency voting.
+
+--source include/galera_cluster.inc
+
+--connection node_2
+CALL mtr.add_suppression("Replica SQL: Error .Check constraint .CHK_i. is violated");
+CALL mtr.add_suppression("Replica SQL: Error 'Duplicate check constraint name .CHK_i.* on query");
+CALL mtr.add_suppression("Replica SQL: Error 'Constraint .CHK_i2. does not exist");
+
+--connection node_1
+
+CREATE TABLE t (id INT PRIMARY KEY, i INT NOT NULL);
+INSERT INTO t VALUES(1, 100);
+
+# TOI will replicate before local execution.
+# Then it will fail locally, as the constraint check fails.
+# It is expected that the replica will fail as well with the same error.
+
+# Case 1: add a constraint which can't be fulfilled
+--error ER_CHECK_CONSTRAINT_VIOLATED
+ALTER TABLE t ADD CONSTRAINT CHK_i CHECK (i <=75);
+
+# Case 2: add a constraint which already exists
+ALTER TABLE t ADD CONSTRAINT CHK_i CHECK (i <=200);
+--error ER_CHECK_CONSTRAINT_DUP_NAME
+ALTER TABLE t ADD CONSTRAINT CHK_i CHECK (i <=200);
+
+# Case 3: drop nonexistent constraint
+--error ER_CONSTRAINT_NOT_FOUND
+ALTER TABLE t DROP CONSTRAINT CHK_i2;
+
+# Case 4: drop the constraint that exists
+ALTER TABLE t DROP CONSTRAINT CHK_i;
+
+DROP TABLE t;

--- a/sql/sql_check_constraint.cc
+++ b/sql/sql_check_constraint.cc
@@ -103,10 +103,18 @@ bool Sql_check_constraint_spec::expr_refers_column(const char *column_name) {
 }
 
 bool is_slave_with_master_without_check_constraints_support(THD *thd) {
+#ifdef WITH_WSREP
+  return (!thd->wsrep_applier &&
+          (thd->system_thread &
+           (SYSTEM_THREAD_SLAVE_SQL | SYSTEM_THREAD_SLAVE_WORKER)) &&
+          (thd->variables.original_server_version == UNDEFINED_SERVER_VERSION ||
+           thd->variables.original_server_version < 80016));
+#else
   return ((thd->system_thread &
            (SYSTEM_THREAD_SLAVE_SQL | SYSTEM_THREAD_SLAVE_WORKER)) &&
           (thd->variables.original_server_version == UNDEFINED_SERVER_VERSION ||
            thd->variables.original_server_version < 80016));
+#endif
 }
 
 bool check_constraint_expr_refers_to_only_column(Item *check_expr,


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4336

Problem:
When constraint, which fails, is set on table, inconsistency voting is kicked off and the node is evicted from the cluster.

Cause:
ALTER TABLE ... ADD CONSTRAINT ... is replicated as TOI before the actual execution on the source node. Than it fails to execute on source node and succeeds on replicated node. This activates inconsistency voting protocol and the source node gets evicted from the cluster.

When the query is executed, before the actual ALTER execution, check constraints specifications are created
(prepare_check_constraints_for_alter()).
On source node they are created, then validated, validatio fails, and the node finishes with error.
On replicated node constraints specifications creation is skipped, so constraints are not validated at all. It is because of the logic of is_slave_with_master_without_check_constraints_support() function, which forces constraints check skipping in case of source node is not supporting such checks. The decision is based on the version of the source node which is carried in Gtid event. Galera does not replicate Gtid events, so this information is missing and the logic assumes that the source node does not support constraints check.

Solution:
Allow constraints check for Galera replication.