### PR TITLE
PXC-4573: SST Role lacks INNODB_REDO_LOG_ARCHIVE

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_privileges.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_privileges.result
@@ -1,0 +1,2 @@
+# restart
+include/assert_grep.inc [Check that innobackup.backup.log doesn't contain privilege-related errors]

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_privileges.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_privileges.cnf
@@ -1,0 +1,9 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_debug=1
+
+[xtrabackup]
+redo-log-arch-dir='backup1:@ENV.MYSQL_TMP_DIR/mysqld.1/redo-log-arch-dir'
+

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_privileges.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_privileges.test
@@ -1,0 +1,37 @@
+#
+# If PXB is configured with redo-log-arch-dir option, it complains about lack of INNODB_REDO_LOG_ARCHIVE during SST
+#
+
+--source include/galera_cluster.inc
+
+# Shutdown node2 and remove the grastate.dat file to force SST.
+--connection node_2
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
+# Wait until the cluster size is updated on node1.
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# remove previous pxb log
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/innobackup.backup.log
+
+# Start node_2
+--connection node_2
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Check donor's innobackup.backup.log. It shouldn't contain error.
+--connection node_1
+--let $assert_select = Access denied; you need (at least one of) the INNODB_REDO_LOG_ARCHIVE privilege(s) for this operation
+--let $assert_count_condition = ==0
+--let $assert_text = Check that innobackup.backup.log doesn't contain privilege-related errors
+--let $assert_file = $MYSQLTEST_VARDIR/mysqld.1/data/innobackup.backup.log
+
+--source include/assert_grep.inc
+

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -1365,13 +1365,14 @@ INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.internal.session', 'lo
 #   See the comments in mysql_system_tables.sql
 
 # These are the values for
-#  GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *.* TO 'mysql.pxc.sst.role'@localhost;
+#  GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER, INNODB_REDO_LOG_ARCHIVE ON *.* TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT ALTER, CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT SELECT ON performance_schema.* TO 'mysql.pxc.sst.role'@localhost;
 #  GRANT CREATE ON PERCONA_SCHEMA.* to 'mysql.pxc.sst.role'@localhost;
 INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.sst.role','N','N','N','N','N','N','Y','N','Y','N','N','N','N','N','N','Y','N','Y','N','N','Y','N','N','N','N','N','N','N','N','','','','',0,0,0,0,'caching_sha2_password','','Y',CURRENT_TIMESTAMP,NULL,'Y','N','N',NULL,NULL,NULL,NULL);
 
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'BACKUP_ADMIN', 'N');
+INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'INNODB_REDO_LOG_ARCHIVE', 'N');
 INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Alter,Select,Insert,Create', '');
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'performance_schema', 'mysql.pxc.sst.role','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N');
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N');

--- a/scripts/mysql_system_users.sql
+++ b/scripts/mysql_system_users.sql
@@ -90,7 +90,7 @@ GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *
 -- See https://www.percona.com/doc/percona-xtrabackup/8.0/using_xtrabackup/privileges.html
 CREATE ROLE 'mysql.pxc.sst.role'@localhost;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql.pxc.sst.role'@localhost;
-GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER ON *.*
+GRANT BACKUP_ADMIN, LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER, INNODB_REDO_LOG_ARCHIVE ON *.*
  TO 'mysql.pxc.sst.role'@localhost;
 GRANT ALTER, CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history
  TO 'mysql.pxc.sst.role'@localhost;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4573

Problem:
When SST xtrabackup is configured with redo-log-arch-dir option, pxb complains about the lack of INNODB_REDO_LOG_ARCHIVE privilege.

Solution:
Missing privilege granted for mysql.pxc.sst.role.