### PR TITLE
PXC-4034: Using sql_log_bin=0 breaks GTID consistency

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_master_gtid.result
+++ b/mysql-test/suite/galera/r/galera_as_master_gtid.result
@@ -61,6 +61,12 @@ mysqld-bin.000001	661	Query	2	729	BEGIN
 mysqld-bin.000001	729	Table_map	2	774	table_id: # (test.t1)
 mysqld-bin.000001	774	Write_rows	2	814	table_id: # flags: STMT_END_F
 mysqld-bin.000001	814	Xid	2	845	COMMIT /* xid=# */
+SET SESSION sql_log_bin=0;
+INSERT INTO t1 VALUES (10);
+include/assert.inc ['gitd_executed should not change']
+# restart
+include/assert.inc ['gtid_purged should be empty']
+include/assert.inc ['INSERT should not be replicated']
 DROP TABLE t1;
 STOP SLAVE;
 RESET SLAVE ALL;

--- a/mysql-test/suite/galera/t/galera_as_master_gtid.test
+++ b/mysql-test/suite/galera/t/galera_as_master_gtid.test
@@ -71,13 +71,45 @@ SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
 --replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
 SHOW BINLOG EVENTS IN 'mysqld-bin.000001' FROM 123;
 
+
+#
+# Test that when the session has disabled binlog, it does not advance gtid_executed
+#
+--connection node_2
+SET SESSION sql_log_bin=0;
+
+--let $gtid_executed_before = `SELECT @@global.gtid_executed`
+INSERT INTO t1 VALUES (10);
+--let $gtid_executed_after = `SELECT @@global.gtid_executed`
+
+# confirm gtid_executed hasn't changed
+--let $assert_text = 'gitd_executed should not change'
+--let $assert_cond = "$gtid_executed_before" = "$gtid_executed_after"
+--source include/assert.inc
+
+# restart PXC node and confirm that gitd_purged is empty
+--source include/shutdown_mysqld.inc
+--let $restart_parameters = "restart"
+--source include/start_mysqld.inc
+
+--let $gtid_purged = `SELECT @@global.gtid_purged`
+--let $assert_text = 'gtid_purged should be empty'
+--let $assert_cond = '$gtid_purged' = ''
+--source include/assert.inc
+
+--connection node_3
+# confirm it was not replicated
+--sleep 5
+--let $assert_text = 'INSERT should not be replicated'
+--let $assert_cond = [SELECT COUNT(*) as count FROM t1 WHERE f1 = 10, count, 1] = 0
+--source include/assert.inc
+
+#cleanup
 --connection node_1
 DROP TABLE t1;
 
 --connection node_3
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
-
 STOP SLAVE;
 RESET SLAVE ALL;
-

--- a/sql/rpl_gtid.h
+++ b/sql/rpl_gtid.h
@@ -2487,7 +2487,11 @@ public:
     that gtid_mode!=ON before calling this function, or else the
     gtid_mode could have changed to ON by a concurrent SET GTID_MODE.)
   */
-  void acquire_anonymous_ownership()
+#ifdef WITH_WSREP
+void acquire_anonymous_ownership(THD *thd);
+void release_anonymous_ownership(THD *thd);
+#else
+void acquire_anonymous_ownership()
   {
     DBUG_ENTER("Gtid_state::acquire_anonymous_ownership");
     sid_lock->assert_some_lock();
@@ -2515,6 +2519,7 @@ public:
     assert(old_value >= 1);
     DBUG_VOID_RETURN;
   }
+#endif  /* WITH_WSREP */
 
   /// Return the number of clients that hold anonymous ownership.
   int32 get_anonymous_ownership_count()

--- a/sql/rpl_gtid_execution.cc
+++ b/sql/rpl_gtid_execution.cc
@@ -86,7 +86,11 @@ bool set_gtid_next(THD *thd, const Gtid_specification &spec)
     thd->variables.gtid_next.set_anonymous();
     thd->owned_gtid.sidno= THD::OWNED_SIDNO_ANONYMOUS;
     thd->owned_gtid.gno= 0;
+#ifdef WITH_WSREP
+    gtid_state->acquire_anonymous_ownership(thd);
+#else
     gtid_state->acquire_anonymous_ownership();
+#endif
   }
   else
   {

--- a/sql/rpl_gtid_state.cc
+++ b/sql/rpl_gtid_state.cc
@@ -543,8 +543,24 @@ enum_return_status Gtid_state::generate_automatic_gtid(THD *thd,
     /* The caller must lock the sid_lock when locked_sidno is passed */
     sid_lock->assert_some_lock();
 
+#ifdef WITH_WSREP
+    bool skip_gtid = false;
+    /* If binlog is disabled permanently we don't get here.
+    If it is disabled only in a particular session, we need to
+    do PXC replication, however we will not binlog it.
+    So we need to skip GTID generation for this transaction.
+    Just pretend for a while that gtid_mode=OFF */
+    if (!(thd->variables.option_bits & OPTION_BIN_LOG) &&
+        !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF))
+        {
+          skip_gtid = true;
+        }
+  // If GTID_MODE = ON_PERMISSIVE or ON, generate a new GTID
+  if (!skip_gtid && get_gtid_mode(GTID_MODE_LOCK_SID) >= GTID_MODE_ON_PERMISSIVE)
+#else
   // If GTID_MODE = ON_PERMISSIVE or ON, generate a new GTID
   if (get_gtid_mode(GTID_MODE_LOCK_SID) >= GTID_MODE_ON_PERMISSIVE)
+#endif
   {
     Gtid automatic_gtid= { specified_sidno, specified_gno };
 
@@ -609,7 +625,11 @@ enum_return_status Gtid_state::generate_automatic_gtid(THD *thd,
     // using an anonymous transaction.
     thd->owned_gtid.sidno= THD::OWNED_SIDNO_ANONYMOUS;
     thd->owned_gtid.gno= 0;
+#ifdef WITH_WSREP
+    acquire_anonymous_ownership(thd);
+#else
     acquire_anonymous_ownership();
+#endif
     thd->owned_gtid.dbug_print(NULL,
                                "set owned_gtid (anonymous) in generate_automatic_gtid");
   }
@@ -1049,7 +1069,11 @@ void Gtid_state::update_gtids_impl_own_anonymous(THD* thd,
   if (!(*more_trx &&
         thd->variables.gtid_next.type == ANONYMOUS_GROUP))
   {
+#ifdef WITH_WSREP
+    release_anonymous_ownership(thd);
+#else
     release_anonymous_ownership();
+#endif
     thd->clear_owned_gtids();
   }
 }
@@ -1086,3 +1110,50 @@ error:
   RETURN_REPORTED_ERROR;
 
 }
+
+#ifdef WITH_WSREP
+void Gtid_state::acquire_anonymous_ownership(THD *thd MY_ATTRIBUTE((unused)))
+{
+  DBUG_ENTER("Gtid_state::acquire_anonymous_ownership");
+  sid_lock->assert_some_lock();
+  /* We are allowed to get here only in two cases:
+  1. If this is WSREP-enabled thread
+      and binlog is disabled
+      and binlog is not disabled internally
+      This means that this is the session with sql_log_bin=OFF.
+  2. if gtid_mode != ON (the original condition) */
+  assert( (WSREP(thd) && !(thd->variables.option_bits & OPTION_BIN_LOG) &&
+          !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF))
+          || (get_gtid_mode(GTID_MODE_LOCK_SID) != GTID_MODE_ON));
+#ifndef NDEBUG
+  int32 old_value=
+#endif
+    anonymous_gtid_count.atomic_add(1);
+  DBUG_PRINT("info", ("anonymous_gtid_count increased to %d", old_value + 1));
+  assert(old_value >= 0);
+  DBUG_VOID_RETURN;
+}
+
+/// Release anonymous ownership.
+void Gtid_state::release_anonymous_ownership(THD *thd MY_ATTRIBUTE((unused)))
+{
+  DBUG_ENTER("Gtid_state::release_anonymous_ownership");
+  sid_lock->assert_some_lock();
+  /* We are allowed to get here only in two cases:
+  1. If this is WSREP-enabled thread
+      and binlog is disabled
+      and binlog is not disabled internally
+      This means that this is the session with sql_log_bin=OFF.
+  2. if gtid_mode != ON (the original condition) */
+  assert( (WSREP(thd) && !(thd->variables.option_bits & OPTION_BIN_LOG) &&
+          !(thd->variables.option_bits & OPTION_BIN_LOG_INTERNAL_OFF))
+          || (get_gtid_mode(GTID_MODE_LOCK_SID) != GTID_MODE_ON));
+#ifndef NDEBUG
+  int32 old_value=
+#endif
+    anonymous_gtid_count.atomic_add(-1);
+  DBUG_PRINT("info", ("anonymous_gtid_count decreased to %d", old_value - 1));
+  assert(old_value >= 1);
+  DBUG_VOID_RETURN;
+}
+#endif  /* WITH_WSREP */


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4034

Problem:
If binlogging is enabled globally, but it is disabled in the session scope, transactions executed within this session advance 'gtid_executed' As transactions are not binlogged, after the node restart, 'gtid_purged' is populated with gtids related to these transactions. When the node acts as the source for async replica, it causes replica to fail, because source is not able to serve not logged, but gtid-related transactions.

Cause:
PXC, even if binlog is disabled, uses binlog infrastructure to cache binlog events for the purpose of creation of Galera writesets. If binlog is disabled, logging to the file is skipped.
GTID is generated during group commit binlog flush stage. PXC flow goes through this stage if binlog is enabled generating GTIDs for every transaction, even if later the transaction is not binlogged.

Solution:
If binlogging is disabled for the particular thread, force the execution path as if gtid_mode was equal OFF.