### PR TITLE
PXC-4399: FLUSH TABLES during writes to table stalls the cluster node

### DIFF
--- a/sql/sql_reload.cc
+++ b/sql/sql_reload.cc
@@ -366,30 +366,6 @@ bool handle_reload_request(THD *thd, unsigned long options, Table_ref *tables,
       }
 
 #ifdef WITH_WSREP
-      if (WSREP(thd) && !thd->lex->no_write_to_binlog &&
-          (options & REFRESH_TABLES) &&
-          !(options & (REFRESH_FOR_EXPORT | REFRESH_READ_LOCK))) {
-        /*
-          This is done here because LOCK TABLES is not replicated in galera,
-          the upgrade of which is checked above.  Hence, done after/if we
-          are able to upgrade locks.
-
-          Also, note that, in error log with debug you may see
-          'thread holds MDL locks at TI' but since this is a flush
-          tables and is required for LOCK TABLE WRITE
-          it can be ignored there.
-        */
-        if (tables) {
-          if (wsrep_to_isolation_begin(thd, NULL, NULL, tables)) {
-            result = 1;
-            goto cleanup;
-          }
-        } else if (wsrep_to_isolation_begin(thd, WSREP_MYSQL_DB, NULL, NULL)) {
-          result = 1;
-          goto cleanup;
-        }
-      }
-
       if (thd && (thd->wsrep_applier || thd->slave_thread)) {
         /*
           In case of wsrep-applier/mysql-slave thread, do not wait for table
@@ -427,9 +403,6 @@ bool handle_reload_request(THD *thd, unsigned long options, Table_ref *tables,
       }
     }
   }
-#ifdef WITH_WSREP
-cleanup:
-#endif /* WITH_WSREP */
   if (options & REFRESH_HOSTS) hostname_cache_refresh();
   if (thd && (options & REFRESH_STATUS)) refresh_status();
   if (options & REFRESH_THREADS)


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4399

Problem:
When we have two concurrent user connections:
T1: inserting into t1
T2: executing "FLUSH TABLES"
the cluster gets stuck after a while.

Cause:
T1 opens t1 table and replicates
T2 replicates "FLUSH TABLES" as TOI, which acquires CommitMonitor T1 tries to acquire CommitMonitor, but it is already acquired by T2, so T1 has to wait
T2 waits for all tables to be closed by other threads that use them.

T1 keeps t1 opened while waiting for CommitMonitor. T2 holds CommitMonitor while waiting for t1 to be closed. The result is the deadlock.

Solution:
Replicate FLUSH TABLES after ensuring that tables are not used by other threads and doing actual flush.
Commit bd6f682f (PXC-3449) added TOI begin after the actual flush (after the call of handle_reload_request() in sql_parse.cc), but didn't remove problematic TOI begin call from handle_reload_request() (which made the call from sql_parse.cc no-op)