### PR TITLE
PXC-4676: Code refresh for  - PXC 8.4.5 (Fixed MYSQL_MAINTAINER_MODE=ON build.)

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -32,11 +32,6 @@
    of the log; if it is the 3rd then there is this combination:
    Format_desc_of_slave, Rotate_of_master, Format_desc_of_master.
 */
-
-#ifdef WITH_WSREP
-#undef WITH_WSREP
-#endif
-
 #include "client/mysqlbinlog.h"
 
 #include <fcntl.h>


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4676

Fixed MYSQL_MAINTAINER_MODE=ON build.
When mysqlbinlog.cc was compiled, WITH_WSREP was undefined. It caused One Definition Rule violation, because handler.h is included indirectly in several compilation units and it contains legacy_db_type that has values conditionally compiled in (WITH_WSREP).

There is no reason why WITH_WSREP should be undefined for mysqlbinlog.cc