### PR TITLE
(trunk) PXC-4403: Wrong field metadata cause assertion in protocol_classic.cc::store_string()

### DIFF
--- a/sql/protocol_classic.h
+++ b/sql/protocol_classic.h
@@ -36,6 +36,10 @@
 #include "sql/protocol.h"  // Protocol
 #include "violite.h"
 
+#ifdef WITH_WSREP
+#include <memory>
+#endif
+
 class Item_param;
 class Send_field;
 class String;
@@ -63,7 +67,10 @@ class Protocol_classic : public Protocol {
   uint field_pos;
   bool send_metadata;
 #ifndef NDEBUG
-  enum enum_field_types *field_types;
+#ifdef WITH_WSREP
+  std::shared_ptr<enum_field_types> field_types_ptr;
+#endif
+  enum_field_types *field_types;
   uint count;
 #endif
   uint field_count;

--- a/sql/query_result.cc
+++ b/sql/query_result.cc
@@ -73,8 +73,8 @@ uint Query_result::field_count(const mem_root_deque<Item *> &fields) const {
 bool Query_result_send::send_result_set_metadata(
     THD *thd, const mem_root_deque<Item *> &list, uint flags) {
 #ifdef WITH_WSREP
-  if (WSREP(thd) && thd->wsrep_retry_query) {
-    /* Metadata is already send during first try that failed so avoid
+  if (WSREP(thd) && thd->wsrep_retry_query && is_result_set_started) {
+    /* If metadata is already sent during first try that failed so avoid
     resending it. Just plan to send the result. */
     WSREP_DEBUG("Skip resending metadata if query is being re-tried");
     return false;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4403

Problem:
When using debug build, sometimes we hit the following assertion:

mysqld: protocol_classic.cc:3423:
virtual bool Protocol_classic::store_string(const char*, size_t,
const CHARSET_INFO*): Assertion `send_metadata || field_types == nullptr
|| field_types[field_pos] == MYSQL_TYPE_DECIMAL ||
field_types[field_pos] == MYSQL_TYPE_BIT ||
field_types[field_pos] == MYSQL_TYPE_NEWDECIMAL ||
field_types[field_pos] == MYSQL_TYPE_NEWDATE ||
field_types[field_pos] == MYSQL_TYPE_JSON ||
(field_types[field_pos] >= MYSQL_TYPE_ENUM && field_types[field_pos]
<= MYSQL_TYPE_GEOMETRY)' failed.

Cause:
Investigation shows that field_types[field_pos] has unknown value.
There are two reasons for this:
1. field_types is allocated in Protocol_classic::start_result_metadata()
from threads's mem_root. This memory is disposed after the command in
Thd::cleanup_after_query(). If we are retrying the query, we are not
sending metadata again, so field_types is a dangling pointer.

2. Even after fixing the above issue, the assertion is still hit.
This time the investigation shows, that field_types[field_pos] contains
not allowed type (e.g. MYSQL_TYPE_LONGLONG). This is because we are not
resending metadata if we retry the query. But it may happen that the
query is aborted before sending metadata. In such a case metadata of
the previous query will be used.

Solution:
1. Allocate field_types from heap.
2. Do not re-send metadata only if it was already sent.