### PR TITLE
(8.4) PXC-4631: Prevent SST after failed attempt to SST/IST

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_clone_timeout.result
+++ b/mysql-test/suite/galera/r/galera_sst_clone_timeout.result
@@ -1,0 +1,20 @@
+SET GLOBAL wsrep_provider_options="pc.weight=1";
+CALL mtr.add_suppression("\[Warning\].*Terminating IST AsyncSender");
+CALL mtr.add_suppression("\[ERROR\].*\[WSREP-SST\]");
+CALL mtr.add_suppression("\[Warning\].*\[WSREP-SST\] Found a stale sst_in_progress file");
+CALL mtr.add_suppression("\[ERROR\].*Process completed with error");
+CALL mtr.add_suppression("\[ERROR\].*Command did not run");
+SET GLOBAL wsrep_provider_options="pc.weight=0";
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+# Adding debug point 'halt_before_sst_donate' to @@GLOBAL.debug
+# restart_abort: <hidden args>
+include/wait_for_pattern_in_file.inc [.*Saving node state to retry with IST instead of full SST after restart.*]
+"continue with node 1"
+SET SESSION wsrep_sync_wait = 0;
+# Removing debug point 'halt_before_sst_donate' from @@GLOBAL.debug
+SET DEBUG_SYNC = "now SIGNAL continue";
+include/assert_grep.inc ["Check for uuid validity"]
+include/assert_grep.inc ["Check for seqno validity"]
+include/assert_grep.inc ["Check that node_2 joined with IST"]
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_timeout.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_timeout.result
@@ -1,0 +1,20 @@
+SET GLOBAL wsrep_provider_options="pc.weight=1";
+CALL mtr.add_suppression("\[Warning\].*Terminating IST AsyncSender");
+CALL mtr.add_suppression("\[ERROR\].*\[WSREP-SST\]");
+CALL mtr.add_suppression("\[Warning\].*\[WSREP-SST\] Found a stale sst_in_progress file");
+CALL mtr.add_suppression("\[ERROR\].*Process completed with error");
+CALL mtr.add_suppression("\[ERROR\].*Command did not run");
+SET GLOBAL wsrep_provider_options="pc.weight=0";
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+# Adding debug point 'halt_before_sst_donate' to @@GLOBAL.debug
+# restart_abort: <hidden args>
+include/wait_for_pattern_in_file.inc [.*Saving node state to retry with IST instead of full SST after restart.*]
+"continue with node 1"
+SET SESSION wsrep_sync_wait = 0;
+# Removing debug point 'halt_before_sst_donate' from @@GLOBAL.debug
+SET DEBUG_SYNC = "now SIGNAL continue";
+include/assert_grep.inc ["Check for uuid validity"]
+include/assert_grep.inc ["Check for seqno validity"]
+include/assert_grep.inc ["Check that node_2 joined with IST"]
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_sst_clone_timeout.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_clone_timeout.cnf
@@ -1,0 +1,11 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+wsrep_sst_allowed_methods=clone
+
+[mysqld.2]
+wsrep_sst_method=clone
+
+[sst]
+joiner-timeout-wait-donor-message=10
+

--- a/mysql-test/suite/galera/t/galera_sst_clone_timeout.test
+++ b/mysql-test/suite/galera/t/galera_sst_clone_timeout.test
@@ -1,0 +1,2 @@
+--let $ist_check_log_message = DONOR SAY IST
+--source galera_sst_timeout.inc

--- a/mysql-test/suite/galera/t/galera_sst_timeout.inc
+++ b/mysql-test/suite/galera/t/galera_sst_timeout.inc
@@ -1,0 +1,145 @@
+#
+# Test scenario:
+# Joiner is able to join with IST only, but there is connection issue between 
+# Joiner and Donor (Joiner is not able to receive sst-info file).
+# In sucha case Joiner timeouts without deleteing data directory, so it
+# should be able to join with IST next time. To be able to do so, grastate.dat
+# file needs to contain valid uuid:seqno pair.
+#
+
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+--source include/galera_cluster.inc
+--source include/force_restart.inc
+
+#
+# node_1 will be Donor, node_2 Joiner.
+# Do initial setup to allow node_2 restarts.
+#
+--connection node_1
+--let $wsrep_provider_options_orig1 = `SELECT @@global.wsrep_provider_options`
+SET GLOBAL wsrep_provider_options="pc.weight=1";
+
+#
+# Donor will fail to donate during the test and complain in logs.
+#
+CALL mtr.add_suppression("\[Warning\].*Terminating IST AsyncSender");
+CALL mtr.add_suppression("\[ERROR\].*\[WSREP-SST\]");
+CALL mtr.add_suppression("\[Warning\].*\[WSREP-SST\] Found a stale sst_in_progress file");
+CALL mtr.add_suppression("\[ERROR\].*Process completed with error");
+CALL mtr.add_suppression("\[ERROR\].*Command did not run");
+
+--connection node_2
+--let $wsrep_provider_options_orig2 = `SELECT @@global.wsrep_provider_options`
+SET GLOBAL wsrep_provider_options="pc.weight=0";
+
+#
+# Shutdown node 2, to get it out of sync with node 1.
+#
+--connection node_2
+--source include/shutdown_mysqld.inc
+
+#
+# Wait until the node_2 is confirmed as being down.
+#
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+#
+# Do some queries, so node_2 will have to catch up after restart.
+#
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+
+#
+# Add a debug point on node_1 to halt just before donating state transfer.
+# This way we will simulate connection issue between Donor and Joiner.
+#
+--let $debug_point= halt_before_sst_donate
+--source include/add_debug_point.inc
+
+#
+# Restart node_2. It should timeout on SST and shutdown.
+#
+--connection node_2
+
+--let $ofile= $MYSQLTEST_VARDIR/tmp/node.2.err
+--let $restart_parameters = "--log-error=$ofile"
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--let $do_not_echo_parameters = 1
+--source include/start_mysqld_expecting_crash.inc
+
+#
+# sleep to avoid checking the file if it was not created yet.
+#
+--sleep 5
+
+#
+# Wait for node_2 to shutdown. Also check that node's state was written back to grastate.dat file.
+# In cnf file we have sst-initial-timeout=10, so waiting for 20 secs is enough.
+#
+--let $grep_pattern = .*Saving node state to retry with IST instead of full SST after restart.*
+--let $grep_file = $ofile
+--let $wait_timeout = 20
+--source include/wait_for_pattern_in_file.inc
+--remove_file $ofile
+
+#
+# Now let node_1 to go on and fail to donate.
+#
+--connection node_1
+--echo "continue with node 1"
+SET SESSION wsrep_sync_wait = 0;
+--source include/remove_debug_point.inc
+SET DEBUG_SYNC = "now SIGNAL continue";
+
+#
+# Wait for node_1 to go back to Synced state. It takes ca. 30 secs for Donor to timeout.
+#
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--let $wait_timeout = 120
+--source include/wait_condition.inc
+
+#
+# Check that node_2's grastate.dat contains valid uuid:seqno pair.
+# Use node_1 for doing assertions because node_2 is still down.
+#
+--connection node_1
+
+--let $assert_text = "Check for uuid validity"
+--let $assert_file = $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+# If uuid is not 00000000-0000-0000-0000-000000000000, it is OK.
+--let $assert_select = .*uuid:.*[1-9]+.*
+--let $assert_match = .*uuid:.*[1-9]+.*
+--source include/assert_grep.inc
+
+--let $assert_text = "Check for seqno validity"
+--let $assert_file = $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+# If it is not -1, it is OK.
+--let $assert_select = .*seqno:.*(?!-1)[0-9]+.*
+--let $assert_match = .*seqno:.*(?!-1)[0-9]+.*
+--source include/assert_grep.inc
+
+#
+# Start node_2 and ensure it joined with IST
+#
+--connection node_2
+--let $restart_parameters = "restart: --log-error=$ofile"
+--source include/start_mysqld_no_echo.inc
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+
+--let $assert_text = "Check that node_2 joined with IST"
+--let $assert_file = $ofile
+--let $assert_select = $ist_check_log_message
+--let $assert_match = $ist_check_log_message
+--source include/assert_grep.inc
+--remove_file $ofile
+
+#
+# cleanup
+#
+--connection node_1
+DROP TABLE t1;
+

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_timeout.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_timeout.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[sst]
+sst-initial-timeout=10

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_timeout.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_timeout.test
@@ -1,0 +1,2 @@
+--let $ist_check_log_message = xtrabackup_ist received from donor: Running IST
+--source galera_sst_timeout.inc

--- a/scripts/wsrep_sst_clone.sh
+++ b/scripts/wsrep_sst_clone.sh
@@ -94,8 +94,9 @@ set -o nounset -o errexit
 
 readonly EINVAL=22
 readonly EPIPE=32
-readonly ETIMEDOUT=110
 readonly ENODATA=61
+readonly ETIMEDOUT=110
+readonly EALREADY=114
 CLEANUP_CLONE_PLUGIN=""
 CLONE_USER=""
 NC_PID=""
@@ -489,7 +490,7 @@ monitor_sst_progress() {
 
 # This is the script execution start point
 
-if test -z "$WSREP_SST_OPT_HOST"; then wsrep_log_error "HOST cannot be empty"; exit $EINVAL; fi
+if test -z "$WSREP_SST_OPT_HOST"; then wsrep_log_error "HOST cannot be empty"; safe_exit $EINVAL; fi
 
 # MySQL client does not seem to agree to [] around IPv6 addresses
 wsrep_check_programs sed
@@ -518,10 +519,10 @@ then
     wsrep_log_debug "-> SST_HOST_STRIPPED = $SST_HOST_STRIPPED "
 
     # Split auth string at the last ':'
-    if test -z "$WSREP_SST_OPT_USER";   then wsrep_log_error "USER cannot be empty";   exit $EINVAL; fi
-    if test -z "$WSREP_SST_OPT_REMOTE_JOINER_USER"; then wsrep_log_error "REMOTE_USER cannot be empty"; exit $EINVAL; fi
-    if test -z "$WSREP_SST_OPT_PORT";   then wsrep_log_error "PORT cannot be empty";   exit $EINVAL; fi
-    if test -z "$WSREP_SST_OPT_SOCKET"; then wsrep_log_error "SOCKET cannot be empty"; exit $EINVAL; fi
+    if test -z "$WSREP_SST_OPT_USER";   then wsrep_log_error "USER cannot be empty";   safe_exit $EINVAL; fi
+    if test -z "$WSREP_SST_OPT_REMOTE_JOINER_USER"; then wsrep_log_error "REMOTE_USER cannot be empty"; safe_exit $EINVAL; fi
+    if test -z "$WSREP_SST_OPT_PORT";   then wsrep_log_error "PORT cannot be empty";   safe_exit $EINVAL; fi
+    if test -z "$WSREP_SST_OPT_SOCKET"; then wsrep_log_error "SOCKET cannot be empty"; safe_exit $EINVAL; fi
 
     CLIENT_VERSION=$($MYSQL_CLIENT --version | grep -vi MariaDB | cut -d ' ' -f 4)
     check_client_version $CLIENT_VERSION
@@ -582,7 +583,7 @@ EOF
         then
             wsrep_log_error "Donor prepare returned code $RC"
             cat $CLONE_PREPARE_SQL >> /dev/stderr
-            exit $RC
+            safe_exit $RC
         fi
 
         # Before waiting for the Joiner Clone mysql we send out the message this is a SST
@@ -592,21 +593,31 @@ EOF
 
         # We stay on hold now, waiting for the Joiner to expose the service
         wsrep_log_info "-> WAIT for Joiner MySQL to be available nc -w 1 -i 1 $SST_HOST_STRIPPED $WSREP_SST_OPT_REMOTE_HOSTPORT"
+        tmt=$DONOR_TIMEOUT_WAIT_JOINER_CLONE_INSTANCE
         while [ true ]; do
+            if [ "$tmt" == "0" ]; then
+                wsrep_log_error "************ FATAL ERROR ************"
+                wsrep_log_error "TIMEOUT Waiting for the Joiner to setup MySQL clone instance $LINENO"
+                wsrep_log_error "Within the last $DONOR_TIMEOUT_WAIT_JOINER_CLONE_INSTANCE seconds (defined by donor-timeout-wait-joiner variable),"
+                wsrep_log_error "the SST process on the Donor (this node) didn't find clone instance"
+                wsrep_log_error "ready on Joiner instance."
+                wsrep_log_error "This error could be caused by broken network connectivity between"
+                wsrep_log_error "the Donor (this node) and the Joiner."
+                wsrep_log_error "Check the network connection and restart the Joiner node."
+                wsrep_log_error "*************************************"
+                safe_exit $EPIPE
+            fi
+
         	NCPING=`nc -w 1 -i 1 $SST_HOST_STRIPPED $WSREP_SST_OPT_REMOTE_HOSTPORT 2> /dev/null | tr -d '\0'` || :
             if [ "$NCPING" == "" ]; then
-                wsrep_log_info "[second(s) to timeout: $DONOR_TIMEOUT_WAIT_JOINER_CLONE_INSTANCE]"
+                wsrep_log_info "[second(s) to timeout: $tmt]"
             else
                 wsrep_log_info "Joiner instance available at $SST_HOST_STRIPPED:$WSREP_SST_OPT_REMOTE_HOSTPORT"
                 break
             fi
-            if [ "$DONOR_TIMEOUT_WAIT_JOINER_CLONE_INSTANCE" == "0" ]; then
-                    wsrep_log_error "TIMEOUT Waiting for the Joiner to setup MySQL clone instance $LINENO"
-                    break ;
-            fi
 
             sleep 1
-            ((DONOR_TIMEOUT_WAIT_JOINER_CLONE_INSTANCE-=1))
+            tmt=$((tmt-1))
         done
         # Wait is over
         wsrep_log_debug "-> Wait is over"
@@ -659,7 +670,7 @@ EOF
             *)  RC=255 # unknown error
                 ;;
             esac
-            exit $RC
+            safe_exit $RC
         fi
     else # BYPASS
         wsrep_log_info "Bypassing state dump."
@@ -697,8 +708,8 @@ then
     wsrep_check_programs ps
     wsrep_check_programs find
 
-    if test -z "$WSREP_SST_OPT_DATA";   then wsrep_log_error "DATA cannot be empty";   exit $EINVAL; fi
-    if test -z "$WSREP_SST_OPT_PARENT"; then wsrep_log_error "PARENT cannot be empty"; exit $EINVAL; fi
+    if test -z "$WSREP_SST_OPT_DATA";   then wsrep_log_error "DATA cannot be empty";   safe_exit $EINVAL; fi
+    if test -z "$WSREP_SST_OPT_PARENT"; then wsrep_log_error "PARENT cannot be empty"; safe_exit $EINVAL; fi
 
     #
     #  Find binary to run
@@ -711,7 +722,7 @@ then
     if [ ! -x "$CLONE_BINARY" ]
     then
         wsrep_log_error "Could not determine binary to run: $CLONE_BINARY"
-        exit $EINVAL
+        safe_exit $EINVAL
     fi
 
     #
@@ -787,7 +798,7 @@ then
     then
         CLONE_PID=`cat $CLONE_PID_FILE`
         wsrep_log_error "cloning daemon already running (PID: $CLONE_PID)"
-        exit 114 # EALREADY
+        safe_exit $EALREADY
     fi
     rm -rf "$CLONE_PID_FILE"
 
@@ -829,7 +840,7 @@ then
                         "'$CLONE_X_SOCK' is greater than commonly acceptable"\
                         "limit of 104 bytes."
                         # Linux: 108, FreeBSD: 104
-        exit $EINVAL
+        safe_exit $EINVAL
     fi
 
     [ -z "$WSREP_SST_OPT_CONF" ] \
@@ -893,35 +904,44 @@ then
     wsrep_log_info "-> NETCAT PID $NC_PID"
     if [ $NC_PID == "" ];then
         wsrep_log_error "-> Cannot open Netcat at given port $JOINER_CLONE_HOST $JOINER_CLONE_PORT check if the port is already taken"
-        exit 1
+        safe_exit 1
     fi
 
+    # Send "ready" message to the application.
+    # Application forms SST request from "ready" data and marks grastate.dat
+    # as 'unsafe'. From now till the point when we delete data directory,
+    # grastate.dat can be turned back to 'safe' state. This will prevent forced
+    # SST in case something goes wrong before datadir deletion.
+    # Fail "soft" until we delete datadir.
+    SAFE_EXIT_CODE_OVERRIDE=${EAGAIN}
     # Report clone credentials/address to the caller
     wsrep_log_debug "-> ready passing string |$CLONE_USER:CLONE_PSWD@$JOINER_CLONE_HOST:$JOINER_CLONE_PORT|"
     echo "ready $CLONE_USER:$CLONE_PSWD@$JOINER_CLONE_HOST:$JOINER_CLONE_PORT"
 
     # WAIT for Donor message
-    wsrep_log_debug "-> wait $JOINER_TIMEOUT_WAIT_DONOR_MESSAGE"
+    tmt=$JOINER_TIMEOUT_WAIT_DONOR_MESSAGE
+    wsrep_log_debug "-> wait $tmt"
 
     until grep -q ".*<EOF>$" "$WSREP_SST_OPT_DATA/XST_FILE.txt" &> /dev/null
     do
-         if [ "$JOINER_TIMEOUT_WAIT_DONOR_MESSAGE" == "0" ]; then
+         if [ "$tmt" == "0" ]; then
             wsrep_log_error "************ FATAL ERROR ************"
             wsrep_log_error "TIMEOUT Waiting for the DONOR MESSAGE"
             wsrep_log_error "Donor message was either incomplete or not sent"
+            wsrep_log_error "within ${JOINER_TIMEOUT_WAIT_DONOR_MESSAGE} seconds (defined by joiner-timeout-wait-donor-message variable)"
             donor_message=`cat $WSREP_SST_OPT_DATA/XST_FILE.txt`
             wsrep_log_error "donor message received: $donor_message"
             wsrep_log_error "*************************************"
-            exit 1 ;
+            safe_exit $EPIPE
          fi
          sleep 1
-
-        ((JOINER_TIMEOUT_WAIT_DONOR_MESSAGE-=1))
+         tmt=$((tmt-1))
     done
 
     wsrep_log_debug "-> WAIT DIR DONOR MESSAGE DONE"
 
     if ! grep -q "SST@" "$WSREP_SST_OPT_DATA/XST_FILE.txt"; then
+        SAFE_EXIT_CODE_OVERRIDE=
         wsrep_log_info "DONOR SAY IST"
         wsrep_log_debug "-> RECOVER POSITION TO SEND OUT DONOR IST"
         RP_PURGED=`cat $WSREP_SST_OPT_DATA/XST_FILE.txt`
@@ -930,7 +950,7 @@ then
         rm -f  $WSREP_SST_OPT_DATA/XST_FILE.txt || :
 
         echo $RP_PURGED
-        exit 0
+        safe_exit 0
     else
         RP_PURGED=`cat $WSREP_SST_OPT_DATA/XST_FILE.txt`
         wsrep_log_info "DONOR SAY SST ($RP_PURGED)"
@@ -964,9 +984,16 @@ then
             wsrep_log_error "$mainfest_config_type"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 1
+            safe_exit $EPIPE
         fi
     fi
+
+    # Up to this point, if anything happened that prevented SST (eg. network
+    # issue, wrong keyring configuration), datadir was not touched, so we should
+    # leave the node as it was (grastate.dat)
+    # From now on, there is no way back: we will receive SST, or the node won't
+    # work.
+    SAFE_EXIT_CODE_OVERRIDE=
 
     # If we need to SST in any case we must remove the data, so let us do it here and be sure we work on a clean directory
     wsrep_log_info "Cleaning Data directory $WSREP_SST_OPT_DATA"
@@ -1016,7 +1043,7 @@ then
           wsrep_log_error "> $msg"
       done
       wsrep_log_error "Full log at $CLONE_ERR"
-      exit 1 )
+      safe_exit 1 )
 
     # Move initialized data directory structure to real datadir and cleanup
     mv -n "$tmp_datadir"/* "$WSREP_SST_OPT_DATA/"
@@ -1056,7 +1083,7 @@ EOF
         wsrep_log_error "-> User Creation on Joiner node failed, possible permission denied. Check permissions for "
         #we will try to silently shutdown the instance
         `$MYSQL_ACLIENT -e "SHUTDOWN" 2> /dev/null` || :
-        exit 1
+        safe_exit 1
     fi
 
     # Wait for the receiver process to start
@@ -1083,7 +1110,7 @@ EOF
         if [ $to_wait -eq 0 ]
         then
             wsrep_log_error "Timeout waiting for clone recipient daemon"
-            exit $ETIMEDOUT
+            safe_exit $ETIMEDOUT
         fi
         to_wait=$((to_wait - 1))
         sleep 1
@@ -1102,7 +1129,7 @@ EOF
     if [ $status -eq 1 ]; then
         # parent process died, we need to exit as well
         wsrep_log_error "Parent mysqld process (PID:$WSREP_SST_OPT_PARENT) terminated unexpectedly."
-        exit $EPIPE
+        safe_exit $EPIPE
     fi
     if [ $status -eq 2 ]; then
         # Stale SST, no progress
@@ -1115,7 +1142,7 @@ EOF
         wsrep_log_error "Check the network connection and restart the joiner node."
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit $ETIMEDOUT
+        safe_exit $ETIMEDOUT
     fi
 
     wsrep_log_info "clone recepient daemon finished"
@@ -1185,7 +1212,7 @@ EOF
         wsrep_log_debug "Invalid Recovery position. Exiting with error $ENODATA (No data available)"
         # We terminate but save the log for inspections given the failure
         CLEANUP_FILES=0
-        exit $ENODATA
+        safe_exit $ENODATA
     fi
 
     echo $RP_PURGED
@@ -1193,7 +1220,7 @@ EOF
     # exit 0 is at the end of the script, after printing the message
 else
     wsrep_log_error "Unrecognized role: '$WSREP_SST_OPT_ROLE'"
-    exit $EINVAL
+    safe_exit $EINVAL
 fi
 
 wsrep_log_debug "-> SST PROCESS FINISHED for $WSREP_SST_OPT_ROLE"

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -43,6 +43,23 @@ declare MYSQLD_PATH=""
 declare MYSQL_UPGRADE_TMPDIR=""
 declare WSREP_LOG_DIR=""
 
+# Exit codes returned by SST script.
+# For now, most of them are hardcoded like exit 32.
+# It would be good to have them here one day.
+
+# SST failed before modifying/deleting original data directory.
+readonly EAGAIN=11
+
+# Exit code used to override the default exit code. Most probably EAGAIN.
+# Use exit_safe <code> instead of exit <code> across the SST script.
+# For now, it is used on the Joiner side to inform mysqld about "soft" errors.
+# By "soft" errors we mean that SST went wrong, but data dir was not changed yet
+# so there is no need to force full SST next time. It may be the problem with
+# some system tool installed, or network connection during sst-info file transfer.
+# Once we start the main SST transfer and delete data dir, default exit codes
+# should not be override.
+SAFE_EXIT_CODE_OVERRIDE=""
+
 while [ $# -gt 0 ]; do
 case "$1" in
     '--address')
@@ -294,6 +311,14 @@ wsrep_log_debug()
 }
 
 #
+# Exit with the provided exit code or global override if defined.
+#
+safe_exit() {
+    local code=$1
+    exit "${SAFE_EXIT_CODE_OVERRIDE:-${code}}"
+}
+
+#
 # This functions stores the mysqld path in the MYSQLD_PATH
 # global variable
 #
@@ -344,7 +369,7 @@ get_mysqld_path()
         wsrep_log_error "Please ensure that ${MYSQLD_NAME} is in the path"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "******************* FATAL ERROR ********************** "
-        exit 22
+        safe_exit 22
     fi
 
     wsrep_log_debug "Found the ${MYSQLD_NAME} binary in ${MYSQLD_PATH}"

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -401,7 +401,7 @@ check_for_dhparams()
                 wsrep_log_error "Please ensure that openssl is installed and is in the path"
                 wsrep_log_error "Line $LINENO"
                 wsrep_log_error "****************************************************** "
-                exit 2
+                safe_exit 2
             fi
             wsrep_log_info "Could not find dhparams file, creating $DATA/dhparams.pem"
 
@@ -411,7 +411,7 @@ check_for_dhparams()
                 wsrep_log_error "* Could not create the dhparams.pem file with OpenSSL. "
                 wsrep_log_error "* Line $LINENO"
                 wsrep_log_error "****************************************************** "
-                exit 22
+                safe_exit 22
             fi
         fi
         ssl_dhparams="$DATA/dhparams.pem"
@@ -438,7 +438,7 @@ verify_cert_matches_key()
         wsrep_log_error "Please ensure that openssl and diff are installed and in the path"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 
     # generate the public key from the cert and the key
@@ -450,7 +450,7 @@ verify_cert_matches_key()
         wsrep_log_error "* Please check your certificate and key files. "
         wsrep_log_error "* Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 22
+        safe_exit 22
     fi
 }
 
@@ -473,7 +473,7 @@ verify_ca_matches_cert()
         wsrep_log_error "Please ensure that openssl is installed and is in the path"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 
     if ! openssl verify -verbose -CAfile "$ca_path" "$cert_path" >/dev/null  2>&1
@@ -484,7 +484,7 @@ verify_ca_matches_cert()
         wsrep_log_error "* Please check your certificate and CA files.                   "
         wsrep_log_error "* Line $LINENO"
         wsrep_log_error "*************************************************************** "
-        exit 22
+        safe_exit 22
     fi
 
 }
@@ -515,7 +515,7 @@ verify_file_exists()
         fi
 
         wsrep_log_error "****************************************************** "
-        exit 22
+        safe_exit 22
     fi
 }
 
@@ -535,7 +535,7 @@ get_transfer()
             wsrep_log_error "nc(netcat) not found in path: $PATH"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 2
+            safe_exit 2
         fi
 
         if [[ $encrypt -eq 4 ]]; then
@@ -544,7 +544,7 @@ get_transfer()
             wsrep_log_error "* is not supported when using nc(netcat)."
             wsrep_log_error "* Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 22
+            safe_exit 22
         fi
 
         wsrep_log_debug "Using netcat as streamer"
@@ -579,7 +579,7 @@ get_transfer()
             wsrep_log_error "socat not found in path: $PATH"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 2
+            safe_exit 2
         fi
 
         donor_extra=""
@@ -603,7 +603,7 @@ get_transfer()
                 wsrep_log_error "* Unable to encrypt SST communications. "
                 wsrep_log_error "* Line $LINENO"
                 wsrep_log_error "****************************************************** "
-                exit 2
+                safe_exit 2
             fi
 
             # Determine the socat version
@@ -613,7 +613,7 @@ get_transfer()
                 wsrep_log_error "* Cannot determine the socat version. "
                 wsrep_log_error "* Line $LINENO"
                 wsrep_log_error "****************************************************** "
-                exit 2
+                safe_exit 2
             fi
 
             # Convert the dhparams path into an absolute path
@@ -903,7 +903,7 @@ get_stream()
             wsrep_log_error "Please verify that PXC was installed correctly."
             wsrep_log_error "* Line $LINENO"
             wsrep_log_error "******************************************** "
-            exit 2
+            safe_exit 2
         fi
 
         # It's ok to use any xbstream, it's compatible across versions
@@ -919,7 +919,7 @@ get_stream()
             wsrep_log_error "tar was not found in PATH! Make sure you have it installed."
             wsrep_log_error "* Line $LINENO"
             wsrep_log_error "******************************************** "
-            exit 2
+            safe_exit 2
         fi
 
         sfmt="tar"
@@ -1206,7 +1206,7 @@ wait_for_listen()
         wsrep_log_error "******** FATAL ERROR *********************** "
         wsrep_log_error "* Cannot find /proc/$$/net/tcp (or tcp6)"
         wsrep_log_error "******************************************** "
-        exit 1
+        safe_exit 1
     fi
     for i in "${!header[@]}"; do
         if [[ ${header[$i]} = "local_address" ]]; then
@@ -1221,7 +1221,7 @@ wait_for_listen()
         wsrep_log_error "* Unexpected /proc/xx/net/tcp layout: cannot find local_address"
         wsrep_log_error "* Line $LINENO"
         wsrep_log_error "******************************************** "
-        exit 1
+        safe_exit 1
     fi
 
     wsrep_log_debug "$LINENO: local_address index is $ip_index"
@@ -1368,7 +1368,7 @@ recv_data_from_donor_to_joiner()
         wsrep_log_error "******************* FATAL ERROR ********************** "
         wsrep_log_error "SST script interrupted"
         wsrep_log_error "****************************************************** "
-        exit 32
+        safe_exit 32
     fi
 
     if [[ ${RC[0]} -eq 124 ]]; then
@@ -1382,7 +1382,7 @@ recv_data_from_donor_to_joiner()
         wsrep_log_error "Check the network connection and restart the joiner node."
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 32
+        safe_exit 32
     fi
 
     # Here we know that transfer pipeline received SIGKILL
@@ -1396,7 +1396,7 @@ recv_data_from_donor_to_joiner()
         wsrep_log_error "exit codes: ${RC[@]}"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 32
+        safe_exit 32
     fi
 
     for ecode in "${RC[@]}"; do
@@ -1406,7 +1406,7 @@ recv_data_from_donor_to_joiner()
                             "exit codes: ${RC[@]}"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 32
+            safe_exit 32
         fi
     done
 
@@ -1423,7 +1423,7 @@ recv_data_from_donor_to_joiner()
         wsrep_log_error "****************************************************** "
         wsrep_log_debug "Contents of datadir"
         wsrep_log_debug "$(ls -l ${dir}/*)"
-        exit 32
+        safe_exit 32
     fi
 }
 
@@ -1448,7 +1448,7 @@ send_data_from_donor_to_joiner()
         wsrep_log_error "Could not find/read the file: $FILE_TO_STREAM"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 
     set +e
@@ -1481,7 +1481,7 @@ send_data_from_donor_to_joiner()
                             "exit codes: ${RC[@]}"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 32
+            safe_exit 32
         fi
     done
 }
@@ -1507,15 +1507,15 @@ initialize_tmpdir()
     if [[ -n "${tmpdir_path}" ]]; then
         if [[ ! -d "${tmpdir_path}" ]]; then
             wsrep_log_error "Cannot find the directory, ${tmpdir_path}, the tmpdir must exist before startup."
-            exit 2
+            safe_exit 2
         fi
         if [[ ! -r "${tmpdir_path}" ]]; then
             wsrep_log_error "The temporary directory, ${tmpdir_path}, is not readable.  Please check the directory permissions."
-            exit 22
+            safe_exit 22
         fi
         if [[ ! -w "${tmpdir_path}" ]]; then
             wsrep_log_error "The temporary directory, ${tmpdir_path}, is not writable.  Please check the directory permissions."
-            exit 22
+            safe_exit 22
         fi
     fi
 
@@ -1606,14 +1606,14 @@ function initialize_pxb_commands()
         wsrep_log_error "Unable to run xtrabackup (does not exist): $pxb_bin_path"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
     if ! [[ -x $pxb_bin_path ]]; then
         wsrep_log_error "******************* FATAL ERROR ********************** "
         wsrep_log_error "Unable to run xtrabackup (non-executable): $pxb_bin_path"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 
     if ${pxb_bin_path} --help 2>/dev/null | grep -q -- '--version-check'; then
@@ -1722,7 +1722,7 @@ function verify_pxb_version()
         wsrep_log_error "    Expected location: $pxb_bin_path"
         wsrep_log_error "Please verify that PXC was installed correctly."
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 
     local xb_version=$($pxb_bin_path --version 2>&1 | grep -oe ' [0-9]\.[0-9]\.[0-9]*' | head -n1)
@@ -1734,7 +1734,7 @@ function verify_pxb_version()
         wsrep_log_error "$pxb_bin_path"
         wsrep_log_error "Please verify that PXC was installed correctly."
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 
     if compare_versions "$xb_version" "<" "$pxb_expected_version"; then
@@ -1743,7 +1743,7 @@ function verify_pxb_version()
         wsrep_log_error "xtrabackup-$pxb_expected_version or higher is needed to perform an SST"
         wsrep_log_error "$pxb_bin_path"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 }
 
@@ -1759,7 +1759,7 @@ if [[ -z $MYSQL_VERSION ]]; then
     wsrep_log_error "******************* FATAL ERROR ********************** "
     wsrep_log_error "FATAL: Cannot determine the mysqld server version"
     wsrep_log_error "****************************************************** "
-    exit 2
+    safe_exit 2
 fi
 
 # Verify PXB versions we have
@@ -1779,13 +1779,13 @@ if [[ ! ${WSREP_SST_OPT_ROLE} == 'joiner' && ! ${WSREP_SST_OPT_ROLE} == 'donor' 
     wsrep_log_error "Invalid role ${WSREP_SST_OPT_ROLE}"
     wsrep_log_error "Line $LINENO"
     wsrep_log_error "****************************************************** "
-    exit 22
+    safe_exit 22
 fi
 
 #
 # read configuration and setup ports for streaming data.
 read_variables_from_stdin
-[[ $? -ne 0 ]] && exit 2
+[[ $? -ne 0 ]] && safe_exit 2
 
 #
 # Only the DONOR is sent the credentials
@@ -1794,7 +1794,7 @@ if [[ $WSREP_SST_OPT_ROLE == "donor" ]]; then
         wsrep_log_error "******************* FATAL ERROR ********************** "
         wsrep_log_error "FATAL: The required auth credentials for an SST have not been received"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 fi
 
@@ -1824,7 +1824,7 @@ if [[ "$pxc_encrypt_cluster_traffic" == "on" ]]; then
             wsrep_log_error "* Please specify a CA file with the 'ssl-ca' option. "
             wsrep_log_error "* Line $LINENO"
             wsrep_log_error "**************************************************** "
-            return 2
+            save_exit 2
         fi
     fi
     if [[ -z "$ssl_cert" ]]; then
@@ -1836,7 +1836,7 @@ if [[ "$pxc_encrypt_cluster_traffic" == "on" ]]; then
             wsrep_log_error "* Please specify a certificate file with the 'ssl-cert' option. "
             wsrep_log_error "* Line $LINENO"
             wsrep_log_error "****************************************************** "
-            return 2
+            safe_exit 2
         fi
     fi
     if [[ -z "$ssl_key" ]]; then
@@ -1848,7 +1848,7 @@ if [[ "$pxc_encrypt_cluster_traffic" == "on" ]]; then
             wsrep_log_error "* Please specify a key file with the 'ssl-key' option. "
             wsrep_log_error "* Line $LINENO"
             wsrep_log_error "****************************************************** "
-            return 2
+            safe_exit 2
         fi
     fi
 
@@ -1864,7 +1864,7 @@ if [[ $encrypt -eq 1 || $encrypt -eq 2 || $encrypt -eq 3 ]]; then
     wsrep_log_error "* Please use SSL-based encryption (encrypt=4)"
     wsrep_log_error "* Line $LINENO"
     wsrep_log_error "****************************************************** "
-    exit 22
+    safe_exit 22
 fi
 
 
@@ -1880,7 +1880,7 @@ if $MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF xtrabackup | grep -q encrypt; then
     wsrep_log_error "* SSL-based encryption (encrypt=4)."
     wsrep_log_error "* Line $LINENO"
     wsrep_log_error "****************************************************** "
-    exit 2
+    safe_exit 2
 fi
 
 
@@ -1933,7 +1933,7 @@ then
                         "is unencrypted. Enable encryption for SST traffic"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 22
+        safe_exit 22
     fi
 
     # Create the SST info file
@@ -1967,7 +1967,7 @@ then
             wsrep_log_error "The joiner is not supported for this version of donor"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 93
+            safe_exit 93
         fi
 
         # main temp directory for xtrabackup (target-dir)
@@ -2113,7 +2113,7 @@ then
         done
 
         if [[ $do_exit -eq 1 ]]; then
-            exit 22
+            safe_exit 22
         fi
 
     else # BYPASS FOR IST
@@ -2169,6 +2169,15 @@ then
     # May need xtrabackup_checkpoints later on
     rm -f ${DATA}/xtrabackup_binary ${DATA}/xtrabackup_galera_info  ${DATA}/xtrabackup_logfile
 
+    # After starting socat listener in recv_data_from_donor_to_joiner sst-info,
+    # wait_for_listen will send "ready" message to the application.
+    # Application forms SST request from "ready" data and marks grastate.dat
+    # as 'unsafe'. From now till the point when we delete data directory,
+    # grastate.dat can be turned back to 'safe' state. This will prevent forced
+    # SST in case something goes wrong before datadir deletion.
+    # Fail "soft" until we delete datadir
+    SAFE_EXIT_CODE_OVERRIDE=${EAGAIN}
+
     # Note: this is started as a background process
     # So it has to wait for processes that are started by THIS process
     wait_for_listen $$ ${WSREP_SST_OPT_HOST} ${WSREP_SST_OPT_PORT:-4444} ${MODULE} &
@@ -2216,7 +2225,7 @@ then
         wsrep_log_error "Did not receive expected file from donor: '${SST_INFO_FILE}'"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 32
+        safe_exit 32
     fi
 
     if [ ! -r "${STATDIR}/${IST_FILE}" ]
@@ -2253,7 +2262,7 @@ then
             wsrep_log_error "${local_version_str} (the same version as this node)."
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 2
+            safe_exit 2
         fi
 
         # Is this node's pxc version < donor's pxc version?
@@ -2264,7 +2273,7 @@ then
             wsrep_log_error "Upgrade this node before joining the cluster."
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 2
+            safe_exit 2
         fi
 
         # Initializes the command-line args for XB
@@ -2282,7 +2291,7 @@ then
                 wsrep_log_error "Please remove it or specify alternative temporary directory location by setting [sst]/tmpdir"
                 wsrep_log_error "Line $LINENO"
                 wsrep_log_error "****************************************************** "
-                exit 2
+                safe_exit 2
             fi
             mkdir -p ${DATA}/sst-xb-tmpdir
             JOINER_SST_DIR=$DATA/sst-xb-tmpdir
@@ -2299,7 +2308,7 @@ then
                             "but DONOR is not"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 32
+            safe_exit 32
 
         fi
         # server-id is already part of backup-my.cnf so avoid appending it.
@@ -2314,7 +2323,7 @@ then
                             "(file/vault) but JOINER is not"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 32
+            safe_exit 32
         fi
 
         if [[ -n $transition_key ]]; then
@@ -2335,13 +2344,20 @@ then
             wsrep_log_error "Parent mysqld process (PID:${WSREP_SST_OPT_PARENT}) terminated unexpectedly."
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 32
+            safe_exit 32
         fi
 
         get_stream
         if [[ -n $sdecomp ]]; then
             strmcmd=" $sdecomp | $strmcmd"
         fi
+
+        # Up to this point, if anything happened that prevented SST (eg. network
+        # issue, wrong keyring configuration), datadir was not touched, so we should
+        # leave the node as it was (grastate.dat)
+        # From now on, there is no way back: we will receive SST, or the node won't
+        # work.
+        SAFE_EXIT_CODE_OVERRIDE=
 
         (recv_data_from_donor_to_joiner "$JOINER_SST_DIR" "${stagemsg}-SST" 0 0) &
         jpid=$!
@@ -2389,7 +2405,7 @@ then
             wsrep_log_error "xtrabackup_checkpoints missing. xtrabackup/SST failed on DONOR. Check DONOR log"
             wsrep_log_error "Line $LINENO"
             wsrep_log_error "****************************************************** "
-            exit 2
+            safe_exit 2
         fi
 
         # Rebuild indexes for compact backups
@@ -2413,7 +2429,7 @@ then
                 wsrep_log_error "qpress not found in path: $PATH"
                 wsrep_log_error "Line $LINENO"
                 wsrep_log_error "****************************************************** "
-                exit 22
+                safe_exit 22
             fi
 
             if [[ -n $progress ]] && pv --help | grep -q 'line-mode'; then
@@ -2452,7 +2468,7 @@ then
                 wsrep_log_error "Decompression failed. Exit code: $extcode"
                 wsrep_log_error "Line $LINENO"
                 wsrep_log_error "****************************************************** "
-                exit 22
+                safe_exit 22
             fi
         fi
 
@@ -2478,7 +2494,7 @@ then
             wsrep_log_error "Line $LINENO"
             cat_file_to_stderr "${DATA}/innobackup.decompress.log" "ERR" "innobackup.decompress.log"
             wsrep_log_error "****************************************************** "
-            exit 22
+            safe_exit 22
         fi
 
         wsrep_log_info "Preparing the backup at ${DATA}"
@@ -2496,7 +2512,7 @@ then
             wsrep_log_error "Line $LINENO"
             cat_file_to_stderr "${DATA}/innobackup.prepare.log" "ERR" "innobackup.prepare.log"
             wsrep_log_error "****************************************************** "
-            exit 22
+            safe_exit 22
         fi
 
         XB_GTID_INFO_FILE_PATH="${TDATA}/${XB_GTID_INFO_FILE}"
@@ -2521,7 +2537,7 @@ then
             wsrep_log_error "Line $LINENO"
             cat_file_to_stderr "${DATA}/innobackup.move.log" "ERR" "innobackup.move.log"
             wsrep_log_error "****************************************************** "
-            exit 22
+            safe_exit 22
         fi
 
         wsrep_log_debug "Move successful, removing ${DATA}"
@@ -2529,6 +2545,8 @@ then
         DATA=${TDATA}
         transfer_type="sst"
     else
+        SAFE_EXIT_CODE_OVERRIDE=
+
         wsrep_log_info "${IST_FILE} received from donor: Running IST"
         transfer_type="ist"
     fi
@@ -2538,7 +2556,7 @@ then
         wsrep_log_error "SST magic file ${XB_GTID_INFO_FILE_PATH} not found/readable"
         wsrep_log_error "Line $LINENO"
         wsrep_log_error "****************************************************** "
-        exit 2
+        safe_exit 2
     fi
 
     #-----------------------------------------------------------------------
@@ -2556,7 +2574,7 @@ then
     set -e
     if [[ $errcode -ne 0 ]]; then
         wsrep_log_info "...........post-processing failed.  Exiting"
-        exit $errcode
+        safe_exit $errcode
     else
         wsrep_log_info "...........post-processing done"
     fi
@@ -2568,4 +2586,4 @@ then
     fi
 fi
 
-exit 0
+safe_exit 0

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -490,7 +490,7 @@ void wsrep_sst_cancel(bool call_wsrep_cb) {
     /*
       If this is a normal shutdown, then we need to notify
       the wsrep provider about completion of the SST, to
-      prevent infinite waitng in the wsrep provider after
+      prevent infinite waiting in the wsrep provider after
       the SST process was canceled:
     */
     if (call_wsrep_cb && sst_awaiting_callback) {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4631

Problem:
If node starts and State Transfer (ST) is available through IST, but because of the network issue ST fails at the beginning, Joiner node stops which is OK. However next attempt to to start the node, forces full SST. As nothing was transferred for the 1st time, IST should be preferred.

Cause:
When ST is requested, SST script is started always. The 1st stage is setting up socat listener, sending "ready" message to the application and waiting for the message from the Donor side.
Once "ready" message is received by the application, it forms SST request string and sends to the donor. It also marks grastate.dat file as 'unsafe'. It means setting uuid:seqno pair to 0:0. It is done to force full SST after restart in case of this SST failure. However, before getting to the main SST transfer, SST script expects to receive sst-info and possibly xtrabackup_ist files. If there is no network connection between Donor and Joiner at this stage, SST script fails with timeout, grastate.dat file remains 'unsafe' and Joiner is stopped. Next start detects that there are no Galera coordiantes in grastate.dat and forces full SST.

Solution:
We can do better, because up to the point when we wipe out Joiner's datadir and start main SST transfer, if there are any errors in SST script we can move grastate.dat back to the 'safe' state.

There is no problem before sending "ready" message, because grastate.dat is marked 'unsafe' after receiving this message.
As the solution, add a way inform the applicaton, that SST script failed but didn't touch Joiner's data directory. To do this, for the time between "ready" message and datadir wipeout, if something goes wrong, exit with EAGAIN(11). This code is recognized in Galera part (ReplicatorSMM::sst_received()), and before node stop, grastate.dat is moved back to 'safe' state.

Adjusted clone SST script to use introduced improvement.

Additionally fixed the following issue:
During timeout calculation, wrong semantic operation was used. When we decrement variable like ((var-=1)), the last decrement results in var=0, but the exit code of the operation is 1 (because 0 is treated by Bash as 'false'). This is considered by Bash as error and the script exits with error immediately. We wanted to exit anyway, but this worked by chance in uncontrolled way, causing script to exit with wrong code and without a message.
Introduced proper timeout calculation and proper messaging.