### PR TITLE
PXC-4683: Node leaves the cluster after an error in a stored procedure(8.4)

### DIFF
--- a/mysql-test/suite/galera/r/galera_sp_toi_error_vote_warn_mismatch.result
+++ b/mysql-test/suite/galera/r/galera_sp_toi_error_vote_warn_mismatch.result
@@ -1,0 +1,36 @@
+##############################################################################
+# 1. Setup
+##############################################################################
+CREATE DATABASE IF NOT EXISTS my_database;
+USE my_database;
+CREATE PROCEDURE testCrashGaleraNode()
+BEGIN
+ALTER TABLE non_existing_table ADD somecolumn tinyint(1);
+END$$
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+USE my_database;
+##############################################################################
+# 2. 1146 and 1681 error, all nodes send only 1146. Cluster stays healthy.
+##############################################################################
+ALTER TABLE non_existing_table ADD somecolumn tinyint(1);
+ERROR 42S02: Table 'my_database.non_existing_table' doesn't exist
+CALL testCrashGaleraNode();
+ERROR 42S02: Table 'my_database.non_existing_table' doesn't exist
+CALL testCrashGaleraNode();
+ERROR 42S02: Table 'my_database.non_existing_table' doesn't exist
+include/assert.inc [Assert node-1 is part of cluster.]
+include/assert.inc [Cluster size remains 2 on node1.]
+include/assert.inc [Assert node-2 is part of cluster.]
+include/assert.inc [Cluster size remains 2 on node2.]
+##############################################################################
+# 3. Assert error log. Only 1146 appears in error log. 1681 does not exist.
+##############################################################################
+include/assert.inc [Node1 vote recompute must not include warning 1681.]
+include/assert.inc [Node2 vote recompute must not include warning 1681.]
+##############################################################################
+# 4. Cleanup
+##############################################################################
+CALL mtr.add_suppression('Replica SQL: Error .*');
+CALL mtr.add_suppression('Replica SQL: Error .*');
+DROP DATABASE my_database;

--- a/mysql-test/suite/galera/t/galera_sp_toi_error_vote_warn_mismatch.test
+++ b/mysql-test/suite/galera/t/galera_sp_toi_error_vote_warn_mismatch.test
@@ -1,0 +1,108 @@
+##############################################################################
+# This test case makes sure when additional warning 1681 is logged in one of
+# the node in cluster, cluster remains healthy.
+#
+# NOTE: 1146+1681 is generated on the client side.
+# 1146 is generated at the applier side.
+# 1681(ER_WARN_DEPRECATED_SYNTAX_NO_REPLACEMENT) is deprecated with no replacement.
+#
+##############################################################################
+# 1. Setup
+# 2. 1146 and 1681 error, all nodes send only 1146. Cluster stays healthy.
+# 3. Assert error log. Only 1146 appears in error log. 1681 does not exist.
+# 4. Cleanup
+##############################################################################
+
+--source include/galera_cluster.inc
+
+--echo ##############################################################################
+--echo # 1. Setup
+--echo ##############################################################################
+
+CREATE DATABASE IF NOT EXISTS my_database;
+USE my_database;
+
+## Procedure that can produce 1146+1681 (deprecated display width).
+--delimiter $$
+CREATE PROCEDURE testCrashGaleraNode()
+BEGIN
+  ALTER TABLE non_existing_table ADD somecolumn tinyint(1);
+END$$
+--delimiter ;
+
+--connection node_2
+USE my_database;
+
+--echo ##############################################################################
+--echo # 2. 1146 and 1681 error, all nodes send only 1146. Cluster stays healthy.
+--echo ##############################################################################
+
+## ALTER TABLE does not show 1681 warning.
+--connection node_1
+--error ER_NO_SUCH_TABLE
+ALTER TABLE non_existing_table ADD somecolumn tinyint(1);
+
+--error ER_NO_SUCH_TABLE
+CALL testCrashGaleraNode();
+
+## Test from node_2.
+--connection node_2
+--error ER_NO_SUCH_TABLE
+CALL testCrashGaleraNode();
+
+# We are not able to do cross version testing but in cross version testing
+# done manually it was observed that when one of the member is OLD, atleast 1
+# server leaves the cluster.
+
+## Assert both nodes still in PRIMARY, size 2.
+
+--connection node_1
+--let $assert_text = Assert node-1 is part of cluster.
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME=\"wsrep_cluster_status\", VARIABLE_VALUE, 1]" = "Primary"
+--source include/assert.inc
+
+--let $assert_text = Cluster size remains 2 on node1.
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME=\"wsrep_cluster_size\", VARIABLE_VALUE, 1]" = 2
+--source include/assert.inc
+
+--connection node_2
+--let $assert_text = Assert node-2 is part of cluster.
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME=\"wsrep_cluster_status\", VARIABLE_VALUE, 1]" = "Primary"
+--source include/assert.inc
+--let $assert_text = Cluster size remains 2 on node2.
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME=\"wsrep_cluster_size\", VARIABLE_VALUE, 1]" = 2
+--source include/assert.inc
+
+--echo ##############################################################################
+--echo # 3. Assert error log. Only 1146 appears in error log. 1681 does not exist.
+--echo ##############################################################################
+
+## Vote recomputation must use real error code only (1146), not warning 1681.
+--connection node_1
+--let $wait_condition= SELECT COUNT(*) >= 1 FROM performance_schema.error_log WHERE DATA LIKE "%Recomputed vote based on error codes: 1146%"
+--source include/wait_condition.inc
+
+--let $assert_text = Node1 vote recompute must not include warning 1681.
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.error_log WHERE DATA LIKE "%Recomputed vote based on error codes: 1146, 1681%"] = 0
+--source include/assert.inc
+
+--connection node_2
+--let $wait_condition= SELECT COUNT(*) >= 1 FROM performance_schema.error_log WHERE DATA LIKE "%Recomputed vote based on error codes: 1146%"
+--source include/wait_condition.inc
+
+--let $assert_text = Node2 vote recompute must not include warning 1681.
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.error_log WHERE DATA LIKE "%Recomputed vote based on error codes: 1146, 1681%"] = 0
+--source include/assert.inc
+
+--echo ##############################################################################
+--echo # 4. Cleanup
+--echo ##############################################################################
+
+--connection node_1
+CALL mtr.add_suppression('Replica SQL: Error .*');
+
+--connection node_2
+CALL mtr.add_suppression('Replica SQL: Error .*');
+
+--connection node_1
+DROP DATABASE my_database;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4823

Problem:
TOI-failed inside a stored procedure e.g. ALTER TABLE on a non-existing table marked the node inconsistent

Cause:
The Galera apply-error voting payload was built from the diagnostics area and included warning codes in addition to the real error code. For cases involving deprecated integer display width (tinyint(1) -> warning 1681), nodes could produce different condition lists (1146 vs 1146+1681), leading to different vote hashes and eventually causing inconsistency.

Fix:
Make wsrep_store_error() store only SL_ERROR conditions and if no error if found check DA error), thus voting is based on the failing error(s) only.