### PR TITLE
PXC-4474 Disables missing-field-initializers warning

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -291,6 +291,11 @@ IF(WITH_WSREP)
    wsrep_thd.cc
  )
  SET(WSREP_LIB wsrep)
+
+ # Suppress warnings for gcc older than gcc-5
+ IF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-missing-field-initializers FILES wsrep_mysqld.cc wsrep_binlog.cc)
+ ENDIF()
 ENDIF()
 
 SET(SQL_SOURCE


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4474

The gcc, g++ compiler version is 4.8.0 on CentOS 7 which causes compilation failures on old code in PXC 5.7. So, supressing the warning.