### PR TITLE
PXC-4367: InnoDB semaphore wait timeout failure after upgrade from 8.…

### DIFF
--- a/mysql-test/suite/galera/r/pxc_error_during_group_commit.result
+++ b/mysql-test/suite/galera/r/pxc_error_during_group_commit.result
@@ -1,0 +1,6 @@
+CALL mtr.add_suppression("Transaction not registered for MySQL 2PC");
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET DEBUG = '+d,innobase_commit_low_fail';
+INSERT INTO t1 VALUES (0);
+INSERT INTO t1 VALUES (1);
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_error_during_group_commit.test
+++ b/mysql-test/suite/galera/t/pxc_error_during_group_commit.test
@@ -1,0 +1,36 @@
+# Test the following problematic case is handled correctly:
+# 1. group commit queue consist of one thread thd_1
+# 2. thd_1 is being processed, it registers in wsrep_group_commit_queue
+# 3. InnoDB commit fails (it may happen because of transaction abort or other reason)
+# 4. As the result thd_1 fails to unregister from wsrep_group_commit_queue
+# 5. thd_2 is being processed as another commit queue
+# 6. thd_2 commits in InnoDB and tries to unregister from wsrep_group_commit_queue
+# 7. thd_2 waits, because thd_1 is still the 1st item in the wsrep_group_commit_queue
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+CALL mtr.add_suppression("Transaction not registered for MySQL 2PC");
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+
+# Force InnoDB commit failure, which will cause skip of unregistration from wsrep_group_commit_queue
+SET DEBUG = '+d,innobase_commit_low_fail';
+INSERT INTO t1 VALUES (0);
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+
+# node_1 connection is the 1st one in wsrep_group_commit_queue, so node_1a will assert in debug build
+# For release build it would cause '[InnoDB] A long semaphore wait', but unfortunately debug_sync
+# is not available, so no way to simulate. 
+INSERT INTO t1 VALUES (1);
+--assert(`SELECT COUNT(*) = 2 FROM t1`)
+
+# cleanup
+--disconnect node_1a
+--connection node_1
+DROP TABLE t1;
+--source include/wait_until_count_sessions.inc

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1846,6 +1846,50 @@ int ha_commit_trans(THD *thd, bool all, bool ignore_global_read_lock) {
     else if (trn_ctx->no_2pc(trx_scope) ||
              trn_ctx->rw_ha_count(trx_scope) == 1) {
       /* cache decision to run wsrep-commit-hook with log_bin=off. */
+      /* KH: The original comment above is not precise.
+         1. If log_bin=off or sql_log_bin=off, binlog is involved anyway
+         (cache for writeset data), so we don't hit this branch.
+         We hit 'if' branch.
+         2. We can get here if log_bin=off && wsrep_on=off
+         But in this case run_wsrep_commit_hooks will be false anyway.
+         3. The other option to get here is to use MyISAM. In sucha  case
+         we've got rw_ha_count()=1 (only binlog). no_2pc is false as
+         MyISAM is not registering itelf in 2pc coordinator.
+         The only option to have run_wsrep_commit_hooks=true is having
+         involved SE which does not support 2pc (MyISAM). In such a case
+         wsrep_run_commit_hook will be evaluated to false as well, because
+         transaction appears to be empty (MyISAM uses TOI replication, so no
+         writeset to replicate).
+
+         4. But streaming replication goes this path if it certifies a fragment.
+         In such a case binlog handler is not involved
+         When wsrep::transaction::certify_fragment() is called,
+         we get to ha_commit_low() via short path which skips wsrep commit hooks
+         certify_fragment:
+         wsrep::transaction::after_row
+         wsrep::transaction::streaming_step
+         wsrep::transaction::certify_fragment
+         Wsrep_storage_service::commit
+         trans_commit
+         ha_commit_trans
+         MYSQL_BIN_LOG::commit
+         trx_coordinator::commit_in_engines
+         ha_commit_low
+         wsrep_before_commit <- here we need to call wsrep commit hook
+
+         5. Applier thread on the server with 'log_replica_updates=OFF'
+         goes this path as well:
+         apply_cb
+         high_priority_service::apply
+         server_state::on_apply
+         apply_write_set
+         Wsrep_high_priority_service::commit
+         trans_commit
+         ha_commit_trans
+         MYSQL_BIN_LOG::commit
+         trx_coordinator::commit_in_engines
+         ha_commit_low <- here we need to call wsrep commit hook
+      */
       thd->run_wsrep_commit_hooks = wsrep_run_commit_hook(thd, all);
     }
 #else
@@ -2071,29 +2115,6 @@ int ha_commit_low(THD *thd, bool all, bool run_after_commit) {
         Commit_order_manager::wait_and_finish(thd, error);
       }
     }
-  } else {
-      /* This function is common for group commit flow and the flow that skips
-      group commit. We register the thread in wsrep_group_commit_queue always.
-      For group commit it is done during binlog flush stage, for 1-phase commit
-      it is done in wsrep_before_commit().
-      Ideally, for one-phase (with binlog=off) or two-phase (with binlog=on)
-      this step would be executed when transaction commits in InnoDB.
-      If galera node is acting as async slave and replicated action from async
-      master result in empty changes on slave (slave directly applied the said
-      changes and has skipped error through skip-slave-error configuration) it
-      can result in said situation. In this case slave protocol directly commits
-      gtid through gtid_end_transaction that invokes ordered_commit causing
-      thread handler to register in wsrep group commit queue but since storage
-      engine commit is not done it would fail to unregister the said thread
-      handler as part of storage engine commit. Handle unregistration here,
-      because doing it in wsrep_after_commit() is too late. If there is another
-      thread following this thread in currently processed commit queue,
-      current thread is commited (but does not commit in SE, so does not unregister
-      from wsrep_group_commit_queue. Then the following thread calls
-      wsrep_wait_for_turn_in_group_commit() but sees the previous thread at the front
-      and waits infinitely. */
-      wsrep_wait_for_turn_in_group_commit(thd);
-      wsrep_unregister_from_group_commit(thd);
   }
 
 err:
@@ -2118,10 +2139,60 @@ err:
   }
 
 #ifdef WITH_WSREP
+  /* This function is common for group commit flow and the flow that skips
+  group commit. We register the thread in wsrep_group_commit_queue always.
+  For group commit it is done during binlog flush stage, for 1-phase commit
+  it is done in wsrep_before_commit() called at the beginning of ha_commit_low()
+  (this function).
+
+  Ideally, for one-phase (without binlog involved) or two-phase
+  (with binlog involved), this step would be executed when transaction commits
+  in InnoDB.
+
+  However, there are cases when the flow does not reach unregistration
+  during InnoDB commit:
+
+  Case 1:
+  If Galera node is acting as async slave and replicated action from async
+  master results in empty changes on slave (slave directly applied the said
+  changes and has skipped error through skip-slave-error configuration) it
+  can result in said situation. In this case slave protocol directly commits
+  gtid through gtid_end_transaction that invokes ordered_commit causing
+  thread handler to register in wsrep group commit queue but since storage
+  engine commit is not done it would fail to unregister the said thread
+  handler as part of storage engine commit.Handle unregistration here,
+  because doing it in wsrep_after_commit() is too late. If there is another
+  thread following this thread in currently processed commit queue,
+  current thread is commited (but does not commit in SE, so does not unregister
+  from wsrep_group_commit_queue. Then the following thread calls
+  wsrep_wait_for_turn_in_group_commit() but sees the previous thread at
+  the front and waits infinitely.
+
+  Case 2:
+  Similar to the above. If the current thd's (thd_1) commit in InnoDB SE fails
+  (innobase_commit returns with error because the thread gets aborted, or
+  any other reason which causes that innobase_commit() desn't reach
+  trx_sys_update_wsrep_checkpoint() where thd unregistration from
+  wsrep_group_commit_queue happens), and there is another thread (thd_2)
+  in the commit queue following thd_1, we end up in the situation when thd_2
+  waits for being the 1st one in wsrep_group_commit_queue, but thd_1 is still
+  the 1st one, so the processing of commit queue is blocked.
+  We need to remove thd_1 from wsrep_group_commit_queue now, no matter if commit
+  failed or not, to give a chance to commit for the following threads.
+
+  Note:
+  Consider removing waiting and unregistration from
+  trx_sys_update_wsrep_checkpoint() as the below unregistration should hadle
+  all cases.
+  */
+  wsrep_wait_for_turn_in_group_commit(thd);
+  wsrep_unregister_from_group_commit(thd);
+
   if (!error && thd->run_wsrep_commit_hooks) {
     (void)wsrep_after_commit(thd, all);
   }
   thd->run_wsrep_commit_hooks = false;
+
 #endif /* WITH_WSREP */
 
   return error;

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -376,8 +376,15 @@ static inline int wsrep_after_commit(THD *thd, bool all) {
               wsrep_has_changes(thd));
   assert(wsrep_run_commit_hook(thd, all));
 
-  /* It has to already unregistered from wsrep_group_commit_queue either
-  during SE commit or directly in ha_commit_low if SE commit was not done. */
+  /* It has to be already unregistered from wsrep_group_commit_queue either
+  during SE commit or directly in ha_commit_low if unregistration during
+  SE commit hasn't happened for any reason. */
+  if (thd->wsrep_enforce_group_commit) {
+    WSREP_WARN("%s",
+               "This thread has still not unregistered from "
+               "the wsrep group commit queue, may be because "
+               "of the storage engine commit. Server hang is expected.")
+  }
   assert(!thd->wsrep_enforce_group_commit);
 
   int ret = 0;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6258,6 +6258,15 @@ void innobase_commit_low(trx_t *trx) /*!< in: transaction handle */
   }
 
   DEBUG_SYNC_C("innobase_commit_low_begin");
+
+  /* Error only for non system thread (skip gtid_clone_thread) */
+  DBUG_EXECUTE_IF("innobase_commit_low_fail", {
+    if (thd->system_thread == NON_SYSTEM_THREAD) {
+      DBUG_SET("-d,innobase_commit_low_fail");
+      return;
+    }
+  });
+
 #endif /* WITH_WSREP */
 
   if (trx_is_started(trx)) {


### PR DESCRIPTION
…0.34 to 8.0.35

https://perconadev.atlassian.net/browse/PXC-4367

Problem:
Under the heavy load, it happens sometimes that the server is stuck waiting for the InnoDB semaphore. After the 600secs timeout the server is intentionally stopped.

Cause:
This bug is the regression caused by commit 3dbdd49b related to PXC-4318 3dbdd49b moved unregistration of thread from wsrep_group_commit_queue from wsrep_after_commit() directly to ha_commit_low() to the execution branch reached when no SE is involved in the commit. However, this fix didn't consider a scenario when SE is involved, but actual innobase_commit() fails (because of different reasons, e.g. transaction abort or others) and the flow doesn't reach trx_sys_update_wsrep_checkpoint() where unregistration from wsrep_group_commit_queue should happen. In such a case the thread is left in front of wsrep_group_commit_queue blocking every other thread from processing (the other thread waits to be the 1st one to continue). Before the above-mentioned fix unregistration happened in wsrep_after_commit().

In other words, the scenario is:
1. thd_1 commits transaction. It calls wsrep_ordered_commit() to register itself in wsrep_group_commit_queue
2. thd_1 calls ha_commit_low , but is aborted -> no unregistration from wsrep_group_commit_queue
3. thd_1 calls wsrep_after_commit. Before 3dbdd49b there was unregistration from wsrep_group_commit_queue if not already unregistered. It was removed. So thd_1 stays on wsrep_group_commit_queue
4. thd_2 commits transaction, it calls wsrep_ordered_commit() to register itself in wsrep_group_commit_queue
5. thd_2 calls ha_commit_low and gets to wsrep_wait_for_turn_in_group_commit
6. thd_2 waits for being the 1st in the queue forever

Reverting that part of the previous fix is not enough, because it will still not work for the following scenario:
1. The following commit queue is being processed: thd_1, thd_2
2. thd_1 becomes the leader of the commit stage of group commit
3. thd_1 calls ha_commit_low, but it fails -> no unregistration from wsrep_group_commit_queue
4. thd_1 processes thd_2 commit
5. it gets to wsrep_wait_for_turn_in_group_commit and waits for thd_2 to be the 1st in the queue

Solution:
A thread has to be removed from wsrep_group_commit_queue after it is committed. No matter if the actual commit succeeded or failed. Call unregistration from wsrep_group_commit_queue unconditionally at the end of ha_commit_low()