### PR TITLE
(8.4) PXC-4789: DDL with FK reference causes MDL BF-BF conflict and evict the nodes out of cluster.

### DIFF
--- a/include/service_wsrep.h
+++ b/include/service_wsrep.h
@@ -72,6 +72,7 @@ extern "C" const char *wsrep_thd_query(const THD *thd);
 extern "C" query_id_t wsrep_thd_transaction_id(const THD *thd);
 
 extern "C" long long wsrep_thd_trx_seqno(const THD *thd);
+extern "C" long long wsrep_thd_trx_depends_on_seqno(const THD *thd);
 
 /* Mark thd own transaction as aborted */
 extern "C" void wsrep_thd_self_abort(THD *thd);

--- a/mysql-test/suite/galera/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf.result
@@ -1,3 +1,4 @@
+########## CASE 1 ########## 
 SET SESSION wsrep_sync_wait = 0;
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 INSERT INTO p1 VALUES (1,1);
@@ -27,6 +28,7 @@ SET GLOBAL wsrep_provider_options = 'dbug=';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE c1;
 DROP TABLE p1;
+########## CASE 2 ########## 
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));;
@@ -38,12 +40,17 @@ SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
 BEGIN;
 INSERT INTO p1 VALUES (1,1);
 COMMIT;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE c1;
 DROP TABLE p1;
+########## CASE 3 ########## 
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
 INSERT INTO p1 VALUES (0, 0);
@@ -58,12 +65,17 @@ SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
 BEGIN;
 UPDATE c1 SET data = 1 WHERE pk = 0;
 COMMIT;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE c1;
 DROP TABLE p1;
+########## CASE 4 ########## 
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
 CREATE TABLE t1 (pk INTEGER PRIMARY KEY);
@@ -78,6 +90,10 @@ SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
 BEGIN;
 INSERT INTO p1 VALUES (1,1);
 COMMIT;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
@@ -86,10 +102,11 @@ SHOW TABLES;
 Tables_in_test
 p1
 DROP TABLE p1;
+########## CASE 5 ########## 
 CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
 SET wsrep_retry_autocommit = 1;
 CREATE TABLE t1 (a INT PRIMARY KEY);
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 ALTER TABLE t1 ADD (b INT);
 SET DEBUG_SYNC='now WAIT_FOR reached';
 ALTER TABLE t1 ADD (c INT);
@@ -102,9 +119,10 @@ t1	CREATE TABLE `t1` (
   PRIMARY KEY (`a`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 DROP TABLE t1;
+########## CASE 6 ########## 
 SET wsrep_retry_autocommit = 0;
 CREATE TABLE t1 (a INT PRIMARY KEY);
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 ALTER TABLE t1 ADD (b INT);
 SET DEBUG_SYNC='now WAIT_FOR reached';
 ALTER TABLE t1 ADD (c INT);
@@ -117,12 +135,13 @@ t1	CREATE TABLE `t1` (
   PRIMARY KEY (`a`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 DROP TABLE t1;
+########## CASE 7 ########## 
 SET wsrep_retry_autocommit = 2;
 CREATE TABLE t1 (a INT PRIMARY KEY);
-SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="+d,wsrep_do_action_for_table_lock_fail";
 ALTER TABLE t1 ADD (b INT);
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
-SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="-d,wsrep_do_action_for_table_lock_fail";
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/galera/r/galera_bf_bf_2.result
+++ b/mysql-test/suite/galera/r/galera_bf_bf_2.result
@@ -114,3 +114,61 @@ SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=after_cert_and_catch';
 DROP TABLE t1, t2;
+############################################################
+# Testcase:
+# DROP TABLE <parent_table> and concurrent UPDATE <child_table>
+############################################################
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+CREATE TABLE parent (id INT PRIMARY KEY); CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, data INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE); INSERT INTO parent values (0); INSERT INTO child values (0, 0, 0); CREATE TABLE parent_new LIKE parent; INSERT INTO parent_new SELECT * FROM parent;;
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_cert_and_catch';
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_applier_threads = 2;
+SET GLOBAL debug = "+d,ordered_commit_blocked";
+SET foreign_key_checks=0; DROP TABLE parent;;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET DEBUG_SYNC = "now WAIT_FOR signal.ordered_commit_waiting";
+SET GLOBAL debug = "-d,ordered_commit_blocked";
+SET GLOBAL wsrep_provider_options = 'dbug=d,sync.apply_trx.start_of_apply_trx';
+UPDATE child SET data = 1 WHERE id = 0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=sync.apply_trx.start_of_apply_trx';
+SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=after_cert_and_catch';
+DROP TABLE parent_new, child;
+############################################################
+# Testcase:
+# RENAME TABLE <parent_table_new> and concurrent UPDATE <child_table>
+############################################################
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = 0;
+CREATE TABLE parent (id INT PRIMARY KEY); CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, data INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE); INSERT INTO parent values (0); INSERT INTO child values (0, 0, 0); CREATE TABLE parent_new LIKE parent; INSERT INTO parent_new SELECT * FROM parent; SET foreign_key_checks=0; DROP TABLE parent;;
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_cert_and_catch';
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_applier_threads = 2;
+SET GLOBAL debug = "+d,ordered_commit_blocked";
+RENAME TABLE parent_new TO parent;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET DEBUG_SYNC = "now WAIT_FOR signal.ordered_commit_waiting";
+SET GLOBAL debug = "-d,ordered_commit_blocked";
+SET GLOBAL wsrep_provider_options = 'dbug=d,sync.apply_trx.start_of_apply_trx';
+UPDATE child SET data = 1 WHERE id = 0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=sync.apply_trx.start_of_apply_trx';
+SET DEBUG_SYNC = "now SIGNAL signal.ordered_commit_continue";
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=after_cert_and_catch';
+DROP TABLE parent, child;

--- a/mysql-test/suite/galera/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf.test
@@ -19,6 +19,7 @@
 --source include/galera_cluster.inc
 --source include/count_sessions.inc
 
+--echo ########## CASE 1 ########## 
 --connect node_1_toi, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --connection node_1_toi
 SET SESSION wsrep_sync_wait = 0;
@@ -99,7 +100,7 @@ DROP TABLE p1;
 # (CREATE TABLE, DROP TABLE are affected).
 #
 
-
+--echo ########## CASE 2 ########## 
 --connection node_1_toi
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 
@@ -109,6 +110,7 @@ CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 --send CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
 
 --connection node_1
+# wait for CREATE TABLE to block
 SET SESSION wsrep_sync_wait=0;
 --let $galera_sync_point = apply_monitor_master_enter_sync
 --source include/galera_wait_sync_point.inc
@@ -124,6 +126,12 @@ INSERT INTO p1 VALUES (1,1);
 --send COMMIT
 
 --connection node_1a
+# wait for COMMIT to block
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
 # Now unblock CREATE TABLE. Without the fix it will BF-abort already certified
 # INSERT which will cause its replay.
 --let $galera_sync_point = apply_monitor_master_enter_sync
@@ -168,6 +176,7 @@ DROP TABLE p1;
 # of the writeset related to TOI done on child table.
 #
 
+--echo ########## CASE 3 ########## 
 --connection node_1_toi
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
@@ -181,6 +190,7 @@ INSERT INTO c1 VALUES (0, 0, 0);
 --send DROP INDEX f2_key ON p1;
 
 --connection node_1
+# wait for DROP INDEX to block
 SET SESSION wsrep_sync_wait=0;
 --let $galera_sync_point = apply_monitor_master_enter_sync
 --source include/galera_wait_sync_point.inc
@@ -196,6 +206,12 @@ UPDATE c1 SET data = 1 WHERE pk = 0;
 --send COMMIT
 
 --connection node_1a
+# wait for COMMIT to block
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
 # Now unblock DROP INDEX. Without the fix it will BF-abort already certified
 # UPDATE which will cause its replay.
 --let $galera_sync_point = apply_monitor_master_enter_sync
@@ -229,6 +245,7 @@ DROP TABLE p1;
 # Additionally we test multi table drop with temporary tables included.
 #
 
+--echo ########## CASE 4 ########## 
 --connection node_1_toi
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
@@ -241,6 +258,7 @@ CREATE TEMPORARY TABLE t2 (pk INTEGER PRIMARY KEY);
 --send DROP TABLE t1, c1, t2;
 
 --connection node_1
+# wait for DROP TABLE to block
 SET SESSION wsrep_sync_wait=0;
 --let $galera_sync_point = apply_monitor_master_enter_sync
 --source include/galera_wait_sync_point.inc
@@ -256,6 +274,12 @@ INSERT INTO p1 VALUES (1,1);
 --send COMMIT
 
 --connection node_1a
+# wait for COMMIT to block
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
 # Now unblock DROP TABLE. Without the fix it will BF-abort already certified
 # INSERT which will cause its replay.
 --let $galera_sync_point = apply_monitor_master_enter_sync
@@ -293,6 +317,8 @@ DROP TABLE p1;
 # may abort the current thread.
 # In such a case we rely on wsrep_retry_autocommit functionality.
 #
+
+--echo ########## CASE 5 ########## 
 --connection node_1
 --let $wsrep_retry_autocommit_saved = `SELECT @@wsrep_retry_autocommit`
 CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
@@ -300,7 +326,7 @@ CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
 SET wsrep_retry_autocommit = 1;
 
 CREATE TABLE t1 (a INT PRIMARY KEY);
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 --send ALTER TABLE t1 ADD (b INT)
 
 --connection node_1a
@@ -316,10 +342,12 @@ DROP TABLE t1;
 #
 # Now the same, but with wsrep_retry_autocommit = 0
 #
+
+--echo ########## CASE 6 ########## 
 SET wsrep_retry_autocommit = 0;
 
 CREATE TABLE t1 (a INT PRIMARY KEY);
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 --send ALTER TABLE t1 ADD (b INT)
 
 --connection node_1a
@@ -340,15 +368,17 @@ DROP TABLE t1;
 #
 # Simulate permanent MDL lock failure
 #
+
+--echo ########## CASE 7 ########## 
 SET wsrep_retry_autocommit = 2;
 
 CREATE TABLE t1 (a INT PRIMARY KEY);
-SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="+d,wsrep_do_action_for_table_lock_fail";
 
 --error ER_LOCK_DEADLOCK
 ALTER TABLE t1 ADD (b INT);
 
-SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="-d,wsrep_do_action_for_table_lock_fail";
 
 SHOW CREATE TABLE t1;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_bf_bf_2.test
+++ b/mysql-test/suite/galera/t/galera_bf_bf_2.test
@@ -87,3 +87,41 @@
 --let $after_test_table_check = SELECT COUNT(*) = 1 FROM t2 WHERE d=2
 --let $drop_query = DROP TABLE t1, t2
 --source galera_bf_bf_2.inc
+
+#
+# Test that
+# DROP TABLE <parent_table> and concurrent UPDATE <child_table>
+# are properly ordered.
+# Originally there is a relation between parent_table and child_table.
+# However the test creates parent_table_new from parent_table and drops parent_table.
+# At the same time child table keeps the reference to the parent_table.
+#
+--let $test_case = DROP TABLE <parent_table> and concurrent UPDATE <child_table>
+--let $setup_query = CREATE TABLE parent (id INT PRIMARY KEY); CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, data INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE); INSERT INTO parent values (0); INSERT INTO child values (0, 0, 0); CREATE TABLE parent_new LIKE parent; INSERT INTO parent_new SELECT * FROM parent;
+--let $setup_check = SELECT COUNT(*) = 1 FROM parent_new
+--let $ddl_query = SET foreign_key_checks=0; DROP TABLE parent;
+--let $dml_query = UPDATE child SET data = 1 WHERE id = 0
+# After the test we expect child table to be updated
+--let $after_test_table_check = SELECT COUNT(*) = 1 FROM child WHERE id =0
+--let $drop_query = DROP TABLE parent_new, child
+--source galera_bf_bf_2.inc
+
+#
+# Test that
+# RENAME TABLE <parent_table_new> and concurrent UPDATE <child_table>
+# are properly ordered.
+# Originally there is a relation between parent_table and child_table.
+# However the test creates parent_table_new from parent_table and drops parent_table.
+# Then it renames parent_table_new back to parent_table.
+# At the same time child table keeps the reference to the parent_table.
+#
+--let $test_case = RENAME TABLE <parent_table_new> and concurrent UPDATE <child_table>
+--let $setup_query = CREATE TABLE parent (id INT PRIMARY KEY); CREATE TABLE child (id INT PRIMARY KEY, parent_id INT, data INT, FOREIGN KEY(parent_id) REFERENCES parent(id) ON DELETE CASCADE ON UPDATE CASCADE); INSERT INTO parent values (0); INSERT INTO child values (0, 0, 0); CREATE TABLE parent_new LIKE parent; INSERT INTO parent_new SELECT * FROM parent; SET foreign_key_checks=0; DROP TABLE parent;
+--let $setup_check = SELECT COUNT(*) = 1 FROM parent_new
+--let $ddl_query = RENAME TABLE parent_new TO parent
+--let $dml_query = UPDATE child SET data = 1 WHERE id = 0
+# After the test we expect child table to be updated
+--let $after_test_table_check = SELECT COUNT(*) = 1 FROM child WHERE id =0
+--let $drop_query = DROP TABLE parent, child
+--source galera_bf_bf_2.inc
+

--- a/mysql-test/suite/galera_nbo/r/galera_bf_bf.result
+++ b/mysql-test/suite/galera_nbo/r/galera_bf_bf.result
@@ -1,3 +1,4 @@
+########## CASE 1 ########## 
 SET SESSION wsrep_sync_wait = 0;
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER);
 INSERT INTO p1 VALUES (1,1);
@@ -29,6 +30,7 @@ ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 SET SESSION wsrep_osu_method=TOI;
 DROP TABLE c1;
 DROP TABLE p1;
+########## CASE 2 ########## 
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
 INSERT INTO p1 VALUES (0, 0);
@@ -43,17 +45,22 @@ SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_master_enter_sync';
 BEGIN;
 UPDATE c1 SET data = 1 WHERE pk = 0;
 COMMIT;
+SET SESSION wsrep_sync_wait=0;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_master_enter_sync';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE c1;
 DROP TABLE p1;
+########## CASE 3 ########## 
 CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
 SET wsrep_retry_autocommit = 1;
 CREATE TABLE t1 (a INT PRIMARY KEY);
 SET SESSION wsrep_osu_method=NBO;
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 ALTER TABLE t1 ADD (b INT);
 SET DEBUG_SYNC='now WAIT_FOR reached';
 ALTER TABLE t1 ADD (c INT);
@@ -67,10 +74,11 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 SET SESSION wsrep_osu_method=TOI;
 DROP TABLE t1;
+########## CASE 4 ########## 
 SET wsrep_retry_autocommit = 0;
 CREATE TABLE t1 (a INT PRIMARY KEY);
 SET SESSION wsrep_osu_method=NBO;
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 ALTER TABLE t1 ADD (b INT);
 SET DEBUG_SYNC='now WAIT_FOR reached';
 ALTER TABLE t1 ADD (c INT);
@@ -84,13 +92,14 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 SET SESSION wsrep_osu_method=TOI;
 DROP TABLE t1;
+########## CASE 5 ########## 
 SET wsrep_retry_autocommit = 2;
 CREATE TABLE t1 (a INT PRIMARY KEY);
 SET SESSION wsrep_osu_method=NBO;
-SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="+d,wsrep_do_action_for_table_lock_fail";
 ALTER TABLE t1 ADD (b INT);
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
-SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="-d,wsrep_do_action_for_table_lock_fail";
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/galera_nbo/t/galera_bf_bf.test
+++ b/mysql-test/suite/galera_nbo/t/galera_bf_bf.test
@@ -19,6 +19,7 @@
 --source include/galera_cluster.inc
 --source include/count_sessions.inc
 
+--echo ########## CASE 1 ########## 
 --connect node_1_toi, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --connection node_1_toi
 SET SESSION wsrep_sync_wait = 0;
@@ -100,6 +101,7 @@ DROP TABLE p1;
 # of the writeset related to TOI done on child table.
 #
 
+--echo ########## CASE 2 ########## 
 --connection node_1_toi
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 INTEGER, KEY f2_key (f2));
 CREATE TABLE c1 (pk INTEGER PRIMARY KEY, data INTEGER, fk INTEGER, FOREIGN KEY (fk) REFERENCES p1(pk));
@@ -113,6 +115,7 @@ INSERT INTO c1 VALUES (0, 0, 0);
 --send DROP INDEX f2_key ON p1;
 
 --connection node_1
+# wait for DROP INDEX to block
 SET SESSION wsrep_sync_wait=0;
 --let $galera_sync_point = apply_monitor_master_enter_sync
 --source include/galera_wait_sync_point.inc
@@ -128,6 +131,12 @@ UPDATE c1 SET data = 1 WHERE pk = 0;
 --send COMMIT
 
 --connection node_1a
+# wait for COMMIT to block
+SET SESSION wsrep_sync_wait=0;
+--let $galera_sync_point = apply_monitor_master_enter_sync apply_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
 # Now unblock DROP INDEX. Without the fix it will BF-abort already certified
 # UPDATE which will cause its replay.
 --let $galera_sync_point = apply_monitor_master_enter_sync
@@ -162,6 +171,8 @@ DROP TABLE p1;
 # may abort the current thread.
 # In such a case we rely on wsrep_retry_autocommit functionality.
 #
+
+--echo ########## CASE 3 ########## 
 --connection node_1
 --let $wsrep_retry_autocommit_saved = `SELECT @@wsrep_retry_autocommit`
 CALL mtr.add_suppression(".*Unable to collect FKs metadata.*");
@@ -171,7 +182,7 @@ SET wsrep_retry_autocommit = 1;
 CREATE TABLE t1 (a INT PRIMARY KEY);
 SET SESSION wsrep_osu_method=NBO;
 
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 --send ALTER TABLE t1 ADD (b INT)
 
 --connection node_1a
@@ -189,12 +200,14 @@ DROP TABLE t1;
 #
 # Now the same, but with wsrep_retry_autocommit = 0
 #
+
+--echo ########## CASE 4 ########## 
 SET wsrep_retry_autocommit = 0;
 
 CREATE TABLE t1 (a INT PRIMARY KEY);
 SET SESSION wsrep_osu_method=NBO;
 
-SET DEBUG_SYNC='wsrep_do_action_for_tables_after_lock SIGNAL reached WAIT_FOR continue';
+SET DEBUG_SYNC='wsrep_do_action_for_table_after_lock SIGNAL reached WAIT_FOR continue';
 --send ALTER TABLE t1 ADD (b INT)
 
 --connection node_1a
@@ -217,17 +230,19 @@ DROP TABLE t1;
 #
 # Simulate permanent MDL lock failure
 #
+
+--echo ########## CASE 5 ########## 
 SET wsrep_retry_autocommit = 2;
 
 CREATE TABLE t1 (a INT PRIMARY KEY);
 SET SESSION wsrep_osu_method=NBO;
 
-SET GLOBAL debug="+d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="+d,wsrep_do_action_for_table_lock_fail";
 
 --error ER_LOCK_DEADLOCK
 ALTER TABLE t1 ADD (b INT);
 
-SET GLOBAL debug="-d,wsrep_do_action_for_tables_lock_fail";
+SET GLOBAL debug="-d,wsrep_do_action_for_table_lock_fail";
 
 SHOW CREATE TABLE t1;
 

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -64,9 +64,18 @@ extern "C" long long wsrep_thd_trx_seqno(const THD *thd) {
     return cs.toi_meta().seqno().get();
   } else if (cs.mode() == wsrep::client_state::m_nbo) {
     return cs.nbo_meta().seqno().get();
-  } else {
-    return cs.transaction().ws_meta().seqno().get();
   }
+  return cs.transaction().ws_meta().seqno().get();
+}
+
+extern "C" long long wsrep_thd_trx_depends_on_seqno(const THD *thd) {
+  const wsrep::client_state &cs = thd->wsrep_cs();
+  if (cs.mode() == wsrep::client_state::m_toi) {
+    return cs.toi_meta().depends_on().get();
+  } else if (cs.mode() == wsrep::client_state::m_nbo) {
+    return cs.nbo_meta().depends_on().get();
+  }
+  return cs.transaction().ws_meta().depends_on().get();
 }
 
 extern "C" void wsrep_thd_self_abort(THD *thd) {

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -722,8 +722,10 @@ static bool wsrep_toi_replication(THD *thd, Table_ref *tables) {
 
   wsrep::key_array keys;
 
-  if (wsrep_append_fk_parent_table(thd, tables, &keys)) {
-    return true;
+  for (Table_ref *table = tables; table; table = table->next_global) {
+    if (wsrep_append_parent_tables(thd, table, &keys)) {
+      return true;
+    }
   }
 
   /* now TOI replication, with no locks held */

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -756,8 +756,10 @@ static bool wsrep_toi_replication(THD *thd, Table_ref *tables) {
 
   wsrep::key_array keys;
 
-  if (wsrep_append_fk_parent_table(thd, tables, &keys)) {
-    return true;
+  for (Table_ref *table = tables; table; table = table->next_global) {
+    if (wsrep_append_parent_tables(thd, table, &keys)) {
+      return true;
+    }
   }
 
   /* now TOI replication, with no locks held */

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -386,17 +386,21 @@ bool Sql_cmd_alter_table::execute(THD *thd) {
     wsrep::key_array keys;
     // append tables referenced by this table
     // append tables that are referencing this table
-    if (wsrep_append_fk_parent_table(thd, first_table, &keys) ||
-        wsrep_append_child_tables(thd, first_table, &keys)) {
-      WSREP_DEBUG("TOI replication for ALTER failed");
-      return true;
+    for (Table_ref *table = first_table; table; table = table->next_global) {
+      if (wsrep_append_parent_tables(thd, table, &keys) ||
+          wsrep_append_child_tables(thd, table, &keys)) {
+        WSREP_DEBUG("TOI replication for ALTER failed. Query: %s",
+                    WSREP_QUERY(thd));
+        return true;
+      }
     }
 
     WSREP_TO_ISOLATION_BEGIN_ALTER(
         ((lex->name.str) ? lex->query_block->db : NULL),
         ((lex->name.str) ? lex->name.str : NULL), first_table, &alter_info,
         &keys) {
-      WSREP_DEBUG("TOI replication for ALTER failed");
+      WSREP_DEBUG("TOI replication for ALTER failed. Query: %s",
+                  WSREP_QUERY(thd));
       return true;
     }
   }

--- a/sql/sql_cmd_ddl_table.cc
+++ b/sql/sql_cmd_ddl_table.cc
@@ -668,10 +668,13 @@ bool Sql_cmd_create_or_drop_index_base::execute(THD *thd) {
 
 #ifdef WITH_WSREP
   wsrep::key_array keys;
-  if (wsrep_append_fk_parent_table(thd, first_table, &keys) ||
-      wsrep_append_child_tables(thd, first_table, &keys)) {
-    WSREP_DEBUG("TOI replication for CREATE/DROP INDEX failed");
-    return true;
+  for (Table_ref *table = first_table; table; table = table->next_global) {
+    if (wsrep_append_parent_tables(thd, table, &keys) ||
+        wsrep_append_child_tables(thd, table, &keys)) {
+      WSREP_DEBUG("TOI replication for CREATE/DROP INDEX failed. Query: %s",
+                  WSREP_QUERY(thd));
+      return true;
+    }
   }
   if (keys.empty()) {
     WSREP_TO_ISOLATION_BEGIN_IF(first_table->db, first_table->table_name,

--- a/sql/sql_cmd_ddl_table.cc
+++ b/sql/sql_cmd_ddl_table.cc
@@ -652,10 +652,13 @@ bool Sql_cmd_create_or_drop_index_base::execute(THD *thd) {
 
 #ifdef WITH_WSREP
   wsrep::key_array keys;
-  if (wsrep_append_fk_parent_table(thd, first_table, &keys) ||
-      wsrep_append_child_tables(thd, first_table, &keys)) {
-    WSREP_DEBUG("TOI replication for CREATE/DROP INDEX failed");
-    return true;
+  for (Table_ref *table = first_table; table; table = table->next_global) {
+    if (wsrep_append_parent_tables(thd, table, &keys) ||
+        wsrep_append_child_tables(thd, table, &keys)) {
+      WSREP_DEBUG("TOI replication for CREATE/DROP INDEX failed. Query: %s",
+                  WSREP_QUERY(thd));
+      return true;
+    }
   }
   if (keys.empty()) {
     WSREP_TO_ISOLATION_BEGIN_IF(first_table->db, first_table->table_name,

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4290,9 +4290,7 @@ int mysql_execute_command(THD *thd, bool first_level) {
     case SQLCOM_RENAME_TABLE: {
       assert(first_table == all_tables && first_table != nullptr);
       Table_ref *table;
-#ifdef WITH_WSREP
-      wsrep::key_array keys;
-#endif
+
       for (table = first_table; table; table = table->next_local->next_local) {
         if (check_access(thd, ALTER_ACL | DROP_ACL, table->db,
                          &table->grant.privilege, &table->grant.m_internal,
@@ -4301,16 +4299,6 @@ int mysql_execute_command(THD *thd, bool first_level) {
                          &table->next_local->grant.privilege,
                          &table->next_local->grant.m_internal, false, false))
           goto error;
-
-#ifdef WITH_WSREP
-        // append tables referenced by this table
-        // append tables that are referencing this table
-        if (wsrep_append_fk_parent_table(thd, table, &keys) ||
-            wsrep_append_child_tables(thd, table, &keys)) {
-          WSREP_DEBUG("TOI replication for RENAME TABLE failed");
-          goto error;
-        }
-#endif
 
         Table_ref old_list = table[0];
         Table_ref new_list = table->next_local[0];
@@ -4332,6 +4320,28 @@ int mysql_execute_command(THD *thd, bool first_level) {
       }
 
 #ifdef WITH_WSREP
+      wsrep::key_array keys;
+      for (table = first_table; table; table = table->next_global) {
+        // append tables referenced by this table
+        // append tables that are referencing this table
+        /* first_table list contains series of old_name-new_name tables.
+           Below call to wsrep_append_child_tables() will try to figure out
+           all children of a given table.
+           pt-osc does the following:
+           1. CREATE TABLE parent_new LIKE parent;
+           2. INSERT INTO parent_new SELECT * FROM parent;
+           3. SET foreign_key_checks=0;
+           4. DROP TABLE parent;
+           5. RENAME TABLE parent_new TO parent;
+
+           Here we are when executing step 5. */
+        if (wsrep_append_parent_tables(thd, table, &keys) ||
+            wsrep_append_child_tables(thd, table, &keys)) {
+          WSREP_DEBUG("TOI replication for RENAME TABLE failed. Query: %s",
+                      WSREP_QUERY(thd));
+          goto error;
+        }
+      }
       if (WSREP(thd) &&
           wsrep_to_isolation_begin(thd, nullptr, nullptr, first_table, nullptr,
                                    nullptr, &keys)) {
@@ -4423,18 +4433,24 @@ int mysql_execute_command(THD *thd, bool first_level) {
       }
 
 #ifdef WITH_WSREP
+      wsrep::key_array keys;
+      bool replicate = false;
       for (Table_ref *table = all_tables; table; table = table->next_global) {
         if (!lex->drop_temporary &&
             (!thd->is_current_stmt_binlog_format_row() ||
              !find_temporary_table(thd, table))) {
-          wsrep::key_array keys;
-          if (wsrep_append_fk_parent_table(thd, all_tables, &keys)) {
+          if (wsrep_append_parent_tables(thd, table, &keys) ||
+              wsrep_append_child_tables(thd, table, &keys)) {
+            WSREP_DEBUG("TOI replication for DROP TABLE failed. Query: %s",
+                        WSREP_QUERY(thd));
             return true;
           }
-          WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(NULL, NULL, all_tables, &keys) {
-            goto error;
-          }
-          break;
+          replicate = true;
+        }
+      }
+      if (replicate) {
+        WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(NULL, NULL, all_tables, &keys) {
+          goto error;
         }
       }
 #endif /* WITH_WSREP */

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4313,9 +4313,7 @@ int mysql_execute_command(THD *thd, bool first_level) {
     case SQLCOM_RENAME_TABLE: {
       assert(first_table == all_tables && first_table != nullptr);
       Table_ref *table;
-#ifdef WITH_WSREP
-      wsrep::key_array keys;
-#endif
+
       for (table = first_table; table; table = table->next_local->next_local) {
         if (check_access(thd, ALTER_ACL | DROP_ACL, table->db,
                          &table->grant.privilege, &table->grant.m_internal,
@@ -4324,16 +4322,6 @@ int mysql_execute_command(THD *thd, bool first_level) {
                          &table->next_local->grant.privilege,
                          &table->next_local->grant.m_internal, false, false))
           goto error;
-
-#ifdef WITH_WSREP
-        // append tables referenced by this table
-        // append tables that are referencing this table
-        if (wsrep_append_fk_parent_table(thd, table, &keys) ||
-            wsrep_append_child_tables(thd, table, &keys)) {
-          WSREP_DEBUG("TOI replication for RENAME TABLE failed");
-          goto error;
-        }
-#endif
 
         Table_ref old_list = table[0];
         Table_ref new_list = table->next_local[0];
@@ -4355,6 +4343,28 @@ int mysql_execute_command(THD *thd, bool first_level) {
       }
 
 #ifdef WITH_WSREP
+      wsrep::key_array keys;
+      for (table = first_table; table; table = table->next_global) {
+        // append tables referenced by this table
+        // append tables that are referencing this table
+        /* first_table list contains series of old_name-new_name tables.
+           Below call to wsrep_append_child_tables() will try to figure out
+           all children of a given table.
+           pt-osc does the following:
+           1. CREATE TABLE parent_new LIKE parent;
+           2. INSERT INTO parent_new SELECT * FROM parent;
+           3. SET foreign_key_checks=0;
+           4. DROP TABLE parent;
+           5. RENAME TABLE parent_new TO parent;
+
+           Here we are when executing step 5. */
+        if (wsrep_append_parent_tables(thd, table, &keys) ||
+            wsrep_append_child_tables(thd, table, &keys)) {
+          WSREP_DEBUG("TOI replication for RENAME TABLE failed. Query: %s",
+                      WSREP_QUERY(thd));
+          goto error;
+        }
+      }
       if (WSREP(thd) &&
           wsrep_to_isolation_begin(thd, nullptr, nullptr, first_table, nullptr,
                                    nullptr, &keys)) {
@@ -4446,19 +4456,22 @@ int mysql_execute_command(THD *thd, bool first_level) {
       }
 
 #ifdef WITH_WSREP
+      wsrep::key_array keys;
       for (Table_ref *table = all_tables; table; table = table->next_global) {
         if (!lex->drop_temporary &&
             (!thd->is_current_stmt_binlog_format_row() ||
              !find_temporary_table(thd, table))) {
-          wsrep::key_array keys;
-          if (wsrep_append_fk_parent_table(thd, all_tables, &keys)) {
+          if (wsrep_append_parent_tables(thd, table, &keys) ||
+              wsrep_append_child_tables(thd, table, &keys)) {
+            WSREP_DEBUG("TOI replication for DROP TABLE failed. Query: %s",
+                        WSREP_QUERY(thd));
             return true;
-          }
-          WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(NULL, NULL, all_tables, &keys) {
-            goto error;
           }
           break;
         }
+      }
+      WSREP_TO_ISOLATION_BEGIN_FK_TABLES_IF(NULL, NULL, all_tables, &keys) {
+        goto error;
       }
 #endif /* WITH_WSREP */
 

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -503,7 +503,7 @@ void Sql_cmd_truncate_table::truncate_base(THD *thd, Table_ref *table_ref) {
 #ifdef WITH_WSREP
   if (!is_perfschema_db(table_ref->db)) {
     wsrep::key_array keys;
-    if (wsrep_append_fk_parent_table(thd, table_ref, &keys)) {
+    if (wsrep_append_parent_tables(thd, table_ref, &keys)) {
       return;
     }
     if (keys.empty()) {

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -503,7 +503,7 @@ void Sql_cmd_truncate_table::truncate_base(THD *thd, Table_ref *table_ref) {
 #ifdef WITH_WSREP
   if (wsrep_should_replicate_for_table(table_ref)) {
     wsrep::key_array keys;
-    if (wsrep_append_fk_parent_table(thd, table_ref, &keys)) {
+    if (wsrep_append_parent_tables(thd, table_ref, &keys)) {
       return;
     }
     if (keys.empty()) {

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1788,76 +1788,78 @@ wsrep::key_array wsrep_prepare_keys_for_toi(const char *db, const char *table,
 }
 
 /*
- * Iterate over the list of tables and for each non-temporary invoke the
- * action function.
+ * Do the provided action for a given table. If table is not found in DD,
+ * do a fallback action directly on a provided Table_ref.
+ * Skip temporary tables during processing.
  */
 using action_fn = std::function<void(const dd::Table *)>;
-static bool wsrep_do_action_for_tables(THD *thd, Table_ref *tables,
-                                       action_fn action) {
+using fallback_action_fn = std::function<void(Table_ref *)>;
+static bool wsrep_do_action_for_table(
+    THD *thd, Table_ref *table, action_fn action,
+    fallback_action_fn fallback_action = nullptr) {
   if (!WSREP(thd) || !WSREP_CLIENT(thd)) return false;
 
   // If we fail to collect FK meta data, we set the error and return true.
   // That will trigger retry logic inside wsrep_dispatch_sql_command()
-  for (auto table = tables; table; table = table->next_local) {
-    if (!is_temporary_table(table)) {
-      DBUG_EXECUTE_IF("wsrep_do_action_for_tables_lock_fail", {
-        my_error(ER_LOCK_DEADLOCK, MYF(0));
-        return true;
-      });
+  if (!is_temporary_table(table)) {
+    DBUG_EXECUTE_IF("wsrep_do_action_for_table_lock_fail", {
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      return true;
+    });
 
-      MDL_ticket *mdl_ticket = nullptr;
-      if (dd::acquire_shared_table_mdl(thd, table->db, table->table_name, false,
-                                       &mdl_ticket)) {
-        WSREP_WARN(
-            "Unable to acquire shared lock on db: %s, table: %s for FKs "
-            "collection",
-            table->db, table->table_name);
-        my_error(ER_LOCK_DEADLOCK, MYF(0));
-        return true;
-      }
+    MDL_ticket *mdl_ticket = nullptr;
+    if (dd::acquire_shared_table_mdl(thd, table->db, table->table_name, false,
+                                     &mdl_ticket)) {
+      WSREP_WARN(
+          "Unable to acquire shared lock on db: %s, table: %s for FKs "
+          "collection",
+          table->db, table->table_name);
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      return true;
+    }
 
-      DEBUG_SYNC(thd, "wsrep_do_action_for_tables_after_lock");
+    DEBUG_SYNC(thd, "wsrep_do_action_for_table_after_lock");
+
+    {
+      /*
+        Dictionary_client does aggressive validation against MDLs locked
+        during the time when DD objects are acquired.
+        Keep the MDL lock as long as the Auto_releaser is alive
+        and unlock just after Auto_releaser destruction.
+      */
+      raii::Sentry<> mdl_release_guard{
+          [thd, mdl_ticket]() -> void { dd::release_mdl(thd, mdl_ticket); }};
 
       {
-        /*
-          Dictionary_client does aggressive validation against MDLs locked
-          during the time when DD objects are acquired.
-          Keep the MDL lock as long as the Auto_releaser is alive
-          and unlock just after Auto_releaser destruction.
-        */
-        raii::Sentry<> mdl_release_guard{
-            [thd, mdl_ticket]() -> void { dd::release_mdl(thd, mdl_ticket); }};
+        const dd::Table *table_obj = nullptr;
+        dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
+        if (thd->dd_client()->acquire(dd::String_type(table->db),
+                                      dd::String_type(table->table_name),
+                                      &table_obj)) {
+          WSREP_WARN(
+              "Unable to acquire dd_client for db: %s, table: %s for FKs "
+              "collection",
+              table->db, table->table_name);
+          my_error(ER_LOCK_DEADLOCK, MYF(0));
+          return true;
+        }
 
-        {
-          const dd::Table *table_obj = nullptr;
-          dd::cache::Dictionary_client::Auto_releaser releaser(
-              thd->dd_client());
-          if (thd->dd_client()->acquire(dd::String_type(table->db),
-                                        dd::String_type(table->table_name),
-                                        &table_obj)) {
-            WSREP_WARN(
-                "Unable to acquire dd_client for db: %s, table: %s for FKs "
-                "collection",
-                table->db, table->table_name);
-            my_error(ER_LOCK_DEADLOCK, MYF(0));
-            return true;
-          }
+        if (table_obj != nullptr) {
+          action(table_obj);
+        } else if (fallback_action) {
+          fallback_action(table);
+        }
+      }  // The end of Dictionary_client::Auto_releaser scope
+    }    // The end of mdl_release_guard scope
 
-          if (table_obj != nullptr) {
-            action(table_obj);
-          }
-        }  // The end of Dictionary_client::Auto_releaser scope
-      }    // The end of mdl_release_guard scope
-
-      // We might have been aborted in the meantime by some other TOI
-      if (thd->killed == THD::KILL_QUERY) {
-        WSREP_WARN(
-            "Unable to collect FKs metadata for db: %s, table: %s for FKs "
-            "collection",
-            table->db, table->table_name);
-        my_error(ER_LOCK_DEADLOCK, MYF(0));
-        return true;
-      }
+    // We might have been aborted in the meantime by some other TOI
+    if (thd->killed == THD::KILL_QUERY) {
+      WSREP_WARN(
+          "Unable to collect FKs metadata for db: %s, table: %s for FKs "
+          "collection",
+          table->db, table->table_name);
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      return true;
     }
   }
 
@@ -1865,47 +1867,65 @@ static bool wsrep_do_action_for_tables(THD *thd, Table_ref *tables,
 }
 
 /*
- * Collect wsrep keys corresponding to child tables
+ * Collect wsrep keys corresponding to child tables of the provided table
  */
-bool wsrep_append_child_tables(THD *thd, Table_ref *tables,
+bool wsrep_append_child_tables(THD *thd, Table_ref *table,
                                wsrep::key_array *keys) {
   auto populate_child_tables = [thd](const dd::Table *table_def) {
     for (const auto fk : table_def->foreign_key_parents()) {
-      std::pair<std::string, std::string> table = std::make_pair(
-          fk->child_schema_name().c_str(), fk->child_table_name().c_str());
-
-      thd->wsrep_thd_context.get_fk_child_tables().push_back(table);
+      thd->wsrep_thd_context.get_fk_child_tables().insert(
+          {fk->child_schema_name().c_str(), fk->child_table_name().c_str()});
     }
   };
 
-  if (wsrep_do_action_for_tables(thd, tables, populate_child_tables))
+  auto populate_child_tables_fallback = [thd](const Table_ref *table_ref) {
+    std::vector<dd::String_type> children_dbs;
+    std::vector<dd::String_type> children_names;
+
+    if (thd->dd_client()->fetch_fk_children_uncached(
+            table_ref->get_db_name(), table_ref->get_table_name(), "InnoDB",
+            true, &children_dbs, &children_names)) {
+      return;
+    }
+
+    for (size_t i = 0; i < children_names.size(); ++i) {
+      thd->wsrep_thd_context.get_fk_child_tables().insert(
+          {children_dbs[i].c_str(), children_names[i].c_str()});
+    }
+  };
+
+  if (wsrep_do_action_for_table(thd, table, populate_child_tables,
+                                populate_child_tables_fallback)) {
+    WSREP_DEBUG("Failed to collect child tables of table db: %s, table: %s",
+                table->db, table->table_name);
     return true;
+  }
 
   for (const auto &table_obj : thd->wsrep_thd_context.get_fk_child_tables()) {
     keys->push_back(wsrep_prepare_key_for_toi(
         table_obj.first.c_str(), table_obj.second.c_str(), wsrep::key::shared));
   }
-
   return false;
 }
 
 /*
- * Collect wsrep keys corresponding to parent  tables
+ * Collect wsrep keys corresponding to parent tables of the provided table
  */
-bool wsrep_append_fk_parent_table(THD *thd, Table_ref *tables,
-                                  wsrep::key_array *keys) {
+bool wsrep_append_parent_tables(THD *thd, Table_ref *table,
+                                wsrep::key_array *keys) {
   auto populate_parent_tables = [thd](const dd::Table *table_def) {
     for (const auto fk : table_def->foreign_keys()) {
-      std::pair<std::string, std::string> table =
-          std::make_pair(fk->referenced_table_schema_name().c_str(),
-                         fk->referenced_table_name().c_str());
-
-      thd->wsrep_thd_context.get_fk_parent_tables().push_back(table);
+      thd->wsrep_thd_context.get_fk_parent_tables().insert(
+          {fk->referenced_table_schema_name().c_str(),
+           fk->referenced_table_name().c_str()});
     }
   };
 
-  if (wsrep_do_action_for_tables(thd, tables, populate_parent_tables))
+  if (wsrep_do_action_for_table(thd, table, populate_parent_tables)) {
+    WSREP_DEBUG("Failed to collect parent tables of table db: %s, table: %s",
+                table->db, table->table_name);
     return true;
+  }
 
   for (const auto &table_obj : thd->wsrep_thd_context.get_fk_parent_tables()) {
     keys->push_back(wsrep_prepare_key_for_toi(
@@ -3111,29 +3131,34 @@ void wsrep_to_isolation_end(THD *thd) {
   DEBUG_SYNC(thd, "wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton");
 }
 
-#define WSREP_MDL_LOG(severity, msg, schema, schema_len, req, gra)           \
-  WSREP_##severity(                                                          \
-      "%s\n\n"                                                               \
-      "schema:  %.*s\n"                                                      \
-      "request: (thd-tid:%u \tseqno:%lld \texec-mode:%s, query-state:%s,"    \
-      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n\n"        \
-      "granted: (thd-tid:%u \tseqno:%lld \texec-mode:%s, query-state:%s,"    \
-      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n",         \
-      msg, schema_len, schema, req->thread_id(),                             \
-                                                                             \
-      (long long)wsrep_thd_trx_seqno(req), wsrep_thd_client_mode_str(req),   \
-      wsrep_thd_client_state_str(req), wsrep_thd_transaction_state_str(req), \
-      req->get_command(), req->lex->sql_command,                             \
-      (req->rewritten_query().length()                                       \
-           ? wsrep_thd_rewritten_query(req).c_ptr_safe()                     \
-           : req->query().str),                                              \
-                                                                             \
-      gra->thread_id(), (long long)wsrep_thd_trx_seqno(gra),                 \
-      wsrep_thd_client_mode_str(gra), wsrep_thd_client_state_str(gra),       \
-      wsrep_thd_transaction_state_str(gra), gra->get_command(),              \
-      gra->lex->sql_command,                                                 \
-      (gra->rewritten_query().length()                                       \
-           ? wsrep_thd_rewritten_query(gra).c_ptr_safe()                     \
+#define WSREP_MDL_LOG(severity, msg, schema, schema_len, req, gra)          \
+  WSREP_##severity(                                                         \
+      "%s\n\n"                                                              \
+      "schema:  %.*s\n"                                                     \
+      "request: (thd-tid:%u \tseqno:%lld \tdep_seqno:%lld \texec-mode:%s, " \
+      "query-state:%s,"                                                     \
+      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n\n"       \
+      "granted: (thd-tid:%u \tseqno:%lld \tdep_seqno:%lld \texec-mode:%s, " \
+      "query-state:%s,"                                                     \
+      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n",        \
+      msg, schema_len, schema, req->thread_id(),                            \
+                                                                            \
+      (long long)wsrep_thd_trx_seqno(req),                                  \
+      (long long)wsrep_thd_trx_depends_on_seqno(req),                       \
+      wsrep_thd_client_mode_str(req), wsrep_thd_client_state_str(req),      \
+      wsrep_thd_transaction_state_str(req), req->get_command(),             \
+      req->lex->sql_command,                                                \
+      (req->rewritten_query().length()                                      \
+           ? wsrep_thd_rewritten_query(req).c_ptr_safe()                    \
+           : req->query().str),                                             \
+                                                                            \
+      gra->thread_id(), (long long)wsrep_thd_trx_seqno(gra),                \
+      (long long)wsrep_thd_trx_depends_on_seqno(gra),                       \
+      wsrep_thd_client_mode_str(gra), wsrep_thd_client_state_str(gra),      \
+      wsrep_thd_transaction_state_str(gra), gra->get_command(),             \
+      gra->lex->sql_command,                                                \
+      (gra->rewritten_query().length()                                      \
+           ? wsrep_thd_rewritten_query(gra).c_ptr_safe()                    \
            : gra->query().str));
 
 /* Returns true if BF-abort was done, false otherwise */

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1788,76 +1788,78 @@ wsrep::key_array wsrep_prepare_keys_for_toi(const char *db, const char *table,
 }
 
 /*
- * Iterate over the list of tables and for each non-temporary invoke the
- * action function.
+ * Do the provided action for a given table. If table is not found in DD,
+ * do a fallback action directly on a provided Table_ref.
+ * Skip temporary tables during processing.
  */
 using action_fn = std::function<void(const dd::Table *)>;
-static bool wsrep_do_action_for_tables(THD *thd, Table_ref *tables,
-                                       action_fn action) {
+using fallback_action_fn = std::function<void(Table_ref *)>;
+static bool wsrep_do_action_for_table(
+    THD *thd, Table_ref *table, action_fn action,
+    fallback_action_fn fallback_action = nullptr) {
   if (!WSREP(thd) || !WSREP_CLIENT(thd)) return false;
 
   // If we fail to collect FK meta data, we set the error and return true.
   // That will trigger retry logic inside wsrep_dispatch_sql_command()
-  for (auto table = tables; table; table = table->next_local) {
-    if (!is_temporary_table(table)) {
-      DBUG_EXECUTE_IF("wsrep_do_action_for_tables_lock_fail", {
-        my_error(ER_LOCK_DEADLOCK, MYF(0));
-        return true;
-      });
+  if (!is_temporary_table(table)) {
+    DBUG_EXECUTE_IF("wsrep_do_action_for_table_lock_fail", {
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      return true;
+    });
 
-      MDL_ticket *mdl_ticket = nullptr;
-      if (dd::acquire_shared_table_mdl(thd, table->db, table->table_name, false,
-                                       &mdl_ticket)) {
-        WSREP_WARN(
-            "Unable to acquire shared lock on db: %s, table: %s for FKs "
-            "collection",
-            table->db, table->table_name);
-        my_error(ER_LOCK_DEADLOCK, MYF(0));
-        return true;
-      }
+    MDL_ticket *mdl_ticket = nullptr;
+    if (dd::acquire_shared_table_mdl(thd, table->db, table->table_name, false,
+                                     &mdl_ticket)) {
+      WSREP_WARN(
+          "Unable to acquire shared lock on db: %s, table: %s for FKs "
+          "collection",
+          table->db, table->table_name);
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      return true;
+    }
 
-      DEBUG_SYNC(thd, "wsrep_do_action_for_tables_after_lock");
+    DEBUG_SYNC(thd, "wsrep_do_action_for_table_after_lock");
+
+    {
+      /*
+        Dictionary_client does aggressive validation against MDLs locked
+        during the time when DD objects are acquired.
+        Keep the MDL lock as long as the Auto_releaser is alive
+        and unlock just after Auto_releaser destruction.
+      */
+      raii::Sentry<> mdl_release_guard{
+          [thd, mdl_ticket]() -> void { dd::release_mdl(thd, mdl_ticket); }};
 
       {
-        /*
-          Dictionary_client does aggressive validation against MDLs locked
-          during the time when DD objects are acquired.
-          Keep the MDL lock as long as the Auto_releaser is alive
-          and unlock just after Auto_releaser destruction.
-        */
-        raii::Sentry<> mdl_release_guard{
-            [thd, mdl_ticket]() -> void { dd::release_mdl(thd, mdl_ticket); }};
+        const dd::Table *table_obj = nullptr;
+        dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
+        if (thd->dd_client()->acquire(dd::String_type(table->db),
+                                      dd::String_type(table->table_name),
+                                      &table_obj)) {
+          WSREP_WARN(
+              "Unable to acquire dd_client for db: %s, table: %s for FKs "
+              "collection",
+              table->db, table->table_name);
+          my_error(ER_LOCK_DEADLOCK, MYF(0));
+          return true;
+        }
 
-        {
-          const dd::Table *table_obj = nullptr;
-          dd::cache::Dictionary_client::Auto_releaser releaser(
-              thd->dd_client());
-          if (thd->dd_client()->acquire(dd::String_type(table->db),
-                                        dd::String_type(table->table_name),
-                                        &table_obj)) {
-            WSREP_WARN(
-                "Unable to acquire dd_client for db: %s, table: %s for FKs "
-                "collection",
-                table->db, table->table_name);
-            my_error(ER_LOCK_DEADLOCK, MYF(0));
-            return true;
-          }
+        if (table_obj != nullptr) {
+          action(table_obj);
+        } else if (fallback_action) {
+          fallback_action(table);
+        }
+      }  // The end of Dictionary_client::Auto_releaser scope
+    }    // The end of mdl_release_guard scope
 
-          if (table_obj != nullptr) {
-            action(table_obj);
-          }
-        }  // The end of Dictionary_client::Auto_releaser scope
-      }    // The end of mdl_release_guard scope
-
-      // We might have been aborted in the meantime by some other TOI
-      if (thd->killed == THD::KILL_QUERY) {
-        WSREP_WARN(
-            "Unable to collect FKs metadata for db: %s, table: %s for FKs "
-            "collection",
-            table->db, table->table_name);
-        my_error(ER_LOCK_DEADLOCK, MYF(0));
-        return true;
-      }
+    // We might have been aborted in the meantime by some other TOI
+    if (thd->killed == THD::KILL_QUERY) {
+      WSREP_WARN(
+          "Unable to collect FKs metadata for db: %s, table: %s for FKs "
+          "collection",
+          table->db, table->table_name);
+      my_error(ER_LOCK_DEADLOCK, MYF(0));
+      return true;
     }
   }
 
@@ -1865,47 +1867,65 @@ static bool wsrep_do_action_for_tables(THD *thd, Table_ref *tables,
 }
 
 /*
- * Collect wsrep keys corresponding to child tables
+ * Collect wsrep keys corresponding to child tables of the provided table
  */
-bool wsrep_append_child_tables(THD *thd, Table_ref *tables,
+bool wsrep_append_child_tables(THD *thd, Table_ref *table,
                                wsrep::key_array *keys) {
   auto populate_child_tables = [thd](const dd::Table *table_def) {
     for (const auto fk : table_def->foreign_key_parents()) {
-      std::pair<std::string, std::string> table = std::make_pair(
-          fk->child_schema_name().c_str(), fk->child_table_name().c_str());
-
-      thd->wsrep_thd_context.get_fk_child_tables().push_back(table);
+      thd->wsrep_thd_context.get_fk_child_tables().insert(
+          {fk->child_schema_name().c_str(), fk->child_table_name().c_str()});
     }
   };
 
-  if (wsrep_do_action_for_tables(thd, tables, populate_child_tables))
+  auto populate_child_tables_fallback = [thd](const Table_ref *table_ref) {
+    std::vector<dd::String_type> children_dbs;
+    std::vector<dd::String_type> children_names;
+
+    if (thd->dd_client()->fetch_fk_children_uncached(
+            table_ref->get_db_name(), table_ref->get_table_name(), "InnoDB",
+            true, &children_dbs, &children_names)) {
+      return;
+    }
+
+    for (size_t i = 0; i < children_names.size(); ++i) {
+      thd->wsrep_thd_context.get_fk_child_tables().insert(
+          {children_dbs[i].c_str(), children_names[i].c_str()});
+    }
+  };
+
+  if (wsrep_do_action_for_table(thd, table, populate_child_tables,
+                                populate_child_tables_fallback)) {
+    WSREP_DEBUG("Failed to collect child tables of table db: %s, table: %s",
+                table->db, table->table_name);
     return true;
+  }
 
   for (const auto &table_obj : thd->wsrep_thd_context.get_fk_child_tables()) {
     keys->push_back(wsrep_prepare_key_for_toi(
         table_obj.first.c_str(), table_obj.second.c_str(), wsrep::key::shared));
   }
-
   return false;
 }
 
 /*
- * Collect wsrep keys corresponding to parent  tables
+ * Collect wsrep keys corresponding to parent tables of the provided table
  */
-bool wsrep_append_fk_parent_table(THD *thd, Table_ref *tables,
-                                  wsrep::key_array *keys) {
+bool wsrep_append_parent_tables(THD *thd, Table_ref *table,
+                                wsrep::key_array *keys) {
   auto populate_parent_tables = [thd](const dd::Table *table_def) {
     for (const auto fk : table_def->foreign_keys()) {
-      std::pair<std::string, std::string> table =
-          std::make_pair(fk->referenced_table_schema_name().c_str(),
-                         fk->referenced_table_name().c_str());
-
-      thd->wsrep_thd_context.get_fk_parent_tables().push_back(table);
+      thd->wsrep_thd_context.get_fk_parent_tables().insert(
+          {fk->referenced_table_schema_name().c_str(),
+           fk->referenced_table_name().c_str()});
     }
   };
 
-  if (wsrep_do_action_for_tables(thd, tables, populate_parent_tables))
+  if (wsrep_do_action_for_table(thd, table, populate_parent_tables)) {
+    WSREP_DEBUG("Failed to collect parent tables of table db: %s, table: %s",
+                table->db, table->table_name);
     return true;
+  }
 
   for (const auto &table_obj : thd->wsrep_thd_context.get_fk_parent_tables()) {
     keys->push_back(wsrep_prepare_key_for_toi(
@@ -3112,29 +3132,34 @@ void wsrep_to_isolation_end(THD *thd) {
   DEBUG_SYNC(thd, "wsrep_to_isolation_end_after_wsrep_skip_wsrep_hton");
 }
 
-#define WSREP_MDL_LOG(severity, msg, schema, schema_len, req, gra)           \
-  WSREP_##severity(                                                          \
-      "%s\n\n"                                                               \
-      "schema:  %.*s\n"                                                      \
-      "request: (thd-tid:%u \tseqno:%lld \texec-mode:%s, query-state:%s,"    \
-      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n\n"        \
-      "granted: (thd-tid:%u \tseqno:%lld \texec-mode:%s, query-state:%s,"    \
-      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n",         \
-      msg, schema_len, schema, req->thread_id(),                             \
-                                                                             \
-      (long long)wsrep_thd_trx_seqno(req), wsrep_thd_client_mode_str(req),   \
-      wsrep_thd_client_state_str(req), wsrep_thd_transaction_state_str(req), \
-      req->get_command(), req->lex->sql_command,                             \
-      (req->rewritten_query().length()                                       \
-           ? wsrep_thd_rewritten_query(req).c_ptr_safe()                     \
-           : req->query().str),                                              \
-                                                                             \
-      gra->thread_id(), (long long)wsrep_thd_trx_seqno(gra),                 \
-      wsrep_thd_client_mode_str(gra), wsrep_thd_client_state_str(gra),       \
-      wsrep_thd_transaction_state_str(gra), gra->get_command(),              \
-      gra->lex->sql_command,                                                 \
-      (gra->rewritten_query().length()                                       \
-           ? wsrep_thd_rewritten_query(gra).c_ptr_safe()                     \
+#define WSREP_MDL_LOG(severity, msg, schema, schema_len, req, gra)          \
+  WSREP_##severity(                                                         \
+      "%s\n\n"                                                              \
+      "schema:  %.*s\n"                                                     \
+      "request: (thd-tid:%u \tseqno:%lld \tdep_seqno:%lld \texec-mode:%s, " \
+      "query-state:%s,"                                                     \
+      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n\n"       \
+      "granted: (thd-tid:%u \tseqno:%lld \tdep_seqno:%lld \texec-mode:%s, " \
+      "query-state:%s,"                                                     \
+      " conflict-state:%s)\n          cmd-code:%d %d \tquery:%s)\n",        \
+      msg, schema_len, schema, req->thread_id(),                            \
+                                                                            \
+      (long long)wsrep_thd_trx_seqno(req),                                  \
+      (long long)wsrep_thd_trx_depends_on_seqno(req),                       \
+      wsrep_thd_client_mode_str(req), wsrep_thd_client_state_str(req),      \
+      wsrep_thd_transaction_state_str(req), req->get_command(),             \
+      req->lex->sql_command,                                                \
+      (req->rewritten_query().length()                                      \
+           ? wsrep_thd_rewritten_query(req).c_ptr_safe()                    \
+           : req->query().str),                                             \
+                                                                            \
+      gra->thread_id(), (long long)wsrep_thd_trx_seqno(gra),                \
+      (long long)wsrep_thd_trx_depends_on_seqno(gra),                       \
+      wsrep_thd_client_mode_str(gra), wsrep_thd_client_state_str(gra),      \
+      wsrep_thd_transaction_state_str(gra), gra->get_command(),             \
+      gra->lex->sql_command,                                                \
+      (gra->rewritten_query().length()                                      \
+           ? wsrep_thd_rewritten_query(gra).c_ptr_safe()                    \
            : gra->query().str));
 
 /* Returns true if BF-abort was done, false otherwise */

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -253,8 +253,8 @@ extern enum wsrep::provider::status wsrep_sync_wait_upto_gtid(
 extern void wsrep_last_committed_id(wsrep_gtid_t *gtid);
 extern int wsrep_check_opts(int argc, char *const *argv);
 extern void wsrep_prepend_PATH(const char *path);
-bool wsrep_append_fk_parent_table(THD *thd, Table_ref *table,
-                                  wsrep::key_array *keys);
+bool wsrep_append_parent_tables(THD *thd, Table_ref *table,
+                                wsrep::key_array *keys);
 bool wsrep_append_child_tables(THD *thd, Table_ref *tables,
                                wsrep::key_array *keys);
 

--- a/sql/wsrep_thd_context.cc
+++ b/sql/wsrep_thd_context.cc
@@ -17,11 +17,13 @@
 
 #include "sql/wsrep_thd_context.h"  // Wsrep_thd_context
 
-std::vector<wsrep_table_t> &Wsrep_thd_context::get_fk_parent_tables() {
+std::multimap<std::string, std::string>
+    &Wsrep_thd_context::get_fk_parent_tables() {
   return fk_parent_tables;
 }
 
-std::vector<wsrep_table_t> &Wsrep_thd_context::get_fk_child_tables() {
+std::multimap<std::string, std::string>
+    &Wsrep_thd_context::get_fk_child_tables() {
   return fk_child_tables;
 }
 

--- a/sql/wsrep_thd_context.h
+++ b/sql/wsrep_thd_context.h
@@ -18,10 +18,8 @@
 #ifndef WSREP_THD_CONTEXT_H
 #define WSREP_THD_CONTEXT_H
 
+#include <map>
 #include <string>
-#include <vector>
-
-using wsrep_table_t = std::pair<std::string, std::string>;
 
 /*
   This class encapsulates the wsrep context associated with the THD
@@ -29,8 +27,16 @@ using wsrep_table_t = std::pair<std::string, std::string>;
  */
 class Wsrep_thd_context {
  private:
-  std::vector<wsrep_table_t> fk_parent_tables;
-  std::vector<wsrep_table_t> fk_child_tables;
+  /*
+    We cache keys related to parent/child tables for some TOIs.
+    We need this cache, because of what is said in comment of
+    wsrep::key::append_key_part():
+    "The caller is supposed to take
+     care that the pointer remains valid over the lifetime
+     if the key object"
+  */
+  std::multimap<std::string, std::string> fk_parent_tables;
+  std::multimap<std::string, std::string> fk_child_tables;
 
   Wsrep_thd_context(const Wsrep_thd_context &) = delete;  // copy constructor
   Wsrep_thd_context operator=(Wsrep_thd_context &&) =
@@ -42,8 +48,8 @@ class Wsrep_thd_context {
   Wsrep_thd_context() {}
   void clear();
 
-  std::vector<wsrep_table_t> &get_fk_parent_tables();
-  std::vector<wsrep_table_t> &get_fk_child_tables();
+  std::multimap<std::string, std::string> &get_fk_parent_tables();
+  std::multimap<std::string, std::string> &get_fk_child_tables();
 };
 
 #endif /* WSREP_THD_CONTEXT_H */


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4789

Problem 1:
There are two tables: 'parent' and 'child'. 'child' holding the FK of
the 'parent'. If we do SET foreign_key_checks=0, it is possible to drop
'parent'.
If such a DROP statement is executed in parallel to UPDATE on 'child'
table, it leads to BF-BF abort conflict on replica.

Cause 1:
DROP TABLE 'parent' acquires MDL locks on 'parent' and 'child' tables.
UPDATE 'child' acquires MDL lock on 'child' table. So these transactions
cannot apply in parallel on replica side - they are dependent.
However, the certification key related to 'child' table was not added
to the writeset of DDL, so certification process considered DDL and DML
not dependent.

Solution 1:
Add 'child' table to the certification keys of DDL. This way
the dependency will be detected and set correctly.

Problem 2:
pt-osc creates 'parent_new' table, then drops 'parent' table and finally
renames 'parent_new' to 'parent'.
Such RENAME of 'parent_new', and simultaneous UPDATE on 'child' table,
cause BF-BF abort on replica node.

Cause 2:
RENAME acquires MDL locks on 'parent_new' 'parent' and 'child' tables.
UPDATE acquires MDL lock on 'child' table.
So these transactions are dependent and should be ordered one after
another. However, when renaming 'parent_new' to 'parent', it is not
possible to get information about 'child' table from DD ('parent_new'
does not have children, 'parent' table object does not exist in DD).
Because of this 'child' table was not added to the certification keys of
DDL. Dependency was not detected, and transactions were allowed to run
in parallel on the replica side causing BF-BF conflict.

Solution:
Improve mechanism of table children detection. In case of no parent
table object in DD, fall back to querying foreign keys table directly.