### PR TITLE
(8.4) PXC-4576: Remove extra_port handling in wsrep_sst_xtrabackup-v2 SST script

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -747,7 +747,6 @@ read_cnf()
 
     ssl_dhparams=$(parse_cnf sst ssl-dhparams "")
 
-    uextra=$(parse_cnf sst use-extra 0)
     iopts=$(parse_cnf sst inno-backup-opts "")
     iapts=$(parse_cnf sst inno-apply-opts "")
     impts=$(parse_cnf sst inno-move-opts "")
@@ -1306,28 +1305,10 @@ wait_for_listen()
 
 #
 # check if there are any extra options to parse.
-# Note: if port is specified socket is not used.
+# This function is executed only on the donor side.
 check_extra()
 {
-    local use_socket=1
-    if [[ $uextra -eq 1 ]]; then
-        if $MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF mysqld | tr '_' '-' | grep -- "--thread-handling=" | grep -q 'pool-of-threads'; then
-            local eport=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF mysqld | tr '_' '-' | grep -- "--extra-port=" | cut -d= -f2)
-            if [[ -n $eport ]]; then
-                # Xtrabackup works only locally.
-                # Hence, setting host to 127.0.0.1 unconditionally.
-                wsrep_log_debug "SST through extra_port $eport"
-                INNOEXTRA+=" --host=127.0.0.1 --port=$eport "
-                use_socket=0
-            else
-                wsrep_log_error "Extra port $eport null, failing"
-                exit 1
-            fi
-        else
-            wsrep_log_warning "Thread pool not set, ignore the option use_extra"
-        fi
-    fi
-    if [[ $use_socket -eq 1 ]] && [[ -n "${WSREP_SST_OPT_SOCKET}" ]]; then
+    if [[ -n "${WSREP_SST_OPT_SOCKET}" ]]; then
         INNOEXTRA+=" --socket=${WSREP_SST_OPT_SOCKET}"
     fi
 }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4576

extra_port configuration variable was removed in 8.0.14 by commit
35365ef. 'extra_port' functionality is covered by
admin_address/admin_port variables.

1. In SST script there was a dead code related to 'extra_port' variable.
2. The old code can't be reused for admin_address/admin_port. It has to
be modified. On the flip side, it seems no one needed SST via
'extra_port'.

Removed obsolete part from SST script.