### PR TITLE
[8.0] PXC-4173: PXC node stalls with parallel replication workers executing…

### DIFF
--- a/sql/rpl_replica.cc
+++ b/sql/rpl_replica.cc
@@ -7277,7 +7277,6 @@ wsrep_restart_point :
   rli->set_commit_order_manager(commit_order_mngr);
 
 #ifdef WITH_WSREP
-  // Restore the last executed seqno
   if (WSREP_ON && wsrep_use_async_monitor
       && opt_replica_preserve_commit_order
       && !rli->is_parallel_exec()

--- a/sql/wsrep_async_monitor.h
+++ b/sql/wsrep_async_monitor.h
@@ -52,7 +52,6 @@ class Wsrep_async_monitor {
   std::set<seqno_t> skipped_seqnos;      // Tracks skipped sequence numbers
   std::queue<seqno_t> scheduled_seqnos;  // Queue to track scheduled seqnos
 };
-;
 
 #endif /* WITH_WSREP */
 #endif /* WSREP_ASYNC_MONITOR_H */

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -567,6 +567,19 @@ static inline void wsrep_commit_empty(THD *thd, bool all) {
     bool have_error = wsrep_current_error(thd);
     int ret = wsrep_before_rollback(thd, all) ||
               wsrep_after_rollback(thd, all) || wsrep_after_statement(thd);
+
+    /* Update empty commits in Async monitor if required.
+     *
+     * If the replicated transaction is transactional, we call the
+     * thd_enter_async_monitor() as part of wsrep_before_commit().
+     *
+     * But non transactional statements (MyISAM) wont call the
+     * wsrep_before_commit() hook. So, we might end up in a deadlock if we dont
+     * remove its seqno from the Async monitor.
+     *
+     * So we remove the seqno of the empty commit here. */
+    thd_enter_async_monitor(thd);
+    thd_leave_async_monitor(thd);
     /* The committing transaction was empty but it held some locks and
        got BF aborted. As there were no certified changes in the
        data, we ignore the deadlock error and rely on error reporting


### PR DESCRIPTION
… DDLs via async node

https://perconadev.atlassian.net/browse/PXC-4173

***
Fix the async monitor flow for non-transactional engines.

If the replicated group of statements is transactional, we call the
thd_enter_async_monitor() as part of wsrep_before_commit().

But non transactional statements (MyISAM) wont call the
wsrep_before_commit() hook. So, we might end up in a deadlock if we dont
remove its seqno from the Async monitor.

Solution: We now call thd_enter_async_monitor() and
thd_leave_async_monitor() in wsrep_commit_empty().

***
Fix the MTR test failure of galera_repl_filtersB


Testing Done
---

Jenkins: https://pxc.cd.percona.com/view/8.0%20parallel%20MTR/job/pxc-8.0-param-parallel-mtr/250/

All galera filter tests are passing
```
==============================================================================
                  TEST NAME                   WORKER RESULT  TIME (ms) COMMENT
------------------------------------------------------------------------------
[ 11%] galera.galera_as_slave_gtid_replicate_do_db 'enc_on' w2  [ pass ]   9548
[ 22%] galera.galera_as_slave_gtid_replicate_do_db 'enc_off' w1  [ pass ]   9398
[ 33%] galera.galera_as_slave_gtid_replicate_do_db_cc 'enc_on' w1  [ pass ]  15873
[ 44%] galera.galera_as_slave_gtid_replicate_do_db_cc 'enc_off' w2  [ pass ]  12630
[ 55%] galera.galera_repl_filtersA 'enc_off'    w1  [ pass ]  10277
[ 66%] galera.galera_repl_filtersA 'enc_on'     w2  [ pass ]  10251
[ 77%] galera.galera_repl_filtersB 'enc_off'    w1  [ pass ]   6675
[ 88%] galera.galera_repl_filtersB 'enc_on'     w2  [ pass ]   6894
[100%] shutdown_report                          w0  [ pass ]       
------------------------------------------------------------------------------
The servers were restarted 6 times
The servers were reinitialized 0 times
Spent 81.546 of 257 seconds executing testcases
```