### PR TITLE
PXC-4825: performance_schema.variables_by_thread does not include wsr…

### DIFF
--- a/mysql-test/suite/wsrep/r/variables_by_thread_wsrep.result
+++ b/mysql-test/suite/wsrep/r/variables_by_thread_wsrep.result
@@ -1,0 +1,19 @@
+
+# 1. List wsrep threads (this should catch any new wsrep thread addition).
+SELECT NAME FROM performance_schema.threads WHERE NAME LIKE '%wsrep%' ORDER BY NAME;
+NAME
+thread/sql/THREAD_wsrep_applier
+thread/sql/THREAD_wsrep_rollbacker
+
+# 2. Assert no wsrep THD is missing in variables_by_thread.
+include/assert.inc [wsrep THDs are present in variables_by_thread]
+
+# 3. Assert wsrep threads have session variables stored (variables_by_thread).
+include/assert.inc [Wsrep thread count matches variables_by_thread and have session variable present.]
+include/assert.inc [Global only variables are not present.]
+
+# 4. Assert no wsrep THD is missing in status_by_thread.
+include/assert.inc [wsrep THDs are present in status_by_thread]
+
+# 5. Assert wsrep threads have session status stored (status_by_thread).
+include/assert.inc [Wsrep thread count matches status_by_thread and have session status present.]

--- a/mysql-test/suite/wsrep/t/variables_by_thread_wsrep.test
+++ b/mysql-test/suite/wsrep/t/variables_by_thread_wsrep.test
@@ -1,0 +1,49 @@
+# This test makes sure all wsrep THDs present in performance_schema.threads
+# appear in performance_schema.variables_by_thread and status_by_thread
+# (tables that use PFS thread's THD association set by mysql_thread_set_psi_THD).
+
+--source include/have_wsrep.inc
+
+--echo
+--echo # 1. List wsrep threads (this should catch any new wsrep thread addition).
+
+SELECT NAME FROM performance_schema.threads WHERE NAME LIKE '%wsrep%' ORDER BY NAME;
+
+--echo
+--echo # 2. Assert no wsrep THD is missing in variables_by_thread.
+
+--let $assert_text = wsrep THDs are present in variables_by_thread
+--let $assert_cond = COUNT(*)=0 FROM performance_schema.threads t WHERE t.NAME LIKE "%wsrep%" AND t.THREAD_ID NOT IN (SELECT DISTINCT THREAD_ID FROM performance_schema.variables_by_thread)
+--source include/assert.inc
+
+--echo
+--echo # 3. Assert wsrep threads have session variables stored (variables_by_thread).
+
+# Let's assume if one variable is present all will be present.
+--let $wsrep_thread_count = `SELECT COUNT(*) FROM performance_schema.threads WHERE NAME LIKE '%wsrep%'`
+--let $wsrep_thds_in_vbt_count = `SELECT COUNT(*) FROM performance_schema.variables_by_thread WHERE THREAD_ID IN (SELECT THREAD_ID FROM performance_schema.threads WHERE NAME LIKE '%wsrep%') AND VARIABLE_NAME = 'wsrep_on'`
+--let $assert_text = Wsrep thread count matches variables_by_thread and have session variable present.
+--let $assert_cond = $wsrep_thread_count = $wsrep_thds_in_vbt_count
+--source include/assert.inc
+
+# Global only variables are not present.
+--let $assert_text = Global only variables are not present.
+--let $wsrep_thds_in_vbt_count = `SELECT COUNT(*) FROM performance_schema.variables_by_thread WHERE THREAD_ID IN (SELECT THREAD_ID FROM performance_schema.threads WHERE NAME LIKE '%wsrep%') AND VARIABLE_NAME = 'wsrep_provider'`
+--let $assert_cond = $wsrep_thds_in_vbt_count = 0
+--source include/assert.inc
+
+--echo
+--echo # 4. Assert no wsrep THD is missing in status_by_thread.
+
+--let $assert_text = wsrep THDs are present in status_by_thread
+--let $assert_cond = COUNT(*)=0 FROM performance_schema.threads t WHERE t.NAME LIKE "%wsrep%" AND t.THREAD_ID NOT IN (SELECT DISTINCT THREAD_ID FROM performance_schema.status_by_thread)
+--source include/assert.inc
+
+--echo
+--echo # 5. Assert wsrep threads have session status stored (status_by_thread).
+
+# Let's assume if one status is present all will be present.
+--let $wsrep_thds_in_sbt_count = `SELECT COUNT(*) FROM performance_schema.status_by_thread WHERE THREAD_ID IN (SELECT THREAD_ID FROM performance_schema.threads WHERE NAME LIKE '%wsrep%') AND VARIABLE_NAME = 'wsrep_last_applied'`
+--let $assert_text = Wsrep thread count matches status_by_thread and have session status present.
+--let $assert_cond = $wsrep_thread_count = $wsrep_thds_in_sbt_count
+--source include/assert.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10812,7 +10812,7 @@ static int init_wsrep_thread(THD *thd) {
 }
 
 extern "C" void *start_wsrep_THD(void *arg) {
-  THD *thd;
+  THD *thd{nullptr};
   bool thd_added = false;
 
   Wsrep_thd_args *thd_args = (Wsrep_thd_args *)arg;
@@ -10851,6 +10851,12 @@ extern "C" void *start_wsrep_THD(void *arg) {
   /* wsrep_running_threads counter is managed in thd_manager */
   thd_manager->add_thd(thd);
   thd_added = true;
+
+  /*
+    Associate THD for instrumentation so performance_schema.variables_by_thread
+    and status_by_thread include this wsrep thread.
+  */
+  mysql_thread_set_psi_THD(thd);
 
 #ifndef SKIP_INNODB_HP
   /* set priority */
@@ -10905,6 +10911,8 @@ err:
     Therefore thd must only be deleted after info_thd is set
     to NULL.
   */
+  /* Dis-associate THD from PFS thread before destroying it. */
+  mysql_thread_set_psi_THD(nullptr);
   delete thd;
   delete static_cast<Wsrep_thd_args*>(arg);
 


### PR DESCRIPTION
…ep threads

https://perconadev.atlassian.net/browse/PXC-4825

Problem: wsrep threads are not in performance_schema.variables_by_thread

Description:
At present we can see wsrep threads thread/sql/THREAD_wsrep_rollbacker and thread/sql/THREAD_wsrep_applier in performance_schema.threads table. However when THREAD_IDs associated with wsrep THDs were checked in performance_schema.variables_by_thread they were not present.

Resolution:
Instrumentation call mysql_thread_set_psi_THD was missing. Instrumentation has been added for wsrep THDs present in Global_THD_manager.