### PR TITLE
(8.0) PXC-4664: Executing transactions with the same GTID on different nodes causes the node to exit

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_async_monitor.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_async_monitor.result
@@ -1,0 +1,24 @@
+include/assert.inc [replica_parallel_type is LOGICAL_CLOCK]
+include/assert.inc [replica_parallel_workers > 1]
+include/assert.inc [replica_preserve_commit_order is ON]
+START REPLICA USER = 'root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+include/assert.inc [binlog_transaction_dependency_tracking is COMMIT_ORDER]
+CREATE TABLE t1 (a INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+SET GLOBAL debug = "+d,wsrep_to_isolation_begin_before_async_monitor";
+SET GLOBAL debug = "+d,wsrep_before_prepare_before_async_monitor";
+# Adding debug point 'set_commit_parent_100' to @@GLOBAL.debug
+INSERT INTO t1 VALUES (1);
+CREATE TABLE t2 (a INT PRIMARY KEY);
+# Removing debug point 'set_commit_parent_100' from @@GLOBAL.debug
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_to_isolation_begin_before_async_monitor.reached';
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_before_prepare_before_async_monitor.reached';
+SET GLOBAL debug = "-d,wsrep_to_isolation_begin_before_async_monitor";
+SET GLOBAL debug = "-d,wsrep_before_prepare_before_async_monitor";
+SET DEBUG_SYNC = 'now SIGNAL wsrep_to_isolation_begin_before_async_monitor.continue';
+SET DEBUG_SYNC = 'now SIGNAL wsrep_before_prepare_before_async_monitor.continue';
+DROP TABLE t1, t2;
+STOP REPLICA;
+RESET REPLICA ALL;

--- a/mysql-test/suite/galera/r/galera_as_slave_gtid_empty_trx.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid_empty_trx.result
@@ -1,0 +1,11 @@
+START REPLICA USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET gtid_next='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1';
+BEGIN;
+COMMIT;
+SET gtid_next=AUTOMATIC;
+INSERT INTO t1 VALUES(1);
+STOP REPLICA;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_as_slave_async_monitor.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_async_monitor.cnf
@@ -1,0 +1,9 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+gtid-mode=ON
+log-bin=mysqld-bin
+log-slave-updates
+enforce-gtid-consistency
+binlog-format=ROW
+wsrep_debug=1

--- a/mysql-test/suite/galera/t/galera_as_slave_async_monitor.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_async_monitor.test
@@ -1,0 +1,152 @@
+#
+# Test Galera as a replica to a MySQL source.
+#
+# suite/galera/galera_2nodes_as_slave.cnf describes the setup of the nodes
+# suite/galera/t/galera_as_slave_gtid.cnf has the GTID options
+#
+# Check that concurrent DML and DDL are ordered in Galera in the same way as
+# they are in async replication.
+# This test checks that wsrep_async_monitor enforces the same ordering of transactions
+# in Galera channel as they are ordered in async replication channel.
+# The test will trigger a deadlock between async workers if ran with wsrep_use_async_monitor = 0.
+#
+
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+#
+# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
+#
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster_master_slave.inc
+--disconnect node_2a
+
+--source include/count_sessions.inc
+
+#
+# Ensure replica settings are correct (defaults are fine)
+#
+--connection node_2
+--let $assert_text = replica_parallel_type is LOGICAL_CLOCK
+--let $assert_cond = "[SHOW VARIABLES LIKE "replica_parallel_type", Value, 1]" = "LOGICAL_CLOCK"
+--source include/assert.inc
+
+--let $assert_text = replica_parallel_workers > 1
+--let $assert_cond = "[SHOW VARIABLES LIKE "replica_parallel_workers", Value, 1]" > 1
+--source include/assert.inc
+
+--let $assert_text = replica_preserve_commit_order is ON
+--let $assert_cond = "[SHOW VARIABLES LIKE "replica_preserve_commit_order", Value, 1]" = "ON"
+--source include/assert.inc
+
+#
+# Configure PXC node as the replica
+#
+--disable_query_log
+--eval CHANGE REPLICATION SOURCE TO SOURCE_HOST = '127.0.0.1', SOURCE_PORT = $NODE_MYPORT_1;
+--enable_query_log
+START REPLICA USER = 'root';
+
+#
+# Ensure source settings are correct (defaults are fine)
+#
+--connection node_1
+--let $assert_text = binlog_transaction_dependency_tracking is COMMIT_ORDER
+--let $assert_cond = "[SHOW VARIABLES LIKE "binlog_transaction_dependency_tracking", Value, 1]" = "COMMIT_ORDER"
+--source include/assert.inc
+
+#
+# Do some queries and wait till they get replicated
+#
+CREATE TABLE t1 (a INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
+#
+# Prepare traps for replicated DDL and DML
+#
+SET GLOBAL debug = "+d,wsrep_to_isolation_begin_before_async_monitor";
+SET GLOBAL debug = "+d,wsrep_before_prepare_before_async_monitor";
+
+
+
+#
+# Async source will commit DML, then DDL.
+# Force them to have the same parent. This will allow parallel processing on the replica side.
+# It is expected by the async replica to commit in the same order.
+# To avoid a deadlock, they should be replicated in Galera in the same order as well.
+# The following actions on source node are inspired by rpl_mts_replica_preserve_commit_order_crash_nobinlog.test,
+# they use the same sync points.
+#
+--connection node_1
+# Make the following transactions have same commit parent. So they can be applied
+# parallel on replica.
+--let $debug_point = set_commit_parent_100
+--source include/add_debug_point.inc
+
+# transaction T1
+INSERT INTO t1 VALUES (1);
+
+# transaction T2
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+CREATE TABLE t2 (a INT PRIMARY KEY);
+
+--let $debug_point = set_commit_parent_100
+--source include/remove_debug_point.inc
+--disconnect node_1a
+
+
+#
+# On replica side, wait for T1 and T2 to be replicated and dispatched to async replica
+# worker threads.
+#
+--connection node_2
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_to_isolation_begin_before_async_monitor.reached';
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_before_prepare_before_async_monitor.reached';
+SET GLOBAL debug = "-d,wsrep_to_isolation_begin_before_async_monitor";
+SET GLOBAL debug = "-d,wsrep_before_prepare_before_async_monitor";
+
+#
+# At this point DDL and DML are stopped before Galera replication
+#
+
+# Allow DDL to go on. Without proper ordering, it will be replicated and ordered in Galera before DML
+SET DEBUG_SYNC = 'now SIGNAL wsrep_to_isolation_begin_before_async_monitor.continue';
+
+#
+# Without a fix, it would be replicated. With fix it should wait on wsrep_async_monitor. Just wait
+# a bit to be sure it moved on.
+#
+--sleep 3
+
+# Allow DML to go on. Without proper ordering, it will be replicated and ordered in Galera after DDL
+SET DEBUG_SYNC = 'now SIGNAL wsrep_before_prepare_before_async_monitor.continue';
+
+#
+# Without wsrep_async_monitor, async workers would deadlock here and below conditions will never be met.
+#
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t1;
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_name = "t2";
+--source include/wait_condition.inc
+
+#
+# Cleanup
+#
+--connection node_1
+DROP TABLE t1, t2;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM information_schema.tables WHERE table_name = "t1";
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM information_schema.tables WHERE table_name = "t2";
+--source include/wait_condition.inc
+
+STOP REPLICA;
+RESET REPLICA ALL;
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid_empty_trx.cnf
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid_empty_trx.cnf
@@ -1,0 +1,9 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+gtid-mode=ON
+log-bin=mysqld-bin
+log-slave-updates
+enforce-gtid-consistency
+binlog-format=ROW
+wsrep_debug=1

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid_empty_trx.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid_empty_trx.test
@@ -1,0 +1,44 @@
+#
+# Test Galera as a slave to a MySQL master using GTIDs
+#
+# suite/galera/galera_2nodes_as_slave.cnf describes the setup of the nodes
+# suite/galera/t/galera_as_slave_gtid.cnf has the GTID options
+#
+# Test that commiting an empty transaction on async source
+# is handled in a proper way by PXC replica (PXC-4688)
+#
+
+--source include/have_log_bin.inc
+--source include/force_restart.inc
+
+# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster_master_slave.inc
+
+--connection node_2
+--disable_query_log
+--eval CHANGE REPLICATION SOURCE TO SOURCE_HOST='127.0.0.1', SOURCE_PORT=$NODE_MYPORT_1;
+--enable_query_log
+START REPLICA USER='root';
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
+--eval SET gtid_next='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1'
+BEGIN;
+COMMIT;
+SET gtid_next=AUTOMATIC;
+
+# Replication should still work
+INSERT INTO t1 VALUES(1);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
+# It should be possible to stop the replica
+STOP REPLICA;
+
+--connection node_1
+# Cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_gtid.test
+++ b/mysql-test/suite/galera/t/galera_gtid.test
@@ -33,4 +33,28 @@ SET SESSION wsrep_sync_wait = 7;
 --eval SELECT '$gtid_executed_node2' = @@global.gtid_executed AS gtid_executed_equal;
 --enable_query_log
 
+#
+# Without fixed PXC-4664, the following sequence will cause sigsegv.
+# With the fix (or in versions ealier than 8.0.41, it will cause a deadlock between
+# wsrep applier and local connection (PXC-4665).
+# As we don't plan to fix PXC-4665 for now, there is no way to provide a reliable test
+# for PXC-4664, that's why the following part is commented out.
+#
+# Uncomment it when PXC-4665 is fixed.
+#
+
+# --connection node_1
+# SET @@SESSION.GTID_NEXT= 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:2';
+# BEGIN;
+# 
+# --connection node_2
+# SET @@SESSION.GTID_NEXT= 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:2';
+# BEGIN;
+# COMMIT;
+# 
+# --connection node_1
+# COMMIT;
+
+
+# cleanup
 DROP TABLE t1;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -8869,14 +8869,12 @@ TC_LOG::enum_result MYSQL_BIN_LOG::commit(THD *thd, bool all) {
          trans_commit_stmt()) the following call to my_error() will allow
          overwriting the error */
       my_error(ER_TRANSACTION_ROLLBACK_DURING_COMMIT, MYF(0));
-      thd_leave_async_monitor(thd);
       return RESULT_ABORTED;
     }
 
     int rc = ordered_commit(thd, all, skip_commit);
 
     if (run_wsrep_hooks) {
-      thd_leave_async_monitor(thd);
       wsrep_after_commit(thd, all);
     }
 

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2042,7 +2042,7 @@ int MYSQL_BIN_LOG::gtid_end_transaction(THD *thd) {
 #ifdef WITH_WSREP
       if (WSREP_ON && !thd->wsrep_applier) {
         /* If the galera node is acting as async slave then capture
-        GTID event from the async slave applied thread and mark it for
+        GTID event from the async slave applier thread and mark it for
         replication in galera channel. */
         /* We need to replicate GTID events, if their origin is not
         slave thread as well (events do not originate from async master).

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -11261,12 +11261,17 @@ static enum_tbl_map_status check_table_map(Relay_log_info const *rli,
       rli->info_thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER &&
       !thd_is_wsrep_applier && res == FILTERED_OUT) {
     Slave_worker *sw =
-        static_cast<Slave_worker *>(const_cast<Relay_log_info *>(rli));
-    Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
-    if (wsrep_async_monitor) {
-      auto seqno = sw->sequence_number();
-      assert(seqno > 0);
-      wsrep_async_monitor->skip(seqno);
+        dynamic_cast<Slave_worker *>(const_cast<Relay_log_info *>(rli));
+    // It should never happen. If this is SYSTEM_THREAD_SLAVE_WORKER, but it
+    // is not wsrep applier, it has to be Slave_worker.
+    assert(sw != nullptr);
+    if (sw) {
+      Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
+      if (wsrep_async_monitor) {
+        auto seqno = sw->sequence_number();
+        assert(seqno > 0);
+        wsrep_async_monitor->skip(seqno);
+      }
     }
   }
 #endif /* WITH_WSREP */

--- a/sql/rpl_gtid_execution.cc
+++ b/sql/rpl_gtid_execution.cc
@@ -362,13 +362,18 @@ static inline void skip_statement(THD *thd) {
 #ifdef WITH_WSREP
   /* Despite the transaction was skipped, it needs to be updated in the
    * Wsrep_async_monitor */
-  if (thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER) {
+  if (thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER && !thd->wsrep_applier) {
     Slave_worker *sw = dynamic_cast<Slave_worker *>(thd->rli_slave);
-    Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
-    if (wsrep_async_monitor) {
-      auto seqno = sw->sequence_number();
-      assert(seqno > 0);
-      wsrep_async_monitor->skip(seqno);
+    // It should never happen. If this is SYSTEM_THREAD_SLAVE_WORKER, but it
+    // is not wsrep applier, it has to be Slave_worker.
+    assert(sw != nullptr);
+    if (sw) {
+      Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
+      if (wsrep_async_monitor) {
+        auto seqno = sw->sequence_number();
+        assert(seqno > 0);
+        wsrep_async_monitor->skip(seqno);
+      }
     }
   }
 #endif /* WITH_WSREP */

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -319,11 +319,16 @@ bool all_tables_not_ok(THD *thd, Table_ref *tables) {
   if (!ret && WSREP(thd) && thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER &&
       !thd->wsrep_applier) {
     Slave_worker *sw = dynamic_cast<Slave_worker *>(thd->rli_slave);
-    Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
-    if (wsrep_async_monitor) {
-      auto seqno = sw->sequence_number();
-      assert(seqno > 0);
-      wsrep_async_monitor->skip(seqno);
+    // It should never happen. If this is SYSTEM_THREAD_SLAVE_WORKER, but it
+    // is not wsrep applier, it has to be Slave_worker.
+    assert(sw != nullptr);
+    if (sw) {
+      Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
+      if (wsrep_async_monitor) {
+        auto seqno = sw->sequence_number();
+        assert(seqno > 0);
+        wsrep_async_monitor->skip(seqno);
+      }
     }
   }
   return ret;
@@ -422,11 +427,16 @@ inline bool check_database_filters(THD *thd, const char *db,
   if (WSREP(thd) && thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER &&
       !thd->wsrep_applier && !db_ok) {
     Slave_worker *sw = dynamic_cast<Slave_worker *>(thd->rli_slave);
-    Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
-    if (wsrep_async_monitor) {
-      auto seqno = sw->sequence_number();
-      assert(seqno > 0);
-      wsrep_async_monitor->skip(seqno);
+    // It should never happen. If this is SYSTEM_THREAD_SLAVE_WORKER, but it
+    // is not wsrep applier, it has to be Slave_worker.
+    assert(sw != nullptr);
+    if (sw) {
+      Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
+      if (wsrep_async_monitor) {
+        auto seqno = sw->sequence_number();
+        assert(seqno > 0);
+        wsrep_async_monitor->skip(seqno);
+      }
     }
   }
 #endif /* WITH_WSREP */

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -3018,6 +3018,13 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
     thd->variables.auto_increment_increment = 1;
   }
 
+  DBUG_EXECUTE_IF("wsrep_to_isolation_begin_before_async_monitor", {
+    const char act[] =
+        "now signal wsrep_to_isolation_begin_before_async_monitor.reached "
+        "wait_for wsrep_to_isolation_begin_before_async_monitor.continue";
+    assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+  });
+
   thd_enter_async_monitor(thd);
 
   DEBUG_SYNC(thd, "wsrep_to_isolation_begin_before_replication");
@@ -3053,6 +3060,8 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
         break;
     }
   }
+
+  thd_leave_async_monitor(thd);
 
   DEBUG_SYNC(thd, "wsrep_to_isolation_begin_after_replication");
 
@@ -3092,8 +3101,6 @@ void wsrep_to_isolation_end(THD *thd) {
     assert(0);
   }
   if (wsrep_emulate_bin_log) wsrep_thd_binlog_trx_reset(thd);
-
-  thd_leave_async_monitor(thd);
 
   DEBUG_SYNC(thd, "wsrep_to_isolation_end_before_wsrep_skip_wsrep_hton");
   mysql_mutex_lock(&thd->LOCK_thd_data);

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2879,19 +2879,26 @@ static void wsrep_RSU_end(THD *thd) {
 
 void thd_enter_async_monitor(THD *thd) {
   // Only replica worker threads are allowed to enter
+  if (thd->wsrep_applier) return;
+
   if (thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER) {
-    // If the thread is already killed, leave it to the called to handle it.
-    if (thd->killed != THD::NOT_KILLED || thd->wsrep_applier) {
+    // If the thread is already killed, leave it to the caller to handle it.
+    if (thd->killed != THD::NOT_KILLED) {
       return;
     }
     Slave_worker *sw = dynamic_cast<Slave_worker *>(thd->rli_slave);
-    Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
-    if (wsrep_async_monitor) {
-      auto seqno = sw->sequence_number();
-      assert(seqno > 0);
-      // TODO: If requied, we must set current_mutex and current_cond here
-      // i.e, thd->enter_cond();
-      wsrep_async_monitor->enter(seqno);
+    // It should never happen. If this is SYSTEM_THREAD_SLAVE_WORKER, but it
+    // is not wsrep applier, it has to be Slave_worker.
+    assert(sw != nullptr);
+    if (sw) {
+      Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
+      if (wsrep_async_monitor) {
+        auto seqno = sw->sequence_number();
+        assert(seqno > 0);
+        // TODO: If requied, we must set current_mutex and current_cond here
+        // i.e, thd->enter_cond();
+        wsrep_async_monitor->enter(seqno);
+      }
     }
   }
 }
@@ -2901,11 +2908,16 @@ void thd_leave_async_monitor(THD *thd) {
 
   if (thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER) {
     Slave_worker *sw = dynamic_cast<Slave_worker *>(thd->rli_slave);
-    Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
-    if (wsrep_async_monitor) {
-      auto seqno = sw->sequence_number();
-      assert(seqno > 0);
-      wsrep_async_monitor->leave(seqno);
+    // It should never happen. If this is SYSTEM_THREAD_SLAVE_WORKER, but it
+    // is not wsrep applier, it has to be Slave_worker.
+    assert(sw != nullptr);
+    if (sw) {
+      Wsrep_async_monitor *wsrep_async_monitor{sw->get_wsrep_async_monitor()};
+      if (wsrep_async_monitor) {
+        auto seqno = sw->sequence_number();
+        assert(seqno > 0);
+        wsrep_async_monitor->leave(seqno);
+      }
     }
   }
 }

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -16,6 +16,7 @@
 #ifndef WSREP_TRANS_OBSERVER_H
 #define WSREP_TRANS_OBSERVER_H
 
+#include "debug_sync.h" /* debug_sync_set_action */
 #include "my_dbug.h"
 #include "service_wsrep.h"
 #include "sql/binlog.h"
@@ -246,6 +247,15 @@ static inline int wsrep_before_prepare(THD *thd, bool all) {
     THD_STAGE_INFO(thd, stage_wsrep_replicating_commit);
   }
 
+  DBUG_EXECUTE_IF("wsrep_before_prepare_before_async_monitor", {
+    const char act[] =
+        "now signal wsrep_before_prepare_before_async_monitor.reached wait_for "
+        "wsrep_before_prepare_before_async_monitor.continue";
+    assert(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+  });
+
+  thd_enter_async_monitor(thd);
+
   if ((ret = thd->wsrep_cs().before_prepare()) == 0) {
     assert(!thd->wsrep_trx().ws_meta().gtid().is_undefined());
     thd->wsrep_xid.reset();
@@ -264,6 +274,7 @@ static inline int wsrep_before_prepare(THD *thd, bool all) {
       THD_STAGE_INFO(thd, stage_wsrep_write_set_replicated);
     }
   }
+  thd_leave_async_monitor(thd);
   DBUG_RETURN(ret);
 }
 
@@ -296,10 +307,19 @@ static inline int wsrep_before_commit(THD *thd, bool all) {
   WSREP_DEBUG("wsrep_before_commit: %d, %lld", wsrep_is_real(thd, all),
               (long long)wsrep_thd_trx_seqno(thd));
   int ret = 0;
+  bool async_monitor_entered = false;
 
-  /* Enter the async monitor */
-  thd_enter_async_monitor(thd);
-
+  if (!thd->wsrep_cs().transaction().ordered()) {
+    /*
+     In normal case, the transactions should have already been replicated and
+     ordered in wsrep_before_prepare. If it is still not the case (e.g. empty
+     transaction with GTID) it will be replicated and ordered as the part of
+     wsrep_cs().before_commit().
+     Enter the async monitor
+    */
+    thd_enter_async_monitor(thd);
+    async_monitor_entered = true;
+  }
   assert(wsrep_run_commit_hook(thd, all));
   if ((ret = thd->wsrep_cs().before_commit()) == 0) {
     assert(!thd->wsrep_trx().ws_meta().gtid().is_undefined());
@@ -313,6 +333,11 @@ static inline int wsrep_before_commit(THD *thd, bool all) {
     wsrep_xid_init(thd->get_transaction()->xid_state()->get_xid(),
                    thd->wsrep_trx().ws_meta().gtid());
   }
+
+  if (async_monitor_entered) {
+    thd_leave_async_monitor(thd);
+  }
+
   DBUG_RETURN(ret);
 }
 

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -186,10 +186,10 @@ static inline bool wsrep_run_commit_hook(THD *thd, bool all) {
   executing slave.
   Let's understand with an example:
   * Topology master <-> slave
-  * Some action is performed on slave which put it out-of-sync from master.
-  * Master then execute same action. Slave may choose to ignore error arising
+  * Some action is performed on slave which puts it out-of-sync from master.
+  * Master then executes same action. Slave may choose to ignore error arising
     from execution of these actions using slave_skip_errors configuration but
-    the GTID sequence increment still need to register on slave to keep it in
+    the GTID sequence increment still needs to register on slave to keep it in
     sync with master. So a dummy trx of this form is created. Galera
     eco-system too will capture this dummy trx and will execute it for
     internal replication to keep GTID sequence consistent across
@@ -547,8 +547,18 @@ static inline void wsrep_commit_empty(THD *thd, bool all) {
      * remove its seqno from the Async monitor.
      *
      * So we remove the seqno of the empty commit here. */
-    thd_enter_async_monitor(thd);
-    thd_leave_async_monitor(thd);
+
+    /* Do it only if the current transaction doesn't own any gtid.
+    It may happen that this is an empty transaction executed on async master
+    but still owning gtid (to skip transaction). Such a case will be handled in
+    MYSQL_BIN_LOG::gtid_end_transaction() when the transaction commits. We will
+    replicate GTID over galera channel. In such a case we will enter and leave
+    async monitor there.`
+    */
+    if (thd->owned_gtid.sidno == 0) {
+      thd_enter_async_monitor(thd);
+      thd_leave_async_monitor(thd);
+    }
     /* The committing transaction was empty but it held some locks and
        got BF aborted. As there were no certified changes in the
        data, we ignore the deadlock error and rely on error reporting


### PR DESCRIPTION
PXC-4688: Empty transaction stalls the replica thread

https://perconadev.atlassian.net/browse/PXC-4664
https://perconadev.atlassian.net/browse/PXC-4688

Both issues are the regression caused by fix for PXC-4173 (introduction
of wsrep_async_monitor).

Problem 1:
When node1 and node2 commit the transaction with the same gtid (after
setting 'gtid_next' to the same value), replicated node exits with
sigsegv.

Cause:
If the transaction with a given GTID was committed on local node, and
another, replicated transaction with the same GTID is being applied by
wsrep applier thread, we detect that this GTID was already committed and
attempt to skip the transaction
(gtid_pre_statement_checks() => skip_statement()).
In skip_statement() there is a code that marks a given transaction to be
skipped by wsrep_async_monitor. wsrep_async_monitor-related code is
valid only for async replica worker thread, not for wsrep applier.
We distinguish both by checking if thd is SYSTEM_THREAD_SLAVE_WORKER
(both galera and async worker) and 'wsrep_applier' flag. Check for
wsrep_applier was missing, so it was incorrectly detected, that we are
in the context of async worker thread. Then we did a dynamic_cast of
thd->rli_slave (of type Relay_log_info) to Slave_worker type.
Such a conversion gives a valid pointer only for async worker thread.
In case of wsrep applier, the object type is Relay_log_info, so
dynamic_cast results in nullptr. Then we dereference a pointer, and as
a consequence of being wsrep applier, we dereference nullptr.

Solution:
Added missing check for wsrep_applier, to access wsrep_async_monitor
path only from async worker thread.

For all similar places:
Added debug assertion.
Additionally, wrapped the block where we try to dereference a pointer
with a check against nullptr.

Note:
After fixing sigsegv, it is still possible to end up with a deadlock
(PXC-4665). It is an old issue.

Problem 2:
Committing an empty transaction on an async replica source causes the
PXC async replica node to stall.

Cause:
If an empty transaction is replicated from async source, PXC flow
commits empty transaction in Galera. This caused entering and releasing
wsrep_async_monitor. As this is an empty transaction, we need to commit
(and replicate) its GTID. It happens in
MYSQL_BIN_LOG::gtid_end_transaction(). Here we replicate and commit
an empty transaction with a given gtid. This path tried to acquire
wsrep_async_monitor again with the same sequence number, which caused
infinite wait.

Solution:
If we commit an empty transaction in Galera, but thd owns a GTID, it
means it will be commited later. In such a case postpone
entering/leaving releasing wsrep_async_monitor to the point when real
replication takes place.

Added MTR tests for both issues, however providing a reliable test for
PXC-4664 is not possible without fixing PXC-4665. PXC-4665 is an old
issue which causes a deadlock between wsrep applier and local session
(gtid lock vs galera commit_monitor).




Improved fix for PXC-4173

https://perconadev.atlassian.net/browse/PXC-4173

Fix for PXC-4173 introduced wsrep_async_monitor.

Problem:
The original fix disables group commit for transactions replicated from
async source.

Cause:
Galera orders transactions during replication (when every transaction
gets its global sequence number). Then transactions are commited in
that order.
TOI transactions are replicated before execution, DML transactions are
replicated during the commit. This was the source of the problems in
PXC-4173: transactions are dispatched to parallel async workers, so it
may happen that DDL that should commit after DML from async replication
perspective gets ordered in Galera before DML. This caused a deadlock
(Galera wants to commit in the other order than server's commit manager)

The idea behind introducing wsrep_async_monitor was  to enforce the same
galera ordering as the node receives from async source.

1. The original implementation acquired wsrep_async_monitor at TOI start
and kept it acquired for the whole time of its execution until TOI end.
2. The original implementation acquired wsrep_async_monitor before
group commit pipeline and released it after.

As the consequence transactions were allowed to get into group commit
pipeline one by one (only one transaction at a time), effectively
disabling group commit (there was no possibility to group transactions).

Solution:
It is enough to enforce the order of replicating transactions in Galera
world to be the same as for async replication. Once the transaction is
replicated in galera, it has the same commit order as for async
replication. So there is no point in keeping wsrep_async_monitor for
a long time (especially for commit time). Doing so will allow multiple
transactions to enter group commit pipeline and be commited together.

A simple benchmark test with 4 async workes shows that this approach
enables back the group commit and improves the performance 3-4 times.

Added MTR test for wsrep_async_monitor.