### PR TITLE
PXC-4756: SST Post-processing Timeout in Large Instances (8.4)

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -874,7 +874,7 @@ function run_post_processing_steps()
     local sst_password="aA!9$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)"
 
     local -i timeout_threshold
-    timeout_threshold=300
+    timeout_threshold=$(parse_cnf sst post-processing-timeout 300)
 
     #-----------------------------------------------------------------------
     # Reuse the SST User (use it to run mysql_upgrade)


### PR DESCRIPTION
    https://perconadev.atlassian.net/browse/PXC-4756
    
    Problem: In scenarios with large InnoDB Buffer Pools where
    *innodb_numa_interleave* is enabled, when performing the *post-processing*
    phase, the instance may take longer to start, potentially exceeding the
    *timeout_threshold* of 300 seconds and causing the SST procedure to abort.
    
    Cause:
    The script *wsrep_sst_common* handles this logic. The value of
    timeout_threshold is hard coded to 300 which maybe less for NUMA.
    innodb_numa_interleave is a system variable that controls memory allocation
    for InnoDB on Non-Uniform Memory Access (NUMA) systems.
    When innodb_numa_interleave=ON, the mysqld startup process attempts to
    interleave memory across all NUMA nodes, which can be useful for balancing
    memory pressure but may lead to a slower start-up.
    https://docs.percona.com/percona-server/5.7/performance/innodb_numa_support.html#version-specific-information
    
    Solution:
    Value of timeout_threshold now can be set via my.cnf file, parameter
    post-processing-timeout in sst section.
