### PR TITLE
(trunk) PXC-4687: When executing SST with clone script and not using SSL and pxc_encrypt_cluster_traffic is disabled the script fails to connect to donor given a bug.

### DIFF
--- a/scripts/wsrep_sst_clone.sh
+++ b/scripts/wsrep_sst_clone.sh
@@ -323,7 +323,7 @@ setup_certificates_for_donor()
 
     # REQUIRE_SSL is used during clone user creation on Donor server
     REQUIRE_SSL=""
-    if [ -n "$server_ssl_ca" ] && [ -n "$server_ssl_cert" ] && [ -n "$server_ssl_key" ]; then
+    if [ -n "$server_ssl_ca" ] && [ -n "$server_ssl_cert" ] && [ -n "$server_ssl_key" ] && [ "$server_ssl_ca" != "NULL" ]; then
         REQUIRE_SSL="REQUIRE SSL"
     fi
     wsrep_log_debug "Clone SSL Server settings on $role from runtime:  CERT=$server_ssl_cert, KEY=$server_ssl_key, CA=$server_ssl_ca"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4687

Cherry pick of commit ef1db13c

Problem:
The script was still keeping the SSL as required and fails given the server settings are not enforcing SSL usage.

Cause:
During check of SSL settings one condition was missed

Solution:
Implemented a check on SSL server variable server_ssl_ca to not be equal NULL. When null MySQL is passing the string "NULL" as such the string is not empty.