### PR TITLE
(trunk) PXC-4500: When innodb_thread_concurrency is set, the cluster can get stuck during SST

### DIFF
--- a/mysql-test/suite/galera/r/galera_innodb_thread_concurrency.result
+++ b/mysql-test/suite/galera/r/galera_innodb_thread_concurrency.result
@@ -1,0 +1,12 @@
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET debug_sync='ib_after_row_insert SIGNAL insert1_done WAIT_FOR continue';
+INSERT INTO t1 VALUES (0);
+SET debug_sync='ib_after_row_insert SIGNAL insert2_done WAIT_FOR continue';
+INSERT INTO t1 VALUES (1);
+SET debug_sync='now WAIT_FOR insert1_done';
+SET debug_sync='now WAIT_FOR insert2_done';
+# restart
+SET debug_sync='now SIGNAL continue';
+SET debug_sync='now SIGNAL continue';
+INSERT INTO t1 VALUES (2);
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_innodb_thread_concurrency.cnf
+++ b/mysql-test/suite/galera/t/galera_innodb_thread_concurrency.cnf
@@ -1,0 +1,3 @@
+!include ../galera_2nodes.cnf
+[mysqld.1]
+innodb_thread_concurrency=2

--- a/mysql-test/suite/galera/t/galera_innodb_thread_concurrency.test
+++ b/mysql-test/suite/galera/t/galera_innodb_thread_concurrency.test
@@ -1,0 +1,65 @@
+# Thest that Galera events processing is not blocked by user threads
+# that have been granted InnoDB access when innodb_thread_concurrency
+# is limited
+
+--source include/have_debug.inc
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
+
+# Stop node 2 and force SST
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+# Remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+--connection node_1
+CREATE TABLE t1 (a INT PRIMARY KEY);
+SET debug_sync='ib_after_row_insert SIGNAL insert1_done WAIT_FOR continue';
+--send INSERT INTO t1 VALUES (0)
+
+--connection node_1a
+SET debug_sync='ib_after_row_insert SIGNAL insert2_done WAIT_FOR continue';
+--send INSERT INTO t1 VALUES (1)
+
+--connection node_1b
+SET debug_sync='now WAIT_FOR insert1_done';
+SET debug_sync='now WAIT_FOR insert2_done';
+
+# Now we have 2 threads granted access to InnoDB
+# No more threads allowed (innodb_thread_concurrency=2)
+# But wsrep applier and SST donor thread should be the exemption
+
+# Start node_2
+--connection node_2
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Now let paused inserts to continue
+--connection node_1b
+SET debug_sync='now SIGNAL continue';
+SET debug_sync='now SIGNAL continue';
+
+--connection node_1
+--reap
+--connection node_1a
+--reap
+
+# Replication should still work
+INSERT INTO t1 VALUES (2);
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1
+--source include/wait_condition.inc
+
+# cleanup
+--connection node_1
+DROP TABLE t1;
+
+--disconnect node_1a
+--disconnect node_1b
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -711,6 +711,7 @@ THD::THD(bool enable_plugins)
       wsrep_prepared_statement_TOI_started(false),
       wsrep_bin_log_flag_save(0),
       wsrep_applier(is_applier),
+      wsrep_sst_donor(false),
       wsrep_applier_closing(false),
       wsrep_client_thread(false),
       wsrep_allow_mdl_conflict(false),

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3169,6 +3169,7 @@ class THD : public MDL_context_owner,
   bool wsrep_prepared_statement_TOI_started;
   ulonglong wsrep_bin_log_flag_save;
   bool wsrep_applier;         /* dedicated slave applier thread */
+  bool wsrep_sst_donor;       /* SST donor thread */
   bool wsrep_applier_closing; /* applier marked to close */
   bool wsrep_client_thread;   /* to identify client threads */
   bool wsrep_allow_mdl_conflict;

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -1123,6 +1123,7 @@ static MYSQL_SESSION setup_server_session(bool initialize_thread) {
   }
   // Turn wsrep off here (because the server session has it's own THD object)
   session->get_thd()->variables.wsrep_on = false;
+  session->get_thd()->wsrep_sst_donor = true;
   return session;
 }
 
@@ -1277,6 +1278,7 @@ static void *sst_donor_thread(void *a) {
   wsp::thd thd(false);  // we turn off wsrep_on for this THD so that it can
                         // operate with wsrep_ready == OFF
 
+  thd.ptr->wsrep_sst_donor = true;
   // Create the SST auth user
   err = wsrep_create_sst_user(true, password.c_str());
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4500

Problem 1:
When innodb_thread_concurrency is set and the node has a heavy user
workload, it can become stuck when it receives a CC event from Galera.

Cause:
Let's say innodb_thread_concurrency = 2.
1. We have two user threads that have been granted access to InnoDB.
They will release the InnoDB access lock after Galera certification,
but for certification, they need to acquire LocalMonitor.
2. At the same time CC happens. The Applier thread acquires LocalMonitor
and notifies the application about the new view. The application tries
to store the view in wsrep schema. Before doing that it turns off
wsrep_on thread's variable (the thread is not marked as wsrep-enabled
thread). Then, it tries to enter InnoDB. As we already have two user
threads in InnoDB and our thread is not wsrep thread, we have to wait.

The above results in a deadlock:
1. The user thread is holding InnoDB lock, waiting for LocalMonitor
2. The Applier thread is holding LocalMonitor, waiting for InnoDB lock

Solution:
The wrong condition was used to detect the wsrep applier thread in
innobase_srv_conc_enter_innodb(). The applier thread should always be
granted access. Fixed.

Problem 2:
Even after fixing Problem 1, the cluster was stuck during SST.

Cause:
The SST thread creates an SST user. For this, it needs to enter InnoDB.
We end up in a similar situation as in Problem 1. The applier thread
holds LocalMonitor and waits for SST to finish. The SST thread waits for
InnoDB. User threads hold the InnoDB lock and wait for LocalMonitor.

Solution:
Allow SST thread to enter InnoDB always.