### PR TITLE
clang-tidy check fixed

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - 5.7
       - 8.0
+      - 8.4
       - trunk
       - release-*
 
@@ -38,6 +39,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --allow-unauthenticated --no-install-recommends clang-${COMPILER_VERSION} clang-tidy-${COMPILER_VERSION} libldap2-dev curl libcurl4-openssl-dev bison libudev-dev libkrb5-dev libreadline-dev zlib1g-dev liblz4-dev \
           libedit-dev libevent-dev protobuf-compiler libprotobuf-dev libprotoc-dev libfido2-dev libldap2-dev libsasl2-dev libsasl2-modules
+          
+          # Galera needs boost and check to be installed in the system
+          sudo apt-get install -y libboost-all-dev check
 
       - name: Cache boost
         id: cache-boost
@@ -49,7 +53,7 @@ jobs:
       - name: Download boost
         if: steps.cache-boost.outputs.cache-hit != 'true'
         run: |
-          wget --progress=dot:giga -P ${BOOST_DIR} "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
+          wget --progress=dot:giga -P ${BOOST_DIR} "https://archives.boost.io/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
           tar -xzf "${BOOST_DIR}/boost_${BOOST_VERSION}.tar.gz" -C "${BOOST_DIR}"
 
       - name: Prepare compile_commands.json


### PR DESCRIPTION
1. Boost url updated
2. 8.4 branch included