### PR TITLE
PXC-4887: "CREATE ROLE" not replicated in pxc when using the validate…(trunk)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_create_role_validate_password.result
+++ b/mysql-test/suite/galera/r/pxc_create_role_validate_password.result
@@ -1,0 +1,33 @@
+INSTALL COMPONENT "file://component_validate_password";
+SET @@global.validate_password.policy = 0;
+SET @@global.validate_password.length = 16;
+SET @@global.validate_password.check_user_name = ON;
+# CREATE ROLE on node_1
+CREATE ROLE testrole;
+USE test;
+CREATE TABLE t1(a INT PRIMARY KEY);
+# GRANT on role and GRANT role to user
+GRANT SELECT ON test.* TO testrole;
+CREATE USER 'u1_pxcrvp'@'localhost' IDENTIFIED BY 'Xx0_strong_mtr_pass!';
+GRANT testrole TO 'u1_pxcrvp'@'localhost';
+# CREATE ROLE and table are replicated to node_2
+include/assert.inc [wsrep_cluster_size must be 2]
+include/assert.inc [wsrep_ready must be ON]
+include/assert.inc [wsrep_cluster_status must be Primary]
+include/assert.inc [wsrep_cluster_size must be 2]
+include/assert.inc [wsrep_ready must be ON]
+include/assert.inc [wsrep_cluster_status must be Primary]
+# DROP ROLE on node_1
+REVOKE SELECT ON test.* FROM testrole;
+DROP USER 'u1_pxcrvp'@'localhost';
+DROP TABLE t1;
+DROP ROLE testrole;
+# DROP ROLE is replicated to node_2
+include/assert.inc [wsrep_cluster_size must be 2]
+include/assert.inc [wsrep_ready must be ON]
+include/assert.inc [wsrep_cluster_status must be Primary]
+include/assert.inc [wsrep_cluster_size must be 2]
+include/assert.inc [wsrep_ready must be ON]
+include/assert.inc [wsrep_cluster_status must be Primary]
+# Cleanup
+UNINSTALL COMPONENT "file://component_validate_password";

--- a/mysql-test/suite/galera/t/pxc_create_role_validate_password.test
+++ b/mysql-test/suite/galera/t/pxc_create_role_validate_password.test
@@ -1,0 +1,101 @@
+#
+# This test makes sure CREATE ROLE statement is replicated in PXC when
+# validate_password component is active.
+#
+
+--source include/have_debug.inc
+--source include/galera_cluster.inc
+--source include/wait_wsrep_ready.inc
+
+--connection node_1
+INSTALL COMPONENT "file://component_validate_password";
+SET @@global.validate_password.policy = 0;
+SET @@global.validate_password.length = 16;
+SET @@global.validate_password.check_user_name = ON;
+--let $assert_escape = 1
+
+--echo # CREATE ROLE on node_1
+CREATE ROLE testrole;
+
+# TOI sync: CREATE TABLE so CREATE ROLE TOI is applied on node_2 before we check
+USE test;
+CREATE TABLE t1(a INT PRIMARY KEY);
+
+--echo # GRANT on role and GRANT role to user
+GRANT SELECT ON test.* TO testrole;
+CREATE USER 'u1_pxcrvp'@'localhost' IDENTIFIED BY 'Xx0_strong_mtr_pass!';
+GRANT testrole TO 'u1_pxcrvp'@'localhost';
+
+--echo # CREATE ROLE and table are replicated to node_2
+--let $assert_text = wsrep_cluster_size must be 2
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size') = 2
+--source include/assert.inc
+--let $assert_text = wsrep_ready must be ON
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready') = 'ON'
+--source include/assert.inc
+--let $assert_text = wsrep_cluster_status must be Primary
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status') = 'Primary'
+--source include/assert.inc
+
+--connection node_2
+--let $assert_text = wsrep_cluster_size must be 2
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size') = 2
+--source include/assert.inc
+--let $assert_text = wsrep_ready must be ON
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready') = 'ON'
+--source include/assert.inc
+--let $assert_text = wsrep_cluster_status must be Primary
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status') = 'Primary'
+--source include/assert.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.user WHERE user = 'testrole'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.db WHERE User = 'testrole' AND Db = 'test' AND Select_priv = 'Y'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM mysql.role_edges WHERE FROM_USER = 'testrole' AND TO_USER = 'u1_pxcrvp' AND TO_HOST = 'localhost'
+--source include/wait_condition.inc
+
+--echo # DROP ROLE on node_1
+--connection node_1
+REVOKE SELECT ON test.* FROM testrole;
+DROP USER 'u1_pxcrvp'@'localhost';
+DROP TABLE t1;
+DROP ROLE testrole;
+
+--echo # DROP ROLE is replicated to node_2
+--let $assert_text = wsrep_cluster_size must be 2
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size') = 2
+--source include/assert.inc
+--let $assert_text = wsrep_ready must be ON
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready') = 'ON'
+--source include/assert.inc
+--let $assert_text = wsrep_cluster_status must be Primary
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status') = 'Primary'
+--source include/assert.inc
+
+--connection node_2
+--let $assert_text = wsrep_cluster_size must be 2
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size') = 2
+--source include/assert.inc
+--let $assert_text = wsrep_ready must be ON
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready') = 'ON'
+--source include/assert.inc
+--let $assert_text = wsrep_cluster_status must be Primary
+--let $assert_cond = (SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status') = 'Primary'
+--source include/assert.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test' AND TABLE_NAME = 't1'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.user WHERE user = 'testrole'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.db WHERE User = 'testrole' AND Db = 'test'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.role_edges WHERE FROM_USER = 'testrole' AND TO_USER = 'u1_pxcrvp'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 0 FROM mysql.user WHERE user = 'u1_pxcrvp'
+--source include/wait_condition.inc
+
+--echo # Cleanup
+--let $assert_escape =
+--connection node_1
+UNINSTALL COMPONENT "file://component_validate_password";

--- a/sql/auth/sql_user.cc
+++ b/sql/auth/sql_user.cc
@@ -3006,7 +3006,7 @@ static LEX_USER *deep_copy(THD *thd, LEX_USER *src) {
     Inconsistency voting: triggered for both sides with ER_PLUGIN_IS_NOT_LOADED
  */
 static bool wsrep_check_for_auth_policy(THD *thd, List<LEX_USER> &list,
-                                        const char *cmd) {
+                                        const char *cmd, bool is_role) {
   if (WSREP(thd) && !thd->wsrep_applier && list.size() > 0) {
     // Accessing ACL cache requires lock. We get WRITE_MODE lock since the call
     // to is_privileged_user_for_credential_change() below, might have to update
@@ -3037,6 +3037,17 @@ static bool wsrep_check_for_auth_policy(THD *thd, List<LEX_USER> &list,
         return false;
       }
 
+      /*
+        get_current_user fetches the current user information.
+        Check if the user is a role or not.
+      */
+      bool is_role_validated = is_role;
+      if (!is_role) {
+        if (ACL_USER *au =
+                find_acl_user(user_from->host.str, user_from->user.str, true))
+          is_role_validated = au->is_role;
+      }
+
       /* set_and_validate_user_attributes() will hash provided password and
        wipe-out its plaintext version in
        user_from_tmp.first_factor_auth_info.auth.str.
@@ -3049,8 +3060,8 @@ static bool wsrep_check_for_auth_policy(THD *thd, List<LEX_USER> &list,
        flow will handle it */
       if (set_and_validate_user_attributes(
               thd, user_from_tmp, dummy_what_to_alter, is_privileged_user,
-              false, nullptr, nullptr, cmd, dummy_generated_passwords,
-              &dummy_mfa, false, false)) {
+              is_role_validated, nullptr, nullptr, cmd,
+              dummy_generated_passwords, &dummy_mfa, false, false)) {
         return true;
       }
     }
@@ -3095,7 +3106,11 @@ bool mysql_create_user(THD *thd, List<LEX_USER> &list, bool if_not_exists,
   if (wsrep_check_system_user_privilege(thd, list)) {
     return true;
   }
-  bool block_toi = wsrep_check_for_auth_policy(thd, list, "CREATE USER");
+  bool block_toi = wsrep_check_for_auth_policy(
+      thd, list,
+      (thd->lex->sql_command == SQLCOM_CREATE_ROLE) ? "CREATE ROLE"
+                                                    : "CREATE USER",
+      is_role);
 #endif
 
   /*
@@ -3820,7 +3835,7 @@ bool mysql_alter_user(THD *thd, List<LEX_USER> &list, bool if_exists) {
   if (wsrep_check_system_user_privilege(thd, list)) {
     return true;
   }
-  bool block_toi = wsrep_check_for_auth_policy(thd, list, "ALTER USER");
+  bool block_toi = wsrep_check_for_auth_policy(thd, list, "ALTER USER", false);
 #endif
 
   /*


### PR DESCRIPTION
… password plugin

https://perconadev.atlassian.net/browse/PXC-4887

Problem: CREATE ROLE not replicated in PXC with validate_password plugin

Description:
Role is getting lost in function call:
mysql_create_user -> wsrep_check_for_auth_policy -> set_and_validate_user_attributes
mysql_create_user has is_role variable.
set_and_validate_user_attributes also has is_role parameter but wsrep_check_for_auth_policy does not have is_role parameter so false is sent to set_and_validate_user_attributes. Which means role is getting lost.

For a role there is no password (empty string). The empty “password” was run through validate_password and it failed the password policy check blocking the TOI. The role was created only on the originating node.

Resolution: Added a is_role parameter in wsrep_check_for_auth_policy(), so that role is not lost between function call and passed the role to set_and_validate_user_attributes.