### PR TITLE
(8.0)PXC-4765: Create trigger with definer causes inconsistency error and …

### DIFF
--- a/mysql-test/suite/galera/r/pxc_create_trigger_failure.result
+++ b/mysql-test/suite/galera/r/pxc_create_trigger_failure.result
@@ -1,0 +1,60 @@
+
+# 1. Create user u1 and u2 and grant required privileges. Revoke SUPER from u2.
+
+CREATE USER u1@localhost IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON test.* TO u1@localhost;
+CREATE USER u2@localhost IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON test.* to u2@localhost;
+REVOKE SUPER ON *.* FROM u2@localhost;
+Warnings:
+Warning	1287	The SUPER privilege identifier is deprecated
+
+# 2. Connect using u1 and create table t1 and t2.
+#    Create trigger trg_t1_insert with definer u1. trg_t1_insert is created.
+
+CREATE TABLE t1(i INT PRIMARY KEY, n VARCHAR(9));
+CREATE TABLE t2(log_message VARCHAR(100));
+CREATE DEFINER=u1@`localhost` TRIGGER trg_t1_insert
+AFTER INSERT ON t1
+FOR EACH ROW
+BEGIN
+INSERT INTO t2 VALUES (CONCAT('Row inserted by: ', USER()));
+END$$
+
+# 3. Assert TRIGGER table is in synch across cluster.
+
+include/assert.inc ['Trigger trg_t1_insert exists on node_1']
+'Trigger trg_t1_insert exists on node_2'
+
+# 4. Perform some operations and ensure cluster is in synch.
+
+INSERT INTO t1 VALUES (1, 'test');
+include/assert.inc ['Check t1 was updated.']
+include/assert.inc ['Check t2 was updated by the trigger']
+'Check t1 was updated.'
+include/assert.inc ['Check t2 was updated by the trigger']
+
+# 5. Connect using u2.
+#    Create trigger trg_t1_insert_fail with definer u1.
+#    trg_t1_insert_fail is not created.
+
+CREATE DEFINER=u1@`localhost` TRIGGER trg_t1_insert_fail
+AFTER INSERT ON t1
+FOR EACH ROW
+BEGIN
+INSERT INTO t2 VALUES ('This should fail');
+END$$
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SET_USER_ID privilege(s) for this operation
+
+# 6. Assert TRIGGER table does not contain trg_t1_insert_fail in any node.
+
+include/assert.inc ['Trigger trg_t1_insert_fail was not created on node_1']
+include/assert.inc ['Trigger trg_t1_insert_fail was not created on node_2']
+
+# 7. Cleanup.
+
+DROP TRIGGER trg_t1_insert;
+DROP TABLE t1;
+DROP TABLE t2;
+DROP USER u1@localhost;
+DROP USER u2@localhost;

--- a/mysql-test/suite/galera/t/pxc_create_trigger_failure.test
+++ b/mysql-test/suite/galera/t/pxc_create_trigger_failure.test
@@ -1,0 +1,155 @@
+################################################################################
+# This test proves that trigger failure on 1 node causes trigger failure on all
+# nodes.
+#
+# Test:
+# 0. The test requires two servers: node1 and node2
+# 1. Create user u1 and u2 and grant required privileges. Revoke SUPER from u2.
+# 2. Connect using u1 and create table t1 and t2.
+#    Create trigger trg_t1_insert with definer u1. trg_t1_insert is created.
+# 3. Assert TRIGGER table is in synch across cluster.
+# 4. Perform some operations and ensure cluster is in synch.
+# 5. Connect using u2.
+#    Create trigger trg_t1_insert_fail with definer u1.
+#    trg_t1_insert_fail is not created.
+# 6. Assert TRIGGER table does not contain trg_t1_insert_fail in any node.
+# 7. Cleanup.
+################################################################################
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--echo
+--echo # 1. Create user u1 and u2 and grant required privileges. Revoke SUPER from u2.
+--echo
+
+CREATE USER u1@localhost IDENTIFIED BY '';
+## u1 will be the DEFINER user for the trigger, granting system user might not be needed here.
+GRANT ALL PRIVILEGES ON test.* TO u1@localhost;
+
+
+CREATE USER u2@localhost IDENTIFIED BY '';
+## u2 will try to create the trigger, but won't have the necessary privileges
+GRANT ALL PRIVILEGES ON test.* to u2@localhost;
+## Revoke a SUPER privilege.
+REVOKE SUPER ON *.* FROM u2@localhost;
+
+
+--echo
+--echo # 2. Connect using u1 and create table t1 and t2.
+--echo #    Create trigger trg_t1_insert with definer u1. trg_t1_insert is created.
+--echo
+
+--connect (u1_connection,localhost,u1,,test, $NODE_MYPORT_1)
+CREATE TABLE t1(i INT PRIMARY KEY, n VARCHAR(9));
+
+## Create a simple table t2 which the trigger will update
+CREATE TABLE t2(log_message VARCHAR(100));
+
+
+## User u1 creates a trigger successfully (u1 is the DEFINER)
+DELIMITER $$;
+CREATE DEFINER=u1@`localhost` TRIGGER trg_t1_insert
+AFTER INSERT ON t1
+FOR EACH ROW
+BEGIN
+    INSERT INTO t2 VALUES (CONCAT('Row inserted by: ', USER()));
+END$$
+DELIMITER ;$$
+
+--echo
+--echo # 3. Assert TRIGGER table is in synch across cluster.
+--echo
+
+# Assert trigger exists on node_1
+--connection node_1
+--let $assert_text= 'Trigger trg_t1_insert exists on node_1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM information_schema.TRIGGERS WHERE TRIGGER_NAME = "trg_t1_insert" AND EVENT_OBJECT_TABLE = "t1", count, 1] = 1
+--source include/assert.inc
+
+# Assert trigger exists on node_2
+--connection node_2
+--echo 'Trigger trg_t1_insert exists on node_2'
+--let $wait_condition= SELECT COUNT(*)=1 FROM information_schema.TRIGGERS WHERE TRIGGER_NAME = "trg_t1_insert" AND EVENT_OBJECT_TABLE = "t1"
+--source include/wait_condition.inc
+
+--echo
+--echo # 4. Perform some operations and ensure cluster is in synch.
+--echo
+
+--connect (u2_connection,localhost,u2,,test, $NODE_MYPORT_1)
+## u2 tries to perform an operation on t1 which fires the trigger.
+## The trigger itself should execute successfully because the DEFINER (u1) has the necessary privileges.
+INSERT INTO t1 VALUES (1, 'test');
+
+--connection node_1
+--let $assert_text= 'Check t1 was updated.'
+--let $assert_cond= [SELECT COUNT(*) FROM t1 WHERE i = 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'Check t2 was updated by the trigger'
+--let $assert_cond= [SELECT COUNT(*) FROM t2 WHERE log_message LIKE "Row inserted by: u2%"] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Check t1 was updated.'
+--let $wait_condition= SELECT COUNT(*)=1 FROM t1 WHERE i = 1
+--source include/wait_condition.inc
+
+--let $assert_text= 'Check t2 was updated by the trigger'
+--let $assert_cond= [SELECT COUNT(*) FROM t2 WHERE log_message LIKE "Row inserted by: u2%"] = 1
+--source include/assert.inc
+
+--echo
+--echo # 5. Connect using u2.
+--echo #    Create trigger trg_t1_insert_fail with definer u1.
+--echo #    trg_t1_insert_fail is not created.
+--echo
+
+--connection u2_connection
+## Create a new trigger as u2, defining it as u1.
+## This requires the SUPER privilege.
+## Since u2 doesn't have SUPER, this should fail.
+DELIMITER $$;
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+CREATE DEFINER=u1@`localhost` TRIGGER trg_t1_insert_fail
+AFTER INSERT ON t1
+FOR EACH ROW
+BEGIN
+    INSERT INTO t2 VALUES ('This should fail');
+END$$
+DELIMITER ;$$
+
+--echo
+--echo # 6. Assert TRIGGER table does not contain trg_t1_insert_fail in any node.
+--echo
+
+# Assert trigger does not exists on node_1
+--connection node_1
+--let $assert_text= 'Trigger trg_t1_insert_fail was not created on node_1'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM information_schema.TRIGGERS WHERE TRIGGER_NAME = "trg_t1_insert_fail", count, 1] = 0
+--source include/assert.inc
+
+# Assert trigger does not exists on node_2
+--connection node_2
+--let $assert_text= 'Trigger trg_t1_insert_fail was not created on node_2'
+--let $assert_cond= [SELECT COUNT(*) AS count FROM information_schema.TRIGGERS WHERE TRIGGER_NAME = "trg_t1_insert_fail", count, 1] = 0
+--source include/assert.inc
+
+--echo
+--echo # 7. Cleanup.
+--echo
+
+--connection u1_connection
+DROP TRIGGER trg_t1_insert;
+DROP TABLE t1;
+DROP TABLE t2;
+
+--disconnect u1_connection
+--disconnect u2_connection
+
+--connection node_1
+DROP USER u1@localhost;
+DROP USER u2@localhost;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -407,26 +407,46 @@ bool Sql_cmd_create_trigger::execute(THD *thd) {
   */
   Security_context *sctx = thd->security_context();
 #ifdef WITH_WSREP
-  if (!trust_function_creators &&
-      (WSREP_EMULATE_BINLOG(thd) || mysql_bin_log.is_open()) &&
-      !(sctx->check_access(SUPER_ACL) ||
-        sctx->has_global_grant(STRING_WITH_LEN("SET_USER_ID")).first)) {
-    /*
-      If WSREP is enabled, then we are ALWAYS doing binlog
-      replication of some sort, and we always require the SUPER
-      privilege (or trust_function_creators).
-      So there is no need to mention anything about the binlog.
-    */
-    if (WSREP(thd))
+  LEX *lex = thd->lex;
+  bool definer_is_current_user =
+      !lex->definer || /* If definer is not specified, consider current user */
+      (strcmp(lex->definer->user.str, sctx->priv_user().str) == 0 &&
+       my_strcasecmp(system_charset_info, lex->definer->host.str,
+                     sctx->priv_host().str) == 0);
+  bool binlog_requires_super =
+      !trust_function_creators &&
+      (WSREP_EMULATE_BINLOG(thd) || mysql_bin_log.is_open());
+  bool has_super_or_set_user_id =
+      sctx->check_access(SUPER_ACL) ||
+      sctx->has_global_grant(STRING_WITH_LEN("SET_USER_ID")).first;
+
+  // Definer check: If a definer is specified and is different from the current
+  // user, then we need to check for SUPER or SET_USER_ID privileges.
+  if ((!definer_is_current_user || binlog_requires_super) &&
+      !has_super_or_set_user_id) {
+    if (!definer_is_current_user) {
+      my_error(ER_SPECIFIC_ACCESS_DENIED_ERROR, MYF(0), "SUPER or SET_USER_ID");
+    } else if (WSREP(thd)) {
+      /*
+        If WSREP is enabled, then we are ALWAYS doing binlog
+        replication of some sort, and we always require the SUPER
+        privilege (or trust_function_creators).
+        So there is no need to mention anything about the binlog.
+      */
       my_message(ER_BINLOG_CREATE_ROUTINE_NEED_SUPER,
-                 "You do not have the SUPER privilege"
-                 " (you *might* want to use the less safe "
-                 "log_bin_trust_function_creators variable)",
+                 "You do not have the SUPER privilege (you *might* want to use "
+                 "the less safe log_bin_trust_function_creators variable)",
                  MYF(0));
-    else
+    } else {
       my_error(ER_BINLOG_CREATE_ROUTINE_NEED_SUPER, MYF(0));
+    }
     return true;
   }
+
+  if (lex->definer && sctx->can_operate_with(lex->definer, consts::system_user,
+                                             true /* report_error */))
+    return true;
+
 #else
   if (!trust_function_creators && mysql_bin_log.is_open() &&
       !(sctx->check_access(SUPER_ACL) ||


### PR DESCRIPTION
…node to disconnect

https://perconadev.atlassian.net/browse/PXC-4765

Problem:
Executing a CREATE TRIGGER statement with a DEFINER set to another user, while connected as a user without SUPER or SET_USER_ID privileges, can cause a replication inconsistency and force the node to disconnect from the cluster.

Description:
In PXC clusters CREATE TRIGGER with a DEFINER clause could lead to inconsistent behavior across nodes.
If the DEFINER user did not exist or had mismatched privileges, the node originating the transaction could reject it, while remote applier nodes might execute it successfully. This led to inconsistency and node leaving the cluster.

Resolution:
Added explicit privilege and user existence checks for DEFINER context:
 - Verify that the executing user matches the definer.
 - Allow execution only if the user has SUPER or SET_USER_ID privileges.
 - Warn if the DEFINER user does not exist in the ACL. This ensures that both locally executed and Galera-applied transactions follow the same access control logic and produce consistent outcomes.