### PR TITLE
PXC-4369: PXC 8.0.36 refresh - Q1 2024 (Fix compilation errors on CentOS-7)

### DIFF
--- a/build-ps/build-rpm.sh
+++ b/build-ps/build-rpm.sh
@@ -123,8 +123,8 @@ export CC="${CC:-gcc}"
 export CXX="${CXX:-g++}"
 export HS_CXX="${HS_CXX:-g++}"
 export UDF_CXX="${UDF_CXX:-g++}"
-export CFLAGS="-fPIC -Wall -O3 -g -static-libgcc -Wno-error=undef -Wno-error=write-strings -fno-omit-frame-pointer -DPERCONA_INNODB_VERSION=$PERCONA_SERVER_VERSION $TARGET_CFLAGS ${CFLAGS:-}"
-export CXXFLAGS="-O2 -Wno-error=undef -Wno-error=write-strings -fno-omit-frame-pointer -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -DPERCONA_INNODB_VERSION=$PERCONA_SERVER_VERSION $TARGET_CFLAGS ${CXXFLAGS:-}"
+export CFLAGS="-fPIC -Wall -O3 -g -static-libgcc -fno-omit-frame-pointer -DPERCONA_INNODB_VERSION=$PERCONA_SERVER_VERSION $TARGET_CFLAGS ${CFLAGS:-}"
+export CXXFLAGS="-O2 -fno-omit-frame-pointer -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -DPERCONA_INNODB_VERSION=$PERCONA_SERVER_VERSION $TARGET_CFLAGS ${CXXFLAGS:-}"
 export MAKE_JFLAG="${MAKE_JFLAG:--j$PROCESSORS}"
 
 # Create directories for rpmbuild if these don't exist

--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -708,7 +708,7 @@ mkdir debug
             sed -e 's/ -unroll2 / /' \
 %if 0%{?rhel} < 9
                 -e 's/ -O[0-9]* / /' \
-                -e 's/-Wp,-D_FORTIFY_SOURCE=2/ -Wno-missing-field-initializers -Wno-error -Wno-error=undef -Wno-error=write-strings/' \
+                -e 's/-Wp,-D_FORTIFY_SOURCE=2/ -Wno-missing-field-initializers -Wno-error /' \
 %endif
                 -e 's/ -ip / /' \
                 -e 's/^ //' \
@@ -717,7 +717,7 @@ mkdir debug
             sed -e 's/ -unroll2 / /' \
 %if 0%{?rhel} < 9
                 -e 's/ -O[0-9]* / /' \
-                -e 's/-Wp,-D_FORTIFY_SOURCE=2/ -Wno-missing-field-initializers -Wno-error -Wno-error=undef -Wno-error=write-strings/' \
+                -e 's/-Wp,-D_FORTIFY_SOURCE=2/ -Wno-missing-field-initializers -Wno-error /' \
 %else
                 -e 's/-D_FORTIFY_SOURCE=2/-D_FORTIFY_SOURCE=2 -Wno-error=stringop-truncation -Wno-error=maybe-uninitialized -Wno-error=odr/' \
 %endif

--- a/build-ps/pxc_builder.sh
+++ b/build-ps/pxc_builder.sh
@@ -859,10 +859,6 @@ build_deb(){
         sed -i 's/gnu++11/gnu++11 -Wno-virtual-move-assign/' cmake/build_configurations/compiler_options.cmake
     fi
 
-    if [[ "x$DEBIAN_VERSION" == "xfocal" || "x$DEBIAN_VERSION" == "xbullseye" || "x$DEBIAN_VERSION" == "xbuster" || "x$DEBIAN_VERSION" == "xbookworm" ]]; then
-        sed -i 's/-fno-omit-frame-pointer/-fno-omit-frame-pointer -Wno-error=undef/' cmake/build_configurations/compiler_options.cmake
-    fi
-
     #==========
     export DEB_CFLAGS_APPEND="$CFLAGS" DEB_CXXFLAGS_APPEND="$CXXFLAGS"
     export MYSQL_BUILD_CFLAGS="$CFLAGS"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4369
    
***
Updated galera submodule pointer after fixing CentOS-7 compilation
errors.
    
***
This patch partially reverts commit f7a11ee0d
(PXC-4398 Release tasks for PXC 8.0.36)
and removes -Wno-error=undef and -Wno-error=write-strings flags from
build scripts.