### PR TITLE
Fixed GH Percona_Server_Diff_Check Azure pipeline.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
 
 - job: Percona_Server_Diff_Check
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
 
   steps:
   - checkout: self


### PR DESCRIPTION
Updated ubuntu image used by the check (previous one is not available anymore causing check to fail)