### PR TITLE
(8.4) PXC-4644: Inconsistency when adding a FK

### DIFF
--- a/mysql-test/suite/galera/r/pxc_fk_inconsistency_voting_2.result
+++ b/mysql-test/suite/galera/r/pxc_fk_inconsistency_voting_2.result
@@ -1,0 +1,21 @@
+CREATE USER testuser identified by 'testpass';
+GRANT ALTER, REFERENCES, DELETE, SELECT ON *.* TO testuser;
+CREATE DATABASE test2;
+USE test2;
+CREATE TABLE parent ( id INT PRIMARY KEY ) ;
+CREATE TABLE child ( id INT PRIMARY KEY, parent_id INT, INDEX par_ind (parent_id));
+INSERT INTO child VALUES (1,1);
+CALL mtr.add_suppression("\[ERROR\].*Cannot add or update a child row");
+CALL mtr.add_suppression("\[ERROR\].*Cannot add or update a child row");
+ALTER TABLE child add FOREIGN KEY (parent_id) REFERENCES parent(id);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`temp_table`, CONSTRAINT `child_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`))
+ALTER TABLE child add FOREIGN KEY (parent_id) REFERENCES parent(id);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails
+INSERT INTO parent VALUES (1);
+ALTER TABLE child add FOREIGN KEY (parent_id) REFERENCES parent(id) ;
+DELETE FROM parent WHERE id = 1;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test2`.`child`, CONSTRAINT `child_ibfk_1` FOREIGN KEY (`parent_id`) REFERENCES `parent` (`id`))
+DELETE FROM parent WHERE id = 1;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
+DROP DATABASE test2;
+DROP USER testuser;

--- a/mysql-test/suite/galera/t/pxc_fk_inconsistency_voting_2.test
+++ b/mysql-test/suite/galera/t/pxc_fk_inconsistency_voting_2.test
@@ -1,0 +1,94 @@
+#
+# Test that FK add error in session of the user with limited
+# tables grants trigger inconsistency voting with the error code
+# compatible with other nodes.
+# WSREP applier thread works in context of root user, so it has
+# full grants. When FK constraint check fails, ER_NO_REFERENCED_ROW_2
+# is generated and used for voting.
+# On the other hand, when FK constraint check fails in session with
+# limited grants, ER_NO_REFERENCED_ROW is generated (with limited
+# error message). Both ER_NO_REFERENCED_ROW and ER_NO_REFERENCED_ROW_2
+# indicate the same error from inconsistency voting viewpoint.
+# The consequence is that it should not matter which error is generated,
+# nodes should agree during voting.
+#
+# The same situation is for ER_ROW_IS_REFERENCED and ER_ROW_IS_REFERENCED_2
+# error codes when deleting referenced row from the parent table.
+#
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+CREATE USER testuser identified by 'testpass';
+GRANT ALTER, REFERENCES, DELETE, SELECT ON *.* TO testuser;
+
+# MTR framework adds all grants for 'test' database (mysql-test-run.pl inserts
+# a row into mysql.db). Let's use another db.
+CREATE DATABASE test2;
+USE test2;
+CREATE TABLE parent ( id INT PRIMARY KEY ) ;
+CREATE TABLE child ( id INT PRIMARY KEY, parent_id INT, INDEX par_ind (parent_id));
+INSERT INTO child VALUES (1,1);
+
+CALL mtr.add_suppression("\[ERROR\].*Cannot add or update a child row");
+--connection node_2
+CALL mtr.add_suppression("\[ERROR\].*Cannot add or update a child row");
+--connection node_1
+
+#
+# ER_NO_REFERENCED_ROW / ER_NO_REFERENCED_ROW_2
+#
+
+#
+# The following query will fail because of FK constraint violation.
+# root user has full grants for 'parent' and 'child' tables
+# so we expect ER_NO_REFERENCED_ROW_2 error.
+#
+--error ER_NO_REFERENCED_ROW_2
+ALTER TABLE child add FOREIGN KEY (parent_id) REFERENCES parent(id);
+
+#
+# The following query will fail because of FK constraint violation.
+# testuser has limited grants for 'parent' and 'child' tables
+# so we expect ER_NO_REFERENCED_ROW error.
+#
+--connect node_1a, 127.0.0.1, testuser, testpass, test2, $NODE_MYPORT_1
+--connection node_1a
+--error ER_NO_REFERENCED_ROW
+ALTER TABLE child add FOREIGN KEY (parent_id) REFERENCES parent(id);
+
+
+#
+# ER_ROW_IS_REFERENCED / ER_ROW_IS_REFERENCED_2
+#
+--connection node_1
+INSERT INTO parent VALUES (1);
+ALTER TABLE child add FOREIGN KEY (parent_id) REFERENCES parent(id) ;
+
+#
+# The following query will fail, because 'parent' table row is referenced
+# by 'child' table. root user has full grants, so we expect
+# ER_ROW_IS_REFERENCED_2
+#
+--error ER_ROW_IS_REFERENCED_2
+DELETE FROM parent WHERE id = 1;
+
+#
+# The following query will fail, because 'parent' table row is referenced
+# by 'child' table. testuser user has limited grants, so we expect
+# ER_ROW_IS_REFERENCED
+#
+--connection node_1a
+--error ER_ROW_IS_REFERENCED
+DELETE FROM parent WHERE id = 1;
+
+
+#
+# cleanup
+#
+--connection node_1
+DROP DATABASE test2;
+DROP USER testuser;
+--disconnect node_1a
+--source include/wait_until_count_sessions.inc
+

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -25,11 +25,11 @@
 #include "sql/binlog_reader.h"
 #include "sql/sql_lex.h"
 
+#include <unordered_map>
 #include "service_wsrep.h"
 #include "wsrep_priv.h"
 #include "wsrep_thd.h"
 #include "wsrep_trans_observer.h"
-
 /*
   read the first event from (*buf). The size of the (*buf) is (*buf_len).
   At the end (*buf) is shitfed to point to the following event or NULL and
@@ -78,6 +78,26 @@ Format_description_log_event *wsrep_get_apply_format(THD *thd) {
   return thd->wsrep_rli->get_rli_description_event();
 }
 
+static uint wsrep_errno_for_voting(uint err) {
+  /* errno_map keeps pairs of error codes that mean
+   the same from inconsistency voting point of view. */
+  static std::unordered_map<uint, uint> errno_map = {
+      /* Use ER_NO_REFERENCED_ROW_2 and ER_ROW_IS_REFERENCED_2 for voting
+       because commit e6dbb7d0 in 8.4 branch changed the behavior to always
+       report _2 code, so it is used for voting. This way voting in mixed
+       version cluster (8.0 and 8.4) will be compatible. */
+      {ER_NO_REFERENCED_ROW, ER_NO_REFERENCED_ROW_2},
+      {ER_ROW_IS_REFERENCED, ER_ROW_IS_REFERENCED_2}};
+
+  if (errno_map.count(err)) {
+    auto res = errno_map[err];
+    WSREP_DEBUG("Overriding ambiguous error code %u -> %u for voting", err,
+                res);
+    return res;
+  }
+  return err;
+}
+
 void wsrep_store_error(const THD *const thd, wsrep::mutable_buffer &dst) {
   Diagnostics_area::Sql_condition_iterator it =
       thd->get_stmt_da()->sql_conditions();
@@ -93,12 +113,15 @@ void wsrep_store_error(const THD *const thd, wsrep::mutable_buffer &dst) {
 
   auto da = thd->get_stmt_da();
   if (da->cond_count() == 0 && da->is_set()) {
+    uint const err_code = wsrep_errno_for_voting(da->mysql_errno());
+    const char *const err_str = da->message_text();
+
     slider += snprintf(slider, buf_end - slider, " %s, Error_code: %d;",
-                       da->message_text(), da->mysql_errno());
+                       err_str, err_code);
   }
 
   for (cond = it++; cond && slider < buf_end; cond = it++) {
-    uint const err_code = cond->mysql_errno();
+    uint const err_code = wsrep_errno_for_voting(cond->mysql_errno());
     const char *const err_str = cond->message_text();
 
     slider += snprintf(slider, buf_end - slider, " %s, Error_code: %d;",


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4644

Merge branch 'PXC-4644-8.0' into PXC-4644-8.4

This commit contains only MTR tests for the problematic scenario.

Commit https://github.com/percona/percona-xtradb-cluster/commit/e6dbb7d0aa6df80d01123e2b6f09d3aa2bcc8ab0 changed the behavior to return ER_ROW_IS_REFERENCED_2
and ER_NO_REFERENCED_ROW_2 always, despite of user privileges, so
PXC-4644 does not exist for the current version.