### PR TITLE
(trunk) PXC-4526: Replication fails and the node becomes Inconsistent if transaction is committed on node by setting tagged gtid

### DIFF
--- a/mysql-test/suite/galera/r/galera_gtid.result
+++ b/mysql-test/suite/galera/r/galera_gtid.result
@@ -8,4 +8,6 @@ UPDATE t1 SET f1 = 2;
 SET SESSION wsrep_sync_wait = 7;
 gtid_executed_equal
 1
+SET @@session.GTID_NEXT='1ed6b5f2-9091-11ef-b382-13ba123de7b3:abc124:1';
+INSERT INTO t1 VALUES (100);
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_gtid.test
+++ b/mysql-test/suite/galera/t/galera_gtid.test
@@ -55,6 +55,16 @@ SET SESSION wsrep_sync_wait = 7;
 # --connection node_1
 # COMMIT;
 
+#
+# Test tagged gtid
+#
+--connection node_1
+SET @@session.GTID_NEXT='1ed6b5f2-9091-11ef-b382-13ba123de7b3:abc124:1';
+INSERT INTO t1 VALUES (100);
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 100
+--source include/wait_condition.inc
+
 
 # cleanup
 DROP TABLE t1;

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -154,6 +154,7 @@ int wsrep_apply_events(THD *thd, Relay_log_info *rli __attribute__((unused)),
         continue;
       /* If gtid_mode=OFF then async master-slave will generate ANONYMOUS GTID.
        */
+      case mysql::binlog::event::GTID_TAGGED_LOG_EVENT:
       case mysql::binlog::event::GTID_LOG_EVENT:
       case mysql::binlog::event::ANONYMOUS_GTID_LOG_EVENT: {
         Gtid_log_event *gev = (Gtid_log_event *)ev;

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -79,7 +79,9 @@ static Relay_log_info *wsrep_relay_log_init(const char *) {
     WSREP_ERROR("Failed to create Relay-Log for wsrep thread, aborting");
     unireg_abort(MYSQLD_ABORT_EXIT);
   }
-  rli->set_rli_description_event(new Format_description_log_event());
+  auto ev = new Format_description_log_event();
+  ev->footer()->checksum_alg = mysql::binlog::event::BINLOG_CHECKSUM_ALG_OFF;
+  rli->set_rli_description_event(ev);
 
   rli->current_mts_submode = new Mts_submode_wsrep();
   return (rli);


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4526

Problem:
If NEXT_GTID is set to tagged GTID, replicated transaction fails triggering inconsistency voting protocol and node eviction.

Cause:
8.4 introduced tagged GTIDs. Together with this, new event type of GTID_TAGGED_LOG_EVENT was introduced. Deserialization of tagged gtid is handled by a dedicated path that uses new deserializer (for now only GTID_TAGGED_LOG_EVENT uses this new serializer/deserializer). Before passing buffer to the deserializer, buffer size is adjusted if event checksum is not disabled. (if it is not BINLOG_CHECKSUM_ALG_OFF). For async replication it can be BINLOG_CHECKSUM_ALG_OFF or BINLOG_CHECKSUM_ALG_CRC32, depending on Format_description_log_event passed from the source.

Wsrep applier thread uses Format_description_log_event with BINLOG_CHECKSUM_ALG_UNDEF because events sent through Galera channel are not followed by CRC. Because of BINLOG_CHECKSUM_ALG_UNDEF, the above logic limited the event buffer size and passed to new deserializer. Deserializer was not able to fully deserialize GTID_TAGGED_LOG_EVENT and reported the error.

Solution:
Because events in Galera writeset are not followed by CRC, and Format_description_log_event is not replicated via Galera channel, it is not clear how replica should consider incoming events. Replica can consider them as:
BINLOG_CHECKSUM_ALG_UNDEF - events from checksum-unaware servers or
BINLOG_CHECKSUM_ALG_OFF - events from servers without checksum

The approach with BINLOG_CHECKSUM_ALG_UNDEF worked so far, but together with introduction the logic around GTID_TAGGED_LOG_EVENT it's not true anymore.

As the solution, explicitly configure replica to consider all events from Galera channel as having no checksum.

Note: It is questionable if original logic around GTID_TAGGED_LOG_EVENT is correct. Probably it would be better if it limited deserializer buffer size only if event explicitly has a checksum (BINLOG_CHECKSUM_ALG_CRC32). But again, the problem is not visible for other replication channels than Galera.