### PR TITLE
(9.6) PXC-4965: Passwords containing ' wrongly handled

### DIFF
--- a/mysql-test/suite/galera/r/pxc_set_password.result
+++ b/mysql-test/suite/galera/r/pxc_set_password.result
@@ -1,0 +1,533 @@
+#
+# Testing for: user: testuser, password: testpassword
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: test'user, password: testp'assword
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "test'user"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "test'user"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "testp'assword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test'user"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "test'user"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "test'user"@"%";;
+SET PASSWORD = "testp'assword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test'user"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "test'user"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "test'user"@"%";;
+SET PASSWORD = "testp'assword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test'user"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: test''user, password: testpa''ssword
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "test''user"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "test''user"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "testpa''ssword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test''user"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "test''user"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "test''user"@"%";;
+SET PASSWORD = "testpa''ssword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test''user"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "test''user"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "test''user"@"%";;
+SET PASSWORD = "testpa''ssword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test''user"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: test'''user, password: testpa'''ssword
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "test'''user"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "test'''user"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "testpa'''ssword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test'''user"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "test'''user"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "test'''user"@"%";;
+SET PASSWORD = "testpa'''ssword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test'''user"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "test'''user"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "test'''user"@"%";;
+SET PASSWORD = "testpa'''ssword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "test'''user"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: testuser', password: testpassword'
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "testuser'"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "testuser'"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "testpassword'";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser'"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser'"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "testuser'"@"%";;
+SET PASSWORD = "testpassword'";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser'"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser'"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "testuser'"@"%";;
+SET PASSWORD = "testpassword'";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser'"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: testuser'', password: testpassword''
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "testuser''"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "testuser''"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "testpassword''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser''"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser''"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "testuser''"@"%";;
+SET PASSWORD = "testpassword''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser''"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser''"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "testuser''"@"%";;
+SET PASSWORD = "testpassword''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser''"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: testuser''', password: testpassword'''
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "testuser'''"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "testuser'''"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "testpassword'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser'''"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser'''"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "testuser'''"@"%";;
+SET PASSWORD = "testpassword'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser'''"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser'''"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "testuser'''"@"%";;
+SET PASSWORD = "testpassword'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser'''"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: 'testuser, password: 'testpassword
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "'testuser"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "'testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "'testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "'testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "'testuser"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "'testuser"@"%";;
+SET PASSWORD = "'testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "'testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "'testuser"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "'testuser"@"%";;
+SET PASSWORD = "'testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "'testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: ''testuser, password: ''testpassword
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "''testuser"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "''testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "''testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "''testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "''testuser"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "''testuser"@"%";;
+SET PASSWORD = "''testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "''testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "''testuser"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "''testuser"@"%";;
+SET PASSWORD = "''testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "''testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: '''testuser, password: '''testpassword
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "'''testuser"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "'''testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "'''testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "'''testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "'''testuser"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "'''testuser"@"%";;
+SET PASSWORD = "'''testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "'''testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "'''testuser"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "'''testuser"@"%";;
+SET PASSWORD = "'''testpassword";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "'''testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: testuser, password: '''testpassword'''
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "'''testpassword'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "'''testpassword'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "'''testpassword'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: testuser, password: '''t'e''s'''tpa'ssw'ord'''
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "'''t'e''s'''tpa'ssw'ord'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "'''t'e''s'''tpa'ssw'ord'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "'''t'e''s'''tpa'ssw'ord'''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+#
+# Testing for: user: testuser, password: ''''''''''''''''''''''''''''''''''''''''''''''
+#
+# Scenario: Fixed source, fixed replica
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_1";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+SET PASSWORD = "''''''''''''''''''''''''''''''''''''''''''''''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Fixed source, old replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_2";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "''''''''''''''''''''''''''''''''''''''''''''''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+# Scenario: Old source, fixed replica
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+CREATE USER "testuser"@"%" IDENTIFIED BY "secret_original_3";;
+GRANT ALL ON *.* TO "testuser"@"%";;
+SET PASSWORD = "''''''''''''''''''''''''''''''''''''''''''''''";;
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;
+SELECT 1;
+1
+1
+DROP USER "testuser"@"%";;
+SET GLOBAL debug = '';
+CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;;

--- a/mysql-test/suite/galera/t/pxc_set_password.inc
+++ b/mysql-test/suite/galera/t/pxc_set_password.inc
@@ -1,0 +1,99 @@
+# For a given tuple of (user, password), test the three scenarios:
+# 1. Fixed source + fixed replica
+# 2. Fixed source + old replica
+# 3. Old source + fixed replica
+#
+# We expect all combinations to work.
+
+--source include/count_sessions.inc
+
+# The test will use this TOI as a simple synchronization point, to know that
+# all previous queries were replicated and executed on remote nodes.
+--let $syncpoint = CREATE TABLE checkpoint(id INT PRIMARY KEY); DROP TABLE checkpoint;
+
+--echo #
+--echo # Testing for: user: $username, password: $password
+--echo #
+
+--echo # Scenario: Fixed source, fixed replica
+
+# Create the user on the source node
+--connection node_1
+--eval CREATE USER "$username"@"%" IDENTIFIED BY "secret_original_1";
+--eval GRANT ALL ON *.* TO "$username"@"%";
+--eval $syncpoint
+
+# Check that it is possible to use this user on replica
+--connect node_2_testuser, 127.0.0.1, $username, secret_original_1,, $NODE_MYPORT_2
+--connection node_2_testuser
+SELECT 1;
+--disconnect node_2_testuser
+
+# Change the password on the source node
+--connect node_1_testuser, 127.0.0.1, $username, secret_original_1,, $NODE_MYPORT_1
+--eval SET PASSWORD = "$password";
+--eval $syncpoint
+--disconnect node_1_testuser
+
+# Check that it is possible to connect with the new password on the replica
+--connect node_2_testuser, 127.0.0.1, $username, $password,, $NODE_MYPORT_2
+--connection node_2_testuser
+SELECT 1;
+--disconnect node_2_testuser
+
+# cleanup
+--connection node_1
+--eval DROP USER "$username"@"%";
+--eval $syncpoint
+
+
+--echo # Scenario: Fixed source, old replica
+
+--connection node_2
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+
+--connection node_1
+--eval CREATE USER "$username"@"%" IDENTIFIED BY "secret_original_2";
+--eval GRANT ALL ON *.* TO "$username"@"%";
+
+--connect node_1_testuser, 127.0.0.1, $username, secret_original_2,, $NODE_MYPORT_1
+--eval SET PASSWORD = "$password";
+--eval $syncpoint
+--disconnect node_1_testuser
+
+--connect node_2_testuser, 127.0.0.1, $username, $password,, $NODE_MYPORT_2
+--connection node_2_testuser
+SELECT 1;
+--disconnect node_2_testuser
+
+--connection node_1
+--eval DROP USER "$username"@"%";
+--connection node_2
+SET GLOBAL debug = '';
+--eval $syncpoint
+
+--echo # Scenario: Old source, fixed replica
+
+--connection node_1
+SET GLOBAL debug = 'd,set_password_simulate_no_pxc_4965';
+
+--connection node_1
+--eval CREATE USER "$username"@"%" IDENTIFIED BY "secret_original_3";
+--eval GRANT ALL ON *.* TO "$username"@"%";
+
+--connect node_1_testuser, 127.0.0.1, $username, secret_original_3,, $NODE_MYPORT_1
+--eval SET PASSWORD = "$password";
+--eval $syncpoint
+--disconnect node_1_testuser
+
+--connect node_2_testuser, 127.0.0.1, $username, $password,, $NODE_MYPORT_2
+--connection node_2_testuser
+SELECT 1;
+--disconnect node_2_testuser
+
+--connection node_1
+--eval DROP USER "$username"@"%";
+SET GLOBAL debug = '';
+--eval $syncpoint
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/pxc_set_password.test
+++ b/mysql-test/suite/galera/t/pxc_set_password.test
@@ -1,0 +1,55 @@
+--source include/have_debug.inc
+--source include/galera_cluster.inc
+
+--let $username = testuser
+--let $password = testpassword
+--source pxc_set_password.inc
+
+--let $username = test'user
+--let $password = testp'assword
+--source pxc_set_password.inc
+
+--let $username = test''user
+--let $password = testpa''ssword
+--source pxc_set_password.inc
+
+--let $username = test'''user
+--let $password = testpa'''ssword
+--source pxc_set_password.inc
+
+--let $username = testuser'
+--let $password = testpassword'
+--source pxc_set_password.inc
+
+--let $username = testuser''
+--let $password = testpassword''
+--source pxc_set_password.inc
+
+--let $username = testuser'''
+--let $password = testpassword'''
+--source pxc_set_password.inc
+
+--let $username = 'testuser
+--let $password = 'testpassword
+--source pxc_set_password.inc
+
+--let $username = ''testuser
+--let $password = ''testpassword
+--source pxc_set_password.inc
+
+--let $username = '''testuser
+--let $password = '''testpassword
+--source pxc_set_password.inc
+
+--let $username = testuser
+--let $password = '''testpassword'''
+--source pxc_set_password.inc
+
+--let $username = testuser
+--let $password = '''t'e''s'''tpa'ssw'ord'''
+--source pxc_set_password.inc
+
+--let $username = testuser
+--let $password = ''''''''''''''''''''''''''''''''''''''''''''''
+--source pxc_set_password.inc
+

--- a/sql/auth/sql_user.cc
+++ b/sql/auth/sql_user.cc
@@ -2178,13 +2178,13 @@ bool change_password(THD *thd, LEX_USER *lex_user, const char *new_password,
   */
   const Save_and_Restore_binlog_format_state binlog_format_state(thd);
 #ifdef WITH_WSREP
-  /*
-    Rewrite query to ensure it is safe to replay on slave thread with proper
-    user context established (this is important if original query fails to
-    explictly specify the user context and if such query is replicated
-    w/o re-writting then applier will not be able to establish user context).
-  */
   if (WSREP(thd) && !thd->wsrep_applier) {
+    /*
+      Rewrite query to ensure it is safe to replay on slave thread with proper
+      user context established (this is important if original query fails to
+      explictly specify the user context and if such query is replicated
+      w/o re-writting then applier will not be able to establish user context).
+    */
     { /* Critical section */
       Acl_cache_lock_guard acl_cache_rlock(thd, Acl_cache_lock_mode::READ_MODE);
 
@@ -2207,22 +2207,9 @@ bool change_password(THD *thd, LEX_USER *lex_user, const char *new_password,
       }
     }
 
-
-
-    size_t query_length_max = strlen("SET PASSWORD FOR ''@''=''") + 3 * 120 + 1;
-    char *buff = (char *)thd->alloc(query_length_max);
-    if (!buff) {
-      my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), 0);
+    if (wsrep_rewrite_set_password_query(thd, lex_user, new_password)) {
       return true;
     }
-
-    ulong query_length =
-        snprintf(buff, query_length_max,
-                 "SET PASSWORD FOR '%-.120s'@'%-.120s'='%-.120s'",
-                 lex_user->user.str ? lex_user->user.str : "",
-                 lex_user->host.str ? lex_user->host.str : "", new_password);
-    buff[query_length_max - 1] = 0;
-    thd->set_query(buff, query_length);
 
     if ((ret = open_grant_tables(thd, tables, &transactional_tables, false,
                                  WSREP_MYSQL_DB, "user"))) {

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -4017,6 +4017,16 @@ Query_log_event::Query_log_event(
     return;
   }
 
+#ifdef WITH_WSREP
+#ifdef MYSQL_SERVER
+  if (current_thd && current_thd->wsrep_applier && query && q_len > 0) {
+    fixed_query = wsrep_fix_received_query(query, q_len);
+    query = fixed_query.c_str();
+    q_len = fixed_query.length();
+  }
+#endif /* MYSQL_SERVER */
+#endif /* WITH_WSREP */
+
   common_header->set_is_valid(query != nullptr && q_len > 0);
 }
 

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1296,6 +1296,10 @@ class Query_log_event : public virtual mysql::binlog::event::Query_event,
  protected:
   mysql::binlog::event::Log_event_header::Byte *data_buf;
 
+#ifdef WITH_WSREP
+  std::string fixed_query;
+#endif
+
  public:
   // disable copy-move semantics
   Query_log_event(Query_log_event &&) noexcept = delete;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -35,6 +35,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <regex>
 #include <sstream>
 #include <string>
 
@@ -3481,6 +3482,7 @@ bool wsrep_keyring_component_loaded() {
   }
   return false;
 }
+
 bool wsrep_should_replicate_for_table(Table_ref * table_ref) {
   if (!table_ref) return false;
 
@@ -3498,4 +3500,108 @@ bool wsrep_should_replicate_for_table(Table_ref * table_ref) {
   //should never get here
   assert(0);
   return false;
+}
+
+static std::string sql_escape(const std::string &s) {
+  std::string out;
+  out.reserve(s.size() * 2);
+  for (char c : s) {
+    if (c == '\'')
+      out += "''";
+    else
+      out += c;
+  }
+  return out;
+}
+
+static const std::string SET_PASSWORD_FOR_PREFIX = "SET PASSWORD FOR";
+
+/* Rewrite SET PASSWORD query on the server side with the proper escaping */
+bool wsrep_rewrite_set_password_query(THD *thd, const LEX_USER *lex_user,
+                                      const char *new_password) {
+  std::string user =
+      sql_escape(lex_user->user.str
+                     ? std::string(lex_user->user.str, lex_user->user.length)
+                     : "");
+
+  std::string host =
+      sql_escape(lex_user->host.str
+                     ? std::string(lex_user->host.str, lex_user->host.length)
+                     : "");
+
+  std::string pass = sql_escape(new_password ? new_password : "");
+
+  std::string comment = " /* proper escaping */";
+
+  DBUG_EXECUTE_IF("set_password_simulate_no_pxc_4965", {
+    user = lex_user->user.str
+               ? std::string(lex_user->user.str, lex_user->user.length)
+               : "";
+    host = lex_user->host.str
+               ? std::string(lex_user->host.str, lex_user->host.length)
+               : "";
+    pass = new_password ? new_password : "";
+    comment = "";
+  });
+
+  std::string query = SET_PASSWORD_FOR_PREFIX + " '" + user + "'@'" + host +
+                      "'='" + pass + "'" + comment;
+
+  char *buff = (char *)thd->alloc(query.size() + 1);
+  if (!buff) {
+    my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), 0);
+    return true;
+  }
+
+  memcpy(buff, query.c_str(), query.size() + 1);
+  thd->set_query(buff, query.size());
+  return false;
+}
+
+/* Versions <= 8.0.45 have a bug PXC-4965. Source when rewriting
+  the SET PASSWORD query, does not escape potential ' characters.
+  This causes the replicated query to be like e.g.
+  SET PASSWORD FOR 'user'@'host'='a'b'
+  which is not correct.
+  Handle the situation when received query originates from such a source.
+  If any other such queries are discovered in the future, here is the place
+  to fix them.
+  */
+static std::string rewrite_received_set_password_query(
+    const std::string &query) {
+  static const std::regex broken_re("^" + SET_PASSWORD_FOR_PREFIX +
+                                    R"(\s+'(.*?)'@'(.*?)'='(.*)'$)");
+
+  DBUG_EXECUTE_IF("set_password_simulate_no_pxc_4965", { return query; });
+
+  std::string query_ret = query;
+  std::smatch m;
+
+  std::string user, host, pass, rewritten;
+
+  /* Note that the query from fixed node has a trailing comment, so it will not
+     match the regex */
+  if (std::regex_match(query, m, broken_re)) {
+    // Broken sender (pre PXC-4965)
+    user = m[1];
+    host = m[2];
+    pass = m[3];
+
+    // Re-escape
+    query_ret = SET_PASSWORD_FOR_PREFIX + " '" + sql_escape(user) + "'@'" +
+                sql_escape(host) + "'='" + sql_escape(pass) + "'";
+  }
+
+  return query_ret;
+}
+
+std::string wsrep_fix_received_query(const char *query, size_t query_len) {
+  std::string query_str(query, query_len);
+  std::string query_ret = query_str;
+
+  if (query_str.find(SET_PASSWORD_FOR_PREFIX) == 0) {
+    query_ret = rewrite_received_set_password_query(query_str);
+  }
+
+  return query_ret;
 }

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -575,4 +575,15 @@ extern LEX_CSTRING PXC_INTERNAL_SESSION_HOST;
 
 bool wsrep_keyring_component_loaded();
 
+/**
+ * Rewrite the SET PASSWORD query into SET PASSWORD FOR before replication.
+ */
+bool wsrep_rewrite_set_password_query(THD *thd, const LEX_USER *lex_user,
+                                      const char *new_password);
+
+/**
+ * Fix replicated query string.
+ */
+std::string wsrep_fix_received_query(const char *query, size_t query_len);
+
 #endif /* WSREP_MYSQLD_H */


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4965

Problem:
When SET PASSWORD="a'b" is executed on the source node, the replicated node triggers inconsistency voting as the query fails on it.

Cause:
On the source node SET PASSWORD statement is rewritten to SET PASSWORD FOR. It is because on the replica node, the applier thread works in the root user context and needs to set the password for the desired user, not root. During rewriting, escaping was missing.

Solution:
1. Source side: fix escaping during the rewrite
2. Replica side: detect if the statement originates from affected node and apply proper escaping before execution