### PR TITLE
Suppressed warning that can be issued when GCache

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -500,6 +500,12 @@ INSERT INTO global_suppressions VALUES
  */
  (".*WARNING: unhandled amd64-linux syscall:.*"),
 
+ /*
+   GCache uses mmaped memory for encryption layer. If mmap fails, the functionality still works
+   but the performance is affected and the warning is printed.
+ */
+ (".*mlock failed. It will still work, but swap pages into the disk, so performance will be affected"),
+
  ("THE_LAST_SUPPRESSION");
 
 


### PR DESCRIPTION
encryption is enabled and but mlock fails.
The functionality still works. The warning is to inform the user about possible performance drop.
When Jenkins executes MTR tests, in some Docker environments the above can happen, affecting tests results.