### PR TITLE
(trunk) PXC-4823: Async PXC replica stalls replication when replicates OPTIMIZE TABLE

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave.result
+++ b/mysql-test/suite/galera/r/galera_as_slave.result
@@ -23,6 +23,18 @@ DROP TABLE t1;
 # Restarting node 3 ...
 # restart
 SHOW REPLICA STATUS;
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+INSERT INTO t1 VALUES (1);
+REPAIR TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	repair	note	The storage engine for the table doesn't support repair
+INSERT INTO t1 VALUES (2);
+DROP TABLE t1;
 # connection node_2
 STOP REPLICA;
 RESET REPLICA ALL;

--- a/mysql-test/suite/galera/t/galera_as_slave.test
+++ b/mysql-test/suite/galera/t/galera_as_slave.test
@@ -75,6 +75,29 @@ query_vertical SHOW REPLICA STATUS;
 
 # ==== PXC-761 TEST END ====
 
+#
+# PXC-4823: Async PXC replica stalls replication when replicates OPTIMIZE TABLE
+#
+--connection node_1
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (0);
+OPTIMIZE TABLE t1;
+INSERT INTO t1 VALUES (1);
+REPAIR TABLE t1;
+INSERT INTO t1 VALUES (2);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_1
+DROP TABLE t1;
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+# ==== PXC-4823 TEST END ====
 
 # Test cleanup
 --connection node_2

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -800,7 +800,11 @@ static bool secondary_engine_analyze(THD *thd, Table_ref *table) {
    ALTER TABLE case is handled in alter table execution path.
 */
 static bool wsrep_toi_replication(THD *thd, Table_ref *tables) {
-  if (!WSREP(thd) || !WSREP_CLIENT(thd)) return false;
+  bool async_replica_applier =
+      (thd->system_thread == SYSTEM_THREAD_SLAVE_WORKER) ||
+      (thd->system_thread == SYSTEM_THREAD_SLAVE_SQL);
+  if (!WSREP(thd) || !(WSREP_CLIENT(thd) || async_replica_applier))
+    return false;
 
   LEX *lex = thd->lex;
   /* only handle OPTIMIZE and REPAIR here */


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4823

Problem:
If PXC node is a replica for async source, OTPIMIZE TABLE executed on async source causes async replication stuck.

Cause:
When async-replicated transaction is to be applied, its sequence number is scheduled in wsrep_async_monitor. Once scheduled, the transaction is expected to either enter-leave the monitor, or skip the scheduled sequence number.

For DDLs, entering the monitor is done in wsrep_to_isolation_begin and leaving in wsrep_to_isolation_end.

For table admin tasks, we decide if replication should be done for a given command in wsrep_toi_replication. We do so for OPTIMIZE and REPAIR.
The logic in this function skipped replication of all table admin DDLs if async replica worker was the originator.

Fix:
Allow replication of table admin DDLs if async replica worker is the originator (note that for multi threaded replica it will be SLAVE_WORKER thread, and for single threaded replicas it will be SLAVE_SQL thread)