### PR TITLE
PXC-4317: Percona XtraDB 8.0.33-25-1 Nodes 2 and 3 cannot join the cluster

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -292,10 +292,23 @@ get_mysqld_path()
     # directory from the SST scripts (it may be in /usr/sbin not /usr/bin)
     # So, first, try to use readlink to read from /proc/<pid>/exe
     if which readlink >/dev/null; then
+
+        # Set +e to instruct the shell interpreter not to exit immediately if
+        # the readlink returns a non-zero exit status.
+        set +e
+
         # Check to see if the symlink for the exe exists
         if [[ -L /proc/${WSREP_SST_OPT_PARENT}/exe ]]; then
             MYSQLD_PATH=$(readlink -f /proc/${WSREP_SST_OPT_PARENT}/exe)
+
+            # Reset MYSQLD_PATH if readlink failed with an error
+            if [[ $? -ne 0 ]]; then
+                MYSQLD_PATH=
+            fi
         fi
+
+        # Set -e again
+        set -e
     fi
     if [[ -z $MYSQLD_PATH ]]; then
         # We don't have readlink, so look for mysqld in the path


### PR DESCRIPTION
PXC-4237: PXC tarball install : Failed wsrep_sst_xtrabackup-v2 when adding new node

https://jira.percona.com/browse/PXC-4317
https://jira.percona.com/browse/PXC-4237

Problem
-------
On newer platforms like AlmaLinux, the readlink command used during the SST process on joiner can fail resulting in the failure to add a new node to an existing cluster.

Solution
--------
Added a pair of `set +e` and `set -e` respectively before and after the readlink command so that any non-zero return value will not be considered as a failure during the execution of the script.