### PR TITLE
PXC-4341: Executing prepared statement can abort node after FLUSH TABLES

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/pxc_prepared_statement_toi_failure.result
+++ b/mysql-test/suite/galera_3nodes/r/pxc_prepared_statement_toi_failure.result
@@ -1,0 +1,28 @@
+PREPARE stmt1 FROM "CREATE TABLE IF NOT EXISTS pxc4341 (id INT PRIMARY KEY AUTO_INCREMENT, a INT)";
+EXECUTE stmt1;
+include/assert.inc [Table pxc4341 was created on node1.]
+FLUSH TABLES;
+EXECUTE stmt1;
+Warnings:
+Note	1050	Table 'pxc4341' already exists
+SHOW TABLES;
+Tables_in_test
+pxc4341
+INSERT INTO pxc4341 VALUES(1,1),(2,2),(3,3);
+include/assert.inc [Table pxc4341 was created on node2.]
+include/assert.inc [Node 2 is up, running and replicating.]
+include/assert.inc [Table pxc4341 was created on node3.]
+include/assert.inc [Node 2 is up, running and replicating.]
+PREPARE stmt1 FROM "CREATE TABLE IF NOT EXISTS temp (id INT PRIMARY KEY AUTO_INCREMENT, a INT)";
+EXECUTE stmt1;
+FLUSH TABLES;
+# Adding debug point 'simulate_max_reprepare_attempts_hit_case' to @@GLOBAL.debug
+EXECUTE stmt1;
+ERROR HY000: Prepared statement needs to be re-prepared
+include/assert_grep.inc [Node 3 inconsistent message was found in the error log]
+include/assert_grep.inc [Node 3 inconsistent message was found in the error log]
+SET SESSION wsrep_sync_wait=0;
+# restart
+CALL mtr.add_suppression("Inconsistency detected: Inconsistent by consensus on");
+DROP TABLE temp;
+DROP TABLE pxc4341;

--- a/mysql-test/suite/galera_3nodes/t/pxc_prepared_statement_toi_failure.test
+++ b/mysql-test/suite/galera_3nodes/t/pxc_prepared_statement_toi_failure.test
@@ -1,0 +1,109 @@
+# This test ensures that transient errors during the execution of the DDL in
+# prepared statement mode are handled properly by server.
+
+--source include/have_debug.inc
+--source include/galera_cluster.inc
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_1
+
+# Create a prepared statement involving a DDL.
+PREPARE stmt1 FROM "CREATE TABLE IF NOT EXISTS pxc4341 (id INT PRIMARY KEY AUTO_INCREMENT, a INT)";
+
+# Execute the prepared statement
+EXECUTE stmt1;
+
+# Assert that table pxc4341 was created on node1.
+--let $assert_text = Table pxc4341 was created on node1.
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "pxc4341"
+--source include/assert.inc
+
+# Introduce a change in table metadata by executing FLUSH TABLES
+FLUSH TABLES;
+
+# Re-execute the prepared statement. Here the expectation is that the server
+# should detect the change in metadata and should re-prepare & re-execute the
+# prepared statement. However the transient error raised during the execution
+# of the query is handled properly by server.
+EXECUTE stmt1;
+
+SHOW TABLES;
+
+INSERT INTO pxc4341 VALUES(1,1),(2,2),(3,3);
+
+# Assert that node2 is still up, running and replicating.
+--connection node_2
+--let $assert_text = Table pxc4341 was created on node2.
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "pxc4341"
+--source include/assert.inc
+
+# Wait till the data is replicated to node2
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.pxc4341
+--source include/wait_condition.inc
+
+# Assert that table has 3 rows on node2
+--let $assert_text = Node 2 is up, running and replicating.
+--let $assert_cond = COUNT(*) = 3 FROM test.pxc4341
+--source include/assert.inc
+
+
+# Assert that node3 is still up, running and replicating.
+--connection node_3
+--let $assert_text = Table pxc4341 was created on node3.
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "pxc4341"
+--source include/assert.inc
+
+# Wait till the data is replicated to node3
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.pxc4341
+--source include/wait_condition.inc
+
+# Assert that table has 3 rows on node3
+--let $assert_text = Node 2 is up, running and replicating.
+--let $assert_cond = COUNT(*) = 3 FROM test.pxc4341
+--source include/assert.inc
+
+#
+# Simulate the case of exhausted retries on node3
+#
+--connection node_3
+PREPARE stmt1 FROM "CREATE TABLE IF NOT EXISTS temp (id INT PRIMARY KEY AUTO_INCREMENT, a INT)";
+EXECUTE stmt1;
+FLUSH TABLES;
+
+--let $debug_point=simulate_max_reprepare_attempts_hit_case
+--source include/add_debug_point.inc
+
+--error ER_NEED_REPREPARE
+EXECUTE stmt1;
+
+# Assert that cluster node3 became inconsistent with the group
+--connection node_1
+--let $assert_only_after = CURRENT_TEST
+--let $assert_count = 1
+--let $assert_text = Node 3 inconsistent message was found in the error log
+--let $assert_select = Member 2(.*) initiates vote .*:  Prepared statement needs to be re-prepared
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.3.err
+--source include/assert_grep.inc
+
+--let $assert_only_after = CURRENT_TEST
+--let $assert_count = 1
+--let $assert_text = Node 3 inconsistent message was found in the error log
+--let $assert_select = Inconsistency detected: Inconsistent by consensus
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.3.err
+--source include/assert_grep.inc
+
+# Restart node3
+--connection node_3
+SET SESSION wsrep_sync_wait=0;
+--source include/shutdown_mysqld.inc
+--source include/start_mysqld.inc
+
+# Test suppressions
+--connection node_3
+CALL mtr.add_suppression("Inconsistency detected: Inconsistent by consensus on");
+
+# Cleanup
+--disconnect node_3
+--connection node_1
+DROP TABLE temp;
+DROP TABLE pxc4341;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -708,6 +708,7 @@ THD::THD(bool enable_plugins)
       parsing_system_view(false),
       sp_runtime_ctx(nullptr),
 #ifdef WITH_WSREP
+      wsrep_prepared_statement_TOI_started(false),
       wsrep_bin_log_flag_save(0),
       wsrep_applier(is_applier),
       wsrep_applier_closing(false),

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3166,6 +3166,7 @@ class THD : public MDL_context_owner,
   } binlog_evt_union;
 
 #ifdef WITH_WSREP
+  bool wsrep_prepared_statement_TOI_started;
   ulonglong wsrep_bin_log_flag_save;
   bool wsrep_applier;         /* dedicated slave applier thread */
   bool wsrep_applier_closing; /* applier marked to close */

--- a/sql/sql_cmd_ddl_table.cc
+++ b/sql/sql_cmd_ddl_table.cc
@@ -516,17 +516,26 @@ bool Sql_cmd_create_table::execute(THD *thd) {
           mysql_mutex_lock(&LOCK_wsrep_alter_tablespace);
         }
 
-        /* Note we are explictly opening the macro as we need to perform
+        bool prepared_stmt_execution = thd->get_reprepare_observer() != nullptr;
+        bool should_start_toi = !prepared_stmt_execution ||
+                                (prepared_stmt_execution &&
+                                 !wsrep_thd_is_in_to_isolation(thd, false));
+        /* Note we are explicitly opening the macro as we need to perform
         cleanup action on TOI failure. */
-        if (WSREP(thd) && wsrep_to_isolation_begin(thd, create_table->db,
-                                                   create_table->table_name,
-                                                   NULL, NULL, &alter_info)) {
+        if (WSREP(thd) && should_start_toi &&
+            wsrep_to_isolation_begin(thd, create_table->db,
+                                     create_table->table_name, NULL, NULL,
+                                     &alter_info)) {
           if (!thd->lex->is_ignore() && thd->is_strict_mode())
             thd->pop_internal_handler();
           if (create_info.tablespace) {
             mysql_mutex_unlock(&LOCK_wsrep_alter_tablespace);
           }
           return true;
+        }
+
+        if (should_start_toi) {
+          thd->wsrep_prepared_statement_TOI_started = true;
         }
 
         if (create_info.tablespace) {

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6093,10 +6093,60 @@ finish:
   }
 
 #ifdef WITH_WSREP
+  /*
+    It can sometimes happen that the DDL executed as a prepared statement may
+    fail with transient errors like ER_NEED_PREPARE if the table metadata was
+    changed between PREPARE and EXECUTE. In such cases, the statement is
+    re-prepared and re-executed from Prepared_statement::execute_loop().
 
+    However, before the statement is reprepared, PXC's TOI_end() hook captures
+    this transient error (i.e, ER_NEED_REPREPARE) and sends it to galera thereby
+    triggering the inconsistenct voting and kicking this node out of the
+    cluster.
+
+    So, in such cases, we need to delay sending the final error to galera until
+    all reprepare attempts are over. This is done by attaching a temporary
+    Diagnostics_area to THD and resetting it later if the required conditions
+    are met.
+
+    The requried conditions are
+
+    1. THD is wsrep enabled.
+    2. THD is a DDL.
+    3. THD is using prepared statement.
+    4. THD can reprepare the prepared statement.
+  */
+  bool thd_needs_da_restore = false;
+  Diagnostics_area tmp_da(true);
+  bool finish_toi = true;
+  if (WSREP(thd) && wsrep_thd_is_in_to_isolation(thd, false)) {
+    Reprepare_observer *reprepare_observer = thd->get_reprepare_observer();
+    if (reprepare_observer != nullptr && reprepare_observer->is_invalidated()) {
+      assert(thd->get_stmt_da()->mysql_errno() == ER_NEED_REPREPARE);
+
+      if (reprepare_observer->can_retry()) {
+        thd->push_diagnostics_area(&tmp_da, false);
+        thd_needs_da_restore = true;
+
+        // We defer calling TOI_end for the prepared statement
+        // if it failed with ER_NEED_REPREPARE as it will be re-prepared and
+        // re-executed.
+        finish_toi = false;
+      } else {
+        // This means all retries are exhausted. We should call TOI_end now.
+        finish_toi = true;
+      }
+    }
+  }
   thd->wsrep_consistency_check = NO_CONSISTENCY_CHECK;
-  WSREP_TO_ISOLATION_END;
+  if (finish_toi) {
+    WSREP_TO_ISOLATION_END;
+    thd->wsrep_prepared_statement_TOI_started = false;
+  }
 
+  if (thd_needs_da_restore) {
+    thd->pop_diagnostics_area();
+  }
   /*
     Force release of transactional locks if not in active MST and wsrep is on.
   */

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -3186,7 +3186,9 @@ reexecute:
 #ifdef WITH_WSREP
     if (!error) { /* Success */
       // We are going to retry the statement, so clean up first.
-      wsrep_after_statement(thd);
+      if (!thd->wsrep_prepared_statement_TOI_started) {
+        wsrep_after_statement(thd);
+      }
       goto reexecute;
     }
 #else


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4341

Problem
-------
Transient errors during the execution of the DDL in a prepared statement mode can trigger inconsistency voting resulting in node eviction from the cluster.

Analysis & Fix
--------------
It can sometimes happen that the DDL executed as a prepared statement may fail with transient errors like ER_NEED_REPREPARE if the table metadata was changed between PREPARE and EXECUTE (due to FLUSH TABLES). In such cases, the statement is re-prepared and re-executed from Prepared_statement::execute_loop().

However, before the statement is reprepared, PXC's TOI_end() hook captures this transient error (i.e, ER_NEED_REPREPARE) and sends it to galera thereby triggering the inconsistenct voting and kicking this node out of the cluster.

So, in such cases, we need to delay sending the final error to galera until all reprepare attempts are over. This is done by attaching a temporary Diagnostics_area to THD and resetting it later if all the required conditions are met.

NOTE
----

The below mentioned commands reprepare the statement if there is any
metadata change (marked with CF_REEXECUTION_FRAGILE)
    
        SQLCOM_CREATE_TABLE
        SQLCOM_LOAD
        SQLCOM_CREATE_VIEW
        SQLCOM_UPDATE
        SQLCOM_UPDATE_MULTI
        SQLCOM_INSERT
        SQLCOM_INSERT_SELECT
        SQLCOM_DELETE
        SQLCOM_DELETE_MULTI
        SQLCOM_REPLACE
        SQLCOM_REPLACE_SELECT
        SQLCOM_SELECT
        SQLCOM_DO
        SQLCOM_CALL
    
Among the above commands, only SQLCOM_CREATE_TABLE and
SQLCOM_CREATE_VIEW are DDLs and thus was affected by this bug.

However in case of CREATE VIEW, table version check is performed before
the query is replicated as TOI, so CREATE TABLE was the only query that
was affected by this bug. So, a special handling has been done only for
the CREATE_TABLE query in this patch.


Testing Done
----
Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/180/console