### PR TITLE
PXC-4504: DROP PROCEDURE/FUNCTION IF EXISTS generates local GTID event

### DIFF
--- a/mysql-test/suite/galera/r/galera_drop_if_exists.result
+++ b/mysql-test/suite/galera/r/galera_drop_if_exists.result
@@ -12,5 +12,11 @@ Note	1051	Unknown table 'test.v1'
 DROP EVENT IF EXISTS ev1;
 Warnings:
 Note	1305	Event ev1 does not exist
-include/gtid_step_assert.inc [count=4, only_count=0]
+DROP PROCEDURE IF EXISTS pr1;
+Warnings:
+Note	1305	PROCEDURE test.pr1 does not exist
+DROP FUNCTION IF EXISTS fn1;
+Warnings:
+Note	1305	FUNCTION test.fn1 does not exist
+include/gtid_step_assert.inc [count=6, only_count=0]
 include/gtid_utils_end.inc

--- a/mysql-test/suite/galera/t/galera_drop_if_exists.test
+++ b/mysql-test/suite/galera/t/galera_drop_if_exists.test
@@ -1,5 +1,6 @@
 # Check that the following requirement is fulfiled
-# The DROP DATABASE IF EXISTS, DROP TABLE IF EXISTS, DROP VIEW IF EXISTS and DROP EVENT IF EXISTS statements are always replicated,
+# The DROP DATABASE IF EXISTS, DROP TABLE IF EXISTS, DROP VIEW IF EXISTS, DROP EVENT IF EXISTS,
+# DROP PROCEDURE IF EXISTS and DROP FUNCTION IF EXISTS statements are always replicated,
 # even if the database, table, or view to be dropped does not exist on the source.
 # This is to ensure that the object to be dropped no longer exists on either the source or the replica,
 # once the replica has caught up with the source.
@@ -15,9 +16,11 @@ DROP DATABASE IF EXISTS db1;
 DROP TABLE IF EXISTS t1;
 DROP VIEW IF EXISTS v1;
 DROP EVENT IF EXISTS ev1;
+DROP PROCEDURE IF EXISTS pr1;
+DROP FUNCTION IF EXISTS fn1;
 
-# check that GTID is advanced by 4
---let $gtid_step_count = 4
+# check that GTID is advanced by 6
+--let $gtid_step_count = 6
 --let $gtid_step_uuid = `SELECT Variable_value FROM performance_schema.global_status WHERE Variable_name='wsrep_cluster_state_uuid'`
 --source include/gtid_step_assert.inc
 

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -968,7 +968,22 @@ enum_sp_return_code sp_drop_routine(THD *thd, enum_sp_type type,
         name->m_db.str, name->m_name.str, &routine);
   if (error) return SP_INTERNAL_ERROR;
 
+#ifdef WITH_WSREP
+  if (routine == nullptr) {
+    if (thd->lex->drop_if_exists) {
+      /* If 'IF EXISTS' clause is present, we replicate always.
+         In such a case binlogging part is done on the caller level. */
+      if (WSREP(thd) &&
+          wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL)) {
+        return SP_INTERNAL_ERROR;
+      }
+    }
+    return SP_DOES_NOT_EXISTS;
+  }
+#else
   if (routine == nullptr) return SP_DOES_NOT_EXISTS;
+#endif
+
   /*
     If definer has the SYSTEM_USER privilege then invoker can drop procedure
     only if latter also has same privilege.


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4504

Problem:
When DROP PROCEDURE/FUNCTION IF EXISTS is executed for non existing object, the event is binlogged with the GTID containing UUID of local server instead of global, cluster-wide UUID.

This case is similar to the one already fixed in commit cc8ec98a (PXC-4312)

Cause:
DROP PROCEDURE/FUNCTION IF EXISTS is not replicated if the object does not exist, however is binlogged. If the query is not replicated, wsrep logic generates GTID using local server UUID instead of cluster-wide UUID.

Solution:
Replicate DROP PROCEDURE/FUNCTION IF EXISTS always. This is enough for GTID to be properly generated.