### PR TITLE
PXC-4963: Discrepancy between GRANTs for in-place upgraded PXC binaries vs fresh installed PXC binaries(trunk)

### DIFF
--- a/mysql-test/r/pxc_sst_role_grants_upgrade_force.result
+++ b/mysql-test/r/pxc_sst_role_grants_upgrade_force.result
@@ -1,0 +1,104 @@
+#
+# 1. Save the fresh-install state for the role 'mysql.pxc.sst.role'.
+#    We need to diff grants of fresh install with upgrade.
+#
+CREATE TABLE test.t_pxc_sst_user_fresh        AS SELECT * FROM mysql.user          WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_db_fresh          AS SELECT * FROM mysql.db            WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_tables_priv_fresh AS SELECT * FROM mysql.tables_priv   WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_procs_priv_fresh  AS SELECT * FROM mysql.procs_priv    WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_global_fresh      AS SELECT * FROM mysql.global_grants WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+SHOW GRANTS FOR 'mysql.pxc.sst.role'@'localhost';
+Grants for mysql.pxc.sst.role@localhost
+GRANT RELOAD, SHUTDOWN, PROCESS, SUPER, LOCK TABLES, EXECUTE, REPLICATION CLIENT, CREATE USER, CREATE ROLE, DROP ROLE ON *.* TO `mysql.pxc.sst.role`@`localhost` WITH GRANT OPTION
+GRANT CLONE_ADMIN,CONNECTION_ADMIN,INNODB_REDO_LOG_ARCHIVE,SYSTEM_USER,SYSTEM_VARIABLES_ADMIN ON *.* TO `mysql.pxc.sst.role`@`localhost`
+GRANT BACKUP_ADMIN ON *.* TO `mysql.pxc.sst.role`@`localhost` WITH GRANT OPTION
+GRANT CREATE ON `PERCONA_SCHEMA`.* TO `mysql.pxc.sst.role`@`localhost`
+GRANT SELECT, INSERT, UPDATE ON `performance_schema`.* TO `mysql.pxc.sst.role`@`localhost` WITH GRANT OPTION
+GRANT SELECT, INSERT, CREATE, ALTER ON `PERCONA_SCHEMA`.`xtrabackup_history` TO `mysql.pxc.sst.role`@`localhost`
+GRANT INSERT, DELETE ON `mysql`.`plugin` TO `mysql.pxc.sst.role`@`localhost`
+include/assert.inc [Fresh install: mysql.user.Shutdown_priv = Y]
+include/assert.inc [Fresh install: mysql.user.Execute_priv = Y]
+include/assert.inc [Fresh install: mysql.user.Grant_priv = Y]
+include/assert.inc [Fresh install: mysql.user.Create_user_priv = Y]
+include/assert.inc [Fresh install: mysql.user.Create_role_priv = Y]
+include/assert.inc [Fresh install: mysql.user.Drop_role_priv = Y]
+include/assert.inc [Fresh install: mysql.db on performance_schema has Insert_priv = Y]
+include/assert.inc [Fresh install: mysql.db on performance_schema has Update_priv = Y]
+include/assert.inc [Fresh install: mysql.db on performance_schema has Grant_priv = Y]
+include/assert.inc [Fresh install: mysql.global_grants BACKUP_ADMIN has WITH_GRANT_OPTION = Y]
+#
+# 2. Create some tables with data; this will confirm the server
+#    post upgrade.
+#
+CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(32)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'fresh'), (2, 'install'), (3, 'data');
+SELECT * FROM t1 ORDER BY id;
+id	val
+1	fresh
+2	install
+3	data
+#
+# 3. Remove the privileges from the ACL rows to simulate the old version
+#    PXC members.
+#
+UPDATE mysql.user SET Shutdown_priv = 'N', Execute_priv = 'N', Grant_priv = 'N', Create_user_priv = 'N', Create_role_priv = 'N', Drop_role_priv = 'N' WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+UPDATE mysql.global_grants SET WITH_GRANT_OPTION = 'N' WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost' AND priv = 'BACKUP_ADMIN';
+UPDATE mysql.db SET Insert_priv = 'N', Update_priv = 'N', Grant_priv = 'N' WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost' AND Db = 'performance_schema';
+FLUSH PRIVILEGES;
+#
+# 4. Assert the broken state.
+#
+include/assert.inc [Broken: mysql.user privileges all flipped to N]
+include/assert.inc [Broken: mysql.db on performance_schema has Insert/Update/Grant flipped to N]
+include/assert.inc [Broken: mysql.global_grants BACKUP_ADMIN has WITH_GRANT_OPTION = N]
+#
+# 5. Restart the server with --upgrade=FORCE.
+#    This re-runs mysql_system_tables_fix.sql.
+#
+# restart:--upgrade=FORCE
+#
+# 6. Check post --upgrade=FORCE state matches the fresh install.
+#
+CREATE TABLE test.t_pxc_sst_user_post        AS SELECT * FROM mysql.user          WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_db_post          AS SELECT * FROM mysql.db            WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_tables_priv_post AS SELECT * FROM mysql.tables_priv   WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_procs_priv_post  AS SELECT * FROM mysql.procs_priv    WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_global_post      AS SELECT * FROM mysql.global_grants WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+SHOW GRANTS FOR 'mysql.pxc.sst.role'@'localhost';
+Grants for mysql.pxc.sst.role@localhost
+GRANT RELOAD, SHUTDOWN, PROCESS, SUPER, LOCK TABLES, EXECUTE, REPLICATION CLIENT, CREATE USER, CREATE ROLE, DROP ROLE ON *.* TO `mysql.pxc.sst.role`@`localhost` WITH GRANT OPTION
+GRANT CLONE_ADMIN,CONNECTION_ADMIN,INNODB_REDO_LOG_ARCHIVE,SYSTEM_USER,SYSTEM_VARIABLES_ADMIN ON *.* TO `mysql.pxc.sst.role`@`localhost`
+GRANT BACKUP_ADMIN ON *.* TO `mysql.pxc.sst.role`@`localhost` WITH GRANT OPTION
+GRANT CREATE ON `PERCONA_SCHEMA`.* TO `mysql.pxc.sst.role`@`localhost`
+GRANT SELECT, INSERT, UPDATE ON `performance_schema`.* TO `mysql.pxc.sst.role`@`localhost` WITH GRANT OPTION
+GRANT SELECT, INSERT, CREATE, ALTER ON `PERCONA_SCHEMA`.`xtrabackup_history` TO `mysql.pxc.sst.role`@`localhost`
+GRANT INSERT, DELETE ON `mysql`.`plugin` TO `mysql.pxc.sst.role`@`localhost`
+include/diff_tables.inc [default:test.t_pxc_sst_user_fresh, default:test.t_pxc_sst_user_post]
+include/diff_tables.inc [default:test.t_pxc_sst_db_fresh, default:test.t_pxc_sst_db_post]
+include/diff_tables.inc [default:test.t_pxc_sst_tables_priv_fresh, default:test.t_pxc_sst_tables_priv_post]
+include/diff_tables.inc [default:test.t_pxc_sst_procs_priv_fresh, default:test.t_pxc_sst_procs_priv_post]
+include/diff_tables.inc [default:test.t_pxc_sst_global_fresh, default:test.t_pxc_sst_global_post]
+include/assert.inc [Post upgrade: mysql.user.Shutdown_priv = Y]
+include/assert.inc [Post upgrade: mysql.user.Execute_priv = Y]
+include/assert.inc [Post upgrade: mysql.user.Grant_priv = Y]
+include/assert.inc [Post upgrade: mysql.user.Create_user_priv = Y]
+include/assert.inc [Post upgrade: mysql.user.Create_role_priv = Y]
+include/assert.inc [Post upgrade: mysql.user.Drop_role_priv = Y]
+include/assert.inc [Post upgrade: mysql.db on performance_schema has Insert_priv = Y]
+include/assert.inc [Post upgrade: mysql.db on performance_schema has Update_priv = Y]
+include/assert.inc [Post upgrade: mysql.db on performance_schema has Grant_priv = Y]
+include/assert.inc [Post upgrade: mysql.global_grants BACKUP_ADMIN has WITH_GRANT_OPTION = Y]
+#
+# 7. Confirm the table created before the upgrade still exists.
+#
+SELECT * FROM t1 ORDER BY id;
+id	val
+1	fresh
+2	install
+3	data
+#
+# 8. Cleanup.
+#
+DROP TABLE t1;
+DROP TABLE test.t_pxc_sst_user_fresh, test.t_pxc_sst_db_fresh, test.t_pxc_sst_tables_priv_fresh, test.t_pxc_sst_procs_priv_fresh, test.t_pxc_sst_global_fresh;
+DROP TABLE test.t_pxc_sst_user_post,  test.t_pxc_sst_db_post,  test.t_pxc_sst_tables_priv_post,  test.t_pxc_sst_procs_priv_post,  test.t_pxc_sst_global_post;

--- a/mysql-test/t/pxc_sst_role_grants_upgrade_force.test
+++ b/mysql-test/t/pxc_sst_role_grants_upgrade_force.test
@@ -1,0 +1,224 @@
+################################################################################
+# PXC-4963: This test proves that GRANTS matches for user/role
+# 'mysql.pxc.sst.role' after inplace upgrade with the fresh install.
+#
+# 1. Save the fresh-install state for the role 'mysql.pxc.sst.role'.
+#    We need to diff grants of fresh install with upgrade.
+# 2. Create some tables with data; this will confirm the server
+#    post upgrade.
+# 3. Remove the privileges from the ACL rows to simulate the old version
+#    PXC members.
+# 4. Assert the broken state.
+# 5. Restart the server with --upgrade=FORCE.
+#    This re-runs mysql_system_tables_fix.sql.
+# 6. Check post --upgrade=FORCE state matches the fresh install.
+# 7. Confirm the table created before the upgrade still exists.
+# 8. Cleanup.
+################################################################################
+
+# Reference mysql_upgrade.test, due to upgrade/restart its going to take time
+--source include/big_test.inc
+--source include/not_valgrind.inc
+
+# If for some reason pxc roles are not present we cannot run the test.
+if (`SELECT COUNT(*) = 0 FROM mysql.user WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost'`)
+{
+  --skip PXC-only: requires mysql.pxc.sst.role (bootstrap).
+}
+
+--echo #
+--echo # 1. Save the fresh-install state for the role 'mysql.pxc.sst.role'.
+--echo #    We need to diff grants of fresh install with upgrade.
+--echo #
+
+# Snapshot every mysql.* ACL table that holds rows for the role so we can
+# do a row-by-row diff against the post-upgrade state in step 6.
+# This is to make sure permissions are same in fresh installation and post upgrade.
+CREATE TABLE test.t_pxc_sst_user_fresh        AS SELECT * FROM mysql.user          WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_db_fresh          AS SELECT * FROM mysql.db            WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_tables_priv_fresh AS SELECT * FROM mysql.tables_priv   WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_procs_priv_fresh  AS SELECT * FROM mysql.procs_priv    WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_global_fresh      AS SELECT * FROM mysql.global_grants WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+
+SHOW GRANTS FOR 'mysql.pxc.sst.role'@'localhost';
+
+# PXC-4963
+# Below are some core privileges, so we have deliberately used assert to make sure core privileges are present.
+# In future if diff of fresh install and upgrade fail, its fine(we can remove table diff), but below asserts should not fail.
+# Table diff only shows upgrade matches the permission same as fresh install.
+
+--let $assert_text = Fresh install: mysql.user.Shutdown_priv = Y
+--let $assert_cond = "[SELECT Shutdown_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.user.Execute_priv = Y
+--let $assert_cond = "[SELECT Execute_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.user.Grant_priv = Y
+--let $assert_cond = "[SELECT Grant_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.user.Create_user_priv = Y
+--let $assert_cond = "[SELECT Create_user_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.user.Create_role_priv = Y
+--let $assert_cond = "[SELECT Create_role_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.user.Drop_role_priv = Y
+--let $assert_cond = "[SELECT Drop_role_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.db on performance_schema has Insert_priv = Y
+--let $assert_cond = "[SELECT Insert_priv FROM mysql.db WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Db = \'performance_schema\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.db on performance_schema has Update_priv = Y
+--let $assert_cond = "[SELECT Update_priv FROM mysql.db WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Db = \'performance_schema\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.db on performance_schema has Grant_priv = Y
+--let $assert_cond = "[SELECT Grant_priv FROM mysql.db WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Db = \'performance_schema\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Fresh install: mysql.global_grants BACKUP_ADMIN has WITH_GRANT_OPTION = Y
+--let $assert_cond = "[SELECT WITH_GRANT_OPTION FROM mysql.global_grants WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND priv = \'BACKUP_ADMIN\']" = "Y"
+--source include/assert.inc
+
+--echo #
+--echo # 2. Create some tables with data; this will confirm the server
+--echo #    post upgrade.
+--echo #
+
+# This is not important but proves that the server is same.
+CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(32)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'fresh'), (2, 'install'), (3, 'data');
+SELECT * FROM t1 ORDER BY id;
+
+--echo #
+--echo # 3. Remove the privileges from the ACL rows to simulate the old version
+--echo #    PXC members.
+--echo #
+
+UPDATE mysql.user SET Shutdown_priv = 'N', Execute_priv = 'N', Grant_priv = 'N', Create_user_priv = 'N', Create_role_priv = 'N', Drop_role_priv = 'N' WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+UPDATE mysql.global_grants SET WITH_GRANT_OPTION = 'N' WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost' AND priv = 'BACKUP_ADMIN';
+UPDATE mysql.db SET Insert_priv = 'N', Update_priv = 'N', Grant_priv = 'N' WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost' AND Db = 'performance_schema';
+FLUSH PRIVILEGES;
+
+--echo #
+--echo # 4. Assert the broken state.
+--echo #
+
+--let $assert_text = Broken: mysql.user privileges all flipped to N
+--let $assert_cond = [SELECT COUNT(*) FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Shutdown_priv = \'N\' AND Execute_priv = \'N\' AND Grant_priv = \'N\' AND Create_user_priv = \'N\' AND Create_role_priv = \'N\' AND Drop_role_priv = \'N\'] = 1
+--source include/assert.inc
+
+--let $assert_text = Broken: mysql.db on performance_schema has Insert/Update/Grant flipped to N
+--let $assert_cond = [SELECT COUNT(*) FROM mysql.db WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Db = \'performance_schema\' AND Insert_priv = \'N\' AND Update_priv = \'N\' AND Grant_priv = \'N\'] = 1
+--source include/assert.inc
+
+--let $assert_text = Broken: mysql.global_grants BACKUP_ADMIN has WITH_GRANT_OPTION = N
+--let $assert_cond = "[SELECT WITH_GRANT_OPTION FROM mysql.global_grants WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND priv = \'BACKUP_ADMIN\']" = "N"
+--source include/assert.inc
+
+--echo #
+--echo # 5. Restart the server with --upgrade=FORCE.
+--echo #    This re-runs mysql_system_tables_fix.sql.
+--echo #
+
+# Reference mysql_upgrade.test, it takes time
+--let $restart_parameters = restart:--upgrade=FORCE
+--let $wait_counter= 10000
+--source include/restart_mysqld.inc
+
+--echo #
+--echo # 6. Check post --upgrade=FORCE state matches the fresh install.
+--echo #
+
+# Snapshot the post-upgrade rows so we can diff them against the
+# fresh-install baseline saved in step 1.
+CREATE TABLE test.t_pxc_sst_user_post        AS SELECT * FROM mysql.user          WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_db_post          AS SELECT * FROM mysql.db            WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_tables_priv_post AS SELECT * FROM mysql.tables_priv   WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_procs_priv_post  AS SELECT * FROM mysql.procs_priv    WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+CREATE TABLE test.t_pxc_sst_global_post      AS SELECT * FROM mysql.global_grants WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+
+SHOW GRANTS FOR 'mysql.pxc.sst.role'@'localhost';
+
+# Full row-by-row diff: every ACL row for the role must match what
+# mysql_system_users.sql produces on a fresh install.
+
+--let $diff_tables= default:test.t_pxc_sst_user_fresh, default:test.t_pxc_sst_user_post
+--source include/diff_tables.inc
+
+--let $diff_tables= default:test.t_pxc_sst_db_fresh, default:test.t_pxc_sst_db_post
+--source include/diff_tables.inc
+
+--let $diff_tables= default:test.t_pxc_sst_tables_priv_fresh, default:test.t_pxc_sst_tables_priv_post
+--source include/diff_tables.inc
+
+--let $diff_tables= default:test.t_pxc_sst_procs_priv_fresh, default:test.t_pxc_sst_procs_priv_post
+--source include/diff_tables.inc
+
+--let $diff_tables= default:test.t_pxc_sst_global_fresh, default:test.t_pxc_sst_global_post
+--source include/diff_tables.inc
+
+# PXC-4963
+# Below are some core privileges so we have deliberately used assert to make sure they are restored.
+# Otherwise in above asserts we make sure permission during fresh installation and post upgrade are same.
+
+--let $assert_text = Post upgrade: mysql.user.Shutdown_priv = Y
+--let $assert_cond = "[SELECT Shutdown_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.user.Execute_priv = Y
+--let $assert_cond = "[SELECT Execute_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.user.Grant_priv = Y
+--let $assert_cond = "[SELECT Grant_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.user.Create_user_priv = Y
+--let $assert_cond = "[SELECT Create_user_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.user.Create_role_priv = Y
+--let $assert_cond = "[SELECT Create_role_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.user.Drop_role_priv = Y
+--let $assert_cond = "[SELECT Drop_role_priv FROM mysql.user WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.db on performance_schema has Insert_priv = Y
+--let $assert_cond = "[SELECT Insert_priv FROM mysql.db WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Db = \'performance_schema\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.db on performance_schema has Update_priv = Y
+--let $assert_cond = "[SELECT Update_priv FROM mysql.db WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Db = \'performance_schema\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.db on performance_schema has Grant_priv = Y
+--let $assert_cond = "[SELECT Grant_priv FROM mysql.db WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND Db = \'performance_schema\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Post upgrade: mysql.global_grants BACKUP_ADMIN has WITH_GRANT_OPTION = Y
+--let $assert_cond = "[SELECT WITH_GRANT_OPTION FROM mysql.global_grants WHERE user = \'mysql.pxc.sst.role\' AND host = \'localhost\' AND priv = \'BACKUP_ADMIN\']" = "Y"
+--source include/assert.inc
+
+--echo #
+--echo # 7. Confirm the table created before the upgrade still exists.
+--echo #
+
+SELECT * FROM t1 ORDER BY id;
+
+--echo #
+--echo # 8. Cleanup.
+--echo #
+
+DROP TABLE t1;
+DROP TABLE test.t_pxc_sst_user_fresh, test.t_pxc_sst_db_fresh, test.t_pxc_sst_tables_priv_fresh, test.t_pxc_sst_procs_priv_fresh, test.t_pxc_sst_global_fresh;
+DROP TABLE test.t_pxc_sst_user_post,  test.t_pxc_sst_db_post,  test.t_pxc_sst_tables_priv_post,  test.t_pxc_sst_procs_priv_post,  test.t_pxc_sst_global_post;

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -1450,6 +1450,32 @@ INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost'
 INSERT IGNORE INTO mysql.global_grants VALUES ('mysql.pxc.sst.role', 'localhost', 'SYSTEM_VARIABLES_ADMIN', 'N');
 INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'mysql', 'mysql.pxc.sst.role', 'plugin', 'root\@localhost', CURRENT_TIMESTAMP, 'Insert,Delete', '');
 
+# PXC-4963: Discrepancy between GRANTs for in-place upgraded PXC binaries vs
+# fresh installed PXC binaries
+# mysql.pxc.sst.role: fix static global privileges left stale after in-place
+# upgrade.
+# INSERT IGNORE above does not change an existing row from older PXC.
+# A fresh install gets these from mysql_system_users.sql
+# (GRANT ... CREATE USER, SHUTDOWN, EXECUTE, ... WITH GRANT OPTION).
+UPDATE mysql.user SET
+  Shutdown_priv = 'Y',
+  Execute_priv = 'Y',
+  Grant_priv = 'Y',
+  Create_user_priv = 'Y',
+  Create_role_priv = 'Y',
+  Drop_role_priv = 'Y'
+WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost';
+
+UPDATE mysql.global_grants SET WITH_GRANT_OPTION = 'Y'
+WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost' AND priv = 'BACKUP_ADMIN';
+
+UPDATE mysql.db SET
+  Select_priv = 'Y',
+  Insert_priv = 'Y',
+  Update_priv = 'Y',
+  Grant_priv = 'Y'
+WHERE user = 'mysql.pxc.sst.role' AND host = 'localhost' AND `Db` = 'performance_schema';
+
 #! PXC_SECTION::END
 # flush privileges at this stage can cause problem with upgrade from 57 -> 80
 # FLUSH PRIVILEGES;


### PR DESCRIPTION
PXC-4963: Discrepancy between GRANTs for in-place upgraded PXC binaries vs fresh installed PXC binaries

https://perconadev.atlassian.net/browse/PXC-4963

Problem:
After an in-place upgrade from an older PXC, the ACL rows for the
internal role 'mysql.pxc.sst.role'@'localhost' retain the narrower
privilege set defined by the older release, while a fresh 8.0.x install
creates the role with the full set required by current SST code paths
(CREATE USER, SHUTDOWN, EXECUTE, CREATE ROLE, DROP ROLE, GRANT OPTION,
BACKUP_ADMIN WITH GRANT OPTION, and Select/Insert/Update/Grant on
performance_schema.*) via mysql_system_users.sql.

mysql_system_tables_fix.sql -- the script mysql_upgrade runs on
existing installs -- only contains INSERT IGNORE statements for this
role. INSERT IGNORE is a no-op when the rows already exist, so upgraded
installs never receive the missing privileges and end up with a role
from an older PXC.

Resolution:
Added UPDATE statements to the scripts mysql_system_tables_fix.sql
