### PR TITLE
PXC-4378: Make the dev-helper.cmake file to download PXB-8.1 automoatically

### DIFF
--- a/cmake/dev-helper.cmake
+++ b/cmake/dev-helper.cmake
@@ -8,25 +8,8 @@ endif(WITH_GALERA_DEV)
 
 if(WITH_PXB_DEV)
   include(ExternalProject)
-  #Note: requires a different boost version than pxc8.0
-  ExternalProject_Add(pxb24
-    GIT_REPOSITORY https://github.com/percona/percona-xtrabackup.git
-    GIT_TAG percona-xtrabackup-2.4.28
-    GIT_SHALLOW 1
-    UPDATE_COMMAND ""
-    INSTALL_DIR "${CMAKE_BINARY_DIR}/scripts/pxc_extra/pxb-2.4/"
-    CMAKE_ARGS 
-    -DDOWNLOAD_BOOST=1
-    -DWITH_BOOST=boost
-    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-    -DMYSQL_MAINTAINER_MODE=OFF
-    -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}
-    -DOPENSSL_LIBRARIES=${OPENSSL_LIBRARIES}
-    )
-  INSTALL(DIRECTORY "${CMAKE_BINARY_DIR}/scripts/pxc_extra/pxb-2.4/"
-    DESTINATION "bin/pxc_extra/pxb-2.4" USE_SOURCE_PERMISSIONS)
 
+  # Previous LTS
   ExternalProject_Add(pxb80
     GIT_REPOSITORY https://github.com/percona/percona-xtrabackup.git
     GIT_TAG percona-xtrabackup-8.0.34-29
@@ -43,4 +26,22 @@ if(WITH_PXB_DEV)
     )
   INSTALL(DIRECTORY "${CMAKE_BINARY_DIR}/scripts/pxc_extra/pxb-8.0/"
     DESTINATION "bin/pxc_extra/pxb-8.0" USE_SOURCE_PERMISSIONS)
+
+  # Current version
+  ExternalProject_Add(pxb81
+    GIT_REPOSITORY https://github.com/percona/percona-xtrabackup.git
+    GIT_TAG percona-xtrabackup-8.1.0-1
+    GIT_SHALLOW 1
+    UPDATE_COMMAND ""
+    INSTALL_DIR "${CMAKE_BINARY_DIR}/scripts/pxc_extra/pxb-8.1/"
+    CMAKE_ARGS 
+    -DWITH_BOOST=${WITH_BOOST}
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DMYSQL_MAINTAINER_MODE=OFF
+    -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}
+    -DOPENSSL_LIBRARIES=${OPENSSL_LIBRARIES}
+    )
+  INSTALL(DIRECTORY "${CMAKE_BINARY_DIR}/scripts/pxc_extra/pxb-8.1/"
+    DESTINATION "bin/pxc_extra/pxb-8.1" USE_SOURCE_PERMISSIONS)
 endif()


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4378

Download, compile and install pxb-8.1 as part of the server compilation when -DWITH_PXB_DEV is passed.

In addition to that, support for download of pxb-2.4 has also been removed.


NOTE
===
- Target branch has been set to `release-8.1.0-1` temporarily. This will be merged only after `trunk` branch is created.