### PR TITLE
PXC-4385: MDL conflict leads to locked nodes

### DIFF
--- a/mysql-test/suite/galera/r/pxc_acl_deadlock.result
+++ b/mysql-test/suite/galera/r/pxc_acl_deadlock.result
@@ -1,0 +1,13 @@
+node_1
+CREATE USER 'test' identified by 'password';
+SET GLOBAL wsrep_provider_options = 'dbug=d,before_replicate_sync';
+SET PASSWORD FOR test = 'password1';
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+node_2
+ALTER USER 'test' ACCOUNT LOCK;
+node_1a
+Waiting for TOI from node_2 to complete
+SET GLOBAL wsrep_provider_options = 'signal=before_replicate_sync';
+DROP USER 'test';

--- a/mysql-test/suite/galera/t/pxc_acl_deadlock.test
+++ b/mysql-test/suite/galera/t/pxc_acl_deadlock.test
@@ -1,0 +1,45 @@
+# Test that TOI that locks ACL tables does not deadlock with replicated TOI that locks ACL tables as well.
+# In other words test that the order of replicating TOI and acquiring MDL locks on ACL tables is correct.
+
+--source include/have_debug_sync.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--connection node_1
+--echo node_1
+CREATE USER 'test' identified by 'password';
+
+# stop just before TOI replication
+--let $galera_sync_point = before_replicate_sync
+--source include/galera_set_sync_point.inc
+
+--send SET PASSWORD FOR test = 'password1'
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+--connection node_2
+--echo node_2
+ALTER USER 'test' ACCOUNT LOCK;
+
+--connection node_1a
+--echo node_1a
+# TOI replicated from node_2 should not be blocked in any way on node_1
+--echo Waiting for TOI from node_2 to complete
+--let $wait_condition = SELECT ACCOUNT_LOCKED = 'Y' FROM mysql.user WHERE USER = 'test'
+--source include/wait_condition.inc
+
+# unblock node_1
+--source include/galera_signal_sync_point.inc
+
+--disconnect node_1a
+
+--connection node_1
+# TOI replicated from node_2 should complete, then TOI from node_1 should proceed.
+# No deadlock expected.
+--reap
+
+# cleanup
+DROP USER 'test';
+--source include/wait_until_count_sessions.inc

--- a/sql/auth/sql_user_table.cc
+++ b/sql/auth/sql_user_table.cc
@@ -1990,6 +1990,65 @@ int open_grant_tables(THD *thd, TABLE_LIST *tables,
 
   DEBUG_SYNC(thd, "wl14084_acl_ddl_before_mdl_acquisition");
 
+#ifdef WITH_WSREP
+  /* We have to check replication filters before TOI.
+     To do the check, we need to acquire MDL locks on ACL tables.
+     The check is done only for replica threads if filters are enabled.
+     Here we decide if async replicated transaction should be  PXC-replicated.
+     If so, we will start TOI, but can't do it while holding MDL lock, because
+     if we call TOI begin here and get to the point where Galera is just about
+     to replicate, and at the same time another, replicated TOI arrives, we will
+     end up waiting in Galera for our turn.
+     If that replicated TOI relates to ACL as well (e.g. SET PASSWORD) and calls
+     acl_tables_setup_for_write_and_acquire_mdl(), it will try to abort us,
+     but we are waiting in Galera, so not able to release locks.
+     The result is a deadlock.
+
+     Let's close ACL tables here and and lock them again after TOI, hoping
+     that replication filters won't change in the meantime. */
+  if (thd->slave_thread && thd->rli_slave->rpl_filter->is_on()) {
+    if (acl_tables_setup_for_write_and_acquire_mdl(thd, tables)) return -1;
+    /*
+      The tables must be marked "updating" so that tables_ok() takes them into
+      account in tests.
+    */
+    for (auto i = 0; i < ACL_TABLES::LAST_ENTRY; i++) tables[i].updating = true;
+
+    if (!(thd->sp_runtime_ctx ||
+          thd->rli_slave->rpl_filter->tables_ok(nullptr, tables))) {
+      thd->mdl_context.release_transactional_locks();
+      return 1;
+    }
+
+    for (auto i = 0; i < ACL_TABLES::LAST_ENTRY; i++)
+      tables[i].updating = false;
+
+    thd->mdl_context.release_transactional_locks();
+  }
+
+  /* CREATE/DROP function/procedure implicitly grant priviliges.
+  Check for detail comment in respected switch handler in sql_parse.cc
+  Since the original statement is already replicated using TOI
+  sub-action of grant/revoke privilges doesn't need to get replicated. */
+  bool skip_toi = (thd->lex->sql_command == SQLCOM_CREATE_SPFUNCTION ||
+                   thd->lex->sql_command == SQLCOM_CREATE_PROCEDURE ||
+                   thd->lex->sql_command == SQLCOM_DROP_FUNCTION ||
+                   thd->lex->sql_command == SQLCOM_DROP_PROCEDURE);
+  /*
+    Perform the TOI after the replication filter check to avoid
+    replicating commands that won't be applied locally (due to a filter).
+  */
+  if (WSREP(thd) && !skip_toi &&
+      wsrep_to_isolation_begin(thd, db, table, nullptr)) {
+    WSREP_ERROR("Fail to replicate: %s", thd->query().str);
+    return -1;
+  }
+
+  /* For replica thread we checked replication filters before TOI and then
+     released MDL locks.
+     Original flow continues with tables locked, so lock them again. */
+  if (acl_tables_setup_for_write_and_acquire_mdl(thd, tables)) return -1;
+#else
   if (acl_tables_setup_for_write_and_acquire_mdl(thd, tables)) return -1;
 
   /*
@@ -2011,29 +2070,6 @@ int open_grant_tables(THD *thd, TABLE_LIST *tables,
 
     for (auto i = 0; i < ACL_TABLES::LAST_ENTRY; i++)
       tables[i].updating = false;
-  }
-
-#ifdef WITH_WSREP
-  /* CREATE/DROP function/procedure implicitly grant priviliges.
-  Check for detail comment in respected switch handler in sql_parse.cc
-  Since the original statement is already replicated using TOI
-  sub-action of grant/revoke privilges doesn't need to get replicated. */
-  bool skip_toi = (thd->lex->sql_command == SQLCOM_CREATE_SPFUNCTION ||
-                   thd->lex->sql_command == SQLCOM_CREATE_PROCEDURE ||
-                   thd->lex->sql_command == SQLCOM_DROP_FUNCTION ||
-                   thd->lex->sql_command == SQLCOM_DROP_PROCEDURE);
-  /*
-    Perform the TOI after the replication filter check to avoid
-    replicating commands that won't be applied locally (due to a filter).
-  */
-  /* Doing TOI here is not the ideal solution, as we are holding
-  MDL locks already and the current thread can still be BF-aborted.
-  But we have to check replication filters before TOI and for this
-  we need MDL locks. */
-  if (WSREP(thd) && !skip_toi &&
-      wsrep_to_isolation_begin(thd, db, table, nullptr)) {
-    WSREP_ERROR("Fail to replicate: %s", thd->query().str);
-    return -1;
   }
 #endif /* WITH_WSREP */
 


### PR DESCRIPTION
https://perconadev.atlassian.net/issues/PXC-4385

Problem:
Execution of queries 'ALTER USER ... ACCOUNT LOCK' and 'SET PASSWORD FOR ... = ...' in parallel on different nodes may lead to the cluster stuck.

Cause:
TOI replication is done in open_grant_tables() after checking replication filters. Validation of replication filters requires call to acl_tables_setup_for_write_and_acquire_mdl() which acquires MDL locks. Then local TOI is replicated.
If at the time when local TOI is about to replicate on Galera level, another, replicated TOI is being processed and calls open_grant_tables() as well, we end up with the situation when replicated TOI should B-F abort local TOI. But local TOI waits for its turn in Galera, so not able to unlock acquired MDL locks. Replicated TOI waits on MDL locks held by local TOI which leads to deadlock.

Solution:
After examining replication filters, release all MDL locks and replicate TOI. Then reacquire needed locks and continue original flow. This is the best we can do.