### PR TITLE
(8.4) PXC-4558: mysql cannot connect to mysql-server in post-processing, if the host is not localhost in the .mylogin.cnf

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_with_mylogin.result
+++ b/mysql-test/suite/galera/r/galera_sst_with_mylogin.result
@@ -1,0 +1,1 @@
+# restart

--- a/mysql-test/suite/galera/t/galera_sst_with_mylogin.test
+++ b/mysql-test/suite/galera/t/galera_sst_with_mylogin.test
@@ -1,0 +1,23 @@
+# The existance of .mylogin.cnf file containing host parameter
+# should not affect SST
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+# Stop node 2 and force SST
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+# Remove the grastate.dat file to force an SST
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# create .mylogin.cnf file
+--exec $MYSQL_CONFIG_EDITOR set --host=127.0.0.1
+
+# Start node_2. It should join with SST
+--connection node_2
+--source include/start_mysqld.inc
+
+# cleanup
+--remove_file $MYSQL_TEST_LOGIN_FILE
+

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -180,6 +180,17 @@ else
     SST_PROGRESS_FILE=""
 fi
 
+# If the user has .mylogin.cnf file, mysqladmin, mysql, xtrabackup will
+# use it for login information. This is especially dangerous if we try to
+# connect to the post-SST instance, which has networking disabled. The only way
+# to connect to it is through the socket, however, if .mylogin.cnf has host
+# specified, mysql client/mysqladmin will use it and fail.
+# That's why we rely on locally generated configs in SST script.
+# Specifying --protocol=SOCKET explicitly to the mysql client, does not solve
+# the issue - if .mylogin.cnf contains host, the client claims that SOCKET
+# is the unknown protocol
+export MYSQL_TEST_LOGIN_FILE=/dev/null
+
 #
 # user can specify xtrabackup specific settings that will be used during sst
 # process like encryption, etc.....


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4558

Problem:
If .mylogin.cnf file is present and it contains 'host' specified which is
not localhost, the SST script is not able to connect to post-processing
(post-sst) mysqld instance and SST fails.

Cause:
SST script, on both sides, donor and joiner, uses socket protocol to
connect to the local mysqld instance (mysql, mysqladmin, pxb).
If .mylogin.cnf file is present and contains 'host' parameter, it takes
precedence over command line options, even if `--protocol=SOCKET' is
specified explicitly. On joiner side, after SST, so-called
post-processing mysqld instance is started. It has networking disabled,
the only way to connect is via socket. Having .mylogin.cnf file in place
causes mysql and mysqladmin to try TCP transport instead of the socket
and SST fails.

As donor instance has networking enabled, this issue unlikely to be
visible on that side. However, if .mylogin.cnf file is present and
contains 'host' and not correct 'port', the donor side will fail as well

Solution:
For SST environment (SST script), override .mylogin.cnf by exporting
MYSQL_TEST_LOGIN_FILE env variable.