### PR TITLE
(trunk) PXC-4802: Misleading log message `Initiating SST cancellation` during handling fatal signal

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -475,7 +475,10 @@ static bool sst_cancelled = false;
 void wsrep_sst_cancel(bool call_wsrep_cb) {
   if (mysql_mutex_lock(&LOCK_wsrep_sst)) abort();
   if (!sst_cancelled) {
-    WSREP_INFO("Initiating SST cancellation");
+    if (sst_process || (call_wsrep_cb && sst_awaiting_callback)) {
+      WSREP_INFO("Initiating SST cancellation");
+    }
+
     sst_cancelled = true;
     /*
       When we launched the SST process, then we need


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4802

Problem:
When the server exits because of abort or fatal signal it prints `Initiating SST cancellation` message. It is printed even if there is no SST in progress, which is misleading.

Cause:
The server installs signal handler to do the cleanup prior exit. One of cleanup actions is stopping a potentially ongoing SST. The problematic message was printed always, regardless of whether SST stop actions were executed afterwards or not.

Solution:
Print the message only if there is ongoing SST to be stopped.