### PR TITLE
(8.4) PXC-5240: Port MDEV-39721 fix for wsrep_notify_cmd shell injection

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_notify_cmd_injection.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_notify_cmd_injection.result
@@ -1,0 +1,5 @@
+SELECT 1;
+1
+1
+call mtr.add_suppression('Unsafe characters in cluster member');
+include/wait_for_pattern_in_file.inc [Unsafe characters in cluster member]

--- a/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.cnf
+++ b/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.cnf
@@ -1,0 +1,10 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+# Victim: /bin/true exits 0 ignoring argv, so injection happens in sh -c parsing.
+wsrep_notify_cmd=/bin/true
+
+[mysqld.2]
+# Attacker: shell metacharacters in wsrep_node_name; trailing '#' comments
+# out whatever the server appends after the name.
+wsrep_node_name='n;touch PWN;#'

--- a/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_notify_cmd_injection.test
@@ -1,0 +1,29 @@
+#
+# Joiner-supplied wsrep_node_name must not inject shell commands into
+# the donor's wsrep_notify_cmd. Fails if "Notification command failed"
+# co-occurs with ";touch" in node_1's error log.
+#
+
+--source include/galera_cluster.inc
+
+SELECT 1;
+
+--connection node_1
+call mtr.add_suppression('Unsafe characters in cluster member');
+--let $datadir=`select @@datadir`
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment'
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# Wait for node_1 to attempt the notify and reject the unsafe member name.
+# The notify is invoked from a background thread after the view change, so
+# polling the error log is more robust than a fixed sleep.
+--let $grep_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $grep_pattern = Unsafe characters in cluster member
+--let $wait_timeout = 60
+--source include/wait_for_pattern_in_file.inc
+
+--list_files $datadir PWN

--- a/sql/wsrep_notify.cc
+++ b/sql/wsrep_notify.cc
@@ -13,12 +13,35 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
+#include <cctype>
 #include "mysql/components/services/log_builtins.h"
 #include "mysqld.h"
 #include "wsrep_priv.h"
 #include "wsrep_utils.h"
 
 const char *wsrep_notify_cmd = "";
+
+/* Allow only alnum and -_. */
+static bool is_valid_node_name(const char *s) {
+  if (!s) return true;
+  for (; *s; ++s) {
+    unsigned char c = (unsigned char)*s;
+    if (!std::isalnum(c) && c != '-' && c != '_' && c != '.') return false;
+  }
+  return true;
+}
+
+/* Allow alnum and -_.:[]/ (host:port and [ipv6] forms). */
+static bool is_valid_node_addr(const char *s) {
+  if (!s) return true;
+  for (; *s; ++s) {
+    unsigned char c = (unsigned char)*s;
+    if (!std::isalnum(c) && c != '-' && c != '_' && c != '.' && c != ':' &&
+        c != '[' && c != ']' && c != '/')
+      return false;
+  }
+  return true;
+}
 
 void wsrep_notify_status(enum wsrep::server_state::state status,
                          const wsrep::view *view) {
@@ -55,12 +78,21 @@ void wsrep_notify_status(enum wsrep::server_state::state status,
       cmd_off += snprintf(cmd_ptr + cmd_off, cmd_len - cmd_off, " --members");
 
       for (unsigned int i = 0; i < members.size(); i++) {
+        const char *name = members[i].name().c_str();
+        const char *incoming = members[i].incoming().c_str();
+        if (!is_valid_node_name(name) || !is_valid_node_addr(incoming)) {
+          WSREP_ERROR(
+              "Unsafe characters in cluster member %u "
+              "wsrep_node_name or wsrep_node_incoming_address, "
+              "aborting notification.",
+              i);
+          return;
+        }
         std::ostringstream id;
         id << members[i].id();
         cmd_off +=
             snprintf(cmd_ptr + cmd_off, cmd_len - cmd_off, "%c%s/%s/%s",
-                     i > 0 ? ',' : ' ', id.str().c_str(),
-                     members[i].name().c_str(), members[i].incoming().c_str());
+                     i > 0 ? ',' : ' ', id.str().c_str(), name, incoming);
       }
     }
   }


### PR DESCRIPTION
Port of MariaDB commit ed8404a73f93 ("MDEV-39721: wsrep_notify.cc: reject shell-unsafe characters in joiner-supplied member fields"). See https://jira.mariadb.org/browse/MDEV-39721 and https://github.com/MariaDB/server/commit/ed8404a73f93e79aff7227bb4560a44cbfdb5d1c

wsp::process spawns the configured wsrep_notify_cmd via /bin/sh -c, so any unescaped shell metacharacter in a remote joiner's wsrep_node_name or wsrep_node_incoming_address reaches the donor's shell as code. A malicious joiner could thus execute arbitrary commands on every node in the cluster on view change.

On view change, validate each member's name and incoming address against a conservative whitelist (alnum + -_. for the name; additionally :[]/ for the address, to permit host:port and [ipv6]). If any member fails the check, abort the notification with an error log entry.

This degrades gracefully: existing clusters whose member names contain characters outside the whitelist remain operational; only the notify callback is skipped for affected views, and the operator is informed via the error log.

Add galera.galera_wsrep_notify_cmd_injection: node_2 starts with a malicious wsrep_node_name containing ';touch PWN;#', and the test asserts node_1 logs the rejection and the injected payload does not execute. Positive end-to-end notify coverage remains in galera.galera_var_notify_cmd.