### PR TITLE
PXC-5209: Corrupted Galera Caches Causes PXC to OOM(trunk)

### DIFF
--- a/mysql-test/suite/galera/r/pxc_gcache_corrupt_seqno.result
+++ b/mysql-test/suite/galera/r/pxc_gcache_corrupt_seqno.result
@@ -1,0 +1,35 @@
+
+# 1. Create table and populate 10 rows on the single node.
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(64)) ENGINE=InnoDB;
+
+# 2. Cleanly shut the node down so the synced preamble is written to galera.cache.
+
+
+# 3. Corrupt the first buffer header's seqno_g on disk to an implausible value.
+
+
+# 4. Restart with gcache.recover=yes; scan() flags the implausible seqno.
+
+# restart
+
+# 5. GCache recovery is aborted and a full reset is forced.
+
+
+# 6. The node does not crash (no fatal signal) or OOM (no std::bad_alloc).
+
+
+# 7. Data is intact after recovery.
+
+SELECT COUNT(*) AS rows_post_recovery FROM t1;
+rows_post_recovery
+10
+
+# 8. Cleanup.
+
+CALL mtr.add_suppression("Skipped GCache ring buffer recovery");
+CALL mtr.add_suppression("Exception while mapping writeset");
+CALL mtr.add_suppression("Aborting GCache recovery");
+CALL mtr.add_suppression("Recovery failed, need to do full reset");
+CALL mtr.add_suppression("implausible seqno");
+DROP TABLE t1;

--- a/mysql-test/suite/galera/r/pxc_gcache_corrupt_size.result
+++ b/mysql-test/suite/galera/r/pxc_gcache_corrupt_size.result
@@ -1,0 +1,37 @@
+
+# 1. Create table and populate 10 rows on node_1; confirm node_2 received them.
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(64)) ENGINE=InnoDB;
+
+# 2. Cleanly shut node_2 down so close_preamble() writes a synced preamble.
+
+
+# 3. Corrupt one on-disk BufferHeader::size to a value larger than the cache.
+
+
+# 4. Restart node_2 with gcache.recover=yes; scan() rejects the header.
+
+# restart
+
+# 5. GCache recovery is aborted and a full reset is forced.
+
+
+# 6. node_2 rejoins (cluster size 2) without crashing or "Memory corruption".
+
+
+# 7. Data is intact and both servers are consistent (diff_servers).
+
+SELECT COUNT(*) AS rows_post_recovery FROM t1;
+rows_post_recovery
+10
+include/diff_servers.inc [servers=1 2]
+
+# 8. Cleanup.
+
+CALL mtr.add_suppression("Exception while mapping writeset");
+CALL mtr.add_suppression("Aborting GCache recovery");
+CALL mtr.add_suppression("Recovery failed, need to do full reset");
+CALL mtr.add_suppression("implausible bh->size");
+CALL mtr.add_suppression("Failed to scan the last segment to the end");
+CALL mtr.add_suppression("Skipped GCache ring buffer recovery");
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_gcache_corrupt_seqno.cnf
+++ b/mysql-test/suite/galera/t/pxc_gcache_corrupt_seqno.cnf
@@ -1,0 +1,9 @@
+!include ../galera_1node.cnf
+
+#
+# Customer-like synthetic regression for PXC-5209:
+# keep the same key knobs as customer repro.
+#   wsrep_provider_options='gcache.size=1g;gcache.recover=yes'
+#
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.recover=yes;gcache.size=1m;@ENV.WSREP_PROVIDER_TIMEOUTS'

--- a/mysql-test/suite/galera/t/pxc_gcache_corrupt_seqno.combinations
+++ b/mysql-test/suite/galera/t/pxc_gcache_corrupt_seqno.combinations
@@ -1,0 +1,3 @@
+[enc_off]
+wsrep-gcache-encrypt=OFF
+wsrep-disk-pages-encrypt=OFF

--- a/mysql-test/suite/galera/t/pxc_gcache_corrupt_seqno.test
+++ b/mysql-test/suite/galera/t/pxc_gcache_corrupt_seqno.test
@@ -1,0 +1,118 @@
+#
+# This test case first corrupts the buffer header's seqno_g on disk to
+# an implausible value (10^12) and verifies recovery rejects it instead of
+# inserting it into seqno2ptr_ (which on a memory-constrained host OOM-kills the
+# node, and elsewhere throws std::bad_alloc).
+#
+# 1. Create table and populate 10 rows on the single node.
+# 2. Cleanly shut the node down so the synced preamble is written to galera.cache.
+# 3. Corrupt the first buffer header's seqno_g on disk to an implausible value.
+# 4. Restart with gcache.recover=yes; scan() flags the implausible seqno.
+# 5. GCache recovery is aborted and a full reset is forced.
+# 6. The node does not crash (no fatal signal) or OOM (no std::bad_alloc).
+# 7. Data is intact after recovery.
+# 8. Cleanup.
+#
+
+--let $galera_cluster_size = 1
+--source include/galera_cluster.inc
+
+--echo
+--echo # 1. Create table and populate 10 rows on the single node.
+--echo
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(64)) ENGINE=InnoDB;
+
+--disable_query_log
+--let $i = 1
+while ($i <= 10)
+{
+  --eval INSERT INTO t1 VALUES ($i, REPEAT('a', 64))
+  --inc $i
+}
+--enable_query_log
+
+--let $NODE1_DATA_DIR = `SELECT @@datadir`
+
+--echo
+--echo # 2. Cleanly shut the node down so the synced preamble is written to galera.cache.
+--echo
+# Clean shutdown so preamble is synced before we patch on-disk cache.
+--source include/shutdown_mysqld.inc
+
+--echo
+--echo # 3. Corrupt the first buffer header's seqno_g on disk to an implausible value.
+--echo
+# opens an existing cache file ($cache_file) in read/write mode
+# seeks to offset 1024 + 32*8 (1280)
+# corrupted seqno_g at offset 1280 (set to 1000000000000)
+# overwrites 8 bytes (seqno_g) with 1000000000000
+# Original cache file size remains same
+# Or take copy of galera.cache file and place it in std_data and copy it to
+# $NODE1_DATA_DIR/`SELECT @@datadir` using --copy_file
+# But this increases the commit and repo size.
+--write_file $MYSQLTEST_VARDIR/tmp/pxc_5209_corrupt_gcache_customerlike.pl
+use strict;
+use warnings;
+
+my $cache_file  = $ARGV[0] or die "usage: $0 <galera.cache>\n";
+my $bogus_seqno = 1_000_000_000_000; # huge, implausible for any realistic cache
+my $first_bh_seqno_offset = 1024 + 32 * 8;
+
+open(my $fh, '+<:raw', $cache_file) or die "open $cache_file: $!";
+seek($fh, $first_bh_seqno_offset, 0) or die "seek $cache_file: $!";
+print $fh pack('q<', $bogus_seqno) or die "write $cache_file: $!";
+close($fh) or die "close $cache_file: $!";
+
+EOF
+
+--exec perl $MYSQLTEST_VARDIR/tmp/pxc_5209_corrupt_gcache_customerlike.pl $NODE1_DATA_DIR/galera.cache
+--remove_file $MYSQLTEST_VARDIR/tmp/pxc_5209_corrupt_gcache_customerlike.pl
+
+--echo
+--echo # 4. Restart with gcache.recover=yes; scan() flags the implausible seqno.
+--echo
+# restart
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/start_mysqld.inc
+
+--connection node_1
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+
+--let $wait_condition = SELECT COUNT(*) >= 1 FROM performance_schema.error_log WHERE data LIKE "%implausible seqno%" AND data LIKE "%cache appears to be corrupt%"
+--source include/wait_condition.inc
+
+--echo
+--echo # 5. GCache recovery is aborted and a full reset is forced.
+--echo
+--let $wait_condition = SELECT COUNT(*) >= 1 FROM performance_schema.error_log WHERE data LIKE "%Aborting GCache recovery%"
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) >= 1 FROM performance_schema.error_log WHERE data LIKE "%Recovery failed, need to do full reset%"
+--source include/wait_condition.inc
+
+--echo
+--echo # 6. The node does not crash (no fatal signal) or OOM (no std::bad_alloc).
+--echo
+--let $wait_condition = SELECT COUNT(*) = 0 FROM performance_schema.error_log WHERE data LIKE "%handle_fatal_signal%"
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 0 FROM performance_schema.error_log WHERE data LIKE "%std::bad_alloc%"
+--source include/wait_condition.inc
+
+--echo
+--echo # 7. Data is intact after recovery.
+--echo
+SELECT COUNT(*) AS rows_post_recovery FROM t1;
+
+--echo
+--echo # 8. Cleanup.
+--echo
+CALL mtr.add_suppression("Skipped GCache ring buffer recovery");
+CALL mtr.add_suppression("Exception while mapping writeset");
+CALL mtr.add_suppression("Aborting GCache recovery");
+CALL mtr.add_suppression("Recovery failed, need to do full reset");
+CALL mtr.add_suppression("implausible seqno");
+
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/pxc_gcache_corrupt_size.cnf
+++ b/mysql-test/suite/galera/t/pxc_gcache_corrupt_size.cnf
@@ -1,0 +1,14 @@
+!include ../galera_2nodes.cnf
+
+#
+# PXC-5209 size-corruption regression.
+#
+# Use gcache.recover=yes so a stopped node reads the on-disk galera.cache on
+# restart. Keep gcache small so the helper can use a deterministic cache-size
+# bound when corrupting BufferHeader::size.
+#
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.recover=yes;gcache.size=1M;@ENV.WSREP_PROVIDER_TIMEOUTS'
+
+[mysqld.2]
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.recover=yes;gcache.size=1M;@ENV.WSREP_PROVIDER_TIMEOUTS'

--- a/mysql-test/suite/galera/t/pxc_gcache_corrupt_size.combinations
+++ b/mysql-test/suite/galera/t/pxc_gcache_corrupt_size.combinations
@@ -1,0 +1,3 @@
+[enc_off]
+wsrep-gcache-encrypt=OFF
+wsrep-disk-pages-encrypt=OFF

--- a/mysql-test/suite/galera/t/pxc_gcache_corrupt_size.test
+++ b/mysql-test/suite/galera/t/pxc_gcache_corrupt_size.test
@@ -1,0 +1,166 @@
+#
+# This test corrupts galera.cache and verifies recovery rejects the bad
+# BufferHeader::size before post-recovery path can run.
+# This test case only extends the code coverage and does not reproduce
+# any customer issue or any code issue.
+#
+# 1. Create table and populate 10 rows on node_1; confirm node_2 received them.
+# 2. Cleanly shut node_2 down so close_preamble() writes a synced preamble.
+# 3. Corrupt one on-disk BufferHeader::size to a value larger than the cache.
+# 4. Restart node_2 with gcache.recover=yes; scan() rejects the header.
+# 5. GCache recovery is aborted and a full reset is forced.
+# 6. node_2 rejoins (cluster size 2) without crashing or "Memory corruption".
+# 7. Data is intact and both servers are consistent (diff_servers).
+# 8. Cleanup.
+#
+
+--source include/galera_cluster.inc
+
+--echo
+--echo # 1. Create table and populate 10 rows on node_1; confirm node_2 received them.
+--echo
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(64)) ENGINE=InnoDB;
+
+--disable_query_log
+--let $i = 1
+while ($i <= 10)
+{
+  --eval INSERT INTO t1 VALUES ($i, REPEAT('a', 64))
+  --inc $i
+}
+--enable_query_log
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1
+--source include/wait_condition.inc
+--let $NODE2_DATA_DIR = `SELECT @@datadir`
+
+--echo
+--echo # 2. Cleanly shut node_2 down so close_preamble() writes a synced preamble.
+--echo
+# Shut node_2 down cleanly so close_preamble() writes a synced preamble and the
+# next start takes the gcache.recover=yes path over the cache we corrupt below.
+--source include/shutdown_mysqld.inc
+
+--echo
+--echo # 3. Corrupt one on-disk BufferHeader::size to a value larger than the cache.
+--echo
+# Corrupt one on-disk BufferHeader::size to a value larger than the whole cache.
+# BH_test() only verifies size >= sizeof(BufferHeader). The scan code must reject
+# this explicitly and abort gcache recovery before inserting bh+1 into seqno2ptr_.
+--disable_query_log
+--disable_result_log
+--write_file $MYSQLTEST_VARDIR/tmp/pxc_5209_corrupt_size.pl
+use strict;
+use warnings;
+
+my $cache_file = $ARGV[0] or die "usage: $0 <galera.cache>\n";
+
+my $PREAMBLE_LEN = 1024;
+my $HEADER_LEN   = 32 * 8;
+my $BH_LEN       = 24;
+my $SIZE_OFF     = 8 + 8;
+
+# Must match the .cnf's gcache.size=1M.
+my $GCACHE_SIZE = 1024 * 1024;
+my $BOGUS_SIZE  = $GCACHE_SIZE + 1;
+
+open(my $fh, '+<:raw', $cache_file)
+    or die "open $cache_file: $!";
+binmode($fh);
+
+my $file_size = -s $cache_file;
+my $start = $PREAMBLE_LEN + $HEADER_LEN;
+my $end = $file_size - $BH_LEN;
+
+my $target;
+for (my $pos = $start; $pos <= $end; $pos += 8) {
+    seek($fh, $pos, 0) or die "seek $cache_file: $!";
+    read($fh, my $buf, $BH_LEN) == $BH_LEN or next;
+    my ($seqno, $ctx, $size, $flags, $store, $type) =
+        unpack('q<Q<L<S<cc', $buf);
+
+    next unless $seqno > 0;
+    next unless $size >= $BH_LEN;
+    next unless $size <= ($file_size - $start);
+    next unless $flags <= 3;
+    next unless $store == 1; # BUFFER_IN_RB
+
+    $target = [$pos, $seqno, $size, $flags, $store, $type];
+    last;
+}
+
+$target or die "no plausible BufferHeader found in $cache_file\n";
+my ($pos, $seqno, $old_size) = @$target;
+my $size_pos = $pos + $SIZE_OFF;
+
+seek($fh, $size_pos, 0) or die "seek size field $size_pos: $!";
+print $fh pack('L<', $BOGUS_SIZE) or die "write bogus size: $!";
+close($fh) or die "close $cache_file: $!";
+
+print "corrupted BufferHeader::size at offset $size_pos ",
+      "(bh=$pos seqno=$seqno old_size=$old_size new_size=$BOGUS_SIZE)\n";
+EOF
+--exec perl $MYSQLTEST_VARDIR/tmp/pxc_5209_corrupt_size.pl $NODE2_DATA_DIR/galera.cache > $MYSQLTEST_VARDIR/log/pxc_5209_corrupt_size_helper.log 2>&1
+--remove_file $MYSQLTEST_VARDIR/tmp/pxc_5209_corrupt_size.pl
+--enable_result_log
+--enable_query_log
+
+--echo
+--echo # 4. Restart node_2 with gcache.recover=yes; scan() rejects the header.
+--echo
+# Restart node_2. With the fix, RingBuffer::scan() rejects the header, aborts
+# recovery, resets the cache, and the node rejoins instead of carrying a corrupt
+# pointer into GCache::free_common().
+--let $_expect_file_name = $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
+--source include/start_mysqld.inc
+
+--connection node_2
+--source include/wait_until_connected_again.inc
+--source include/galera_wait_ready.inc
+
+--echo
+--echo # 5. GCache recovery is aborted and a full reset is forced.
+--echo
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) >= 1 FROM performance_schema.error_log WHERE data LIKE "%Recovery failed, need to do full reset%"
+--source include/wait_condition.inc
+
+--echo
+--echo # 6. node_2 rejoins (cluster size 2) without crashing or "Memory corruption".
+--echo
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM performance_schema.error_log WHERE data LIKE "%handle_fatal_signal%"
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 0 FROM performance_schema.error_log WHERE data LIKE "%Memory corruption: unrecognized store%"
+--source include/wait_condition.inc
+
+--echo
+--echo # 7. Data is intact and both servers are consistent (diff_servers).
+--echo
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1
+--source include/wait_condition.inc
+SELECT COUNT(*) AS rows_post_recovery FROM t1;
+
+--let $diff_servers = 1 2
+--source include/diff_servers.inc
+
+--echo
+--echo # 8. Cleanup.
+--echo
+CALL mtr.add_suppression("Exception while mapping writeset");
+CALL mtr.add_suppression("Aborting GCache recovery");
+CALL mtr.add_suppression("Recovery failed, need to do full reset");
+CALL mtr.add_suppression("implausible bh->size");
+CALL mtr.add_suppression("Failed to scan the last segment to the end");
+
+--connection node_1
+CALL mtr.add_suppression("Skipped GCache ring buffer recovery");
+DROP TABLE t1;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXC-5209

When a node restarts with gcache.recover=yes, RingBuffer::scan() walks the on-disk galera.cache and rebuilds the seqno2ptr_ map. The scan trusted the BufferHeader metadata read from disk: BH_test() only checks that the recorded size is at least sizeof(BufferHeader), and seqno_g is not validated. A truncated or otherwise corrupted cache could therefore present a buffer header whose size advertised a payload larger than the whole cache, or a seqno_g outside range.

Two failure modes follow from this:

  - A large bh->size makes ptr + bh->size look like the start of the next valid header, so the scan keeps "recovering" garbage and a bad pointer is later handed to GCache::free_common()

  - A corrupted seqno_g (e.g. 10^12) is inserted into the seqno2ptr_ deque, which then tries to allocate an enormous index range. On a memory-constrained host this may reported OOM kill or may throw std::bad_alloc

Fix (percona-xtradb-cluster-galera):

  - Before inserting into seqno2ptr_, reject a header whose bh->size exceeds the cache, whose seqno_g falls outside the [seqno_min, seqno_max] range
  - Forward the preamble's seqno_min / seqno_max bounds from recover() into scan() so the preamble-anchored check can run even for the very first buffer, when seqno2ptr_ is still empty.
  - log the corruption in such cases, clear the recovered state and force a full reset