### PR TITLE
PXC-4313: Statements executed in RSU mode generate local GTID events

### DIFF
--- a/mysql-test/suite/galera/r/GAL-480.result
+++ b/mysql-test/suite/galera/r/GAL-480.result
@@ -1,39 +1,104 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 CREATE TABLE t1 (f1 CHAR(10), f0 integer) ENGINE=InnoDB;
 FLUSH TABLE t1 FOR EXPORT;
 UNLOCK TABLES;
 ALTER TABLE t1 DROP COLUMN f1;
 SET SESSION wsrep_osu_method='RSU';
 ALTER TABLE t1 ADD COLUMN f1 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f1;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f2 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f2;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f3 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f3;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f4 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f4;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f5 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f5;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f6 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f6;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f7 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f7;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f8 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f8;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f9 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f9;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f10 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f10;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f11 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f11;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f12 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f12;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f13 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f13;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f14 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f14;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f15 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f15;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 ADD COLUMN f16 CHAR(10);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 ALTER TABLE t1 DROP COLUMN f16;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SET SESSION wsrep_osu_method='TOI';
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/MW-258.result
+++ b/mysql-test/suite/galera/r/MW-258.result
@@ -1,3 +1,4 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 CREATE TABLE t1 (f1 INTEGER);
 LOCK TABLE t1 WRITE;
 value prior to RSU:
@@ -24,6 +25,10 @@ wsrep_desync	OFF
 UNLOCK TABLES;
 SET GLOBAL wsrep_provider_options = 'signal=wsrep_desync_left_local_monitor';
 SET GLOBAL wsrep_provider_options = 'dbug=';
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 value after RSU:
 SHOW STATUS LIKE 'wsrep_desync_count';
 Variable_name	Value

--- a/mysql-test/suite/galera/r/MW-259.result
+++ b/mysql-test/suite/galera/r/MW-259.result
@@ -1,3 +1,4 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 SET GLOBAL wsrep_desync=0;
 Warnings:
@@ -9,3 +10,5 @@ SET GLOBAL wsrep_desync=1;;
 SET DEBUG_SYNC= 'now SIGNAL continue';
 DROP TABLE t1;
 SET GLOBAL wsrep_desync=0;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.

--- a/mysql-test/suite/galera/r/MW-44.result
+++ b/mysql-test/suite/galera/r/MW-44.result
@@ -1,3 +1,4 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 SET @old_log_output = @@global.log_output;
 SET GLOBAL log_output="TABLE";
 SET @old_log_output = @@global.log_output;
@@ -10,6 +11,8 @@ SET SESSION wsrep_osu_method=TOI;
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 SET SESSION wsrep_osu_method=RSU;
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SET SESSION wsrep_osu_method=TOI;
 include/assert.inc [General log should have 2 queries for ALTER and CREATE]
 include/assert.inc [General log should have no queries which don't have SELECT]

--- a/mysql-test/suite/galera/r/galera_alter_table_mdl.result
+++ b/mysql-test/suite/galera/r/galera_alter_table_mdl.result
@@ -44,13 +44,14 @@ SET SESSION wsrep_sync_wait = 0;
 include/assert.inc [INSERT query should be waiting for the metadata lock.]
 SET DEBUG_SYNC = 'now SIGNAL continue_inplace_alter';
 SET DEBUG_SYNC = 'RESET';
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SELECT * FROM t1;
 a
 10
 11
 12
 SET SESSION wsrep_OSU_method = DEFAULT;
-include/assert_binlog_events.inc [Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid]
 # Removing debug point 'halt_alter_table_after_lock_downgrade' from @@GLOBAL.debug
 # --------------------------------
 # Test 4: Testing with ALGORITHM and LOCK syntax.
@@ -136,6 +137,7 @@ ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
 affected rows: 0
 ALTER TABLE t2 RENAME TO t1, ALGORITHM= INPLACE, LOCK= DEFAULT;
 affected rows: 0
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 CALL mtr.add_suppression("LOCK=NONE is not supported for this operation. Try LOCK=SHARED.");
 CALL mtr.add_suppression("LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.");
 CALL mtr.add_suppression("LOCK=NONE/SHARED is not supported for this operation. Try LOCK=EXCLUSIVE.");

--- a/mysql-test/suite/galera/r/galera_rsu_add_pk.result
+++ b/mysql-test/suite/galera/r/galera_rsu_add_pk.result
@@ -1,3 +1,5 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 CREATE TABLE ten (f1 INTEGER);
 INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
@@ -5,6 +7,8 @@ INSERT INTO t1 (f1) SELECT 000000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3
 INSERT INTO t1 (f1) SELECT 100000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3.f1) + (10 * a4.f1) + a5.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5;;
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 ADD PRIMARY KEY (f1);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SET SESSION wsrep_OSU_method = "TOI";
 INSERT INTO t1 (f1) SELECT 200000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3.f1) + (10 * a4.f1) + a5.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5;
 SELECT COUNT(*) = 300000 FROM t1;
@@ -21,6 +25,8 @@ MAX(f1) =  299999
 1
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 ADD PRIMARY KEY (f1);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SET SESSION wsrep_OSU_method = "TOI";
 DROP TABLE t1;
 DROP TABLE ten;

--- a/mysql-test/suite/galera/r/galera_rsu_drop_pk.result
+++ b/mysql-test/suite/galera/r/galera_rsu_drop_pk.result
@@ -1,3 +1,5 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 CREATE TABLE ten (f1 INTEGER);
 INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
@@ -5,6 +7,8 @@ INSERT INTO t1 (f1) SELECT 000000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3
 INSERT INTO t1 (f1) SELECT 100000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3.f1) + (10 * a4.f1) + a5.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5;;
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 DROP PRIMARY KEY;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SET SESSION wsrep_OSU_method = "TOI";
 INSERT INTO t1 (f1) SELECT 200000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3.f1) + (10 * a4.f1) + a5.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5;
 SELECT COUNT(*) = 300000 FROM t1;
@@ -21,6 +25,8 @@ MAX(f1) =  299999
 1
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 DROP PRIMARY KEY;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SET SESSION wsrep_OSU_method = "TOI";
 INSERT INTO t1 (f1) VALUES (1);
 INSERT INTO t1 (f1) VALUES (10);

--- a/mysql-test/suite/galera/r/galera_rsu_during_sst.result
+++ b/mysql-test/suite/galera/r/galera_rsu_during_sst.result
@@ -9,8 +9,11 @@ Shutting down server ...
 SET GLOBAL wsrep_provider_options = 'dbug=d,sst_sent';
 Starting server ...
 # restart
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 SET SESSION wsrep_OSU_method = "RSU";
 CREATE TABLE t2 (f1 INTEGER);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SET GLOBAL wsrep_provider_options = 'signal=sst_sent';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SELECT * FROM t1;
@@ -19,4 +22,6 @@ f1	f2
 2	a
 3	a
 DROP TABLE t2;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_rsu_error.result
+++ b/mysql-test/suite/galera/r/galera_rsu_error.result
@@ -1,5 +1,6 @@
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 INSERT INTO t1 VALUES (1), (1);
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 ADD PRIMARY KEY (f1);
 ERROR 23000: Duplicate entry '1' for key 't1.PRIMARY'

--- a/mysql-test/suite/galera/r/galera_rsu_simple.result
+++ b/mysql-test/suite/galera/r/galera_rsu_simple.result
@@ -1,6 +1,10 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't1';
 COUNT(*) = 2
 1
@@ -25,6 +29,8 @@ BEGIN;
 UPDATE t1 SET k=k+1 WHERE id<100;
 SET wsrep_OSU_method = RSU;
 ALTER TABLE t1 ADD KEY(k);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 COMMIT;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE t1;
@@ -35,6 +41,8 @@ BEGIN;
 UPDATE t1 SET k=k+1 WHERE id<100;
 SET wsrep_OSU_method = RSU;
 ALTER TABLE t1 ADD KEY(k);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 COMMIT;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 SET SESSION wsrep_on = ON;

--- a/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
+++ b/mysql-test/suite/galera/r/galera_rsu_wsrep_desync.result
@@ -1,4 +1,5 @@
 call mtr.add_suppression("Trying to desync a node that is already paused");
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 ** Test #1 **
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 SET GLOBAL wsrep_desync=1;
@@ -19,6 +20,8 @@ wsrep_desync	OFF
 Variable_name	Value
 wsrep_desync_count	1
 SET DEBUG_SYNC= 'now SIGNAL continue';
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -82,6 +85,8 @@ wsrep_desync	OFF
 Variable_name	Value
 wsrep_desync_count	2
 SET DEBUG_SYNC= 'now SIGNAL continue';
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/galera/r/galera_var_OSU_method.result
+++ b/mysql-test/suite/galera/r/galera_var_OSU_method.result
@@ -1,9 +1,12 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 SET SESSION wsrep_OSU_method = "RSU";
 SET DEBUG_SYNC = 'alter_table_before_open_tables WAIT_FOR continue';
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;;
 SET GLOBAL wsrep_OSU_method = "TOI";
 SET DEBUG_SYNC= 'now SIGNAL continue';
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't1';
 COUNT(*) = 2
 1

--- a/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
+++ b/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
@@ -151,9 +151,17 @@ select @@session.wsrep_OSU_method;
 RSU
 use test;
 create table is1 (i int) engine=myisam;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 insert into is1 values (11), (12);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 insert is1 values (13), (14);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 rename table is1 to is2;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 select * from is2;
 i
 11
@@ -161,6 +169,8 @@ i
 13
 14
 drop table is2;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 #node-1
 set global wsrep_replicate_myisam = 0;
 set global wsrep_OSU_method = TOI;

--- a/mysql-test/suite/galera/r/mysql-wsrep#247.result
+++ b/mysql-test/suite/galera/r/mysql-wsrep#247.result
@@ -1,11 +1,16 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 SET GLOBAL wsrep_desync=1;
 SET wsrep_OSU_method=RSU;
 CREATE TABLE t1 (i int primary key);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SHOW VARIABLES LIKE 'wsrep_desync';
 Variable_name	Value
 wsrep_desync	ON
 SET GLOBAL wsrep_desync=0;
 DROP TABLE t1;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
 SHOW VARIABLES LIKE 'wsrep_desync';
 Variable_name	Value
 wsrep_desync	OFF

--- a/mysql-test/suite/galera/r/pxc_rsu_binlog.result
+++ b/mysql-test/suite/galera/r/pxc_rsu_binlog.result
@@ -1,0 +1,19 @@
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+SET wsrep_OSU_method = RSU;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+CREATE USER 'testuser'@'%' IDENTIFIED BY 'testpass';
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+include/assert.inc [Assert that the above event has not been added to binlog                                                                                                                                   ]
+include/assert_grep.inc [Assert that DDL query warning was logged]
+include/assert_grep.inc [Assert that DDL query warning was logged without secrets]
+DROP TABLE IF EXISTS t1;
+DROP USER IF EXISTS 'testuser'@'%';

--- a/mysql-test/suite/galera/t/GAL-480.test
+++ b/mysql-test/suite/galera/t/GAL-480.test
@@ -1,6 +1,8 @@
 --source include/galera_cluster.inc
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
 CREATE TABLE t1 (f1 CHAR(10), f0 integer) ENGINE=InnoDB;
 
 FLUSH TABLE t1 FOR EXPORT;

--- a/mysql-test/suite/galera/t/MW-258.test
+++ b/mysql-test/suite/galera/t/MW-258.test
@@ -5,6 +5,7 @@
 --source suite/galera/include/galera_have_debug_sync.inc
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 CREATE TABLE t1 (f1 INTEGER);
 LOCK TABLE t1 WRITE;
 --echo value prior to RSU:

--- a/mysql-test/suite/galera/t/MW-259.test
+++ b/mysql-test/suite/galera/t/MW-259.test
@@ -5,6 +5,8 @@
 --connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 
 SET GLOBAL wsrep_desync=0;

--- a/mysql-test/suite/galera/t/MW-44.test
+++ b/mysql-test/suite/galera/t/MW-44.test
@@ -5,6 +5,8 @@
 --source include/galera_cluster.inc
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
 SET @old_log_output = @@global.log_output;
 SET GLOBAL log_output="TABLE";
 

--- a/mysql-test/suite/galera/t/galera_alter_table_mdl.test
+++ b/mysql-test/suite/galera/t/galera_alter_table_mdl.test
@@ -152,9 +152,10 @@ SELECT * FROM t1;
 SET SESSION wsrep_OSU_method = DEFAULT;
 
 # Assert that INSERT query commits after the ALTER query
---let $limit= 2,10
---let $event_sequence= Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid
---source include/assert_binlog_events.inc
+# PXC-4313 disables binlogging for RSU, so no ALTER TABLE in binlog
+# --let $limit= 2,10
+# --let $event_sequence= Anonymous_Gtid # Query/.*ALTER TABLE.* # Anonymous_Gtid # Query/.*BEGIN # Table_map # Write_rows # Xid
+# --source include/assert_binlog_events.inc
 
 # Reset the debug point before further testing.
 --source include/remove_debug_point.inc
@@ -210,6 +211,8 @@ ALTER TABLE t1 RENAME TO t2, ALGORITHM= INPLACE, LOCK= EXCLUSIVE;
 ALTER TABLE t2 RENAME TO t1, ALGORITHM= INPLACE, LOCK= DEFAULT;
 
 --disable_info
+--connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 --connection node_2
 CALL mtr.add_suppression("LOCK=NONE is not supported for this operation. Try LOCK=SHARED.");
 CALL mtr.add_suppression("LOCK=NONE is not supported. Reason: COPY algorithm requires a lock. Try LOCK=SHARED.");

--- a/mysql-test/suite/galera/t/galera_rsu_add_pk.test
+++ b/mysql-test/suite/galera/t/galera_rsu_add_pk.test
@@ -6,6 +6,11 @@
 --source include/galera_cluster.inc
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+--connection node_2
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
+--connection node_1
 CREATE TABLE ten (f1 INTEGER);
 INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 

--- a/mysql-test/suite/galera/t/galera_rsu_drop_pk.test
+++ b/mysql-test/suite/galera/t/galera_rsu_drop_pk.test
@@ -6,6 +6,11 @@
 --source include/galera_cluster.inc
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+--connection node_2
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
+--connection node_1
 CREATE TABLE ten (f1 INTEGER);
 INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 

--- a/mysql-test/suite/galera/t/galera_rsu_during_sst.test
+++ b/mysql-test/suite/galera/t/galera_rsu_during_sst.test
@@ -54,6 +54,8 @@ SELECT * FROM t1;
 
 # Initiate RSU operation during SST:
 
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
 SET SESSION wsrep_OSU_method = "RSU";
 CREATE TABLE t2 (f1 INTEGER);
 

--- a/mysql-test/suite/galera/t/galera_rsu_error.test
+++ b/mysql-test/suite/galera/t/galera_rsu_error.test
@@ -9,6 +9,8 @@ CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 INSERT INTO t1 VALUES (1), (1);
 
 --connection node_2
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
 SET SESSION wsrep_OSU_method = "RSU";
 --error ER_DUP_ENTRY
 ALTER TABLE t1 ADD PRIMARY KEY (f1);

--- a/mysql-test/suite/galera/t/galera_rsu_simple.test
+++ b/mysql-test/suite/galera/t/galera_rsu_simple.test
@@ -9,6 +9,11 @@
 
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
 
+--connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+--connection node_2
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
 --connection node_2
 SET SESSION wsrep_OSU_method = "RSU";
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;

--- a/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
+++ b/mysql-test/suite/galera/t/galera_rsu_wsrep_desync.test
@@ -6,6 +6,7 @@
 --source include/have_debug_sync.inc
 
 call mtr.add_suppression("Trying to desync a node that is already paused");
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 
 #-------------------------------------------------------------------------------
 #

--- a/mysql-test/suite/galera/t/galera_var_OSU_method.test
+++ b/mysql-test/suite/galera/t/galera_var_OSU_method.test
@@ -9,6 +9,8 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
 SET SESSION wsrep_OSU_method = "RSU";
 SET DEBUG_SYNC = 'alter_table_before_open_tables WAIT_FOR continue';
 --send ALTER TABLE t1 ADD COLUMN f2 INTEGER;

--- a/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
+++ b/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
@@ -7,6 +7,7 @@
 --connection node_1
 --disable_query_log
 call mtr.add_suppression("Ignoring error 'Duplicate entry '1' for key 't1.PRIMARY");
+call mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 --enable_query_log
 
 --connection node_1

--- a/mysql-test/suite/galera/t/mysql-wsrep#247.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#247.test
@@ -6,6 +6,7 @@
 --source include/galera_cluster.inc
 
 --connection node_1
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
 
 SET GLOBAL wsrep_desync=1;
 

--- a/mysql-test/suite/galera/t/pxc_rsu_binlog.test
+++ b/mysql-test/suite/galera/t/pxc_rsu_binlog.test
@@ -1,0 +1,53 @@
+#
+# When wsrep_OSU_method = RSU, DDL should not create binlog event
+# and GTID should not be generated.
+#
+
+--source include/galera_cluster.inc
+
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+--let $wsrep_OSU_method_save = `SELECT @@global.wsrep_OSU_method`
+
+SET wsrep_OSU_method = RSU;
+
+--let $gtid_executed_begin = `SELECT @@global.gtid_executed`
+--let $pos_begin = query_get_value(SHOW MASTER STATUS, Position, 1)
+
+# Let's do some DDLs. 
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SHOW WARNINGS;
+
+CREATE USER 'testuser'@'%' IDENTIFIED BY 'testpass';
+SHOW WARNINGS;
+
+# No events logged
+--let $assert_text = Assert that the above event has not been added to binlog                                                                                                                                   
+--let $assert_cond = [SHOW MASTER STATUS, Position, 1] = $pos_begin                                                                                                                                             
+--source include/assert.inc
+
+# No gtid generated
+#--let $assert_text = Assert that GTID was not generated                                                                                                                                   
+#--let $assert_cond = [SHOW GLOBAL VARIABLES LIKE "gtid_executed", Value, 1] = $gtid_begin                                                                                                                                             
+#--source include/assert.inc
+
+# Log file should have warnings related to DDL execution
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_count = 1
+
+--let $assert_select = Warning.*he statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU. Query: CREATE TABLE t1 \(a INT PRIMARY KEY\)
+--let $assert_text = Assert that DDL query warning was logged
+--source include/assert_grep.inc
+
+# No secrets logged
+--let $assert_select = Warning.*he statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU. Query: CREATE USER 'testuser'@'%' IDENTIFIED BY <secret>
+--let $assert_text = Assert that DDL query warning was logged without secrets
+--source include/assert_grep.inc
+
+
+# Cleanup
+--disable_query_log
+--eval SET wsrep_OSU_method = $wsrep_OSU_method_save
+--enable_query_log
+DROP TABLE IF EXISTS t1;
+DROP USER IF EXISTS 'testuser'@'%';

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -167,6 +167,7 @@ struct LOG_INFO;
 #include "wsrep_thd_context.h"
 
 class Wsrep_applier_service;
+class Disable_binlog_guard;
 #endif /* WITH_WSREP */
 
 extern bool opt_log_slow_admin_statements;
@@ -3339,6 +3340,9 @@ class THD : public MDL_context_owner,
     thd->lex->sql_command == SQLCOM_ROLLBACK_TO_SAVEPOINT skips actual
     rollback. */
   bool wsrep_force_savept_rollback;
+
+  /* Used to disable binlog when DDL is executed with wsrep_OSU_method=RSU. */
+  std::shared_ptr<Disable_binlog_guard> disable_binlog_guard;
 
   /*
     Transaction id:


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4313

Problem:
When the DDL is executed in RSU mode it generates binlog event and new GTID. As this is RSU, the change is not replicated, which results with binlog inconsistencies between PXC cluster nodes.
If PXC acts as source for async replica, the failover process doesn't work as nodes have different binlogs.

Solution:
When DDL is executed in RSU mode:
1. Do not create binlog event
2. Do not generate GTID
3. Log a warning containing the DDL query
4. Send warning to the client