### PR TITLE
PXC-4362: PXC node evicted when create function by

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_ddl_access_checking2.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_ddl_access_checking2.result
@@ -704,6 +704,45 @@ GRANT SELECT ON `testdb`.* TO `testme`@`%`
 GRANT INSERT ON `testdb`.`counter` TO `testme`@`%`
 FLUSH PRIVILEGES;
 #
+# SQLCOM_CREATE_SPFUNCTION (with log_bin_trust_function_creators=OFF) access test
+#
+# connection node_1
+SET @old_log_bin_trust_function_creators= @@global.log_bin_trust_function_creators;
+Warnings:
+Warning	1287	'@@log_bin_trust_function_creators' is deprecated and will be removed in a future release.
+SET global log_bin_trust_function_creators=OFF;
+Warnings:
+Warning	1287	'@@log_bin_trust_function_creators' is deprecated and will be removed in a future release.
+GRANT ALL PRIVILEGES ON testdb.* TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO `testme`@`%`
+GRANT ALL PRIVILEGES ON `testdb`.* TO `testme`@`%`
+GRANT INSERT ON `testdb`.`counter` TO `testme`@`%`
+FLUSH PRIVILEGES;
+# connection node_testme
+use testdb;
+CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello, ',s,'!');
+ERROR HY000: You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable)
+INSERT INTO counter(count) VALUES(23);;
+# connection node_1
+include/assert.inc [The hello function should not exist on node 1]
+# connection node_2
+include/assert.inc [The hello function should not exist on node 2]
+# connection node_1
+REVOKE ALL ON testdb.* FROM 'testme'@'%';
+GRANT SELECT ON testdb.* TO 'testme'@'%';
+GRANT INSERT ON testdb.counter TO 'testme'@'%';
+SHOW GRANTS FOR 'testme';
+Grants for testme@%
+GRANT USAGE ON *.* TO `testme`@`%`
+GRANT SELECT ON `testdb`.* TO `testme`@`%`
+GRANT INSERT ON `testdb`.`counter` TO `testme`@`%`
+FLUSH PRIVILEGES;
+SET @@global.log_bin_trust_function_creators= @old_log_bin_trust_function_creators;
+Warnings:
+Warning	1287	'@@log_bin_trust_function_creators' is deprecated and will be removed in a future release.
+#
 # SQLCOM_DROP_PROCEDURE access test
 #
 # connection node_1
@@ -730,7 +769,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 DROP PROCEDURE hellop;
-INSERT INTO counter(count) VALUES(23);;
+INSERT INTO counter(count) VALUES(24);;
 # connection node_1
 include/assert.inc [The hellop procedure should not exist on node 1]
 # connection node_2
@@ -773,7 +812,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 ALTER PROCEDURE hellop SQL SECURITY INVOKER;
-INSERT INTO counter(count) VALUES(24);;
+INSERT INTO counter(count) VALUES(25);;
 # connection node_1
 include/assert.inc [The hellop procedure should use the invoker on node 1]
 # connection node_2
@@ -816,7 +855,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 ALTER FUNCTION hellof SQL SECURITY INVOKER;
-INSERT INTO counter(count) VALUES(25);;
+INSERT INTO counter(count) VALUES(26);;
 # connection node_1
 include/assert.inc [The hellof function should use the invoker on node 1]
 # connection node_2
@@ -845,7 +884,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 CREATE VIEW testview AS SELECT * FROM t1;
-INSERT INTO counter(count) VALUES(26);;
+INSERT INTO counter(count) VALUES(27);;
 # connection node_1
 include/assert.inc [The testview VIEW should exist on node 1]
 # connection node_2
@@ -882,7 +921,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 DROP VIEW helloview;
-INSERT INTO counter(count) VALUES(27);;
+INSERT INTO counter(count) VALUES(28);;
 # connection node_1
 include/assert.inc [The helloview VIEW should not exist on node 1]
 # connection node_2
@@ -910,7 +949,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 CREATE TRIGGER testtrigger BEFORE INSERT ON t1 FOR EACH ROW SET @sum = @sum + 1;
-INSERT INTO counter(count) VALUES(28);;
+INSERT INTO counter(count) VALUES(29);;
 # connection node_1
 include/assert.inc [The testtrigger TRIGGER should exist on node 1]
 # connection node_2
@@ -944,7 +983,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 DROP TRIGGER hellotrigger;
-INSERT INTO counter(count) VALUES(29);;
+INSERT INTO counter(count) VALUES(30);;
 # connection node_1
 include/assert.inc [The hellotrigger TRIGGER should not exist on node 1]
 # connection node_2
@@ -971,7 +1010,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 INSTALL PLUGIN audit_log SONAME "audit_log.so";
-INSERT INTO counter(count) VALUES(30);;
+INSERT INTO counter(count) VALUES(31);;
 # connection node_1
 include/assert.inc [The audit_log PLUGIN should be installed on node 1]
 # connection node_2
@@ -1003,7 +1042,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 UNINSTALL PLUGIN null_audit;
-INSERT INTO counter(count) VALUES(31);;
+INSERT INTO counter(count) VALUES(32);;
 # connection node_1
 include/assert.inc [The null_audit PLUGIN should not be installed on node 1]
 # connection node_2
@@ -1032,7 +1071,7 @@ use testdb;
 CREATE EVENT testevent
 ON SCHEDULE EVERY 1 HOUR
 DO INSERT INTO t1(f2) VALUES(3);
-INSERT INTO counter(count) VALUES(32);;
+INSERT INTO counter(count) VALUES(33);;
 # connection node_1
 include/assert.inc [The testevent EVENT should exist on node 1]
 # connection node_2
@@ -1072,7 +1111,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 ALTER EVENT helloevent ON SCHEDULE EVERY '2:3' DAY_HOUR;
-INSERT INTO counter(count) VALUES(33);;
+INSERT INTO counter(count) VALUES(34);;
 # connection node_1
 include/assert.inc [The helloevent EVENT should still exist on node 1]
 # connection node_2
@@ -1099,7 +1138,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 DROP EVENT helloevent;
-INSERT INTO counter(count) VALUES(34);;
+INSERT INTO counter(count) VALUES(35);;
 # connection node_1
 include/assert.inc [The helloevent EVENT should not exist on node 1]
 # connection node_2
@@ -1128,7 +1167,7 @@ FLUSH PRIVILEGES;
 # connection node_testme
 use testdb;
 ALTER USER 'testother'@'%' PASSWORD EXPIRE;
-INSERT INTO counter(count) VALUES(35);;
+INSERT INTO counter(count) VALUES(36);;
 # connection node_1
 include/assert.inc [User testother should be expired on node 1]
 # connection node_2

--- a/mysql-test/suite/galera/t/galera_wsrep_ddl_access_checking2.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_ddl_access_checking2.test
@@ -1470,6 +1470,67 @@ REVOKE CREATE ROUTINE,EXECUTE,ALTER ROUTINE ON testdb.* FROM 'testme'@'%';
 SHOW GRANTS FOR 'testme';
 FLUSH PRIVILEGES;
 
+--echo #
+--echo # SQLCOM_CREATE_SPFUNCTION (with log_bin_trust_function_creators=OFF) access test
+--echo #
+#
+# All tests are executed with log_bin_trust_function_creators=ON
+# (set in default_mysqld.cnf)
+# however OFF is the default value. Test CREATE FUNCTION with default
+# log_bin_trust_function_creators=OFF
+#
+--inc $test_id
+
+--echo # connection node_1
+--connection node_1
+SET @old_log_bin_trust_function_creators= @@global.log_bin_trust_function_creators;
+SET global log_bin_trust_function_creators=OFF;
+
+GRANT ALL PRIVILEGES ON testdb.* TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+
+--echo # connection node_testme
+--disconnect node_testme
+--connect node_testme, 127.0.0.1, testme, secret,, $NODE_MYPORT_1
+--connection node_testme
+use testdb;
+
+--error ER_BINLOG_CREATE_ROUTINE_NEED_SUPER
+CREATE FUNCTION hello (s CHAR(20)) RETURNS CHAR(50) DETERMINISTIC RETURN CONCAT('Hello, ',s,'!');
+
+--eval INSERT INTO counter(count) VALUES($test_id);
+
+--echo # connection node_1
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = The hello function should not exist on node 1
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.routines where ROUTINE_NAME="hello"
+--source include/assert.inc
+
+--echo # connection node_2
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = $test_id FROM counter;
+--source include/wait_condition.inc
+
+--let $assert_text = The hello function should not exist on node 2
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.routines where ROUTINE_NAME="hello"
+--source include/assert.inc
+
+--echo # connection node_1
+--connection node_1
+# revoke what was granted for the current check
+REVOKE ALL ON testdb.* FROM 'testme'@'%';
+# restore common grants
+GRANT SELECT ON testdb.* TO 'testme'@'%';
+GRANT INSERT ON testdb.counter TO 'testme'@'%';
+--replace_regex /\*[0-9A-Z]+/<SECRET>/
+SHOW GRANTS FOR 'testme';
+FLUSH PRIVILEGES;
+SET @@global.log_bin_trust_function_creators= @old_log_bin_trust_function_creators;
 
 #
 # SQLCOM_DROP_PROCEDURE

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5340,10 +5340,6 @@ int mysql_execute_command(THD *thd, bool first_level) {
       */
       thd->binlog_invoker();
 
-#ifdef WITH_WSREP
-      WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL)
-#endif /* WITH_WSREP */
-
       bool sp_already_exists = false;
       if (!(res = sp_create_routine(
                 thd, lex->sphead, thd->lex->definer,


### PR DESCRIPTION
user don't have super privilege and binary loggin is enabled

https://perconadev.atlassian.net/browse/PXC-4362

Problem:
If log_bin_trust_function_creators=OFF (default), CREATE FUNCTION statement fails locally with error "You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable)", but doesn't fail on the remote node which leads to node being evicted from the cluster.

Cause:
CREATE FUNCTION is replicated as TOI, before doing checks on local node. As it is executed from applier thread context on the remote node, it succeeds remotely, but fails locally. This kicks-in inconsistency voting protocol, which causes node to be evicted from the cluster.

Solution:
Do privileges checks before replicating TOI.