### PR TITLE
Disable clang-tidy workflow

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   clang-tidy:
+    if: false  # Disable this job. It produces flood of warnings impossible to manage
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Disable clang-tidy workflow. It floods the PR with an unmanageable amount of warnings. The issue needs to be investigated and solved separately