### PR TITLE
fix: support encrypted sst via ipv6 without config change

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -637,7 +637,13 @@ get_transfer()
             stagemsg+="-OpenSSL-Encrypted-4"
             if [[ "$WSREP_SST_OPT_ROLE"  == "joiner" ]]; then
                 wsrep_log_debug "Decrypting with SSL. CERT: $ssl_cert, KEY: $ssl_key, CA: $ssl_ca"
-                tcmd="socat -u openssl-listen:${TSST_PORT},reuseaddr,cert=${ssl_cert},key=${ssl_key},cafile=${ssl_ca},verify=1${joiner_extra}${sockopt} stdio"
+                # PXC-3767 - IPv6 support in PXC (wsrep_sst_xtrabackup-v2)
+                # socat require pf=ip6 for openssl-listen to work with IPv6 addresses
+                local ipv6_listen_opt=""
+                if [[ "$WSREP_SST_OPT_HOST" =~ .*:.* ]]; then
+                    ipv6_listen_opt=",pf=ip6"
+                fi
+                tcmd="socat -u openssl-listen:${TSST_PORT},reuseaddr,${ipv6_listen_opt}cert=${ssl_cert},key=${ssl_key},cafile=${ssl_ca},verify=1${joiner_extra}${ipv6_listen_opt}${sockopt} stdio"
             else
                 wsrep_log_debug "Encrypting with SSL. CERT: $ssl_cert, KEY: $ssl_key, CA: $ssl_ca"
                 tcmd="socat ${socat_T} -u stdio openssl-connect:${REMOTEIP}:${TSST_PORT},cert=${ssl_cert},key=${ssl_key},cafile=${ssl_ca},verify=1${donor_extra}${sockopt}${socat_donor_connect_timeout}"


### PR DESCRIPTION
[PXC-3767](https://perconadev.atlassian.net/browse/PXC-3767) addressed an issue regarding SST via IPv6

The previously added fix only works for non-encrypted SST and still requires setting

```
[sst]
sockopt=,pf=ip6
```

for IPv6 support over encrypted SST.

This change adds the support for encrypted SST via IPv6 while using the same logic as in plain SST.



[PXC-3767]: https://perconadev.atlassian.net/browse/PXC-3767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This issue also applies to [8.4](https://github.com/percona/percona-xtradb-cluster/blob/9e36d80765508d7ab16dad67ab046b1b39442137/scripts/wsrep_sst_xtrabackup-v2.sh#L693) and could be fixed the same way 