### PR TITLE
PXC-4805: PXC 8.4 Missing mysqlchk script(trunk)

### DIFF
--- a/build-ps/debian/extra/clustercheck.socket
+++ b/build-ps/debian/extra/clustercheck.socket
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 Percona Inc
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not, write to the
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston
+# MA  02110-1301  USA.
+#
+# PXC packaging override -- mirrors how build-ps/debian/extra/mysql.service
+# overrides upstream's CMake-installed unit. Keep behaviorally in sync with
+# scripts/systemd/clustercheck.socket.in (the @bindir@-templated source
+# used by tarball / dev builds with -DWITH_SYSTEMD=ON). The .in template
+# has no @-substitutions in the .socket unit, so this file is byte-equal
+# except for this header comment.
+#
+# Validate after install: systemd-analyze verify clustercheck.socket clustercheck@.service
+# No Service=: Accept=yes relies on implicit mapping
+# clustercheck.socket -> clustercheck@.service (systemd.socket(5))
+
+[Unit]
+Description=Percona XtraDB Cluster clustercheck (HAProxy HTTP check)
+Documentation=https://docs.percona.com/percona-xtradb-cluster/
+Documentation=man:systemd.socket(5)
+After=network.target
+Wants=network.target
+
+[Socket]
+ListenStream=9200
+Accept=yes
+NoDelay=yes
+KeepAlive=yes
+
+[Install]
+WantedBy=sockets.target

--- a/build-ps/debian/extra/clustercheck@.service
+++ b/build-ps/debian/extra/clustercheck@.service
@@ -1,0 +1,75 @@
+# Copyright (C) 2024, 2026 Percona Inc
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not, write to the
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston
+# MA  02110-1301  USA.
+#
+# PXC packaging override -- mirrors how build-ps/debian/extra/mysql.service
+# overrides upstream's CMake-installed unit. Keep behaviorally in sync with
+# scripts/systemd/clustercheck@.service.in (the @bindir@-templated source
+# used by tarball / dev builds with -DWITH_SYSTEMD=ON). The only difference
+# from the .in template is @bindir@ resolved to /usr/bin for PXC packages.
+#
+# Validate after install: systemd-analyze verify clustercheck.socket clustercheck@.service
+
+[Unit]
+Description=Percona XtraDB Cluster clustercheck connection %i
+Documentation=https://docs.percona.com/percona-xtradb-cluster/
+Documentation=man:systemd.service(5)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=mysql
+Group=mysql
+
+StandardInput=socket
+StandardOutput=socket
+StandardError=journal
+
+SuccessExitStatus=0 1
+
+# Requires /etc/mysql/clustercheck.cnf with proper credentials before enabling the socket.
+#
+# 4th positional arg is the mysql client error file (ERR_FILE) used by
+# clustercheck.sh as `mysql ... 2>${ERR_FILE}`. We pass /dev/null on purpose:
+#
+#   * Under socket activation StandardError=journal, so fd 2 is a journal
+#     stream socket. open("/proc/self/fd/2", O_WRONLY|O_CREAT|O_TRUNC) on
+#     such a socket fails with ENXIO ("No such device or address"), the
+#     redirect '2>/proc/self/fd/2' aborts the line BEFORE mysql runs,
+#     PXC_NODE_STATUS stays empty and the script always replies HTTP 503
+#     even on a healthy synced node (HAProxy then marks every PXC node DOWN).
+#   * /dev/stderr resolves to the same /proc/self/fd/2 path and fails the
+#     same way, so it is NOT a substitute.
+#   * /dev/null is always openable, never causes an unrelated open(2) to fail
+#     the check, and mysql connection errors are still observable via the
+#     server's own error log (and via systemctl edit override below).
+#
+# Operators who want to capture mysql client stderr can override with a
+# drop-in, e.g.:
+#   sudo systemctl edit clustercheck@.service
+#   [Service]
+#   ExecStart=
+#   ExecStart=/usr/bin/clustercheck - 1 /var/log/mysql/clustercheck.err 1 /etc/mysql/clustercheck.cnf
+ExecStart=/usr/bin/clustercheck - 1 /dev/null 1 /etc/mysql/clustercheck.cnf
+
+# Hardening kept compatible with systemd 219; stronger options can be added via drop-in on newer systems.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=yes
+ProtectHome=yes
+PrivateDevices=yes
+
+TimeoutStopSec=30
+RuntimeMaxSec=30

--- a/build-ps/debian/percona-xtradb-cluster-server.install
+++ b/build-ps/debian/percona-xtradb-cluster-server.install
@@ -57,6 +57,8 @@ etc/default/mysql
 libgalera_smm.so usr/lib/galera4
 lib/systemd/system/mysql.service
 lib/systemd/system/mysql@.service
+lib/systemd/system/clustercheck.socket
+lib/systemd/system/clustercheck@.service
 # private shared libs
 usr/lib/mysql/private/libprotobuf-lite.so.*
 usr/lib/mysql/private/libprotobuf.so.*

--- a/build-ps/debian/rules
+++ b/build-ps/debian/rules
@@ -223,6 +223,11 @@ override_dh_auto_install:
 	install -m 0644 debian/extra/mysql.service $(TMP)/lib/systemd/system/
 	install -m 0644 debian/extra/mysql@.service $(TMP)/lib/systemd/system/
 
+	# install clustercheck service and related files.
+	install -m 0644 debian/extra/clustercheck.socket $(TMP)/lib/systemd/system/
+	install -m 0644 debian/extra/clustercheck@.service $(TMP)/lib/systemd/system/
+	install -D -m 0644 scripts/clustercheck.cnf.example $(TMP)/usr/share/mysql/clustercheck.cnf.example
+
 	install -m 0755 $(TMP)/garb/files/garb-systemd $(TMP)/usr/bin/
 	install -m 0644 $(TMP)/garb/files/garb.service $(TMP)/lib/systemd/system/garb.service
 	sed -i 's/sysconfig\/garb/default\/garb/' $(TMP)/lib/systemd/system/garb.service

--- a/build-ps/percona-xtradb-cluster.spec
+++ b/build-ps/percona-xtradb-cluster.spec
@@ -999,6 +999,9 @@ install -d %{buildroot}%{_sysconfdir}/my.cnf.d
   install -D -m 0644 $MBD/build-ps/rpm/mysql.service $RBR%{_unitdir}/mysql.service
   install -D -m 0644 $MBD/build-ps/rpm/mysql@.service $RBR%{_unitdir}/mysql@.service
   install -D -m 0644 $MBD/build-ps/rpm/mysql.bootstrap $RBR%{_sysconfdir}/sysconfig/mysql.bootstrap
+  install -D -m 0644 $MBD/build-ps/rpm/clustercheck.socket $RBR%{_unitdir}/clustercheck.socket
+  install -D -m 0644 $MBD/build-ps/rpm/clustercheck@.service $RBR%{_unitdir}/clustercheck@.service
+  install -D -m 0644 $MBD/scripts/clustercheck.cnf.example $RBR%{_datadir}/mysql/clustercheck.cnf.example
 %else
   install -m 755 $MBD/release/support-files/mysql.server $RBR%{_sysconfdir}/init.d/mysql
 %endif
@@ -1785,6 +1788,9 @@ fi
 %if 0%{?systemd}
 %attr(644, root, root) %{_unitdir}/mysql.service
 %attr(644, root, root) %{_unitdir}/mysql@.service
+%attr(644, root, root) %{_unitdir}/clustercheck.socket
+%attr(644, root, root) %{_unitdir}/clustercheck@.service
+%attr(644, root, root) %{_datadir}/mysql/clustercheck.cnf.example
 %attr(644, root, root) %config(noreplace,missingok) %{_sysconfdir}/sysconfig/mysql.bootstrap
 %attr(755, root, root) %{_bindir}/mysql-systemd
 %else

--- a/build-ps/pxc_builder.sh
+++ b/build-ps/pxc_builder.sh
@@ -249,6 +249,22 @@ get_sources(){
             cp -p mysql.logrotate.in mysql.logrotate
         fi
 
+    # Ensure clustercheck units exist for RPM/DEB packaging paths.
+    mkdir -p ${PXCDIR}/build-ps/rpm ${PXCDIR}/build-ps/debian/extra
+    if [ ! -f ${PXCDIR}/build-ps/rpm/clustercheck.socket ]; then
+        cp -p ${PXCDIR}/scripts/systemd/clustercheck.socket.in ${PXCDIR}/build-ps/rpm/clustercheck.socket
+    fi
+    if [ ! -f ${PXCDIR}/build-ps/rpm/clustercheck@.service ]; then
+        cp -p ${PXCDIR}/scripts/systemd/clustercheck@.service.in ${PXCDIR}/build-ps/rpm/clustercheck@.service
+        sed -i 's:@bindir@:/usr/bin:g' ${PXCDIR}/build-ps/rpm/clustercheck@.service
+    fi
+    if [ ! -f ${PXCDIR}/build-ps/debian/extra/clustercheck.socket ]; then
+        cp -p ${PXCDIR}/build-ps/rpm/clustercheck.socket ${PXCDIR}/build-ps/debian/extra/clustercheck.socket
+    fi
+    if [ ! -f ${PXCDIR}/build-ps/debian/extra/clustercheck@.service ]; then
+        cp -p ${PXCDIR}/build-ps/rpm/clustercheck@.service ${PXCDIR}/build-ps/debian/extra/clustercheck@.service
+    fi
+
     cd ${WORKDIR} || exit
     #
     pushd ${PXCDIR}

--- a/build-ps/rpm/clustercheck.socket
+++ b/build-ps/rpm/clustercheck.socket
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 Percona Inc
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not, write to the
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston
+# MA  02110-1301  USA.
+#
+# PXC packaging override -- mirrors how build-ps/rpm/mysql.service overrides
+# upstream's CMake-installed unit. Keep behaviorally in sync with
+# scripts/systemd/clustercheck.socket.in (the @bindir@-templated source used
+# by tarball / dev builds with -DWITH_SYSTEMD=ON) and with
+# build-ps/debian/extra/clustercheck.socket. The .in template has no
+# @-substitutions in the .socket unit, so this file is byte-equal to its
+# deb counterpart except for this header comment.
+#
+# Validate after install: systemd-analyze verify clustercheck.socket clustercheck@.service
+# No Service=: Accept=yes relies on implicit mapping
+# clustercheck.socket -> clustercheck@.service (systemd.socket(5))
+
+[Unit]
+Description=Percona XtraDB Cluster clustercheck (HAProxy HTTP check)
+Documentation=https://docs.percona.com/percona-xtradb-cluster/
+Documentation=man:systemd.socket(5)
+After=network.target
+Wants=network.target
+
+[Socket]
+ListenStream=9200
+Accept=yes
+NoDelay=yes
+KeepAlive=yes
+
+[Install]
+WantedBy=sockets.target

--- a/build-ps/rpm/clustercheck@.service
+++ b/build-ps/rpm/clustercheck@.service
@@ -1,0 +1,76 @@
+# Copyright (C) 2024, 2026 Percona Inc
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not, write to the
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston
+# MA  02110-1301  USA.
+#
+# PXC packaging override -- mirrors how build-ps/rpm/mysql.service overrides
+# upstream's CMake-installed unit. Keep behaviorally in sync with
+# scripts/systemd/clustercheck@.service.in (the @bindir@-templated source
+# used by tarball / dev builds with -DWITH_SYSTEMD=ON) and with
+# build-ps/debian/extra/clustercheck@.service. The only difference from the
+# .in template is @bindir@ resolved to /usr/bin for PXC packages.
+#
+# Validate after install: systemd-analyze verify clustercheck.socket clustercheck@.service
+
+[Unit]
+Description=Percona XtraDB Cluster clustercheck connection %i
+Documentation=https://docs.percona.com/percona-xtradb-cluster/
+Documentation=man:systemd.service(5)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=mysql
+Group=mysql
+
+StandardInput=socket
+StandardOutput=socket
+StandardError=journal
+
+SuccessExitStatus=0 1
+
+# Requires /etc/mysql/clustercheck.cnf with proper credentials before enabling the socket.
+#
+# 4th positional arg is the mysql client error file (ERR_FILE) used by
+# clustercheck.sh as `mysql ... 2>${ERR_FILE}`. We pass /dev/null on purpose:
+#
+#   * Under socket activation StandardError=journal, so fd 2 is a journal
+#     stream socket. open("/proc/self/fd/2", O_WRONLY|O_CREAT|O_TRUNC) on
+#     such a socket fails with ENXIO ("No such device or address"), the
+#     redirect '2>/proc/self/fd/2' aborts the line BEFORE mysql runs,
+#     PXC_NODE_STATUS stays empty and the script always replies HTTP 503
+#     even on a healthy synced node (HAProxy then marks every PXC node DOWN).
+#   * /dev/stderr resolves to the same /proc/self/fd/2 path and fails the
+#     same way, so it is NOT a substitute.
+#   * /dev/null is always openable, never causes an unrelated open(2) to fail
+#     the check, and mysql connection errors are still observable via the
+#     server's own error log (and via systemctl edit override below).
+#
+# Operators who want to capture mysql client stderr can override with a
+# drop-in, e.g.:
+#   sudo systemctl edit clustercheck@.service
+#   [Service]
+#   ExecStart=
+#   ExecStart=/usr/bin/clustercheck - 1 /var/log/mysql/clustercheck.err 1 /etc/mysql/clustercheck.cnf
+ExecStart=/usr/bin/clustercheck - 1 /dev/null 1 /etc/mysql/clustercheck.cnf
+
+# Hardening kept compatible with systemd 219; stronger options can be added via drop-in on newer systems.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=yes
+ProtectHome=yes
+PrivateDevices=yes
+
+TimeoutStopSec=30
+RuntimeMaxSec=30

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -644,6 +644,25 @@ ELSE()
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
       )
     ENDIF()
+
+    # clustercheck
+    CONFIGURE_FILE(systemd/clustercheck.socket.in
+      ${CMAKE_CURRENT_BINARY_DIR}/clustercheck.socket ESCAPE_QUOTES @ONLY)
+    CONFIGURE_FILE(systemd/clustercheck@.service.in
+      ${CMAKE_CURRENT_BINARY_DIR}/clustercheck@.service ESCAPE_QUOTES @ONLY)
+
+    INSTALL(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/clustercheck.socket
+      ${CMAKE_CURRENT_BINARY_DIR}/clustercheck@.service
+      DESTINATION ${SYSTEMD_INSTALL_PREFIX}${SYSTEMD_SERVICES_DIR}
+      COMPONENT Server
+      PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+    )
+    INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/clustercheck.cnf.example
+      DESTINATION ${INSTALL_MYSQLSHAREDIR}
+      COMPONENT Server
+      PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+    )
   ENDIF()
 ENDIF()
 

--- a/scripts/clustercheck.cnf.example
+++ b/scripts/clustercheck.cnf.example
@@ -1,0 +1,8 @@
+# Example client defaults for clustercheck (systemd socket / HAProxy health check).
+# Copy to /etc/mysql/clustercheck.cnf and tighten permissions, e.g.:
+#   install -m 0640 -o root -g mysql clustercheck.cnf.example /etc/mysql/clustercheck.cnf
+# Replace user/password and remove this comment block after editing.
+
+[client]
+user=clustercheck
+password=REPLACE_WITH_A_STRONG_SECRET

--- a/scripts/clustercheck.sh
+++ b/scripts/clustercheck.sh
@@ -12,16 +12,51 @@
 # GRANT PROCESS ON *.* TO 'clustercheckuser'@'localhost' IDENTIFIED BY 'clustercheckpassword!';
 
 if [[ $1 == '-h' || $1 == '--help' ]];then
-    echo "Usage: $0 <user> <pass> <available_when_donor=0|1> <log_file> <available_when_readonly=0|1> <defaults_extra_file>"
+    echo "Usage:"
+    echo "  $0 <user> <pass> <available_when_donor=0|1> <log_file> <available_when_readonly=0|1> <defaults_extra_file>"
+    echo "      Pass credentials directly on the command line. Default form, compatible"
+    echo "      with existing operator scripts."
+    echo ""
+    echo "  $0 - <available_when_donor=0|1> <log_file> <available_when_readonly=0|1> <defaults_extra_file>"
+    echo "      Use '-' in place of <user> <pass> to keep credentials off the command"
+    echo "      line. The mysql client reads [client] user= and password= from"
+    echo "      <defaults_extra_file> (typically /etc/mysql/clustercheck.cnf, 0640"
+    echo "      root:mysql). Used by the systemd socket-activated clustercheck@.service"
+    echo "      shipped with PXC; see /usr/share/mysql/clustercheck.cnf.example."
     exit
 fi
 
-MYSQL_USERNAME="${1-clustercheckuser}" 
-MYSQL_PASSWORD="${2-clustercheckpassword!}" 
-AVAILABLE_WHEN_DONOR=${3:-0}
-ERR_FILE="${4:-/dev/null}" 
-AVAILABLE_WHEN_READONLY=${5:-1}
-DEFAULTS_EXTRA_FILE=${6:-/etc/my.cnf}
+# Leading "-" omits --user/--password so mysql reads credentials only from defaults_extra_file.
+if [[ "$1" == "-" ]]; then
+  shift
+  MYSQL_USERNAME=""
+  MYSQL_PASSWORD=""
+  AVAILABLE_WHEN_DONOR=${1:-0}
+  ERR_FILE="${2:-/dev/null}"
+  AVAILABLE_WHEN_READONLY=${3:-1}
+  DEFAULTS_EXTRA_FILE=${4:-/etc/my.cnf}
+else
+  MYSQL_USERNAME="${1-clustercheckuser}"
+  MYSQL_PASSWORD="${2-clustercheckpassword!}"
+  AVAILABLE_WHEN_DONOR=${3:-0}
+  ERR_FILE="${4:-/dev/null}"
+  AVAILABLE_WHEN_READONLY=${5:-1}
+  DEFAULTS_EXTRA_FILE=${6:-/etc/my.cnf}
+fi
+
+# if ERR_FILE cannot actually be opened for append, fall back to
+# /dev/null. Otherwise the very first 'mysql ... 2>${ERR_FILE}' below would
+# fail on the redirect (e.g. ENXIO) before mysql even runs, leaving the
+# status array empty and the node falsely reported as down.
+#
+# The case is /proc/self/fd/2 when stderr is a systemd journal
+# stream socket: opening that path returns ENXIO and the redirect aborts the
+# command. Any unwritable path (read-only fs, missing parent dir, denied perm)
+# would do the same, so we test once here and substitute /dev/null.
+if ! ( : >> "$ERR_FILE" ) 2>/dev/null; then
+    ERR_FILE=/dev/null
+fi
+
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=10
 

--- a/scripts/systemd/clustercheck.socket.in
+++ b/scripts/systemd/clustercheck.socket.in
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 2 of
+# the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+[Unit]
+Description=Percona XtraDB Cluster clustercheck (HAProxy HTTP check)
+Documentation=https://docs.percona.com/percona-xtradb-cluster/
+After=network.target
+Wants=network.target
+
+[Socket]
+ListenStream=9200
+Accept=yes
+NoDelay=yes
+KeepAlive=yes
+
+[Install]
+WantedBy=sockets.target

--- a/scripts/systemd/clustercheck@.service.d/10-hardening-modern.conf.example
+++ b/scripts/systemd/clustercheck@.service.d/10-hardening-modern.conf.example
@@ -1,0 +1,20 @@
+# Optional stronger sandboxing for clustercheck@.service (systemd >= ~232).
+# Suitable for RHEL 8+, Ubuntu 20.04+, Debian 10+, and similar.
+#
+# Install:
+#   sudo mkdir -p /etc/systemd/system/clustercheck@.service.d
+#   sudo cp 10-hardening-modern.conf.example /etc/systemd/system/clustercheck@.service.d/10-hardening.conf
+#   sudo systemctl daemon-reload
+#
+# Validate (after daemon-reload), e.g.:
+#   systemd-analyze verify /usr/lib/systemd/system/clustercheck@.service \
+#       /etc/systemd/system/clustercheck@.service.d/10-hardening.conf
+#
+# This overrides ProtectSystem=yes from the vendor unit with ProtectSystem=full
+# and restores paths needed for the MySQL client Unix socket under /run/mysqld.
+
+[Service]
+ProtectSystem=full
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ReadWritePaths=/run/mysqld /var/run/mysqld

--- a/scripts/systemd/clustercheck@.service.in
+++ b/scripts/systemd/clustercheck@.service.in
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 2 of
+# the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+[Unit]
+Description=Percona XtraDB Cluster clustercheck connection %i
+Documentation=https://docs.percona.com/percona-xtradb-cluster/
+Documentation=man:systemd.service(5)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=mysql
+Group=mysql
+
+StandardInput=socket
+StandardOutput=socket
+StandardError=journal
+
+SuccessExitStatus=0 1
+
+# Requires /etc/mysql/clustercheck.cnf with proper credentials before enabling the socket.
+#
+# 4th positional arg is the mysql client error file (ERR_FILE) used by
+# clustercheck.sh as `mysql ... 2>${ERR_FILE}`. We pass /dev/null on purpose:
+#
+#   * Under socket activation StandardError=journal, so fd 2 is a journal
+#     stream socket. open("/proc/self/fd/2", O_WRONLY|O_CREAT|O_TRUNC) on
+#     such a socket fails with ENXIO ("No such device or address"), the
+#     redirect '2>/proc/self/fd/2' aborts the line BEFORE mysql runs,
+#     PXC_NODE_STATUS stays empty and the script always replies HTTP 503
+#     even on a healthy synced node (HAProxy then marks every PXC node DOWN).
+#   * /dev/stderr resolves to the same /proc/self/fd/2 path and fails the
+#     same way, so it is NOT a substitute.
+#   * /dev/null is always openable, never causes an unrelated open(2) to fail
+#     the check, and mysql connection errors are still observable via the
+#     server's own error log (and via systemctl edit override below).
+#
+# Operators who want to capture mysql client stderr can override with a
+# drop-in, e.g.:
+#   sudo systemctl edit clustercheck@.service
+#   [Service]
+#   ExecStart=
+#   ExecStart=/usr/bin/clustercheck - 1 /var/log/mysql/clustercheck.err 1 /etc/mysql/clustercheck.cnf
+ExecStart=@bindir@/clustercheck - 1 /dev/null 1 /etc/mysql/clustercheck.cnf
+
+# Hardening kept compatible with systemd 219; stronger options can be added via drop-in on newer systems.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=yes
+ProtectHome=yes
+PrivateDevices=yes
+
+TimeoutStopSec=30
+RuntimeMaxSec=30


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-4805

Description:
It was observed that `mysqlchk` (xinetd config) was missing from package and binary tarball installs in PXC 8.0/8.4. The legacy xinetd-based setup is obsolete on modern distros, where systemd socket activation is the default service model.

Resolution:
Kept `clustercheck` as the health-check script, and provided a supported systemd `clustercheck.socket` and `clustercheck@.service` and `clustercheck.cnf.example` for credentials. Updated packaging paths for RPM/DEB and add builder fallback generation from `scripts/systemd` templates so source tarballs without pre-generated unit files do not fail packaging.

Also updated `clustercheck.sh` to better support defaults-file credentials and to avoid stderr redirection failures that can cause false HTTP 503 responses during health checks.