### PR TITLE
PXC-4499: Remove checks for prev pxb from SST script

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -1786,7 +1786,10 @@ fi
 
 # Verify PXB versions we have
 verify_pxb_version "${XTRABACKUP_THIS_VER_PATH}" "${XB_THIS_REQUIRED_VERSION}"
-verify_pxb_version "${XTRABACKUP_PREV_VER_PATH}" "${XB_PREV_REQUIRED_VERSION}"
+# We intentionally don't check prev PXB version. This is because for public
+# releases we support only LTS -> LTS SST and will not bundle PXC with
+# previous innovative version of PXB.
+# verify_pxb_version "${XTRABACKUP_PREV_VER_PATH}" "${XB_PREV_REQUIRED_VERSION}"
 verify_pxb_version "${XTRABACKUP_PREV_LTS_VER_PATH}" "${XB_PREV_LTS_REQUIRED_VERSION}"
 
 rm -f "${XB_GTID_INFO_FILE_PATH}"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4499

Problem:
PXC 8.4 will be released for Ubuntu Noble. SST script allows PXC SST to be done for the following combinations:
1. Previous LTS -> this version (8.0.x -> 8.4)
2. Previous version -> this version (8.3 -> 8.4)
4. This version -> this version (8.4 -> 8.4)

Support of path 2 would need PXB 8.3 to be released for Ubuntu Noble, but it was not released.

On the other hand, all innovative releases are internal, so public release needs to support only paths 1 and 3

Solution:
Remove check for prev PXB version from SST script. This way only previous LTS and 'this version' will be a hard dependency.