### PR TITLE
8.4.2 merge - Valgrind

### DIFF
--- a/mysql-test/suites-groups.sh
+++ b/mysql-test/suites-groups.sh
@@ -39,9 +39,9 @@ function set_suites() {
     WORKER_2_MTR_SUITES="galera_nbo,galera_3nodes,galera_sr,galera_3nodes_nbo,galera_3nodes_sr,galera_encryption,wsrep,galera-x,rpl|nobig"
     WORKER_3_MTR_SUITES="engines/funcs,innodb,perfschema,percona_innodb,component_keyring_file"
     WORKER_4_MTR_SUITES="main|big,rpl|big"
-    WORKER_5_MTR_SUITES="rpl_nogtid,rpl_gtid,galera|big"
-    WORKER_6_MTR_SUITES="parts,group_replication,clone,innodb_gis"
-    WORKER_7_MTR_SUITES="gcol,engines/iuds,encryption,federated,funcs_1,auth_sec,binlog_nogtid,binlog_gtid,funcs_2,jp,information_schema,rpl_encryption,sysschema,json,opt_trace,collations,gis,query_rewrite_plugins,test_service_sql_api,secondary_engine,component_audit_log_filter,component_encryption_udf,percona,component_masking_functions"
+    WORKER_5_MTR_SUITES="rpl_nogtid,rpl_gtid,galera|big,group_replication|nobig"
+    WORKER_6_MTR_SUITES="parts,group_replication|big,innodb_gis"
+    WORKER_7_MTR_SUITES="clone,gcol,engines/iuds,encryption,federated,funcs_1,auth_sec,binlog_nogtid,binlog_gtid,funcs_2,jp,information_schema,rpl_encryption,sysschema,json,opt_trace,collations,gis,query_rewrite_plugins,test_service_sql_api,secondary_engine,component_audit_log_filter,component_encryption_udf,percona,component_masking_functions"
     WORKER_8_MTR_SUITES="galera|nobig,main|nobig"
   fi
 }

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -315,6 +315,17 @@ get_mysqld_path()
         MYSQLD_PATH=$(which ${MYSQLD_NAME})
     fi
 
+    if [[ $MYSQLD_PATH == *"memcheck"* ]]; then
+      wsrep_log_debug "Detected valgrind, adjusting mysqld path accordingly"
+      while read -r line
+      do
+        if [[ ${line::1} != "-" ]]; then
+          MYSQLD_PATH=$line
+          wsrep_log_debug "Adjusted mysqld to $line"
+        fi
+      done < <(cat /proc/${WSREP_SST_OPT_PARENT}/cmdline | strings -1)
+    fi
+
     if [[ -z $MYSQLD_PATH ]]; then
         wsrep_log_error "******************* FATAL ERROR ********************** "
         wsrep_log_error "Could not locate ${MYSQLD_NAME} (needed for post-processing)"
@@ -687,16 +698,6 @@ function run_post_processing_steps()
     fi
 
     local mysqld_path=$MYSQLD_PATH
-    if [[ $mysqld_path == *"memcheck"* ]]; then
-      wsrep_log_debug "Detected valgrind, adjusting mysqld path accordingly"
-      while read -r line
-      do
-        if [[ ${line::1} != "-" ]]; then
-          mysqld_path=$line
-          wsrep_log_debug "Adjusted mysqld to $line"
-        fi
-      done < <(cat /proc/${WSREP_SST_OPT_PARENT}/cmdline | strings -1)
-    fi
 
     # Verify any other needed programs
     wsrep_check_program "${MYSQLADMIN_NAME}"

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -12442,7 +12442,7 @@ int prepend_binlog_control_event(THD *const thd) {
 
   int ret = 0;
   Intvar_log_event ev(
-      (uchar)mysql::binlog::event::Intvar_event::BINLOG_CONTROL_EVENT, 0);
+      thd, (uchar)mysql::binlog::event::Intvar_event::BINLOG_CONTROL_EVENT, 0);
   if (ev.write(&tmp_io_cache)) {
     ret = ER_ERROR_ON_WRITE;
     goto cleanup;

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1620,10 +1620,12 @@ class Intvar_log_event : public mysql::binlog::event::Intvar_event,
     common_header->set_is_valid(true);
   }
 #ifdef WITH_WSREP
-  Intvar_log_event(uchar type_arg, ulonglong val_arg)
+  Intvar_log_event(THD *thd_arg, uchar type_arg, ulonglong val_arg)
       : mysql::binlog::event::Intvar_event(type_arg, val_arg),
         Log_event(header(), footer()) {
     common_header->set_is_valid(true);
+    server_id = thd_arg->server_id;
+    common_header->unmasked_server_id = server_id;
   }
 #endif /* WITH_WSREP */
   int pack_info(Protocol *protocol) override;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1934,7 +1934,8 @@ int wsrep_to_buf_helper(THD *thd, const char *query, uint query_len,
 
   if ((thd->variables.option_bits & OPTION_BIN_LOG) == 0) {
     Intvar_log_event ev(
-        (uchar)mysql::binlog::event::Intvar_event::BINLOG_CONTROL_EVENT, 0);
+        thd, (uchar)mysql::binlog::event::Intvar_event::BINLOG_CONTROL_EVENT,
+        0);
     if (ev.write(&tmp_io_cache)) ret = 1;
   }
 

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -6584,6 +6584,13 @@ void os_fusionio_get_sector_size() {
     alignas(MAX_SECTOR_SIZE) byte data[MAX_SECTOR_SIZE];
 #endif
 
+#ifdef WITH_WSREP
+#ifdef USE_VALGRIND
+  // For Valgrind to not complain about unititialized buffer usage
+  memset(data, 0, MAX_SECTOR_SIZE);
+#endif
+#endif /* WITH_WSREP */
+
     while (sector_size <= MAX_SECTOR_SIZE) {
       block_ptr = static_cast<byte *>(ut_align(&data, sector_size));
       ret = pwrite(check_file, block_ptr, sector_size, 0);


### PR DESCRIPTION
1. Better suites split for Jenkins
3. Fixed detection of Valgrind in SST script
4. Fixed not initialized 'unmasked_server_id' member of the header of Intvar_log_event. It is not used, but it was detected by Valgrind in galera.galera_log_bin MTR test. The event is stored in gcache with this uninitialized value, them msync-ed with the file during server shutdown which triggers Valgrind waring.