### PR TITLE
PXC-4814: Failed OPTIMIZE TABLE due to case sensitivity writes to Bin…(trunk)

### DIFF
--- a/mysql-test/suite/galera/r/galera_optimize_table_case_sensitive.result
+++ b/mysql-test/suite/galera/r/galera_optimize_table_case_sensitive.result
@@ -1,0 +1,272 @@
+##############################################################################
+# 1. Setup.
+##############################################################################
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+SELECT @@global.lower_case_table_names;
+@@global.lower_case_table_names
+0
+CREATE DATABASE reproduction_lab;
+CREATE TABLE reproduction_lab.heavy_test (id int) ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method='RSU';
+##############################################################################
+# 2. Optimize table should not be logged.
+##############################################################################
+FLUSH BINARY LOGS;
+PURGE BINARY LOGS TO '<binlog_file>';;
+OPTIMIZE TABLE Heavy_test, heavy_test;
+Table	Op	Msg_type	Msg_text
+reproduction_lab.Heavy_test	optimize	Warning	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+reproduction_lab.Heavy_test	optimize	Error	Table 'reproduction_lab.Heavy_test' doesn't exist
+reproduction_lab.Heavy_test	optimize	status	Operation failed
+reproduction_lab.heavy_test	optimize	note	Table does not support optimize, doing recreate + analyze instead
+reproduction_lab.heavy_test	optimize	status	OK
+SHOW BINLOG EVENTS IN '<binlog_file>' FROM 5;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+<binlog_file>	#	Previous_gtids	1	#	
+##############################################################################
+# 3. Base table
+##############################################################################
+CREATE TABLE t_rsu (
+id INT PRIMARY KEY,
+v  INT
+);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+##############################################################################
+# 4. ALL RSU DDL (must NOT be written to binlog)
+##############################################################################
+ALTER TABLE t_rsu ADD COLUMN v2 INT;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+TRUNCATE TABLE t_rsu;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+CREATE INDEX idx_v ON t_rsu(v);
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+DROP INDEX idx_v ON t_rsu;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+RENAME TABLE t_rsu TO t_rsu_new;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+RENAME TABLE t_rsu_new TO t_rsu;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+CREATE VIEW v_rsu AS SELECT * FROM t_rsu;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+DROP VIEW v_rsu;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+CREATE TRIGGER trg_rsu
+BEFORE INSERT ON t_rsu
+FOR EACH ROW SET NEW.v2 = 10$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+DROP TRIGGER trg_rsu$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+CREATE FUNCTION f_rsu(x INT)
+RETURNS INT
+DETERMINISTIC
+RETURN x + 1$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+DROP FUNCTION f_rsu$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+CREATE PROCEDURE p_rsu(IN x INT)
+BEGIN
+SELECT x;
+END$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+DROP PROCEDURE p_rsu$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+CREATE EVENT ev_rsu
+ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+DO
+INSERT INTO t_rsu VALUES (100,100,100)$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+DROP EVENT ev_rsu$$
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+SHOW BINLOG EVENTS IN '<binlog_file>' FROM 5;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+<binlog_file>	#	Previous_gtids	1	#	
+##############################################################################
+# 5. Admin / session commands (NOT binlogged)
+##############################################################################
+ANALYZE TABLE t_rsu;
+Table	Op	Msg_type	Msg_text
+reproduction_lab.t_rsu	analyze	Warning	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+reproduction_lab.t_rsu	analyze	status	OK
+CHECK TABLE t_rsu;
+Table	Op	Msg_type	Msg_text
+reproduction_lab.t_rsu	check	status	OK
+OPTIMIZE TABLE t_rsu;
+Table	Op	Msg_type	Msg_text
+reproduction_lab.t_rsu	optimize	Warning	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+reproduction_lab.t_rsu	optimize	note	Table does not support optimize, doing recreate + analyze instead
+reproduction_lab.t_rsu	optimize	status	OK
+DROP TABLE t_rsu;
+Warnings:
+Warning	1105	The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.
+SET SESSION autocommit=0;
+SET SESSION autocommit=1;
+SHOW BINLOG EVENTS IN '<binlog_file>' FROM 5;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+<binlog_file>	#	Previous_gtids	1	#	
+##############################################################################
+# 6. DML (MUST be written to binlog even in RSU)
+##############################################################################
+INSERT INTO reproduction_lab.heavy_test VALUES (1);
+UPDATE reproduction_lab.heavy_test SET id=99 WHERE id=1;
+DELETE FROM reproduction_lab.heavy_test WHERE id=99;
+REPLACE INTO reproduction_lab.heavy_test VALUES (2);
+SHOW BINLOG EVENTS IN '<binlog_file>' FROM 5;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+<binlog_file>	#	Previous_gtids	1	#	
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	BEGIN
+<binlog_file>	#	Table_map	1	#	table_id: # (reproduction_lab.heavy_test)
+<binlog_file>	#	Write_rows	1	#	table_id: # flags: STMT_END_F
+<binlog_file>	#	Query	1	#	COMMIT
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	BEGIN
+<binlog_file>	#	Table_map	1	#	table_id: # (reproduction_lab.heavy_test)
+<binlog_file>	#	Update_rows	1	#	table_id: # flags: STMT_END_F
+<binlog_file>	#	Query	1	#	COMMIT
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	BEGIN
+<binlog_file>	#	Table_map	1	#	table_id: # (reproduction_lab.heavy_test)
+<binlog_file>	#	Delete_rows	1	#	table_id: # flags: STMT_END_F
+<binlog_file>	#	Query	1	#	COMMIT
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	BEGIN
+<binlog_file>	#	Table_map	1	#	table_id: # (reproduction_lab.heavy_test)
+<binlog_file>	#	Write_rows	1	#	table_id: # flags: STMT_END_F
+<binlog_file>	#	Query	1	#	COMMIT
+##############################################################################
+# 7. ALL TOI DDL (must be written to binlog)
+##############################################################################
+SET SESSION wsrep_OSU_method='TOI';
+FLUSH BINARY LOGS;
+PURGE BINARY LOGS TO '<binlog_file>';;
+CREATE TABLE t_rsu (
+id INT PRIMARY KEY,
+v  INT
+);
+ALTER TABLE t_rsu ADD COLUMN v2 INT;
+TRUNCATE TABLE t_rsu;
+CREATE INDEX idx_v ON t_rsu(v);
+DROP INDEX idx_v ON t_rsu;
+RENAME TABLE t_rsu TO t_rsu_new;
+RENAME TABLE t_rsu_new TO t_rsu;
+CREATE VIEW v_rsu AS SELECT * FROM t_rsu;
+DROP VIEW v_rsu;
+CREATE TRIGGER trg_rsu
+BEFORE INSERT ON t_rsu
+FOR EACH ROW SET NEW.v2 = 10$$
+DROP TRIGGER trg_rsu$$
+CREATE FUNCTION f_rsu(x INT)
+RETURNS INT
+DETERMINISTIC
+RETURN x + 1$$
+DROP FUNCTION f_rsu$$
+CREATE PROCEDURE p_rsu(IN x INT)
+BEGIN
+SELECT x;
+END$$
+DROP PROCEDURE p_rsu$$
+CREATE EVENT ev_rsu
+ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+DO
+INSERT INTO t_rsu VALUES (100,100,100)$$
+DROP EVENT ev_rsu$$
+SHOW BINLOG EVENTS IN '<binlog_file>' FROM 5;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+<binlog_file>	#	Previous_gtids	1	#	
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; CREATE TABLE t_rsu (
+id INT PRIMARY KEY,
+v  INT
+)
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; ALTER TABLE t_rsu ADD COLUMN v2 INT
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; TRUNCATE TABLE t_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; CREATE INDEX idx_v ON t_rsu(v)
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; DROP INDEX idx_v ON t_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; RENAME TABLE t_rsu TO t_rsu_new
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; RENAME TABLE t_rsu_new TO t_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v_rsu` AS SELECT * FROM t_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; DROP VIEW v_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; CREATE DEFINER=`root`@`localhost` TRIGGER trg_rsu
+BEFORE INSERT ON t_rsu
+FOR EACH ROW SET NEW.v2 = 10
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; DROP TRIGGER trg_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; CREATE DEFINER=`root`@`localhost` FUNCTION `f_rsu`(x INT) RETURNS int
+    DETERMINISTIC
+RETURN x + 1
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; DROP FUNCTION f_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; CREATE DEFINER=`root`@`localhost` PROCEDURE `p_rsu`(IN x INT)
+BEGIN
+SELECT x;
+END
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; DROP PROCEDURE p_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; CREATE DEFINER=`root`@`localhost` EVENT ev_rsu
+ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+DO
+INSERT INTO t_rsu VALUES (100,100,100)
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; DROP EVENT ev_rsu
+##############################################################################
+# 8. Admin / session commands (binlogged)
+##############################################################################
+FLUSH BINARY LOGS;
+PURGE BINARY LOGS TO '<binlog_file>';;
+ANALYZE TABLE t_rsu;
+Table	Op	Msg_type	Msg_text
+reproduction_lab.t_rsu	analyze	status	OK
+CHECK TABLE t_rsu;
+Table	Op	Msg_type	Msg_text
+reproduction_lab.t_rsu	check	status	OK
+OPTIMIZE TABLE t_rsu;
+Table	Op	Msg_type	Msg_text
+reproduction_lab.t_rsu	optimize	note	Table does not support optimize, doing recreate + analyze instead
+reproduction_lab.t_rsu	optimize	status	OK
+DROP TABLE t_rsu;
+SET SESSION autocommit=0;
+SET SESSION autocommit=1;
+SHOW BINLOG EVENTS IN '<binlog_file>' FROM 5;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+<binlog_file>	#	Previous_gtids	1	#	
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; ANALYZE TABLE t_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; OPTIMIZE TABLE t_rsu
+<binlog_file>	#	Anonymous_Gtid	1	#	SET @@SESSION.GTID_NEXT= 'GTID';
+<binlog_file>	#	Query	1	#	use `reproduction_lab`; DROP TABLE `t_rsu` /* generated by server */
+##############################################################################
+# 9. Cleanup
+##############################################################################
+DROP DATABASE reproduction_lab;
+FLUSH BINARY LOGS;
+PURGE BINARY LOGS TO '<binlog_file>';;

--- a/mysql-test/suite/galera/t/galera_optimize_table_case_sensitive.test
+++ b/mysql-test/suite/galera/t/galera_optimize_table_case_sensitive.test
@@ -1,0 +1,266 @@
+##############################################################################
+# This test case makes sure DDL and related admin commands are not logged
+# in binlog in RSU mode but are logged in TOI mode.
+##############################################################################
+# 1. Setup.
+# 2. Base table
+# 3. Base table
+# 4. ALL RSU DDL (must NOT be written to binlog)
+# 5. Admin / session commands (NOT binlogged)
+# 6. DML (MUST be written to binlog even in RSU)
+# 7. ALL TOI DDL (must be written to binlog)
+# 8. Admin / session commands (binlogged)
+# 9. Cleanup
+##############################################################################
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--echo ##############################################################################
+--echo # 1. Setup.
+--echo ##############################################################################
+
+CALL mtr.add_suppression("The statement was neither written to the binary log nor any GTID was generated as the statement was executed with wsrep_OSU_method = RSU.");
+
+SELECT @@global.lower_case_table_names;
+
+CREATE DATABASE reproduction_lab;
+CREATE TABLE reproduction_lab.heavy_test (id int) ENGINE=InnoDB;
+
+--connect node_1a, 127.0.0.1, root,,reproduction_lab, $NODE_MYPORT_1
+--connection node_1a
+
+SET SESSION wsrep_OSU_method='RSU';
+
+--echo ##############################################################################
+--echo # 2. Optimize table should not be logged.
+--echo ##############################################################################
+
+FLUSH BINARY LOGS;
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--eval PURGE BINARY LOGS TO '$binlog_file';
+
+# Below command actually succed but while looping tables Heavy_test will error.
+# Command status and table Heavy_test case failure are 2 different thingss
+OPTIMIZE TABLE Heavy_test, heavy_test;
+
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--replace_column 2 # 5 #
+--replace_regex /\/\* xid=.* \*\//\/* XID *\// /table_id: [0-9]+/table_id: #/ /SET @@SESSION.GTID_NEXT=.*$/SET @@SESSION.GTID_NEXT= 'GTID';/ /GROUPS: .*:(.*,.*)/GROUPS: GTID:(X,X)/ / \/\* XID \*\/// /Xid/Query/
+--eval SHOW BINLOG EVENTS IN '$binlog_file' FROM 5
+
+--echo ##############################################################################
+--echo # 3. Base table
+--echo ##############################################################################
+CREATE TABLE t_rsu (
+  id INT PRIMARY KEY,
+  v  INT
+);
+
+--echo ##############################################################################
+--echo # 4. ALL RSU DDL (must NOT be written to binlog)
+--echo ##############################################################################
+
+## CREATE / ALTER / DROP / TRUNCATE
+ALTER TABLE t_rsu ADD COLUMN v2 INT;
+TRUNCATE TABLE t_rsu;
+
+## INDEX
+CREATE INDEX idx_v ON t_rsu(v);
+DROP INDEX idx_v ON t_rsu;
+
+## RENAME
+RENAME TABLE t_rsu TO t_rsu_new;
+RENAME TABLE t_rsu_new TO t_rsu;
+
+## VIEW
+CREATE VIEW v_rsu AS SELECT * FROM t_rsu;
+DROP VIEW v_rsu;
+
+## TRIGGER
+DELIMITER $$;
+CREATE TRIGGER trg_rsu
+BEFORE INSERT ON t_rsu
+FOR EACH ROW SET NEW.v2 = 10$$
+DROP TRIGGER trg_rsu$$
+DELIMITER ;$$
+
+## FUNCTION
+DELIMITER $$;
+CREATE FUNCTION f_rsu(x INT)
+RETURNS INT
+DETERMINISTIC
+RETURN x + 1$$
+DROP FUNCTION f_rsu$$
+DELIMITER ;$$
+
+## PROCEDURE
+DELIMITER $$;
+CREATE PROCEDURE p_rsu(IN x INT)
+BEGIN
+  SELECT x;
+END$$
+DROP PROCEDURE p_rsu$$
+DELIMITER ;$$
+
+## EVENT
+DELIMITER $$;
+CREATE EVENT ev_rsu
+ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+DO
+  INSERT INTO t_rsu VALUES (100,100,100)$$
+DROP EVENT ev_rsu$$
+DELIMITER ;$$
+
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--replace_column 2 # 5 #
+--replace_regex /\/\* xid=.* \*\//\/* XID *\// /table_id: [0-9]+/table_id: #/ /SET @@SESSION.GTID_NEXT=.*$/SET @@SESSION.GTID_NEXT= 'GTID';/ /GROUPS: .*:(.*,.*)/GROUPS: GTID:(X,X)/ / \/\* XID \*\/// /Xid/Query/
+--eval SHOW BINLOG EVENTS IN '$binlog_file' FROM 5
+
+--echo ##############################################################################
+--echo # 5. Admin / session commands (NOT binlogged)
+--echo ##############################################################################
+
+ANALYZE TABLE t_rsu;
+CHECK TABLE t_rsu;
+OPTIMIZE TABLE t_rsu;
+DROP TABLE t_rsu; # Cleanup
+
+SET SESSION autocommit=0;
+SET SESSION autocommit=1;
+
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--replace_column 2 # 5 #
+--replace_regex /\/\* xid=.* \*\//\/* XID *\// /table_id: [0-9]+/table_id: #/ /SET @@SESSION.GTID_NEXT=.*$/SET @@SESSION.GTID_NEXT= 'GTID';/ /GROUPS: .*:(.*,.*)/GROUPS: GTID:(X,X)/ / \/\* XID \*\/// /Xid/Query/
+--eval SHOW BINLOG EVENTS IN '$binlog_file' FROM 5
+
+--echo ##############################################################################
+--echo # 6. DML (MUST be written to binlog even in RSU)
+--echo ##############################################################################
+
+INSERT INTO reproduction_lab.heavy_test VALUES (1);
+UPDATE reproduction_lab.heavy_test SET id=99 WHERE id=1;
+DELETE FROM reproduction_lab.heavy_test WHERE id=99;
+REPLACE INTO reproduction_lab.heavy_test VALUES (2);
+
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--replace_column 2 # 5 #
+--replace_regex /\/\* xid=.* \*\//\/* XID *\// /table_id: [0-9]+/table_id: #/ /SET @@SESSION.GTID_NEXT=.*$/SET @@SESSION.GTID_NEXT= 'GTID';/ /GROUPS: .*:(.*,.*)/GROUPS: GTID:(X,X)/ / \/\* XID \*\/// /Xid/Query/
+--eval SHOW BINLOG EVENTS IN '$binlog_file' FROM 5
+
+--echo ##############################################################################
+--echo # 7. ALL TOI DDL (must be written to binlog)
+--echo ##############################################################################
+
+SET SESSION wsrep_OSU_method='TOI';
+
+FLUSH BINARY LOGS;
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--eval PURGE BINARY LOGS TO '$binlog_file';
+
+CREATE TABLE t_rsu (
+  id INT PRIMARY KEY,
+  v  INT
+);
+
+## CREATE / ALTER / DROP / TRUNCATE
+ALTER TABLE t_rsu ADD COLUMN v2 INT;
+TRUNCATE TABLE t_rsu;
+
+## INDEX
+CREATE INDEX idx_v ON t_rsu(v);
+DROP INDEX idx_v ON t_rsu;
+
+## RENAME
+RENAME TABLE t_rsu TO t_rsu_new;
+RENAME TABLE t_rsu_new TO t_rsu;
+
+## VIEW
+CREATE VIEW v_rsu AS SELECT * FROM t_rsu;
+DROP VIEW v_rsu;
+
+## TRIGGER
+DELIMITER $$;
+CREATE TRIGGER trg_rsu
+BEFORE INSERT ON t_rsu
+FOR EACH ROW SET NEW.v2 = 10$$
+DROP TRIGGER trg_rsu$$
+DELIMITER ;$$
+
+## FUNCTION
+DELIMITER $$;
+CREATE FUNCTION f_rsu(x INT)
+RETURNS INT
+DETERMINISTIC
+RETURN x + 1$$
+DROP FUNCTION f_rsu$$
+DELIMITER ;$$
+
+## PROCEDURE
+DELIMITER $$;
+CREATE PROCEDURE p_rsu(IN x INT)
+BEGIN
+  SELECT x;
+END$$
+DROP PROCEDURE p_rsu$$
+DELIMITER ;$$
+
+## EVENT
+DELIMITER $$;
+CREATE EVENT ev_rsu
+ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
+DO
+  INSERT INTO t_rsu VALUES (100,100,100)$$
+DROP EVENT ev_rsu$$
+DELIMITER ;$$
+
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--replace_column 2 # 5 #
+--replace_regex /\/\* xid=.* \*\//\/* XID *\// /table_id: [0-9]+/table_id: #/ /SET @@SESSION.GTID_NEXT=.*$/SET @@SESSION.GTID_NEXT= 'GTID';/ /GROUPS: .*:(.*,.*)/GROUPS: GTID:(X,X)/ / \/\* XID \*\/// /Xid/Query/
+--eval SHOW BINLOG EVENTS IN '$binlog_file' FROM 5
+
+--echo ##############################################################################
+--echo # 8. Admin / session commands (binlogged)
+--echo ##############################################################################
+FLUSH BINARY LOGS;
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--eval PURGE BINARY LOGS TO '$binlog_file';
+
+ANALYZE TABLE t_rsu;
+# CHECK TABLE is not written to binlog.
+CHECK TABLE t_rsu;
+OPTIMIZE TABLE t_rsu;
+DROP TABLE t_rsu; # Cleanup
+
+SET SESSION autocommit=0;
+SET SESSION autocommit=1;
+
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--replace_column 2 # 5 #
+--replace_regex /\/\* xid=.* \*\//\/* XID *\// /table_id: [0-9]+/table_id: #/ /SET @@SESSION.GTID_NEXT=.*$/SET @@SESSION.GTID_NEXT= 'GTID';/ /GROUPS: .*:(.*,.*)/GROUPS: GTID:(X,X)/ / \/\* XID \*\/// /Xid/Query/
+--eval SHOW BINLOG EVENTS IN '$binlog_file' FROM 5
+
+--echo ##############################################################################
+--echo # 9. Cleanup
+--echo ##############################################################################
+
+--disconnect node_1a
+
+--connection node_1
+--source include/wait_until_count_sessions.inc
+
+DROP DATABASE reproduction_lab;
+FLUSH BINARY LOGS;
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--replace_result $binlog_file <binlog_file>
+--eval PURGE BINARY LOGS TO '$binlog_file';
+

--- a/sql/thd_raii.h
+++ b/sql/thd_raii.h
@@ -179,9 +179,16 @@ class Disable_binlog_guard {
         m_wsrep_on(thd->variables.wsrep_on),
         m_binlog_internal_off_at_entry(thd->variables.option_bits &
                                        OPTION_BIN_LOG_INTERNAL_OFF),
+        m_no_write_to_binlog(thd->lex ? thd->lex->no_write_to_binlog : false),
         m_binlog_disabled(thd->variables.option_bits & OPTION_BIN_LOG) {
     thd->variables.option_bits &= ~OPTION_BIN_LOG;
     thd->variables.option_bits |= OPTION_BIN_LOG_INTERNAL_OFF;
+    /*
+     * no_write_to_binlog is a cleaner method and works, Disable_binlog_guard
+     * is actually not a guard since lifetime and variables are not perfectly
+     * maintained as stack so this caused old value being overwritten.
+     */
+    if (thd->lex) thd->lex->no_write_to_binlog = true;
     if (turn_off_wsrep) {
       thd->variables.wsrep_on = false;
     }
@@ -197,6 +204,7 @@ class Disable_binlog_guard {
   ~Disable_binlog_guard() {
     if (m_binlog_disabled) m_thd->variables.option_bits |= OPTION_BIN_LOG;
 #ifdef WITH_WSREP
+    if (m_thd->lex) m_thd->lex->no_write_to_binlog = m_no_write_to_binlog;
     if (!m_binlog_internal_off_at_entry) {
       m_thd->variables.option_bits &= ~OPTION_BIN_LOG_INTERNAL_OFF;
     }
@@ -209,6 +217,7 @@ class Disable_binlog_guard {
 #ifdef WITH_WSREP
   const bool m_wsrep_on;
   const bool m_binlog_internal_off_at_entry;
+  const bool m_no_write_to_binlog;
 #endif /* WITH_WSREP */
   const bool m_binlog_disabled;
 };


### PR DESCRIPTION
…log with error_code=0 when wsrep_OSU_method='RSU'

OPTIMIZE TABLE must not be written to the binary log when wsrep_OSU_method=RSU, but it could still appear in the binlog

Root cause:
Disable_binlog_guard is designed to be used as a stack-based RAII guard, for example:

  { Disable_binlog_guard binlog_guard(thd); ... }

so that binlog state is restored automatically when the scope unwinds. OPTIMIZE TABLE, however, cannot rely on such local scoping because the actual binlog write occurs outside mysql_admin_table().

To accommodate this, a shared Disable_binlog_guard is stored in thd->disable_binlog_guard. While this is functionally necessary, it breaks the intended lifetime semantics of the guard.

Additionally, wsrep_RSU_begin() is executed from mysql_admin_table(), while wsrep_RSU_end() is invoked later from wsrep_to_isolation_end() during mysql_execute_command(), further widening the lifetime gap.

As a result, once mysql_admin_table() returns, unrelated destructors (e.g. Attachable_trx, Disable_autocommit_guard) may overwrite variables.option_bits and clear OPTION_BIN_LOG before statement completion, allowing OPTIMIZE TABLE to be written to the binlog.

Resolution:
Suppress binlog writes for OPTIMIZE TABLE in RSU mode using the existing no_write_to_binlog flag. This flag is a statement-scoped THD control already used by the server for selected administrative and metadata-only operations (such as OPTIMIZE, ANALYZE, CHECK TABLE etc), where binlogging must be suppressed without affecting session-level binlog behavior.

no_write_to_binlog is evaluated at the final binlog write decision point and remains effective for the entire statement execution, independent of stack unwinding, guard lifetimes, or destructor ordering. This makes it suitable for execution paths where the actual binlog write occurs outside mysql_admin_table() and spans multiple subsystems.

Importantly, no_write_to_binlog has no impact on DML execution or binlogging. It is only set for the specific statement where suppression is required and is cleared at statement completion. This preserves the intended RSU semantics: schema and administrative operations execute locally, while DML continues to be written to the binary log and replicated normally.

(cherry picked from commit a4204b6a8036dd09289fe836a360a5f6896c3c16)