### PR TITLE
(trunk) PXC-3576 PXC create a role mapping an upper case database with lower_…

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_with_lower_case_table_names.result
+++ b/mysql-test/suite/galera/r/galera_sst_with_lower_case_table_names.result
@@ -1,0 +1,6 @@
+select count(*) from mysql.db where user='mysql.pxc.sst.role' and db='percona_schema';
+count(*)
+1
+select count(*) from mysql.db where user='mysql.pxc.sst.role' and db='PERCONA_SCHEMA';
+count(*)
+0

--- a/mysql-test/suite/galera/t/galera_sst_with_lower_case_table_names-master.opt
+++ b/mysql-test/suite/galera/t/galera_sst_with_lower_case_table_names-master.opt
@@ -1,0 +1,1 @@
+--initialize=--lower_case_table_names=1

--- a/mysql-test/suite/galera/t/galera_sst_with_lower_case_table_names.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_with_lower_case_table_names.cnf
@@ -1,0 +1,9 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_debug=1
+lower_case_table_names=1
+
+[xtrabackup]
+history=backup

--- a/mysql-test/suite/galera/t/galera_sst_with_lower_case_table_names.test
+++ b/mysql-test/suite/galera/t/galera_sst_with_lower_case_table_names.test
@@ -1,0 +1,16 @@
+# Using the setting lower_case_table_names=1 on the startup
+# should not affect SST and should not produce a duplicated entry
+# for mysql.pxc.sst.role and percona_schema database in upper case letters.
+
+--source include/force_restart.inc
+--source include/galera_cluster.inc
+
+
+# Check that the cluster starts up
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Check that role mapping is not duplicated in upper case letters
+--connection node_1
+select count(*) from mysql.db where user='mysql.pxc.sst.role' and db='percona_schema';
+select count(*) from mysql.db where user='mysql.pxc.sst.role' and db='PERCONA_SCHEMA';

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -1419,8 +1419,30 @@ INSERT IGNORE INTO mysql.user VALUES ('localhost','mysql.pxc.sst.role','N','N','
 #  pxb-sst
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'BACKUP_ADMIN', 'Y');
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'INNODB_REDO_LOG_ARCHIVE', 'N');
-INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Alter,Select,Insert,Create', '');
-INSERT IGNORE INTO mysql.db VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N');
+DROP PROCEDURE IF EXISTS conditional_grants;
+DELIMITER $$
+CREATE PROCEDURE conditional_grants()
+BEGIN
+  DECLARE lctn INT DEFAULT 0;
+
+  -- Get the value of lower_case_table_names
+  SET lctn = @@lower_case_table_names;
+
+  IF lctn = 1 THEN
+    -- Case-insensitive system: use lowercase schema/table
+    INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'percona_schema', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Alter,Select,Insert,Create', '');
+    INSERT IGNORE INTO mysql.db VALUES ('localhost', 'percona_schema', 'mysql.pxc.sst.role', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N');
+  ELSE
+    -- Case-sensitive system: match the exact case used when creating DB
+    INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'xtrabackup_history', 'root\@localhost', CURRENT_TIMESTAMP, 'Alter,Select,Insert,Create', '');
+    INSERT IGNORE INTO mysql.db VALUES ('localhost', 'PERCONA_SCHEMA', 'mysql.pxc.sst.role', 'N', 'N', 'N', 'N', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N', 'N');
+  END IF;
+END $$
+DELIMITER ;
+
+CALL conditional_grants();
+
+DROP PROCEDURE conditional_grants;
 
 #  common
 INSERT IGNORE INTO mysql.db VALUES ('localhost', 'performance_schema', 'mysql.pxc.sst.role','Y','Y','Y','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N');

--- a/scripts/mysql_system_users.sql
+++ b/scripts/mysql_system_users.sql
@@ -99,7 +99,33 @@ REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql.pxc.sst.role'@localhost;
 
 -- Needed by sst_xtrabackup-v2
 GRANT LOCK TABLES, PROCESS, RELOAD, REPLICATION CLIENT, SUPER, INNODB_REDO_LOG_ARCHIVE ON *.* TO 'mysql.pxc.sst.role'@localhost;
-GRANT ALTER, CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history TO 'mysql.pxc.sst.role'@localhost;
+
+DROP PROCEDURE IF EXISTS conditional_grants;
+DELIMITER $$
+CREATE PROCEDURE conditional_grants()
+BEGIN
+    DECLARE lctn INT DEFAULT 0;
+
+    -- Get the value of lower_case_table_names
+    SET lctn = @@lower_case_table_names;
+
+    IF lctn = 1 THEN
+        -- Case-insensitive system: use lowercase schema/table
+        GRANT ALTER, CREATE, SELECT, INSERT ON percona_schema.xtrabackup_history TO 'mysql.pxc.sst.role'@'localhost';
+        -- Need this to create the percona_schema database if needed
+        GRANT CREATE ON percona_schema.* TO 'mysql.pxc.sst.role'@localhost;
+    ELSE
+        -- Case-sensitive system: match the exact case used when creating DB
+        GRANT ALTER, CREATE, SELECT, INSERT ON PERCONA_SCHEMA.xtrabackup_history TO 'mysql.pxc.sst.role'@'localhost';
+        -- Need this to create the PERCONA_SCHEMA database if needed
+        GRANT CREATE ON PERCONA_SCHEMA.* TO 'mysql.pxc.sst.role'@localhost;
+    END IF;
+END $$
+DELIMITER ;
+
+CALL conditional_grants();
+
+DROP PROCEDURE conditional_grants;
 
 -- Common. WITH GRANT OPTION is needed by clone-sst script
 GRANT BACKUP_ADMIN, EXECUTE ON *.* TO 'mysql.pxc.sst.role'@localhost WITH GRANT OPTION;
@@ -116,9 +142,6 @@ GRANT SELECT ON performance_schema.* TO 'mysql.pxc.sst.role'@localhost WITH GRAN
 GRANT CLONE_ADMIN, SYSTEM_USER, SHUTDOWN, CONNECTION_ADMIN, CREATE USER, CREATE ROLE, DROP ROLE, SYSTEM_VARIABLES_ADMIN ON *.* TO 'mysql.pxc.sst.role'@localhost;
 GRANT INSERT, DELETE ON mysql.plugin TO 'mysql.pxc.sst.role'@localhost;
 GRANT UPDATE, INSERT ON performance_schema.* TO 'mysql.pxc.sst.role'@localhost;
-
--- Need this to create the PERCONA_SCHEMA database if needed
-GRANT CREATE ON PERCONA_SCHEMA.* to 'mysql.pxc.sst.role'@localhost;
 
 -- this is a plugin priv that might not be registered
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.infoschema', 'localhost', 'AUDIT_ABORT_EXEMPT', 'N');


### PR DESCRIPTION
…case_table_names=1

Problem:
The PXC startup script grants the mysql.pxc.sst.role role access to the PERCONA_SCHEMA database to support PXB’s history feature. However, when the lower_case_table_names = 1 setting is used in a PXC cluster, it results in duplicate role mapping entries — one for the `PERCONA_SCHEMA` database and another for `percona_schema` database. This happens because PXB creates the PERCONA_SCHEMA database using uppercase letters.

Solution:
To address this issue, a fix should be applied on the PXB side by renaming the PERCONA_SCHEMA database to lowercase.

As a temporary workaround, during grants in startup script we check whether lower_case_table_names = 1 is set.

If it is, we grant permissions for mysql.pxc.sst.role on the lowercase percona_schema database. Otherwise, we use the original uppercase PERCONA_SCHEMA.