### PR TITLE
PXC-5229: WSREP applier threads should never have tx_read_only=true(8.0)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_5229_wsrep_applier_tx_read_only.result
+++ b/mysql-test/suite/galera/r/pxc_5229_wsrep_applier_tx_read_only.result
@@ -1,0 +1,16 @@
+SET @transaction_read_only_save = @@GLOBAL.transaction_read_only;
+SET @wsrep_applier_threads_save = @@GLOBAL.wsrep_applier_threads;
+SET GLOBAL transaction_read_only = 1;
+SET GLOBAL wsrep_applier_threads = 10;
+CREATE TABLE test.pxc_5229_t1(id INT PRIMARY KEY, v INT);
+CREATE TABLE test.pxc_5229_t2(id INT PRIMARY KEY, v INT);
+LOCK TABLE test.pxc_5229_t1 READ;
+UNLOCK TABLES;
+include/assert.inc [node_2 wsrep_cluster_status must stay Primary]
+include/assert.inc [node_2 wsrep_connected must stay ON]
+include/assert.inc [node_2 wsrep_ready must stay ON]
+include/assert.inc [node_2 wsrep_local_state_comment must stay Synced]
+SET @@GLOBAL.transaction_read_only = @transaction_read_only_save;
+SET @@GLOBAL.wsrep_applier_threads = @wsrep_applier_threads_save;
+DROP TABLE test.pxc_5229_t1;
+DROP TABLE test.pxc_5229_t2;

--- a/mysql-test/suite/galera/t/pxc_5229_wsrep_applier_tx_read_only.cnf
+++ b/mysql-test/suite/galera/t/pxc_5229_wsrep_applier_tx_read_only.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_applier_threads=1

--- a/mysql-test/suite/galera/t/pxc_5229_wsrep_applier_tx_read_only.test
+++ b/mysql-test/suite/galera/t/pxc_5229_wsrep_applier_tx_read_only.test
@@ -1,0 +1,80 @@
+# === Purpose ===
+# Verify wsrep applier threads never run with transaction_read_only=1.
+#
+# === Reference ===
+# PXC-5229: WSREP applier threads should never have tx_read_only=true
+
+--source include/galera_cluster.inc
+
+--connection node_2
+SET @transaction_read_only_save = @@GLOBAL.transaction_read_only;
+SET @wsrep_applier_threads_save = @@GLOBAL.wsrep_applier_threads;
+
+SET GLOBAL transaction_read_only = 1;
+SET GLOBAL wsrep_applier_threads = 10;
+# Confirm 10 applier threads
+--let $wait_condition = SELECT COUNT(*) = @@wsrep_applier_threads + 1 FROM performance_schema.processlist WHERE USER = 'system user'
+--source include/wait_condition.inc
+
+# Have 2 tables a lock one of the table
+--connection node_1
+CREATE TABLE test.pxc_5229_t1(id INT PRIMARY KEY, v INT);
+CREATE TABLE test.pxc_5229_t2(id INT PRIMARY KEY, v INT);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_schema = 'test' AND table_name = 'pxc_5229_t1'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_schema = 'test' AND table_name = 'pxc_5229_t2'
+--source include/wait_condition.inc
+
+LOCK TABLE test.pxc_5229_t1 READ;
+
+--connection node_1
+# Generate workload to distribute among applier threads
+--disable_query_log
+--let $i = 1
+while ($i <= 50)
+{
+  --eval INSERT INTO test.pxc_5229_t1 VALUES ($i, $i)
+  --eval INSERT INTO test.pxc_5229_t2 VALUES ($i, $i)
+  --inc $i
+}
+UPDATE test.pxc_5229_t1 SET v = v + 5;
+UPDATE test.pxc_5229_t2 SET v = v + 5;
+--enable_query_log
+
+# Sleep to let workload distribute and UNLOCK tables
+--connection node_2
+
+--sleep 2
+UNLOCK TABLES;
+
+--let $wait_condition = SELECT COUNT(*) = 50 FROM test.pxc_5229_t2
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 50 FROM test.pxc_5229_t1
+--source include/wait_condition.inc
+
+--let $assert_text = node_2 wsrep_cluster_status must stay Primary
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = \'wsrep_cluster_status\', VARIABLE_VALUE, 1]" = "Primary"
+--source include/assert.inc
+
+--let $assert_text = node_2 wsrep_connected must stay ON
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = \'wsrep_connected\', VARIABLE_VALUE, 1]" = "ON"
+--source include/assert.inc
+
+--let $assert_text = node_2 wsrep_ready must stay ON
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = \'wsrep_ready\', VARIABLE_VALUE, 1]" = "ON"
+--source include/assert.inc
+
+--let $assert_text = node_2 wsrep_local_state_comment must stay Synced
+--let $assert_cond = "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = \'wsrep_local_state_comment\', VARIABLE_VALUE, 1]" = "Synced"
+--source include/assert.inc
+
+SET @@GLOBAL.transaction_read_only = @transaction_read_only_save;
+SET @@GLOBAL.wsrep_applier_threads = @wsrep_applier_threads_save;
+
+--connection node_1
+DROP TABLE test.pxc_5229_t1;
+DROP TABLE test.pxc_5229_t2;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10765,6 +10765,14 @@ static int init_wsrep_thread(THD *thd) {
 #endif /* GALERA */
   thd->enable_slow_log = opt_log_slow_replica_statements;
   set_slave_thread_options(thd);
+  /*
+    Wsrep applier threads must always be able to apply writesets.
+    A freshly created applier THD would inherit a global
+    transaction_read_only. The flag is not just a SQL-layer gate: it also
+    propagates into InnoDB.
+  */
+  thd->variables.transaction_read_only = false;
+  thd->tx_read_only = false;
   thd->get_protocol_classic()->set_client_capabilities(CLIENT_LOCAL_FILES);
 
   /*

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -49,6 +49,8 @@ static void init_service_thd(THD *thd, const char *thread_stack) {
   thd->set_time();
   thd->set_command(COM_SLEEP);
   thd->reset_for_next_command();
+  thd->variables.transaction_read_only = false;
+  thd->tx_read_only = false;
 }
 
 wsrep::storage_service *Wsrep_server_service::storage_service(


### PR DESCRIPTION
WSREP applier threads may inherit global `transaction_read_only=1` after changing `wsrep_applier_threads`, leading to apply failures such as:
  - `Cannot execute statement in a READ ONLY transaction.`
  - BF applier errors
  - Cluster inconsistency `transaction_read_only` is a SESSION+GLOBAL variable. NOTE:
transaction_read_only has NO_CMD_LINE means there is no command-line/option-file entry registered for it.
The only way to set the global is SET GLOBAL transaction_read_only=1 at runtime. (But persist works, which can be used as a hack.)

`SET GLOBAL wsrep_applier_threads=N` spawns brand new applier THDs (`start_wsrep_THD -> init_wsrep_thread`) *after* `transaction_read_only=1` was set, so those new appliers inherit `tx_read_only=true` and fail to apply writes.

The read-only-transaction flag is not just a SQL-layer gate. It is enforced at `open_tables`/`lock_tables` (`sql/sql_base.cc`, raising `ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION`) and it propagates into InnoDB. Therefore a fix that only bypasses the SQL-layer check is insufficient/unsafe: InnoDB would still start a read-only `trx` and the replicated write would fail at the storage engine.

Resolution:
Code has been modified to set transaction_read_only for the needed threads.