### PR TITLE
(8.4) PXC-4770: Move "Pro" features into the community version 

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -430,19 +430,22 @@ function get_length_in_bytes()
 }
 
 # Returns the version string in a standardized format
-# Input "1.2.3" => echoes "010203"
+# Input "1.2.3-4" => echoes "01020304"
 # Wrongly formatted values => echoes "000000"
+# 1.2 are mandatory
+# 3-4 are optional. If not provided, the function will normalize each of them
+# as 00
 #
 # Globals:
 #   None
 #
 # Arguments:
 #   Parameter 1: a version string
-#                like "5.1.12"
-#                anything after the major.minor.revision is ignored
+#                like "8.4.0-5"
+#                anything after the major.minor.revision-build is ignored
 # Outputs:
 #   A string that can be used directly with string comparisons.
-#   So, the string "5.1.12" is transformed into "050112"
+#   So, the string "8.4.0-5" is transformed into "08040005"
 #   Note that individual version numbers can only go up to 99.
 #
 function normalize_version()
@@ -450,16 +453,17 @@ function normalize_version()
     local major=0
     local minor=0
     local patch=0
-
-    # Only parses purely numeric version numbers, 1.2.3
-    # Everything after the first three values are ignored
-    if [[ $1 =~ ^([0-9]+)\.([0-9]+)\.?([0-9]*)([^ ])* ]]; then
+    local build=0
+    # Only parses purely numeric version numbers, 1.2.3-4
+    # Everything after the first four values is ignored
+    if [[ $1 =~ ^([0-9]+)\.([0-9]+)\.?([0-9]*)\-?([0-9]*)([^ ])* ]]; then
         major=${BASH_REMATCH[1]}
         minor=${BASH_REMATCH[2]}
         patch=${BASH_REMATCH[3]}
+        build=${BASH_REMATCH[4]}
     fi
 
-    printf %02d%02d%02d $major $minor $patch
+    printf %02d%02d%02d%02d $major $minor $patch $build
 }
 
 # Compares two version strings

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -123,6 +123,12 @@ fi
 pcmd=""
 declare -a RC
 
+# regex to extract pxb version from xtrabackup --version output
+# major - mandatory, multiple digits
+# minor - mandatory, multiple digits
+# patch - optional, multiple digits
+# build - optional, multiple digits
+xb_version_regex=' [0-9]\+\(\.[0-9]\+\)\{1,2\}\(-[0-9]\+\)\?'
 # default XB (xtrabackup-binary) to use.
 XTRABACKUP_BIN=xtrabackup
 DATA="${WSREP_SST_OPT_DATA}"
@@ -185,7 +191,7 @@ XTRABACKUP_PREV_LTS_VER_PATH="$(dirname $0)/pxc_extra/pxb-8.0"
 
 # Minimum PXB required versions for this node to work
 # To be able to service this version
-XB_THIS_REQUIRED_VERSION="8.4.0"
+XB_THIS_REQUIRED_VERSION="8.4.0-5"
 # To be able to service previous version
 XB_PREV_REQUIRED_VERSION="8.3.0"
 # To be able to service previous LTS version
@@ -1626,25 +1632,15 @@ function initialize_pxb_commands()
     #
     # --lock-ddl option
     #
-    # Use user-provided option if set
+    # Use user-provided option if set, if not, use REDUCED by default.
+    # Starting from PXB 8.4.0-5, --lock-ddl=REDUCED is available in
+    # the community version. 8.4.0-5 is the minimum required version for this
+    # script to work (see XB_THIS_REQUIRED_VERSION))
+    lock_ddl="--lock-ddl=REDUCED"
     [[ -n "$lock_ddl_opt" ]] && lock_ddl="--lock-ddl=$lock_ddl_opt"
+    wsrep_log_info "Using PXB option ${lock_ddl} for SST"
 
-    # Check if xtrabackup (PXB) Pro version is used (supports --lock-ddl=REDUCED)
-    if ${pxb_bin_path} --version 2>&1 | grep -q -- '-pro'; then
-        if [[ -z "$lock_ddl_opt" ]]; then
-            lock_ddl="--lock-ddl=REDUCED"
-            wsrep_log_info "PXB Pro detected; using default --lock-ddl=REDUCED for SST"
-        fi
-    elif [[ "${lock_ddl_opt^^}" == "REDUCED" ]]; then
-        # If REDUCED is requested but not supported, exit with error
-        wsrep_log_error "******************* FATAL ERROR **********************"
-        wsrep_log_error "The xtrabackup version does not support --lock-ddl=REDUCED option."
-        wsrep_log_error "Line $LINENO"
-        wsrep_log_error "******************************************************"
-        safe_exit 2
-    fi
-
-    local xb_version=$(${pxb_bin_path} --version 2>&1 | grep -oe ' [0-9]\.[0-9][\.0-9]*' | head -n1)
+    local xb_version=$(${pxb_bin_path} --version 2>&1 | grep -oe ${xb_version_regex} | head -n1)
     xb_version=${xb_version# }
     wsrep_log_debug "pxb-version:$xb_version"
 
@@ -1749,7 +1745,7 @@ function verify_pxb_version()
         safe_exit 2
     fi
 
-    local xb_version=$($pxb_bin_path --version 2>&1 | grep -oe ' [0-9]\.[0-9]\.[0-9]*' | head -n1)
+    local xb_version=$($pxb_bin_path --version 2>&1 | grep -oe "${xb_version_regex}" | head -n1)
     xb_version=${xb_version# }
 
     if [[ -z "$xb_version" ]]; then
@@ -1848,7 +1844,7 @@ if [[ "$pxc_encrypt_cluster_traffic" == "on" ]]; then
             wsrep_log_error "* Please specify a CA file with the 'ssl-ca' option. "
             wsrep_log_error "* Line $LINENO"
             wsrep_log_error "**************************************************** "
-            save_exit 2
+            safe_exit 2
         fi
     fi
     if [[ -z "$ssl_cert" ]]; then


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4770

PXB-8.4.0-5 provides --lock-ddl=REDUCED option. It will be bundled with next versions of PXC. Use --lock-ddl=REDUCED option by default.