### PR TITLE
PXC-4393: Error lost in wsrep_sst_xtrabackup_v2

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -2096,13 +2096,22 @@ then
             wsrep_log_error "****************************************************** "
             do_exit=1
         fi
-        if [[ ${RC[$(( ${#RC[@]}-1 ))]} -eq 1 ]]; then
-            wsrep_log_error "******************* FATAL ERROR ********************** "
-            wsrep_log_error "$tcmd finished with error: ${RC[1]}"
-            wsrep_log_error "Line $LINENO"
-            wsrep_log_error "****************************************************** "
-            do_exit=1
-        fi
+
+        # Now let's go through the rest of return codes and see if there were
+        # any errors in tcmd (it may be a pipeline of several commands)
+        for ecode in "${RC[@]:1}"; do
+            if [[ $ecode -ne 0 ]]; then
+                wsrep_log_error "******************* FATAL ERROR ********************** "
+                wsrep_log_error "${tcmd} finished with error codes: ${RC[@]:1}"
+                wsrep_log_error "Line $LINENO"
+                wsrep_log_error "****************************************************** "
+                do_exit=1
+
+                # All exit codes already printed out, no need to iterate more
+                break
+            fi
+        done
+
         if [[ $do_exit -eq 1 ]]; then
             exit 22
         fi


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4393

Problem:
On the donor side, if the sending pipeline consists of more than 2 commands, only the failure of the last command is detected, but the error is printed for the penultimate command.

Cause:
The sending pipeline can be like xtrabackup | pv | socat. The error code of the last command was checked, and if it failed, there was printed error corresponding to 'pv'.

Solution:
Iterate over all exit codes and if any error found, print all exit codes and exit the script.