### PR TITLE
PXC-5106: Set sql_require_primary_key=1 when using pxc_strict_mode=EN…

### DIFF
--- a/mysql-test/suite/galera/r/galera_pxc_sql_require_primary_key.result
+++ b/mysql-test/suite/galera/r/galera_pxc_sql_require_primary_key.result
@@ -1,0 +1,95 @@
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Replica SQL: Error .Unable to create or change a table without a primary key");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Replica SQL: Error .Unable to create or change a table without a primary key");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+include/assert.inc [sql_require_primary_key global is OFF.]
+include/assert.inc [pxc_strict_mode is DISABLED]
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = OFF;
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_b;
+SET GLOBAL sql_require_primary_key = ON;
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_b;
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = ON;
+
+# 1. Degrade ENFORCING -> DISABLED does not change sql_require_primary_key
+
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+include/assert.inc [sql_require_primary_key global stays ON after degrade to DISABLED.]
+SET GLOBAL sql_require_primary_key = ON;
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = OFF;
+CREATE TABLE pxc_srp_d (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_d;
+
+# 2. pxc_strict_mode=ENFORCING also sets global sql_require_primary_key ON
+
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+include/assert.inc [sql_require_primary_key global is ON.]
+# sql_require_primary_key=OFF cannot be set to OFF when pxc_strict_mode is ENFORCING
+SET GLOBAL sql_require_primary_key = OFF;
+ERROR 42000: Variable 'sql_require_primary_key' can't be set to the value of 'OFF'
+SET SESSION sql_require_primary_key = OFF;
+ERROR 42000: Variable 'sql_require_primary_key' can't be set to the value of 'OFF'
+SET GLOBAL sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = ON;
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+ERROR HY000: Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.
+
+# 3. Degrade ENFORCING -> PERMISSIVE does not change sql_require_primary_key
+
+SET GLOBAL pxc_strict_mode = 'PERMISSIVE';
+include/assert.inc [sql_require_primary_key global still ON after PERMISSIVE degrade.]
+SET GLOBAL sql_require_primary_key = ON;
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = OFF;
+CREATE TABLE pxc_srp_d (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_d;
+
+# 4. pxc_strict_mode = MASTER also sets global sql_require_primary_key ON
+
+SET GLOBAL pxc_strict_mode = 'MASTER';
+include/assert.inc [sql_require_primary_key is ON.]
+# sql_require_primary_key = OFF cannot be set to OFF when pxc_strict_mode is MASTER
+SET GLOBAL sql_require_primary_key = OFF;
+ERROR 42000: Variable 'sql_require_primary_key' can't be set to the value of 'OFF'
+SET SESSION sql_require_primary_key = OFF;
+ERROR 42000: Variable 'sql_require_primary_key' can't be set to the value of 'OFF'
+SET GLOBAL sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = ON;
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+ERROR HY000: Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.
+
+# 5. ALTER DROP PRIMARY KEY under ENFORCING
+
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+CREATE TABLE pxc_srp_f (c1 INT PRIMARY KEY) ENGINE = InnoDB;
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+ALTER TABLE pxc_srp_f DROP PRIMARY KEY;
+ERROR HY000: Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set. Add a primary key to the table or unset this variable to avoid this message. Note that tables without a primary key can cause performance problems in row-based replication, so please consult your DBA before changing this setting.
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SET SESSION sql_require_primary_key = OFF;
+ALTER TABLE pxc_srp_f DROP PRIMARY KEY;
+DROP TABLE pxc_srp_f;
+
+# 6. restart node_2 with ENFORCING and sql-require-primary-key = OFF
+
+# restart:--pxc_strict_mode=ENFORCING --sql-require-primary-key=OFF
+include/assert.inc [pxc_strict_mode should be ENFORCING after restart]
+include/assert.inc [global sql_require_primary_key should be ON, OFF value is ignored]
+include/assert.inc [session sql_require_primary_key should be ON]
+# restore node_2 default options from suite cnf
+# restart
+
+# 7. Cleanup.
+
+SET GLOBAL pxc_strict_mode = DISABLED;
+SET GLOBAL sql_require_primary_key = OFF;
+SET GLOBAL pxc_strict_mode = DISABLED;

--- a/mysql-test/suite/galera/r/galera_rpl_pxc_strict_mode_mismatch.result
+++ b/mysql-test/suite/galera/r/galera_rpl_pxc_strict_mode_mismatch.result
@@ -1,0 +1,28 @@
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Replica SQL: Error .*Unable to create or change a table without a primary key");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+call mtr.add_suppression("Pending to replicate MySQL GTID event .* Discarding it now");
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+include/assert.inc [sql_require_primary_key global is OFF.]
+include/assert.inc [pxc_strict_mode is DISABLED]
+include/assert.inc [pxc_strict_mode is ENFORCING]
+include/assert.inc [sql_require_primary_key global is ON.]
+include/assert.inc [pxc_strict_mode is ENFORCING]
+include/assert.inc [sql_require_primary_key global is ON.]
+# Start replication on node-2
+START REPLICA USER = 'root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+include/wait_for_slave_io_to_start.inc
+include/wait_for_slave_sql_to_start.inc
+# Source runs DDL without PK; replica applier uses replicated session metadata
+CREATE TABLE t_rpl_nopk (c1 INT) ENGINE = InnoDB;
+INSERT INTO t_rpl_nopk VALUES (1);
+DROP TABLE t_rpl_nopk;
+SET GLOBAL pxc_strict_mode = DISABLED;
+SET GLOBAL sql_require_primary_key = 0;
+STOP REPLICA;
+RESET REPLICA ALL;
+SET GLOBAL pxc_strict_mode = DISABLED;
+SET GLOBAL sql_require_primary_key = 0;

--- a/mysql-test/suite/galera/r/pxc_install_gr.result
+++ b/mysql-test/suite/galera/r/pxc_install_gr.result
@@ -9,5 +9,7 @@ INSTALL PLUGIN group_replication SONAME 'group_replication.so';
 ERROR HY000: Group replication cannot be used with Percona XtraDB Cluster in strict mode.
 CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT);
 SET GLOBAL pxc_strict_mode = 0;
+SET GLOBAL sql_require_primary_key = OFF;
 SET GLOBAL pxc_strict_mode = 0;
+SET GLOBAL sql_require_primary_key = OFF;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_pxc_sql_require_primary_key.test
+++ b/mysql-test/suite/galera/t/galera_pxc_sql_require_primary_key.test
@@ -1,0 +1,213 @@
+# This test proves that setting pxc_strict_mode to ENFORCING or MASTER
+# sets @@global sql_require_primary_key ON and test few related scenarios.
+# Session values are not updated by pxc_strict_mode.
+#
+# 1. Degrade ENFORCING -> DISABLED does not change sql_require_primary_key
+# 2. pxc_strict_mode=ENFORCING also sets global sql_require_primary_key ON
+# 3. Degrade ENFORCING -> PERMISSIVE does not change sql_require_primary_key
+# 4. pxc_strict_mode=MASTER also sets global sql_require_primary_key ON
+# sql_require_primary_key=OFF cannot be set to OFF when pxc_strict_mode is MASTER
+# 5. ALTER DROP PRIMARY KEY under ENFORCING
+# 6. restart node_2 with ENFORCING and sql-require-primary-key=OFF
+# 7. Cleanup.
+
+--source include/galera_cluster.inc
+# Due to restart, lets make this test big-test.
+--source include/big_test.inc
+#--source include/force_restart.inc
+
+--connection node_1
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Replica SQL: Error .Unable to create or change a table without a primary key");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+--let $pxc_saved_1 = `SELECT @@global.pxc_strict_mode`
+
+--connection node_2
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Replica SQL: Error .Unable to create or change a table without a primary key");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+--let $pxc_saved_2 = `SELECT @@global.pxc_strict_mode`
+
+--let $assert_text = sql_require_primary_key global is OFF.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 0 ]
+--source include/assert.inc
+
+--let $pxc_strict_baseline = `SELECT @@global.pxc_strict_mode`
+--let $assert_text = pxc_strict_mode is DISABLED
+--let $assert_cond = "$pxc_strict_baseline" = "DISABLED"
+--source include/assert.inc
+
+## sql_require_primary_key behavior ##
+# Below command prove that even if GLOBAL sql_require_primary_key is set to ON
+# session variable value is not changed, allowing DDL without primary key to
+# run successfully.
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = OFF;
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_b;
+
+# Though sql_require_primary_key is ON sesson values are not changed allowing
+# DDL without primary key to run successfully.
+SET GLOBAL sql_require_primary_key = ON;
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_b;
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = ON;
+
+## NOTE-1: Upgrade pxc_strict_mode into ENFORCING/MASTER forces @@global
+## sql_require_primary_key = ON existing @@sessions are not changed.
+## Refer above testing that confirms behavior is in synch with
+## sql_require_primary_key
+## NOTE-2: Degrading strict mode does not clear global sql_require_primary_key.
+
+--echo
+--echo # 1. Degrade ENFORCING -> DISABLED does not change sql_require_primary_key
+--echo
+
+--connection node_1
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+
+--let $assert_text = sql_require_primary_key global stays ON after degrade to DISABLED.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+# sql_require_primary_key can be set to ON and OFF when pxc_strict_mode = DISABLED/PERMISSIVE
+# since pxc_strict_mode is not strict but customer may need the flag.
+SET GLOBAL sql_require_primary_key = ON;
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = OFF;
+
+CREATE TABLE pxc_srp_d (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_d;
+
+--echo
+--echo # 2. pxc_strict_mode=ENFORCING also sets global sql_require_primary_key ON
+--echo
+
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+
+--let $assert_text = sql_require_primary_key global is ON.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+--echo # sql_require_primary_key=OFF cannot be set to OFF when pxc_strict_mode is ENFORCING
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL sql_require_primary_key = OFF;
+--error ER_WRONG_VALUE_FOR_VAR
+SET SESSION sql_require_primary_key = OFF;
+
+SET GLOBAL sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = ON;
+
+# NOTE: Old session can still execute below statements.
+--error ER_TABLE_WITHOUT_PK
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+
+--echo
+--echo # 3. Degrade ENFORCING -> PERMISSIVE does not change sql_require_primary_key
+--echo
+
+SET GLOBAL pxc_strict_mode = 'PERMISSIVE';
+
+--let $assert_text = sql_require_primary_key global still ON after PERMISSIVE degrade.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+# sql_require_primary_key can be set to ON and OFF when pxc_strict_mode = DISABLED/PERMISSIVE
+# since pxc_strict_mode is not strict but customer may need the flag.
+SET GLOBAL sql_require_primary_key = ON;
+SET GLOBAL sql_require_primary_key = OFF;
+SET SESSION sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = OFF;
+
+CREATE TABLE pxc_srp_d (c1 INT) ENGINE = InnoDB;
+DROP TABLE pxc_srp_d;
+
+--echo
+--echo # 4. pxc_strict_mode = MASTER also sets global sql_require_primary_key ON
+--echo
+
+SET GLOBAL pxc_strict_mode = 'MASTER';
+
+--let $assert_text = sql_require_primary_key is ON.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+--echo # sql_require_primary_key = OFF cannot be set to OFF when pxc_strict_mode is MASTER
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL sql_require_primary_key = OFF;
+--error ER_WRONG_VALUE_FOR_VAR
+SET SESSION sql_require_primary_key = OFF;
+
+SET GLOBAL sql_require_primary_key = ON;
+SET SESSION sql_require_primary_key = ON;
+
+# NOTE: Old sessions can still execute below statements.
+--error ER_TABLE_WITHOUT_PK
+CREATE TABLE pxc_srp_b (c1 INT) ENGINE = InnoDB;
+
+--echo
+--echo # 5. ALTER DROP PRIMARY KEY under ENFORCING
+--echo
+
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+
+CREATE TABLE pxc_srp_f (c1 INT PRIMARY KEY) ENGINE = InnoDB;
+
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+
+--error ER_TABLE_WITHOUT_PK
+ALTER TABLE pxc_srp_f DROP PRIMARY KEY;
+
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SET SESSION sql_require_primary_key = OFF;
+
+ALTER TABLE pxc_srp_f DROP PRIMARY KEY;
+DROP TABLE pxc_srp_f;
+
+--echo
+--echo # 6. restart node_2 with ENFORCING and sql-require-primary-key = OFF
+--echo
+
+--connection node_2
+--let $restart_parameters = restart:--pxc_strict_mode=ENFORCING --sql-require-primary-key=OFF
+--source include/restart_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_2
+--let $pxc_mode_boot = `SELECT @@global.pxc_strict_mode`
+--let $assert_text = pxc_strict_mode should be ENFORCING after restart
+--let $assert_cond = "$pxc_mode_boot" = "ENFORCING"
+--source include/assert.inc
+
+--let $assert_text = global sql_require_primary_key should be ON, OFF value is ignored
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+--let $assert_text = session sql_require_primary_key should be ON
+--let $assert_cond = [ SELECT @@session.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+--echo # restore node_2 default options from suite cnf
+--let $restart_parameters = restart
+--source include/restart_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--echo
+--echo # 7. Cleanup.
+--echo
+
+--connection node_1
+--eval SET GLOBAL pxc_strict_mode = $pxc_saved_1
+SET GLOBAL sql_require_primary_key = OFF;
+
+--connection node_2
+--eval SET GLOBAL pxc_strict_mode = $pxc_saved_2

--- a/mysql-test/suite/galera/t/galera_rpl_pxc_strict_mode_mismatch.cnf
+++ b/mysql-test/suite/galera/t/galera_rpl_pxc_strict_mode_mismatch.cnf
@@ -1,0 +1,5 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld.2]
+
+[mysqld.3]

--- a/mysql-test/suite/galera/t/galera_rpl_pxc_strict_mode_mismatch.test
+++ b/mysql-test/suite/galera/t/galera_rpl_pxc_strict_mode_mismatch.test
@@ -1,0 +1,134 @@
+# This tests make sure transactions received from remote node of galera or from
+# asynch source are applied successfully in both galera and replica even if
+# pxc_strict_mode is ENFORCING.
+#
+# Setup Summary
+# ------------------------------------
+# Node-1 is the async replication 'source' not part of cluster.
+# The test turns 'sql_require_primary_key=OFF' so it can run CREATE TABLE
+# without a PK,
+#
+# Node-2 is the 'Galera member'. It is async-replica of node-1.
+# The test turns 'pxc_strict_mode=ENFORCING' before START REPLICA.
+# sql_require_primary_key is ON.
+# DDLs without primary key received from node-1 are executed successfully.
+#
+# Node-3 is the 'Galera member'. It is not async-replica.
+# The test turns 'pxc_strict_mode=ENFORCING' so sql_require_primary_key is ON.
+# Node-3 will receive DDL from node-2 and apply successfully.
+#
+# Testcase: On node-1 execute CREATE TABLE without a primary key and INSERT;
+# expect the table and row on node-2 (replica applier) and on node-3 (Galera).
+# Then DROP on node-1 and expect removal on the cluster; stop replication and
+# restore node-2 globals.
+#
+# Why node-2/node-3 boot with pxc_strict_mode=DISABLED (.cnf)
+# -----------------------------------------------------------
+# MTR runs include/check-testcase.test before each run; it does SET SESSION
+# sql_require_primary_key=0, which errors if pxc_strict_mode is ENFORCING. The test
+# then switches node-2 to ENFORCING before START REPLICA (strict replica after modes
+# are set, as intended). mysqld.2 also uses replica_parallel_workers=0 so upstream
+# DDL does not stall under parallel apply with Galera.
+
+--source include/have_log_bin.inc
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--source include/galera_cluster_master_slave.inc
+
+--connection node_2
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Replica SQL: Error .*Unable to create or change a table without a primary key");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+call mtr.add_suppression("Pending to replicate MySQL GTID event .* Discarding it now");
+
+--let $pxc_saved_2 = `SELECT @@global.pxc_strict_mode`
+--let $pk_saved_2 = `SELECT @@global.sql_require_primary_key`
+
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+--connection node_3
+--let $pxc_saved_3 = `SELECT @@global.pxc_strict_mode`
+--let $pk_saved_3 = `SELECT @@global.sql_require_primary_key`
+
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+
+--connection node_1
+--let $assert_text = sql_require_primary_key global is OFF.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 0 ]
+--source include/assert.inc
+
+--let $pxc_strict_baseline = `SELECT @@global.pxc_strict_mode`
+--let $assert_text = pxc_strict_mode is DISABLED
+--let $assert_cond = "$pxc_strict_baseline" = "DISABLED"
+--source include/assert.inc
+
+--connection node_2
+--let $pxc_boot = `SELECT @@global.pxc_strict_mode`
+--let $assert_text = pxc_strict_mode is ENFORCING
+--let $assert_cond = "$pxc_boot" = "ENFORCING"
+--source include/assert.inc
+
+--let $assert_text = sql_require_primary_key global is ON.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+--connection node_3
+--let $pxc_boot = `SELECT @@global.pxc_strict_mode`
+--let $assert_text = pxc_strict_mode is ENFORCING
+--let $assert_cond = "$pxc_boot" = "ENFORCING"
+--source include/assert.inc
+
+--let $assert_text = sql_require_primary_key global is ON.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+--echo # Start replication on node-2
+--connection node_2
+--disable_query_log
+--eval CHANGE REPLICATION SOURCE TO SOURCE_HOST = '127.0.0.1', SOURCE_PORT = $NODE_MYPORT_1
+--enable_query_log
+START REPLICA USER = 'root';
+
+--source include/wait_for_slave_io_to_start.inc
+--source include/wait_for_slave_sql_to_start.inc
+
+--echo # Source runs DDL without PK; replica applier uses replicated session metadata
+--connection node_1
+CREATE TABLE t_rpl_nopk (c1 INT) ENGINE = InnoDB;
+INSERT INTO t_rpl_nopk VALUES (1);
+
+## NODE-2 is replica
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 't_rpl_nopk'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t_rpl_nopk
+--source include/wait_condition.inc
+
+## NODE-3 is Galera
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 't_rpl_nopk'
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t_rpl_nopk
+--source include/wait_condition.inc
+
+--connection node_1
+DROP TABLE t_rpl_nopk;
+
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 0 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 't_rpl_nopk'
+--source include/wait_condition.inc
+--eval SET GLOBAL pxc_strict_mode = $pxc_saved_3
+--eval SET GLOBAL sql_require_primary_key = $pk_saved_3
+--disconnect node_3
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = 't_rpl_nopk'
+--source include/wait_condition.inc
+
+STOP REPLICA;
+RESET REPLICA ALL;
+
+--eval SET GLOBAL pxc_strict_mode = $pxc_saved_2
+--eval SET GLOBAL sql_require_primary_key = $pk_saved_2

--- a/mysql-test/suite/galera/t/pxc_block_write_while_in_rolling_upgrade.test
+++ b/mysql-test/suite/galera/t/pxc_block_write_while_in_rolling_upgrade.test
@@ -11,6 +11,7 @@ CALL mtr.add_suppression("Percona-XtraDB-Cluster doesn't recommend use of multip
 CALL mtr.add_suppression("pxc_maint_mode cannot be changed while using of multiple major versions");
 CALL mtr.add_suppression("Percona-XtraDB-Cluster prohibits use of multiple major versions while accepting write workload with pxc_strict_mode = ENFORCING");
 SET @global_saved_strict_tmp = @@global.pxc_strict_mode;
+# Below statement also sets @@global.sql_require_primary_key = ON;
 SET GLOBAL pxc_strict_mode = ENFORCING;
 CREATE TABLE tb1 (ID INT PRIMARY KEY);
 INSERT INTO tb1 VALUES (1),(2),(3);
@@ -76,5 +77,6 @@ SET SESSION wsrep_sync_wait = 0;
 --source include/wait_condition.inc
 SET SESSION wsrep_sync_wait = DEFAULT;
 DROP TABLE tb1;
+SET GLOBAL sql_require_primary_key = OFF;
 --enable_query_log
 

--- a/mysql-test/suite/galera/t/pxc_install_gr.test
+++ b/mysql-test/suite/galera/t/pxc_install_gr.test
@@ -42,7 +42,9 @@ INSTALL PLUGIN group_replication SONAME 'group_replication.so';
 CREATE TABLE t1(id INT PRIMARY KEY AUTO_INCREMENT);
 
 SET GLOBAL pxc_strict_mode = 0;
+SET GLOBAL sql_require_primary_key = OFF;
 --connection node_2
 SET GLOBAL pxc_strict_mode = 0;
+SET GLOBAL sql_require_primary_key = OFF;
 --connection node_1
 DROP TABLE t1;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5716,6 +5716,15 @@ int init_common_variables() {
   WSREP statements. */
   global_system_variables.wsrep_on = true;
 
+  if (wsrep_provider_loaded && !opt_initialize &&
+      pxc_strict_mode >= PXC_STRICT_MODE_ENFORCING &&
+      !global_system_variables.sql_require_primary_key) {
+    WSREP_WARN(
+        "Setting sql_require_primary_key=ON because pxc_strict_mode is "
+        "ENFORCING or MASTER.");
+    global_system_variables.sql_require_primary_key = true;
+  }
+
   if (wsrep_setup_allowed_sst_methods()) return 1;
 
   /*

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -387,6 +387,12 @@ static bool check_session_admin_no_super(sys_var *self, THD *thd,
   @param thd the session context
   @param setv the SET operations metadata
  */
+#ifdef WITH_WSREP
+static bool check_session_admin_and_sql_require_primary_key_on_check(sys_var *,
+                                                                     THD *,
+                                                                     set_var *);
+#endif /* WITH_WSREP */
+
 static bool check_session_admin(sys_var *self, THD *thd, set_var *setv) {
   Security_context *sctx = thd->security_context();
 
@@ -8177,7 +8183,11 @@ static Sys_var_bool Sys_sql_require_primary_key{
     DEFAULT(false),
     NO_MUTEX_GUARD,
     IN_BINLOG,
+#ifdef WITH_WSREP
+    ON_CHECK(check_session_admin_and_sql_require_primary_key_on_check)};
+#else
     ON_CHECK(check_session_admin)};
+#endif
 
 static Sys_var_bool Sys_sql_generate_invisible_primary_key(
     "sql_generate_invisible_primary_key",
@@ -8434,6 +8444,22 @@ static Sys_var_charptr Sys_protocol_compression_algorithms(
 #include "wsrep_binlog.h"
 #include "wsrep_sst.h"
 #include "wsrep_var.h"
+
+static bool check_session_admin_and_sql_require_primary_key_on_check(
+    sys_var *self, THD *thd, set_var *var) {
+  if (check_session_admin(self, thd, var)) return true;
+  if (pxc_strict_mode < PXC_STRICT_MODE_ENFORCING) return false;
+  if (var->save_result.ulonglong_value == 0) {
+    const char *strict_name =
+        (pxc_strict_mode == PXC_STRICT_MODE_MASTER) ? "MASTER" : "ENFORCING";
+    WSREP_ERROR(
+        "Cannot set sql_require_primary_key=OFF while pxc_strict_mode is %s.",
+        strict_name);
+    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), self->name.str, "OFF");
+    return true;
+  }
+  return false;
+}
 
 static PolyLock_mutex PLock_wsrep_cluster_config(&LOCK_wsrep_cluster_config);
 static Sys_var_charptr Sys_wsrep_provider(
@@ -8813,7 +8839,7 @@ static Sys_var_enum Sys_pxc_strict_mode(
     "PXC strict mode help control behavior of experimental features",
     GLOBAL_VAR(pxc_strict_mode), CMD_LINE(OPT_ARG), pxc_strict_modes,
     DEFAULT(PXC_STRICT_MODE_ENFORCING), NO_MUTEX_GUARD, NOT_IN_BINLOG,
-    ON_CHECK(pxc_strict_mode_check), ON_UPDATE(0));
+    ON_CHECK(pxc_strict_mode_check), ON_UPDATE(pxc_strict_mode_update));
 
 static const char *pxc_maint_modes[] = {"DISABLED", "SHUTDOWN", "MAINTENANCE",
                                         NullS};
@@ -9125,4 +9151,3 @@ static Sys_var_enum_default_table_encryption Sys_default_table_encryption(
     HINT_UPDATEABLE SESSION_VAR(default_table_encryption), CMD_LINE(OPT_ARG),
     default_table_encryption_type_names, DEFAULT(DEFAULT_TABLE_ENC_OFF),
     NO_MUTEX_GUARD, IN_BINLOG, ON_CHECK(check_set_default_table_encryption));
-

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -1006,6 +1006,23 @@ bool pxc_strict_mode_check(sys_var *, THD *thd, set_var *var) {
   return (block);
 }
 
+bool pxc_strict_mode_update(sys_var *, THD *, enum_var_type) {
+  /*
+    When pxc_strict_mode=ENFORCING/MASTER, we set sql_require_primary_key=ON.
+    Only global is set; existing sessions keep their session value
+    (new sessions inherit the updated global default).
+  */
+  if (pxc_strict_mode >= PXC_STRICT_MODE_ENFORCING &&
+      global_system_variables.sql_require_primary_key == false) {
+    global_system_variables.sql_require_primary_key = true;
+    WSREP_INFO(
+        "Setting sql_require_primary_key=ON because pxc_strict_mode is "
+        "being changed to %s.",
+        pxc_strict_mode_to_string(pxc_strict_mode));
+  }
+  return false;
+}
+
 static const char *pxc_maint_mode_to_string(ulong value) {
   switch (value) {
     case PXC_MAINT_MODE_DISABLED:

--- a/sql/wsrep_var.h
+++ b/sql/wsrep_var.h
@@ -100,6 +100,7 @@ extern bool wsrep_debug_update UPDATE_ARGS;
 extern bool wsrep_replicate_myisam_check CHECK_ARGS;
 
 extern bool pxc_strict_mode_check CHECK_ARGS;
+extern bool pxc_strict_mode_update UPDATE_ARGS;
 
 extern bool pxc_maint_mode_check CHECK_ARGS;
 extern bool pxc_maint_mode_update UPDATE_ARGS;


### PR DESCRIPTION
…FORCING

Problem:
Setting pxc_strict_mode to ENFORCING/MASTER does not set sql_require_primary_key=1

Description
When pxc_strict_mode=ENFORCING or MASTER is set we get ERROR when doing operations on table without primary key.
Example:
>insert into table_1 values(1);
ERROR 1105 (HY000): Percona-XtraDB-Cluster prohibits use of DML command on a table (test.table_1) without an explicit primary key with pxc_strict_mode = ENFORCING or MASTER
However pxc_strict_mode=ENFORCING or MASTER does not restrict table creation without primary keys.
Another system variable sql_require_primary_key enforce the requirement that tables have a primary key for both creation of new tables or altering the structure of existing tables
pxc_strict_mode=ENFORCING or MASTER should also enforce the requirement that tables have a primary key for both creation of new tables or altering the structure of existing tables

Resolution:

1. Policy consistency Before, operators could set 'sql_require_primary_key=OFF' while the cluster was in a strict PXC mode, which weakened the intended “primary key required” policy. The server now enforces: under 'ENFORCING'/'MASTER', turning 'sql_require_primary_key' 'ON' (via 'SET GLOBAL' or 'SET SESSION') is rejected when moving into strict mode, if global 'sql_require_primary_key' was 'OFF', the server now sets 'global' to 'ON'.

2. Session vs global Changing 'pxc_strict_mode' may update '@@global.sql_require_primary_key' as above. The server does not rewrite '@@session.sql_require_primary_key' on 'existing' connections. Each session keeps its session value until the client changes it or opens a new connection (new sessions inherit the global default as usual).

3. Startup If Galera is active and 'pxc_strict_mode' is 'ENFORCING' or 'MASTER' but the server would otherwise start with 'global' 'sql_require_primary_key' 'OFF' (e.g. from options or config), startup forces 'global' 'ON' so the effective policy matches strict mode.