### PR TITLE
(8.4) PXC-4657: MDL BF-BF conflict between two applier threads

### DIFF
--- a/include/service_wsrep.h
+++ b/include/service_wsrep.h
@@ -42,6 +42,7 @@ extern bool wsrep_recovery;
 typedef int64 query_id_t;
 
 class THD;
+struct TABLE;
 
 extern "C" long long wsrep_xid_seqno(const struct xid_t *xid);
 const unsigned char *wsrep_xid_uuid(const struct xid_t *xid);
@@ -142,4 +143,6 @@ extern "C" bool wsrep_consistency_check(const THD *thd);
 extern "C" my_thread_id wsrep_thd_thread_id(THD *thd);
 
 extern "C" bool get_wsrep_recovery();
+
+extern "C" bool wsrep_compare_records(const TABLE *table, THD *thd);
 #endif /* MYSQL_SERVICE_WSREP_INCLUDED */

--- a/mysql-test/suite/galera/r/galera_bf_bf_2.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf_2.result
@@ -1,10 +1,11 @@
+############################################################
+# Testcase:
+# RENAME TABLE <child_table> and concurrent INSERT INTO <parent_table>
+############################################################
 SET SESSION wsrep_sync_wait = 0;
 SET SESSION wsrep_sync_wait = 0;
 SET SESSION wsrep_sync_wait = 0;
-CREATE TABLE parent (id INT PRIMARY KEY);
-CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE);
-INSERT INTO parent values (0);
-INSERT INTO child values (0, 0);
+CREATE TABLE parent (id INT PRIMARY KEY); CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE); INSERT INTO parent values (0); INSERT INTO child values (0, 0);;
 SET GLOBAL wsrep_provider_options = 'dbug=d,after_cert_and_catch';
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_applier_threads = 2;
@@ -23,17 +24,17 @@ SET SESSION wsrep_on = 1;
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=sync.apply_trx.start_of_apply_trx';
 SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
-Timeout in wait_condition.inc for SELECT COUNT(*) = 2 FROM parent
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=after_cert_and_catch';
 DROP TABLE child_new, parent;
+############################################################
+# Testcase:
+# RENAME TABLE <parent_table> and concurrent INSERT INTO <child_table>
+############################################################
 SET SESSION wsrep_sync_wait = 0;
 SET SESSION wsrep_sync_wait = 0;
 SET SESSION wsrep_sync_wait = 0;
-CREATE TABLE parent (id INT PRIMARY KEY);
-CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE);
-INSERT INTO parent values (0);
-INSERT INTO child values (0, 0);
+CREATE TABLE parent (id INT PRIMARY KEY); CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE); INSERT INTO parent values (0); INSERT INTO child values (0, 0);;
 SET GLOBAL wsrep_provider_options = 'dbug=d,after_cert_and_catch';
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_applier_threads = 2;
@@ -52,7 +53,64 @@ SET SESSION wsrep_on = 1;
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=sync.apply_trx.start_of_apply_trx';
 SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
-Timeout in wait_condition.inc for SELECT COUNT(*) = 2 FROM child
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=after_cert_and_catch';
 DROP TABLE child, parent_new;
+############################################################
+# Testcase:
+# t1 update trigger replication after noop update
+############################################################
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+CREATE TABLE t1 (i INT NOT NULL AUTO_INCREMENT, d INT, PRIMARY KEY(i)); CREATE TABLE t2 LIKE t1; CREATE TRIGGER t1_on_update AFTER UPDATE ON t1 FOR EACH ROW INSERT INTO t2 (d) VALUES (NEW.d); INSERT INTO t1 VALUES (1, 1);;
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_cert_and_catch';
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_applier_threads = 2;
+SET GLOBAL debug = "+d,ordered_commit_blocked";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET DEBUG_SYNC = "now WAIT_FOR signal.ordered_commit_waiting";
+SET GLOBAL debug = "-d,ordered_commit_blocked";
+SET GLOBAL wsrep_provider_options = 'dbug=d,sync.apply_trx.start_of_apply_trx';
+UPDATE t1 SET d=d LIMIT 1;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=sync.apply_trx.start_of_apply_trx';
+SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=after_cert_and_catch';
+DROP TABLE t1, t2;
+############################################################
+# Testcase:
+# UPDATE test.t2 JOIN test.t1 USING (i) SET t2.d = t2.d+1, t1.d = t1.d
+############################################################
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+CREATE TABLE t1 (i int NOT NULL AUTO_INCREMENT, d int, PRIMARY KEY (i) ) ENGINE=InnoDB; CREATE TABLE t2 like t1; INSERT INTO t2 values (1,1); INSERT INTO t1 values (1,1);;
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_cert_and_catch';
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_applier_threads = 2;
+SET GLOBAL debug = "+d,ordered_commit_blocked";
+ALTER TABLE t1 ENGINE=InnoDB;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET DEBUG_SYNC = "now WAIT_FOR signal.ordered_commit_waiting";
+SET GLOBAL debug = "-d,ordered_commit_blocked";
+SET GLOBAL wsrep_provider_options = 'dbug=d,sync.apply_trx.start_of_apply_trx';
+UPDATE test.t2 JOIN test.t1 USING (i) SET t2.d = t2.d+1, t1.d = t1.d;;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=sync.apply_trx.start_of_apply_trx';
+SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=after_cert_and_catch';
+DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/galera_bf_bf_2.inc
+++ b/mysql-test/suite/galera/t/galera_bf_bf_2.inc
@@ -1,20 +1,26 @@
 #
-# The scenario is:
-# Setup parent-child tables
+# This is the common, parametrized scenario when DDL and DML on two related tables are executed in parallel.
+#
+# Setup tables according to $setup_query
 # node2: Setup DDL applier trap before commit
 # node1: Block DDL and DML after cert_and_catch()
-# node1: DDL: RENAME TABLE child to child_new
+# node1: Execute DDL
 # node2: Wait for DDL applier to reach trap
 # node2: Setup DML applier trap before applying the writeset
-# node1: DML INSERT INTO parent VALUES (0)
+# node1: Execute DML
 # node2: Wait for DDL applier to reach trap
-# node2: DDL will block before commit (acquires locks on child and parent tables), DML will block before applying
-# node2: Unblock DML. Without the fix it will try to acquire locks on parent table, which will end up with BF-BF
+# node2: DDL will block before commit (acquires all needed locks), DML will block before applying
+# node2: Unblock DML. As the tables are related, without the fix it will try to acquire DML lock that is already acquired by DDL applier, which will end up with BF-BF
 # node2: Unblock DDL
 # node1: Unblock DDL and DML. Collect results
 #
 
 --source include/count_sessions.inc
+
+--echo ############################################################
+--echo # Testcase:
+--echo # $test_case
+--echo ############################################################
 
 --connect node_1_ddl, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --connection node_1_ddl
@@ -26,10 +32,8 @@ SET SESSION wsrep_sync_wait = 0;
 
 --connection node_1
 SET SESSION wsrep_sync_wait = 0;
-CREATE TABLE parent (id INT PRIMARY KEY);
-CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE);
-INSERT INTO parent values (0);
-INSERT INTO child values (0, 0);
+--eval $setup_query
+
 --let $galera_sync_point = after_cert_and_catch
 --source include/galera_set_sync_point.inc
 
@@ -38,9 +42,7 @@ SET SESSION wsrep_sync_wait = 0;
 --let $wsrep_applier_threads_orig = `SELECT @@wsrep_applier_threads`
 SET GLOBAL wsrep_applier_threads = 2;
 
---let $wait_condition = SELECT COUNT(*) = 1 FROM parent
---source include/wait_condition.inc
---let $wait_condition = SELECT COUNT(*) = 1 FROM child
+--let $wait_condition = $setup_check
 --source include/wait_condition.inc
 
 # DDL applier should stop here
@@ -75,29 +77,44 @@ SET GLOBAL debug = "-d,ordered_commit_blocked";
 
 #
 # Let the DML applier proceed. As DDL applier already acquired all MDL locks
-# it will cause BF-BF abort if the dependency between transactions is not set
-# properly
+# it will cause BF-BF.
+# With the fix, certification will detect conflict between DDL key that is already in
+# cert index (EXCLUSIVE) and the key used by DML (UPDATE (internally changed by galera 
+# to REFERENCE as it is not leaf key). So the certification of DML will fail and will be
+# scheduled to retry (wsrep_retry_autocommit).
+# Before retry, we call transaction::release_commit_order() (advance it).
+# To do so, we acquire and release commit_order monitor, but we block on acquire, because it is
+# already acquired by DDL. So we have to wait till DDL finishes, then retry kicks-in assigning
+# depends_on of DML to the seqno of DDL.
 #
 --source include/galera_clear_sync_point.inc
 --source include/galera_signal_sync_point.inc
 
 SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
 
---let $wait_condition = SELECT COUNT(*) = 2 FROM $dml_table
---source include/wait_condition.inc
-
 #
-# Reap results on node_1
+# Let DDL and DML go ahead. DML already failed certificationa and will be retried after
+# waiting for DDL to finish.
 #
 --connection node_1
 --source include/galera_clear_sync_point.inc
 --let $galera_sync_point = after_cert_and_catch
 --source include/galera_signal_sync_point.inc
 
+#
+# Reap results on node_1
+#
 --connection node_1_ddl
 --reap
 --connection node_1_dml
 --reap
+
+#
+# Now we can check if retried DML was replicated
+#
+--connection node_2
+--let $wait_condition = $after_test_table_check
+--source include/wait_condition.inc
 
 #
 # cleanup

--- a/mysql-test/suite/galera/t/galera_bf_bf_2.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf_2.test
@@ -1,23 +1,89 @@
+--source include/have_debug_sync.inc
+--source suite/galera/include/galera_have_debug_sync.inc
+--source include/galera_cluster.inc
+
 #
 # Test that
 # RENAME TABLE <child_table> and concurrent INSERT INTO <parent_table>
 # RENAME TABLE <parent_table> and concurrent INSERT INTO <child_table>
 # are properly ordered.
 #
-
---source include/have_debug_sync.inc
---source suite/galera/include/galera_have_debug_sync.inc
---source include/galera_cluster.inc
-
+# The scenario is:
+# Setup parent-child tables
+# node2: Setup DDL applier trap before commit
+# node1: Block DDL and DML after cert_and_catch()
+# node1: DDL: RENAME TABLE child to child_new
+# node2: Wait for DDL applier to reach trap
+# node2: Setup DML applier trap before applying the writeset
+# node1: DML INSERT INTO parent VALUES (0)
+# node2: Wait for DDL applier to reach trap
+# node2: DDL will block before commit (acquires locks on child and parent tables), DML will block before applying
+# node2: Unblock DML. Without the fix it will try to acquire locks on parent table, which will end up with BF-BF
+# node2: Unblock DDL
+# node1: Unblock DDL and DML. Collect results
+#
+--let $test_case = RENAME TABLE <child_table> and concurrent INSERT INTO <parent_table>
+--let $setup_query = CREATE TABLE parent (id INT PRIMARY KEY); CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE); INSERT INTO parent values (0); INSERT INTO child values (0, 0);
+--let $setup_check = SELECT COUNT(*) = 1 FROM child
 --let $ddl_query = RENAME TABLE child TO child_new
 --let $dml_query = INSERT INTO parent VALUES (1)
---let $dml_table = parent
+# After the test we expect 'parent' table to have two rows
+--let $after_test_table_check = SELECT COUNT(*) = 2 FROM parent
 --let $drop_query = DROP TABLE child_new, parent
 --source galera_bf_bf_2.inc
 
+--let $test_case = RENAME TABLE <parent_table> and concurrent INSERT INTO <child_table>
 --let $ddl_query = RENAME TABLE parent TO parent_new
 --let $dml_query = INSERT INTO child VALUES (1, 0)
+# After the test we expect 'child' table to have two rows
+--let $after_test_table_check = SELECT COUNT(*) = 2 FROM child
 --let $drop_query = DROP TABLE child, parent_new
---let $dml_table = child
 --source galera_bf_bf_2.inc
 
+#
+# Test that DDL on table t1 and simultaneous DML on table t2 are properly ordered
+# in the case when t1 has an update trigger that inserts a row to t2, but update
+# doesn't change a row. In sucha case only t2 insert is replicated, but the replica
+# locks also t1, so DDL (t1) and INSERT (t2) should depend on each other.
+#
+# The scenario is:
+# Setup t1, t2 and update trigger on t1 that inserts into t2
+# node2: Setup DDL applier trap before commit
+# node1: Block DDL and DML after cert_and_catch()
+# node1: DDL: ALTER TABLE t1
+# node2: Wait for DDL applier to reach trap - it acquired MDL lock on t1
+# node2: Setup DML applier trap before applying the writeset
+# node1: UPDATE t1 SET d=d LIMIT 1 - no row update, but it will cause trigger execution that will insert into t2
+# node2: Wait for DDL applier to reach the trap
+# node2: DDL is blocked before commit (acquires t1 MDL), DML is blocked before applying
+# node2: Unblock DML. Without the fix it will try to acquire MDL lock on t1, which will end up with BF-BF
+# node2: Unblock DDL
+# node1: Unblock DDL and DML. Collect results
+#
+--let $test_case = t1 update trigger replication after noop update
+--let $setup_query = CREATE TABLE t1 (i INT NOT NULL AUTO_INCREMENT, d INT, PRIMARY KEY(i)); CREATE TABLE t2 LIKE t1; CREATE TRIGGER t1_on_update AFTER UPDATE ON t1 FOR EACH ROW INSERT INTO t2 (d) VALUES (NEW.d); INSERT INTO t1 VALUES (1, 1);
+--let $setup_check = SELECT COUNT(*) = 1 FROM t1
+--let $ddl_query = ALTER TABLE t1 ENGINE=InnoDB
+--let $dml_query = UPDATE t1 SET d=d LIMIT 1
+# After the test we expect one row inserted by the trigger to t2
+--let $after_test_table_check = SELECT COUNT(*) = 1 FROM t2
+--let $drop_query = DROP TABLE t1, t2
+--source galera_bf_bf_2.inc
+
+
+#
+# Test that DDL on table t1 and simultaneous DML on table t2 are properly ordered
+# in the case when DML uses t1 and t2, but t1 row update is noop. In such a case resulting
+# writeset contains only changes related to t2, but also information that replicated
+# node should lock t1 (and t2). It means that DDL and DML can not go in parallel
+# on the applier node, because they would cause BF-BF abort (conflict on t1).
+#
+--let $test_case = UPDATE test.t2 JOIN test.t1 USING (i) SET t2.d = t2.d+1, t1.d = t1.d
+--let $setup_query = CREATE TABLE t1 (i int NOT NULL AUTO_INCREMENT, d int, PRIMARY KEY (i) ) ENGINE=InnoDB; CREATE TABLE t2 like t1; INSERT INTO t2 values (1,1); INSERT INTO t1 values (1,1);
+--let $setup_check = SELECT COUNT(*) = 1 FROM t1
+--let $ddl_query = ALTER TABLE t1 ENGINE=InnoDB
+--let $dml_query = UPDATE test.t2 JOIN test.t1 USING (i) SET t2.d = t2.d+1, t1.d = t1.d;
+# After the test we expect t2.d to be updated to 2
+--let $after_test_table_check = SELECT COUNT(*) = 1 FROM t2 WHERE d=2
+--let $drop_query = DROP TABLE t1, t2
+--source galera_bf_bf_2.inc

--- a/sql/auth/acl_table_user.cc
+++ b/sql/auth/acl_table_user.cc
@@ -750,7 +750,11 @@ Acl_table_op_status Acl_table_user_writer::finish_operation(
         We should NEVER delete from the user table, as a uses can still
         use mysqld even if he doesn't have any privileges in the user table!
       */
+#ifdef WITH_WSREP
+      if (wsrep_compare_records(m_table, m_thd)) {
+#else
       if (compare_records(m_table)) {
+#endif
         out_error = m_table->file->ha_update_row(m_table->record[1],
                                                  m_table->record[0]);
         assert(out_error != HA_ERR_FOUND_DUPP_KEY);

--- a/sql/auth/role_tables.cc
+++ b/sql/auth/role_tables.cc
@@ -136,8 +136,13 @@ bool modify_role_edges_in_table(THD *thd, TABLE *table,
       store_record(table, record[1]);
       table->field[MYSQL_ROLE_EDGES_FIELD_TO_WITH_ADMIN_OPT]->store(
           &with_admin_option_char, 1, system_charset_info, CHECK_FIELD_IGNORE);
+#ifdef WITH_WSREP
+      if (wsrep_compare_records(
+              table, thd))  // if we already have WITH ADMIN this is a NOP
+#else
       if (compare_records(
               table))  // if we already have WITH ADMIN this is a NOP
+#endif
         ret = table->file->ha_update_row(table->record[1], table->record[0]);
     }
   }  // else if !delete_option

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -77,6 +77,9 @@
 #include "string_with_len.h"     // STRING_WITH_LEN
 #include "thr_lock.h"            // thr_lock_type
 #include "typelib.h"
+#ifdef WITH_WSREP
+#include <service_wsrep.h>  // Wsrep_service_key_type
+#endif
 
 class Alter_info;
 class Create_field;
@@ -7541,6 +7544,14 @@ class handler {
     such as table->in_use == current_thd are relaxed to support cloning a
     handler belonging to a different thread. */
   bool cloned;
+
+#ifdef WITH_WSREP
+ public:
+  virtual int wsrep_append_keys(THD *, Wsrep_service_key_type, const uchar *,
+                                const uchar *) {
+    return 0;
+  }
+#endif /* WITH_WSREP */
 };
 
 /* Temporary Table handle for opening uncached table */

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -21,6 +21,9 @@
 #include "log.h"
 #include "service_wsrep.h"
 #include "sql_class.h"
+#include "sql_thd_internal_api.h"  // thd_binlog_format
+#include "sql_update.h"            // compare_records
+#include "table.h"                 // TABLE
 #include "wsrep/key.hpp"
 #include "wsrep_thd.h"
 #include "wsrep_trans_observer.h"
@@ -307,4 +310,48 @@ extern "C" bool wsrep_consistency_check(const MYSQL_THD thd) {
 
 extern "C" my_thread_id wsrep_thd_thread_id(THD *thd) {
   return thd->thread_id();
+}
+
+extern "C" bool wsrep_compare_records(const TABLE *table, THD *thd) {
+  bool res = compare_records(table);
+  if (!res) {
+    /*
+      Update didn't change a record,
+      but we still need to update certification keys of the current writeset
+      because it may be related to the table, that will be locked on replicated
+      node (so we need to set proper dependencies between writesets).
+      This is the same condition as we have in
+      ha_innodb.cc static bool wsrep_do_replication(THD *thd) which is called
+      always before wsrep_append_keys(). The ideal would be having this inside
+      wsrep_append_keys() (as it is checked always), but it is as it is.
+    */
+    bool do_replication = wsrep_on(thd) && wsrep_thd_is_local(thd) &&
+                          !wsrep_consistency_check(thd) &&
+                          thd_binlog_format(thd) == BINLOG_FORMAT_ROW;
+    if (do_replication) {
+      table->file->wsrep_append_keys(thd,
+                                     wsrep_protocol_version >= WsrepVersion::V4
+                                         ? WSREP_SERVICE_KEY_UPDATE
+                                         : WSREP_SERVICE_KEY_EXCLUSIVE,
+                                     table->record[1], table->record[0]);
+
+      /*
+        It is possible that we are here when executing something like
+        UPDATE t1 SET d = d LIMIT 1;
+        In such a case, nothing will be replicated, but galera flow
+        will commit empty transaction. (ha_commit_trans -> wsrep_commit_empty)
+        That would cause the assertion, because wsrep_commit_empty() checks
+        if the transaction is really empty (wsrep_has_changes() which checks
+        for transaction's cert keys to be empty). We would relax the original
+        assertion in wsrep_commit_empty(), but that would cause other
+        erroneous cases to sneak in. Instead of this, let's remember that we
+        added extra keys and if we end up with empty transaction, we will
+        simply ignore them.
+      */
+#ifndef NDEBUG
+      thd->wsrep_transaction_added_extra_cert_key = true;
+#endif
+    }
+  }
+  return res;
 }

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -162,6 +162,7 @@
 #include "thr_mutex.h"
 
 #ifdef WITH_WSREP
+#include "sql_thd_internal_api.h"  // thd_binlog_format
 #include "wsrep_mysqld.h"
 #include "wsrep_thd.h"
 #include "wsrep_trans_observer.h"
@@ -10221,7 +10222,6 @@ inline bool call_before_insert_triggers(THD *thd, TABLE *table,
     @retval false   OK
     @retval true    Error occurred
 */
-
 bool fill_record_n_invoke_before_triggers(
     THD *thd, COPY_INFO *optype_info, const mem_root_deque<Item *> &fields,
     const mem_root_deque<Item *> &values, TABLE *table,
@@ -10234,7 +10234,11 @@ bool fill_record_n_invoke_before_triggers(
     Fill DEFAULT functions (like CURRENT_TIMESTAMP) and DEFAULT expressions on
     the columns that are not on the list of assigned columns.
   */
+#ifdef WITH_WSREP
+  auto fill_function_defaults = [table, optype_info, is_row_changed, thd]() {
+#else
   auto fill_function_defaults = [table, optype_info, is_row_changed]() {
+#endif
     /*
       Unlike INSERT and LOAD, UPDATE operation requires comparison of old
       and new records to determine whether function defaults have to be
@@ -10242,7 +10246,11 @@ bool fill_record_n_invoke_before_triggers(
     */
     if (optype_info->get_operation_type() == COPY_INFO::UPDATE_OPERATION) {
       *is_row_changed =
+#ifdef WITH_WSREP
+          (!records_are_comparable(table) || wsrep_compare_records(table, thd));
+#else
           (!records_are_comparable(table) || compare_records(table));
+#endif
       /*
         Evaluate function defaults for columns with ON UPDATE clause only
         if any other column of the row is updated.
@@ -10304,7 +10312,12 @@ bool fill_record_n_invoke_before_triggers(
             optype_info->get_operation_type() == COPY_INFO::UPDATE_OPERATION &&
             !(*is_row_changed))
           *is_row_changed =
+#ifdef WITH_WSREP
+              (!records_are_comparable(table) ||
+               wsrep_compare_records(table, thd));
+#else
               (!records_are_comparable(table) || compare_records(table));
+#endif
       }
     }
     /*

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -759,7 +759,9 @@ THD::THD(bool enable_plugins)
       wsrep_post_insert_error(false),
       wsrep_stmt_transaction_rolled_back(false),
       wsrep_force_savept_rollback(false),
-
+#ifndef NDEBUG
+      wsrep_transaction_added_extra_cert_key(false),
+#endif
       /* wsrep-lib */
       m_wsrep_next_trx_id(WSREP_UNDEFINED_TRX_ID),
       m_wsrep_mutex(LOCK_wsrep_thd),
@@ -1257,6 +1259,9 @@ void THD::init(void) {
   wsrep_post_insert_error = false;
   wsrep_stmt_transaction_rolled_back = false;
   wsrep_force_savept_rollback = false;
+#ifndef NDEBUG
+  wsrep_transaction_added_extra_cert_key = false;
+#endif
 #endif /* WITH_WSREP */
 
   if (variables.sql_log_bin)

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3420,6 +3420,15 @@ class THD : public MDL_context_owner,
     rollback. */
   bool wsrep_force_savept_rollback;
 
+  /**
+    Set to true if certification keys were added from sql layer level.
+    Right now, it is used only in assertion in wsrep_commit_empty, so let's keep
+    it only in debug builds.
+   */
+#ifndef NDEBUG
+  bool wsrep_transaction_added_extra_cert_key;
+#endif
+
   /* Used to disable binlog when DDL is executed with wsrep_OSU_method=RSU. */
   std::shared_ptr<Disable_binlog_guard> disable_binlog_guard;
 

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -2771,7 +2771,12 @@ bool UpdateRowsIterator::DoDelayedUpdates(bool *trans_safe,
         if (rc || check_record(thd(), table->field)) goto err;
       }
 
+#ifdef WITH_WSREP
+      if (!records_are_comparable(table) ||
+          wsrep_compare_records(table, thd())) {
+#else
       if (!records_are_comparable(table) || compare_records(table)) {
+#endif
         /*
           This function does not call the fill_record_n_invoke_before_triggers
           which sets function defaults automagically. Hence calling

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -310,6 +310,8 @@ static int update_or_insert(TABLE *table) {
       ret = 1;
     }
   } else if (!records_are_comparable(table) || compare_records(table)) {
+    // No need to call wsrep_compare_records, as wsrep_schema changes are not
+    // replicated
     /*
       Record has changed
     */

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -527,7 +527,9 @@ static inline void wsrep_commit_empty(THD *thd, bool all) {
     /* @todo CTAS with STATEMENT binlog format and empty result set
        seems to be committing empty. Figure out why and try to fix
        elsewhere. */
-    assert(!wsrep_has_changes(thd) || thd->wsrep_stmt_transaction_rolled_back ||
+    assert(!wsrep_has_changes(thd) ||
+           thd->wsrep_transaction_added_extra_cert_key ||
+           thd->wsrep_stmt_transaction_rolled_back ||
            (thd->lex->sql_command == SQLCOM_CREATE_TABLE &&
             !thd->is_current_stmt_binlog_format_row()) ||
            thd->wsrep_post_insert_error);

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -535,7 +535,7 @@ class ha_innobase : public handler {
 
 #ifdef WITH_WSREP
   int wsrep_append_keys(THD *thd, Wsrep_service_key_type key_type,
-                        const uchar *record0, const uchar *record1);
+                        const uchar *record0, const uchar *record1) override;
 #endif /* WITH_WSREP */
 
  private:


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4657

Fixes also:
PXC-4684: UPDATE query that matches two tables but modifies only one causes an MDL BF-BF conflict on other nodes.

https://perconadev.atlassian.net/browse/PXC-4684

PXC-4657:

Problem:
We have tables t1 and t2 and an update trigger on t1 that inserts into t2. If update on t1 doesn't change a row, no events related to update are created however, t2 insert event is created by the trigger. As the result a writeset corresponding to t1 update contains Table_map_log_event related to t1 and t2. On the applier side it causes locking of t1 and t2 tables, even if only t2 is modified. But as the update to t1 was skipped on the source node, a writeset doesn't contain t1-related certification keys.
If at the same time a DDL is executed on t1, Galera certification mechanism doesn't see the dependency between these two transactions and order them for parallel apply.
As both transactions acquire MDL locks on t1, on the applier side we end up with BF-BF abort.

Cause:
Writeset related to t1 update does not contain t1-related certification keys.

PXC-4684:

Problem:
For queries like
UPDATE t2 JOIN t1 USING (i) SET t2.d = t2.d+1, t1.d = t1.d; t1 is not updated, as MySql detects that t1 row didn't change. The result is a writeset having Table_map_log_event related to t1 and t2 but having only t2 certification keys.

Cause:
Transaction dependencies calculation is affected and BF-BF abort is seen on replicated node that have more than one applier thread.

Solution:
In 'normal' case, when the row is updated, certification keys are added from InnoDB level during row update. The update is skipped, but we still need to add t1 to the certification keys in case there are triggers on t1.