### PR TITLE
PXC-4365: PXC nodes leave cluster when row size is too large and has more than 3 NVARCHAR columns (trunk)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_long_error_message.result
+++ b/mysql-test/suite/galera/r/pxc_long_error_message.result
@@ -1,0 +1,45 @@
+CREATE TABLE TestTable (
+ID INT NOT NULL,
+A1 VARCHAR(512),
+A2 VARCHAR(512),
+A3 VARCHAR(512),
+A4 VARCHAR(512),
+A5 VARCHAR(512),
+A6 VARCHAR(512),
+A7 VARCHAR(512),
+A8 VARCHAR(512),
+A9 VARCHAR(512),
+A10 VARCHAR(512),
+A11 VARCHAR(512),
+A12 VARCHAR(512),
+A13 VARCHAR(512),
+A14 VARCHAR(512),
+A15 VARCHAR(512),
+A16 VARCHAR(512),
+A17 VARCHAR(512),
+A18 VARCHAR(512),
+A19 VARCHAR(512),
+A20 VARCHAR(512),
+A21 VARCHAR(512),
+A22 VARCHAR(512),
+A23 VARCHAR(512),
+A24 VARCHAR(512),
+A25 VARCHAR(512),
+A26 VARCHAR(512),
+A27 VARCHAR(512),
+A28 VARCHAR(512),
+A29 VARCHAR(512),
+A30 NVARCHAR(512),
+A31 NVARCHAR(512),
+A32 NVARCHAR(512),
+A33 NVARCHAR(512),
+PRIMARY KEY (ID)
+) ENGINE = InnoDB;
+ERROR 42000: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
+CREATE TABLE pxc4365 (i INT PRIMARY KEY, j INT);
+INSERT INTO pxc4365 VALUES(1,1),(2,2),(3,3);
+include/assert.inc [Table pxc4365 was created on node2.]
+include/assert.inc [Node 2 is up, running and replicating.]
+CALL mtr.add_suppression("Row size too large.");
+DROP TABLE pxc4365;
+include/assert.inc [Table pxc4365 was deleted on node1.]

--- a/mysql-test/suite/galera/t/pxc_long_error_message.test
+++ b/mysql-test/suite/galera/t/pxc_long_error_message.test
@@ -1,0 +1,86 @@
+# This test verifies that long messages resulting from the concatenation of
+# warnings and errors from the query are handled properly by galera while
+# performing inconsistency voting.
+
+--source include/galera_cluster.inc
+
+# Create a table that produces warnings and errors.
+--error ER_TOO_BIG_ROWSIZE
+CREATE TABLE TestTable (
+	ID INT NOT NULL,
+	A1 VARCHAR(512),
+	A2 VARCHAR(512),
+	A3 VARCHAR(512),
+	A4 VARCHAR(512),
+	A5 VARCHAR(512),
+	A6 VARCHAR(512),
+	A7 VARCHAR(512),
+	A8 VARCHAR(512),
+	A9 VARCHAR(512),
+	A10 VARCHAR(512),
+	A11 VARCHAR(512),
+	A12 VARCHAR(512),
+	A13 VARCHAR(512),
+	A14 VARCHAR(512),
+	A15 VARCHAR(512),
+	A16 VARCHAR(512),
+	A17 VARCHAR(512),
+	A18 VARCHAR(512),
+	A19 VARCHAR(512),
+	A20 VARCHAR(512),
+	A21 VARCHAR(512),
+	A22 VARCHAR(512),
+	A23 VARCHAR(512),
+	A24 VARCHAR(512),
+	A25 VARCHAR(512),
+	A26 VARCHAR(512),
+	A27 VARCHAR(512),
+	A28 VARCHAR(512),
+	A29 VARCHAR(512),
+	A30 NVARCHAR(512),
+	A31 NVARCHAR(512),
+	A32 NVARCHAR(512),
+  A33 NVARCHAR(512),
+  PRIMARY KEY (ID)
+) ENGINE = InnoDB;
+
+CREATE TABLE pxc4365 (i INT PRIMARY KEY, j INT);
+INSERT INTO pxc4365 VALUES(1,1),(2,2),(3,3);
+
+#
+# Assert that cluster is still operational
+#
+
+--connection node_2
+# Wait till the data is replicated to node2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "pxc4365"
+--source include/wait_condition.inc
+
+# Assert that node2 is still up, running and replicating.
+--let $assert_text = Table pxc4365 was created on node2.
+--let $assert_cond = COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "pxc4365"
+--source include/assert.inc
+
+# Wait till the data is replicated to node2
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.pxc4365
+--source include/wait_condition.inc
+
+# Assert that table has 3 rows on node2
+--let $assert_text = Node 2 is up, running and replicating.
+--let $assert_cond = COUNT(*) = 3 FROM test.pxc4365
+--source include/assert.inc
+
+# MTR suppressions
+CALL mtr.add_suppression("Row size too large.");
+
+# Cleanup
+DROP TABLE pxc4365;
+
+# Assert that node1 is still up, running and replicating.
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 0 FROM information_schema.tables WHERE table_name = "pxc4365"
+--source include/wait_condition.inc
+
+--let $assert_text = Table pxc4365 was deleted on node1.
+--let $assert_cond = COUNT(*) = 0 FROM information_schema.tables WHERE table_name = "pxc4365"
+--source include/assert.inc


### PR DESCRIPTION

https://perconadev.atlassian.net/browse/PXC-4365

Problem
-------
Server evicts from the cluster if the query failed with a long error message > 1024 characters.

Analysis
--------
While creating a table, if the table structure has any NVARCHAR columns, the server will generate a warning saying

    NATIONAL/NCHAR/NVARCHAR implies the character set UTF8MB3, which will
    be replaced by UTF8MB4 in a future release. Please consider using
    CHAR(x) CHARACTER SET UTF8MB4 in order to be unambiguous.

If row length of the new table exceeds the max row length supported by the storage engine, then the query will fail with error

    Row size too large. The maximum row size for the used table type, not
    counting BLOBs, is 65535. This includes storage overhead, check the
    manual. You have to change some columns to TEXT or BLOBs

When we try to create a table having nvarchar columns and if the total row length exceeds the value supported by storage enging, then the query fails with both warnings and error.

When such a query fails in a clustered environment, warnings and errors generated by the query are concatenated into a single string and is sent to the cluster to peform inconsistency voting.

However, if this concatenated error message has more than 991 characters, then it undergoes truncation to 991 characters which caused the voting mechanism to calculate different votes, eventually resulting in node eviction from the cluster.

Solution
--------
The size of the buffer (used while sending the vote message to the cluster) has been increased to 2070 characters (2048 for error message + 32 for coded message) to accomodate even the longest error message sent by server.

(cherry picked from commit d92abd5161b19c32210052442ecbb3b64db8ced2)