### PR TITLE
PXC-4397: ALTER DATABASE and DROP TRIGGER hangs the instance

### DIFF
--- a/mysql-test/suite/galera/r/pxc_trigger_deadlock.result
+++ b/mysql-test/suite/galera/r/pxc_trigger_deadlock.result
@@ -1,0 +1,21 @@
+node_1
+CREATE DATABASE test2;
+USE test2;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET GLOBAL wsrep_provider_options = 'dbug=d,before_replicate_sync';
+CREATE TRIGGER trg1 BEFORE INSERT ON t1 FOR EACH ROW DELETE FROM t1 WHERE a=1;
+node_1a
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+ALTER DATABASE test2 CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci;
+SET GLOBAL wsrep_provider_options = 'signal=before_replicate_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=d,before_replicate_sync';
+DROP TRIGGER trg1;
+node_1a
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+ALTER DATABASE test2 CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci;
+SET GLOBAL wsrep_provider_options = 'signal=before_replicate_sync';
+DROP DATABASE test2;

--- a/mysql-test/suite/galera/t/pxc_trigger_deadlock.test
+++ b/mysql-test/suite/galera/t/pxc_trigger_deadlock.test
@@ -1,0 +1,75 @@
+# Test that during replication of TOI related to CREATE/DROP TRIGGER no MDL locks are acquired.
+# Having MDL locks acquired (especially on database level) will lead to the deadlock, when
+# another DDL (ALTER DATABASE) which acquires them runs in parallel.
+
+--source include/have_debug_sync.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--connection node_1
+--echo node_1
+CREATE DATABASE test2;
+USE test2;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+
+#
+# CREATE TRIGGER
+#
+
+# stop just before TOI replication
+--let $galera_sync_point = before_replicate_sync
+--source include/galera_set_sync_point.inc
+
+--send CREATE TRIGGER trg1 BEFORE INSERT ON t1 FOR EACH ROW DELETE FROM t1 WHERE a=1
+
+--connect node_1a, 127.0.0.1, root, , test2, $NODE_MYPORT_1
+--echo node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# ALTER DATABASE should be replicated as TOI, should not block waiting for CREATE TRIGGER
+# as node_1 should not hold any MDL locks at the moment.
+ALTER DATABASE test2 CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci;
+
+# unblock node_1
+--source include/galera_signal_sync_point.inc
+
+--connection node_1
+# TOI replicated from node_2 should complete, then TOI from node_1 should proceed.
+# No deadlock expected.
+--reap
+
+#
+# DROP TRIGGER
+#
+
+# stop just before TOI replication
+--let $galera_sync_point = before_replicate_sync
+--source include/galera_set_sync_point.inc
+
+--send DROP TRIGGER trg1
+
+--connection node_1a
+--echo node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# ALTER DATABASE should be replicated as TOI, should not block waiting for DROP TRIGGER
+# as node_1 should not hold any MDL locks at the moment.
+ALTER DATABASE test2 CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci;
+
+# unblock node_1
+--source include/galera_signal_sync_point.inc
+
+--connection node_1
+# TOI replicated from node_2 should complete, then TOI from node_1 should proceed.
+# No deadlock expected.
+--reap
+
+
+--disconnect node_1a
+
+# cleanup
+DROP DATABASE test2;
+--source include/wait_until_count_sessions.inc
+

--- a/sql/dd/dd_schema.cc
+++ b/sql/dd/dd_schema.cc
@@ -130,4 +130,11 @@ Schema_MDL_locker::~Schema_MDL_locker() {
   if (m_ticket) m_thd->mdl_context.release_lock(m_ticket);
 }
 
+#ifdef WITH_WSREP
+void Schema_MDL_locker::unlock() {
+  if (m_ticket) m_thd->mdl_context.release_lock(m_ticket);
+  m_ticket = nullptr;
+}
+#endif
+
 }  // namespace dd

--- a/sql/dd/dd_schema.h
+++ b/sql/dd/dd_schema.h
@@ -105,6 +105,10 @@ class Schema_MDL_locker {
 
   bool ensure_locked(const char *schema_name);
 
+#ifdef WITH_WSREP
+  void unlock();
+#endif
+
   /**
     Release the MDL ticket, if any, when the instance of this
     class leaves scope or is deleted.

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -444,9 +444,17 @@ bool Sql_cmd_create_trigger::execute(THD *thd) {
   }
 
 #ifdef WITH_WSREP
-  if (WSREP(thd) && wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL,
-                                             m_trigger_table, NULL)) {
-    return true;
+  if (WSREP(thd)) {
+    schema_mdl_locker.unlock();
+    assert(!thd->mdl_context.has_locks());
+    if (wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, m_trigger_table,
+                                 NULL)) {
+      return true;
+    }
+    if (thd->locked_tables_mode &&
+        schema_mdl_locker.ensure_locked(m_trigger_table->db)) {
+      return true;
+    }
   }
 #endif /* WITH_WSREP */
 
@@ -545,6 +553,10 @@ bool Sql_cmd_drop_trigger::execute(THD *thd) {
 
   if (check_schema_readonly(thd, thd->lex->spname->m_db.str)) return true;
 
+#ifdef WITH_WSREP
+  MDL_savepoint mdl_savepoint = thd->mdl_context.mdl_savepoint();
+#endif
+
   if (acquire_exclusive_mdl_for_trigger(thd, thd->lex->spname->m_db.str,
                                         thd->lex->spname->m_name.str))
     return true;
@@ -576,9 +588,13 @@ bool Sql_cmd_drop_trigger::execute(THD *thd) {
 #ifdef WITH_WSREP
     /* Table doesn't exist but query is still being logged
     so replicate a query with NULL construct. */
-    if (WSREP(thd) &&
-        wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, tables)) {
-      return true;
+    if (WSREP(thd)) {
+      thd->mdl_context.rollback_to_savepoint(mdl_savepoint);
+      schema_mdl_locker.unlock();
+      assert(!thd->mdl_context.has_locks());
+      if (wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, tables)) {
+        return true;
+      }
     }
 #endif /* WITH_WSREP */
 
@@ -592,10 +608,19 @@ bool Sql_cmd_drop_trigger::execute(THD *thd) {
   if (check_trg_priv_on_subj_table(thd, tables)) return true;
 
 #ifdef WITH_WSREP
-  /* Table exist so log query with normal constrct */
-  if (WSREP(thd) &&
-      wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, tables)) {
-    return true;
+  if (WSREP(thd)) {
+    thd->mdl_context.rollback_to_savepoint(mdl_savepoint);
+    schema_mdl_locker.unlock();
+    assert(!thd->mdl_context.has_locks());
+    /* Table exist so log query with normal constrct */
+    if (wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, tables)) {
+      return true;
+    }
+    if (schema_mdl_locker.ensure_locked(thd->lex->spname->m_db.str) ||
+        acquire_exclusive_mdl_for_trigger(thd, thd->lex->spname->m_db.str,
+                                          thd->lex->spname->m_name.str)) {
+      return true;
+    }
   }
 #endif /* WITH_WSREP */
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4397

Problem:
When ALTER DATABASE and DROP TRIGGER are executed in parallel on the same node, the node hangs.

Cause:
connection_1: DROP TRIGGER acquires database level MDL lock and trigger-related MDL locks before replicating TOI. connection_2: ALTER DATABASE acquires database level MDL lock after replicating TOI.
If we are about to replicate DROP TRIGGER to the Galera channel and at the same time ALTER DATABASE is replicated,
connection_1 waits for connection_2 to finish. connection_2 tries to acquire MDL lock and should BF-abort connection_1, but as it waits in Galera for its turn, it is not possible to release MDL locks. We end up in deadlock state.

I found that CREATE TRIGGER is affected in the same way.

Solution:
After initial checks in CREATE/DROP TRIGGER, release all MDL locks, replicate TOI and re-acquire MDL locks.
This is the best we can do.