### PR TITLE
PXC-4348: Cluster state interruption with MDL BF-BF conflict and exec…

### DIFF
--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -4479,6 +4479,21 @@ void MDL_context::release_locks_stored_before(enum_mdl_duration duration,
 void MDL_context::release_explicit_locks() {
   release_locks_stored_before(MDL_EXPLICIT, NULL);
 }
+
+void MDL_context::dump_locks() {
+  MDL_ticket *ticket;
+  WSREP_INFO("MDL_context::dump_locks() >>>\n");
+  for (int i = 0; i < MDL_DURATION_END; i++) {
+    enum_mdl_duration duration = static_cast<enum_mdl_duration>(i);
+
+    MDL_ticket_store::List_iterator it = m_ticket_store.list_iterator(duration);
+    while ((ticket = it++)) {
+      WSREP_INFO("duration: %d, name: %s", i, ticket->get_lock()->key.name());
+    }
+  }
+  WSREP_INFO("MDL_context::dump_locks() <<<\n");
+}
+
 #endif /* WITH_WSREP */
 
 /**

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -1602,6 +1602,7 @@ class MDL_context {
   inline bool has_explicit_locks() const {
     return !(m_ticket_store.is_empty(MDL_EXPLICIT));
   }
+  void dump_locks();
 #endif /* WITH_WSREP */
   bool has_locks(MDL_key::enum_mdl_namespace mdl_namespace) const;
 

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -780,17 +780,18 @@ bool Sql_cmd_truncate_table::execute(THD *thd) {
 
     // mdl_lock scope begin
     {
+      bool mdl_acquired = false;
       // Acquire lock on the table as it is needed to get the instance from DD
       MDL_request mdl_request;
       MDL_REQUEST_INIT(&mdl_request, MDL_key::TABLE, table->db,
                        table->table_name, MDL_SHARED, MDL_EXPLICIT);
       wsrep_scope_guard mdl_lock(
-          [thd, &mdl_request]() {
-            thd->mdl_context.acquire_lock(&mdl_request,
-                                          thd->variables.lock_wait_timeout);
+          [thd, &mdl_request, &mdl_acquired]() {
+            mdl_acquired = !thd->mdl_context.acquire_lock(
+                &mdl_request, thd->variables.lock_wait_timeout);
           },
-          [thd, &mdl_request]() {
-            thd->mdl_context.release_lock(mdl_request.ticket);
+          [thd, &mdl_request, &mdl_acquired]() {
+            if (mdl_acquired) thd->mdl_context.release_lock(mdl_request.ticket);
           });
 
       const char *schema_name = table->db;
@@ -810,7 +811,6 @@ bool Sql_cmd_truncate_table::execute(THD *thd) {
 
       handlerton *hton = nullptr;
       if (dd::table_storage_engine(thd, table_ref, &hton)) {
-        thd->mdl_context.release_lock(mdl_request.ticket);
         return true;
       }
 

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -594,6 +594,14 @@ void Wsrep_high_priority_service::debug_crash(const char *crash_point __attribut
   DBUG_EXECUTE_IF(crash_point, DBUG_SUICIDE(););
 }
 
+bool Wsrep_high_priority_service::has_mdl_locks() {
+  assert(m_thd == current_thd);
+  bool has_mdl_locks = m_thd->mdl_context.has_locks();
+  if (has_mdl_locks) {
+    m_thd->mdl_context.dump_locks();
+  }
+  return has_mdl_locks;
+}
 /****************************************************************************
                            Applier service
 *****************************************************************************/

--- a/sql/wsrep_high_priority_service.h
+++ b/sql/wsrep_high_priority_service.h
@@ -55,6 +55,8 @@ class Wsrep_high_priority_service : public wsrep::high_priority_service,
 
   int next_fragment(const wsrep::ws_meta&) override;
 
+  bool has_mdl_locks() override;
+
  protected:
   friend Wsrep_server_service;
   THD *m_thd;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1881,7 +1881,7 @@ bool wsrep_append_child_tables(THD *thd, Table_ref *tables,
 }
 
 /*
- * Collect wsrep keys corresponding to parent tables
+ * Collect wsrep keys corresponding to parent  tables
  */
 bool wsrep_append_fk_parent_table(THD *thd, Table_ref *tables,
                                   wsrep::key_array *keys) {

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -357,9 +357,8 @@ static MY_ATTRIBUTE((warn_unused_result)) dberr_t
         (node->is_delete ||
          row_upd_changes_first_fields_binary(entry, index, node->update,
                                              foreign->n_fields))) {
-      if (foreign->referenced_table == NULL) {
-        MDL_ticket *mdl;
-
+      MDL_ticket *mdl = nullptr;
+      if (foreign->referenced_table == nullptr) {
         foreign->referenced_table = dd_table_open_on_name(
             trx->mysql_thd, &mdl, foreign->referenced_table_name_lookup, false,
             DICT_ERR_IGNORE_NONE);
@@ -373,9 +372,9 @@ static MY_ATTRIBUTE((warn_unused_result)) dberr_t
 
       err = row_ins_check_foreign_constraint(true, foreign, table, entry, thr);
 
-      if (foreign->referenced_table != NULL) {
+      if (foreign->referenced_table != nullptr) {
         if (opened) {
-          dict_table_close(foreign->referenced_table, false, false);
+          dd_table_close(foreign->referenced_table, current_thd, &mdl, false);
           opened = false;
         }
       }


### PR DESCRIPTION
…-mode:toi

https://perconadev.atlassian.net/browse/PXC-4348

Problem:
The Joiner node crashes with BF-BF abort during IST.

Cause:
Let's consider the following case in 2-nodes cluster: 0. Two wsrep_applier threads (A1, A2)
1. The schema consists of two tables: t1 - parent, t2 - child
2. Two sessions on node_1 execute workloads which conflict and cause certification failures, like:
session_1: OPTIMZE TABLE t1
session_2: DELETE FROM t2 WHERE ...; INSERT INTO t2 VALUES ...;
3. Queries are dependant (writeset's depends_seqno set to previous transaction), because of parent-child tables relation. However, because of certification conflicts, so-called dummy writesets are logged.
4. Dummy writeset does not depend on other writeset (depends_seqno == -1), but other writeset can depend on dummy writeset.
5. When DELETE FROM ... is executed we call wsrep_row_upd_check_foreign_constraints(). If foreign->referenced_table is nullptr we call dd_table_open_on_name() which creates explicit lock on t1 table. Later we call dict_table_close(), which closes the table, but does not release the lock. dd_table_close() should be called instead. This is the root cause of the problem.
6. Let's say during IST we've got the following chain of dependencies: T1 (DML) -> T2 (DDL, depends on T1) -> T3 (dummy, no dependency)
7. T1 is executed by A1. T2 waits. (A2 is bussy with other WS - doesn't matter)
8. A1 finishes with T1. Explicit lock on t1 is owned by A1.
9. T2 is executed by A2, T3 is executed by A1 - they have no dependency, so execution is in parallel. T2 brute forces T3 as they conflict on having t1 MDL.

Solution:
1. Release explicit MDL lock by calling dd_table_close()
2. Added assertions in server_state::on_apply() before and after writeset apply to catch situations when we start or end processing with MDL locks acquired.
3. In places when we check pxc_strict_mode, handled the situation when MDL lock can't be acquired. In such a case it shouldn't be released (sql_alter.cc, sql_truncate.cc and sql_tablespace.cc)
4. Removed not neded unlock of MDL lock in sql_truncate.cc. It is handled by wsrep_scope_guard mdl_lock.