### PR TITLE
(8.4) PXC-5241: unsafe usage of `wsrep_sst_receive_address` values on the joiner side

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_sst_donor.result
+++ b/mysql-test/suite/galera/r/galera_var_sst_donor.result
@@ -1,0 +1,25 @@
+SET @sst_donor_orig=@@GLOBAL.wsrep_sst_donor;
+set global wsrep_sst_donor='127.0.0.1;';
+ERROR 42000: Variable 'wsrep_sst_donor' can't be set to the value of '127.0.0.1;'
+select @@wsrep_sst_donor;
+@@wsrep_sst_donor
+
+set global wsrep_sst_donor='node1\'';
+ERROR 42000: Variable 'wsrep_sst_donor' can't be set to the value of 'node1''
+select @@wsrep_sst_donor;
+@@wsrep_sst_donor
+
+set global wsrep_sst_donor='node_2&';
+ERROR 42000: Variable 'wsrep_sst_donor' can't be set to the value of 'node_2&'
+select @@wsrep_sst_donor;
+@@wsrep_sst_donor
+
+set global wsrep_sst_donor='127.0.0.1|';
+ERROR 42000: Variable 'wsrep_sst_donor' can't be set to the value of '127.0.0.1|'
+select @@wsrep_sst_donor;
+@@wsrep_sst_donor
+
+set global wsrep_sst_donor='node2';
+select @@wsrep_sst_donor;
+@@wsrep_sst_donor
+node2

--- a/mysql-test/suite/galera/r/galera_var_sst_receive_address.result
+++ b/mysql-test/suite/galera/r/galera_var_sst_receive_address.result
@@ -1,0 +1,13 @@
+SET @sst_receive_address_orig=@@GLOBAL.wsrep_sst_receive_address;
+set global wsrep_sst_receive_address='127.0.0.1;';
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of '127.0.0.1;'
+set global wsrep_sst_receive_address='127.0.0.1\'';
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of '127.0.0.1''
+set global wsrep_sst_receive_address='127.0.0.1&';
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of '127.0.0.1&'
+set global wsrep_sst_receive_address='127.0.0.1|';
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of '127.0.0.1|'
+set global wsrep_sst_receive_address=NULL;
+ERROR 42000: Variable 'wsrep_sst_receive_address' can't be set to the value of 'NULL'
+set global wsrep_sst_receive_address='';
+set global wsrep_sst_receive_address='127.0.0.1:19000';

--- a/mysql-test/suite/galera/t/galera_var_sst_donor.test
+++ b/mysql-test/suite/galera/t/galera_var_sst_donor.test
@@ -1,0 +1,31 @@
+#
+# Check the handling of @@wsrep_sst_donor: shell-unsafe characters must
+# be rejected to prevent SST command injection (MDEV-39676 / PXC-5241).
+#
+
+--source include/galera_cluster.inc
+
+--connection node_1
+SET @sst_donor_orig=@@GLOBAL.wsrep_sst_donor;
+
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_donor='127.0.0.1;';
+select @@wsrep_sst_donor;
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_donor='node1\'';
+select @@wsrep_sst_donor;
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_donor='node_2&';
+select @@wsrep_sst_donor;
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_donor='127.0.0.1|';
+select @@wsrep_sst_donor;
+
+set global wsrep_sst_donor='node2';
+select @@wsrep_sst_donor;
+
+--disable_query_log
+SET GLOBAL wsrep_sst_donor = @sst_donor_orig;
+--enable_query_log
+
+--source include/galera_end.inc

--- a/mysql-test/suite/galera/t/galera_var_sst_receive_address.test
+++ b/mysql-test/suite/galera/t/galera_var_sst_receive_address.test
@@ -1,0 +1,30 @@
+#
+# Check the handling of @@wsrep_sst_receive_address: shell-unsafe
+# characters and NULL must be rejected to prevent SST command injection
+# (MDEV-39676 / PXC-5241). Empty value and valid host:port are accepted.
+#
+
+--source include/galera_cluster.inc
+
+--connection node_1
+SET @sst_receive_address_orig=@@GLOBAL.wsrep_sst_receive_address;
+
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_receive_address='127.0.0.1;';
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_receive_address='127.0.0.1\'';
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_receive_address='127.0.0.1&';
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_receive_address='127.0.0.1|';
+--error ER_WRONG_VALUE_FOR_VAR
+set global wsrep_sst_receive_address=NULL;
+
+set global wsrep_sst_receive_address='';
+set global wsrep_sst_receive_address='127.0.0.1:19000';
+
+--disable_query_log
+SET GLOBAL wsrep_sst_receive_address = @sst_receive_address_orig;
+--enable_query_log
+
+--source include/galera_end.inc

--- a/mysql-test/suite/wsrep/t/wsrep_sst_receive_address_basic.test
+++ b/mysql-test/suite/wsrep/t/wsrep_sst_receive_address_basic.test
@@ -27,16 +27,13 @@ SELECT @@global.wsrep_sst_receive_address;
 
 --echo
 --echo # invalid values
-#--error ER_WRONG_VALUE_FOR_VAR
-#SET @@global.wsrep_sst_receive_address='127.0.0.1:4444';
-#--error ER_WRONG_VALUE_FOR_VAR
-#SET @@global.wsrep_sst_receive_address='127.0.0.1';
 SELECT @@global.wsrep_sst_receive_address;
 --error ER_WRONG_VALUE_FOR_VAR
 SET @@global.wsrep_sst_receive_address=NULL;
 SELECT @@global.wsrep_sst_receive_address;
-# Currently there is no strict checking performed for wsrep_sst_receive_address
-# so following values jusr pass through.
+# Address values are restricted to a conservative whitelist (alnum, -_.:[]/);
+# shell metacharacters are rejected to prevent SST command injection
+# (MDEV-39676 / PXC-5241). Values below contain no metacharacters and pass.
 SET @@global.wsrep_sst_receive_address='OFF';
 SELECT @@global.wsrep_sst_receive_address;
 SET @@global.wsrep_sst_receive_address=ON;

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -14,6 +14,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #include "wsrep_sst.h"
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <regex>
@@ -90,6 +91,36 @@ static std::vector<std::string> allowed_sst_methods;
 
 bool wsrep_sst_donor_rejects_queries = false;
 
+/* alphanumerics plus -_. (POSIX portable filename character set) */
+static bool filename_char(int const c) {
+  return std::isalnum(c) || (c == '-') || (c == '_') || (c == '.');
+}
+
+/* comma, used as separator in donor lists */
+static bool comma_char(int const c) { return (c == ','); }
+
+/* characters valid in a single address (host:port or [ipv6]/...) */
+static bool address_char(int const c) {
+  return filename_char(c) || (c == ':') || (c == '[') || (c == ']') ||
+         (c == '/');
+}
+
+/* characters valid in a comma-separated list of node addresses */
+static bool names_list(int const c) { return address_char(c) || comma_char(c); }
+
+static bool check_request_str(const char *const str, bool (*check)(int c),
+                              bool log_warn = true) {
+  for (size_t i(0); str[i] != '\0'; ++i) {
+    if (!check(str[i])) {
+      if (log_warn)
+        WSREP_WARN("Illegal character in state transfer request: %i (%c).",
+                   str[i], str[i]);
+      return true;
+    }
+  }
+  return false;
+}
+
 /* Function checks if the new value for sst_method is valid.
 @return false if no error encountered with check else return true. */
 bool wsrep_sst_method_check(sys_var *self, THD *, set_var *var) {
@@ -118,17 +149,22 @@ bool wsrep_sst_method_update(sys_var *, THD *, enum_var_type) { return 0; }
 /* Function checks if the new value for sst_recieve_address is valid.
 @return false if no error encountered with check else return true. */
 bool wsrep_sst_receive_address_check(sys_var *self, THD *, set_var *var) {
-  char addr_buf[FN_REFLEN];
+  if (!var->save_result.string_value.str) goto err;
 
-  if ((!var->save_result.string_value.str) ||
-      (var->save_result.string_value.length > (FN_REFLEN - 1)))  // safety
+  /* Allow empty value. */
+  if (var->save_result.string_value.length == 0) return false;
+
+  /* Check length. */
+  if (var->save_result.string_value.length > (FN_REFLEN - 1))  // safety
   {
     goto err;
   }
 
-  memcpy(addr_buf, var->save_result.string_value.str,
-         var->save_result.string_value.length);
-  addr_buf[var->save_result.string_value.length] = 0;
+  /* Reject shell-unsafe characters (MDEV-39676 / PXC-5241). */
+  if (check_request_str(var->save_result.string_value.str, address_char,
+                        false)) {
+    goto err;
+  }
 
   return false;
 
@@ -143,7 +179,30 @@ bool wsrep_sst_receive_address_update(sys_var *, THD *, enum_var_type) {
   return 0;
 }
 
-bool wsrep_sst_donor_check(sys_var *, THD *, set_var *) { return 0; }
+bool wsrep_sst_donor_check(sys_var *self, THD *, set_var *var) {
+  if (!var->save_result.string_value.str ||
+      var->save_result.string_value.length == 0)
+    return false;
+
+  /* Check length. */
+  if (var->save_result.string_value.length > (FN_REFLEN - 1))  // safety
+  {
+    goto err;
+  }
+
+  /* Reject shell-unsafe characters (MDEV-39676 / PXC-5241). */
+  if (check_request_str(var->save_result.string_value.str, names_list, false)) {
+    goto err;
+  }
+
+  return false;
+
+err:
+  my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), self->name.str,
+           var->save_result.string_value.str ? var->save_result.string_value.str
+                                             : "NULL");
+  return true;
+}
 
 bool wsrep_sst_donor_update(sys_var *, THD *, enum_var_type) { return 0; }
 


### PR DESCRIPTION
Port MDEV-39676 fix for SST sys-var shell injection

Port of MariaDB PR #5100 ("10.6 mdev 39676") — commits 13e6808 ("MDEV-39676 : Galera Cluster-peer > Donor command execution") and the follow-up a9e2f7f ("MDEV-39676 disallow global.wsrep_sst_donor=NULL again"). See:

https://jira.mariadb.org/browse/MDEV-39676
https://github.com/MariaDB/server/pull/5100
https://github.com/MariaDB/server/commit/13e6808f0138175ad48bf91b6487f56f33c51919 https://github.com/MariaDB/server/commit/a9e2f7f648f339c6f49b5bbe0435fa6b04a27ed2

The values of wsrep_sst_donor and wsrep_sst_receive_address are interpolated into the SST command string that wsp::process executes via /bin/sh -c. A user with SUPER privileges could set either variable to a value containing shell metacharacters and get arbitrary commands executed as the mysqld user on the next SST.

Validate both variables at SET-time against a conservative whitelist that excludes every shell metacharacter:
- wsrep_sst_receive_address: alnum and -_.:[]/ (host:port / [ipv6])
- wsrep_sst_donor:           the same set plus ',' (donor list)

Helper functions filename_char/comma_char/address_char/names_list/ check_request_str are introduced in sql/wsrep_sst.cc to mirror the upstream implementation. wsrep_sst_method_check is not touched: PXC already restricts the value to the literal "xtrabackup-v2", so no shell injection is possible through that path.

NULL handling deliberately diverges from upstream: PXC preserves its pre-fix semantics on both variables to avoid breaking customer deployments and operational scripts. Neither divergence is needed to fix the problem — character-set validation alone is sufficient.

- wsrep_sst_receive_address=NULL: kept as ER_WRONG_VALUE_FOR_VAR (PXC has always rejected NULL here; upstream now allows it).
- wsrep_sst_donor=NULL: kept as accepted (PXC's prior check was a no-op, so existing scripts may rely on NULL being a valid clear; upstream now rejects it).

The peer-supplied SST request path is already protected in PXC by is_sst_request_valid() (sql/wsrep_sst.cc), which gatekeeps every incoming donate request against a regex that excludes shell metacharacters from the joiner-supplied auth@addr field, and by the fact that auth credentials are passed to the SST script over a stdin pipe, never on the shell command line. So an old joiner / garbd cannot inject shell commands on the donor either. This commit closes the remaining (locally-privileged) attack surface.

Tests:
- suite/wsrep/wsrep_sst_donor_basic and wsrep_sst_receive_address_basic extended to assert the new character-set rejection. NULL expectations remain as they were before this change.
- suite/galera/galera_var_sst_donor and galera_var_sst_receive_address added (ported from upstream, adapted to PXC's NULL semantics) to cover rejection of ';', '\'', '&', '|' and acceptance of valid host/list values.

The upstream galera_var_sst_method test is not ported: PXC's stricter exact-match method check already rejects every value other than "xtrabackup-v2", and the upstream test's positive cases ('mariabackup', 'rsync') would fail under PXC's existing semantics.