### PR TITLE
(8.0) PXC-4292: Improve datadir cleanup during SST

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_same_dirs.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_same_dirs.result
@@ -1,0 +1,1 @@
+# restart

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_same_dirs.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_same_dirs.cnf
@@ -1,0 +1,16 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_debug=1
+
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=1;pc.ignore_sb=true'
+
+[mysqld.2]
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.size=1;pc.ignore_sb=true'
+datadir=@ENV.MYSQL_TMP_DIR/n2/mysql_data_directory
+innodb_data_home_dir=@ENV.MYSQL_TMP_DIR/n2/mysql_data_directory
+innodb_log_group_home_dir=@ENV.MYSQL_TMP_DIR/n2/mysql_data_directory
+innodb_undo_directory=@ENV.MYSQL_TMP_DIR/n2/mysql_data_directory
+

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_same_dirs.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_same_dirs.test
@@ -1,0 +1,34 @@
+#
+# During the State Transfer, SST script cleans up:
+# datadir
+# innodb_data_home_dir
+# innodb_log_group_home_dir
+# innodb_undo_directory
+# This is to test the case if all above variables are set explicitly in my.cnf
+# to the same value.
+# 
+--source include/galera_cluster.inc
+
+--disable_query_log
+--connection node_1
+CALL mtr.add_suppression("Failed to remove page file");
+--connection node_2
+CALL mtr.add_suppression("Failed to remove page file");
+--enable_query_log
+
+# Stop node_2
+--connection node_2
+--let $node_2_datadir=`SELECT @@datadir`
+--source include/shutdown_mysqld.inc
+
+# Wait for 1-node cluster
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Start node_2 with forced SST
+--remove_file $node_2_datadir/grastate.dat
+--connection node_2
+--source include/start_mysqld.inc
+--source include/wait_until_connected_again.inc
+

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -2444,9 +2444,14 @@ then
         wsrep_log_info "Proceeding with SST........."
 
         wsrep_log_debug "Cleaning the existing datadir and innodb-data/log directories"
+
+        # Deduplicate directories before 'find'. This step is not absolutely necessary
+        # but in case some variables point to the same directory, we can avoid searching
+        # through the same directory multiple times.
+        dirs=$(printf "%s\n" "$ib_home_dir" "$ib_log_dir" "$ib_undo_dir" "$DATA" | sort -u)
         # Avoid emitting the find command output to log file. It just fill the
         # with ever increasing number of files and achieve nothing.
-        find $ib_home_dir $ib_log_dir $ib_undo_dir $DATA -mindepth 1  -regex $cpat  -prune  -o -exec rm -rfv {} 1>/dev/null \+
+        find $dirs -mindepth 1  -regex $cpat  -prune  -o -exec rm -rfv {} 1>/dev/null \+
 
         if [[ -z $transition_key ]]; then
             if [[ -r "${keyring_file_data}.backup" ]];


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4292

Problem:

During SST the script cleans up:
datadir
innodb_data_home_dir
innodb_log_group_home_dir
innodb_undo_directory

If above variables are set explicitly in my.cnf to the same value, the logic in xtrabackup-v2 script searched the same directory multiple times, resulting in duplicate results.
Then the result of search is passed to 'rm'. Because we use '-f' option of 'rm' it is not a problem (attempt to delete already deleted file), however we can avoid searching the same directory multiple times.

Solution:
Before searching directories that have to be cleaned up, deduplicate these directories names.