### PR TITLE
PXC-5251: SST: opt-in [sst] transfer-fifo-streams=N for parallel TCP …

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_fifo16.result
+++ b/mysql-test/suite/galera/r/galera_sst_xtrabackup-v2_fifo16.result
@@ -1,0 +1,362 @@
+Performing State Transfer on a server that has been shut down cleanly and restarted
+CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+COMMIT;
+Shutting down server ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+COMMIT;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+Starting server ...
+# restart
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+COMMIT;
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+COMMIT;
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+ROLLBACK;
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+COMMIT;
+SET AUTOCOMMIT=ON;
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+DROP TABLE t1;
+COMMIT;
+SET AUTOCOMMIT=ON;
+Performing State Transfer on a server that starts from a clean var directory
+This is accomplished by shutting down node #2 and removing its var directory before restarting it
+CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+COMMIT;
+Shutting down server ...
+Cleaning var directory ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+COMMIT;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+Starting server ...
+# restart
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+COMMIT;
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+COMMIT;
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+ROLLBACK;
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+COMMIT;
+SET AUTOCOMMIT=ON;
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+DROP TABLE t1;
+COMMIT;
+SET AUTOCOMMIT=ON;
+Performing State Transfer on a server that has been killed and restarted
+CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+COMMIT;
+Killing server ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+INSERT INTO t1 VALUES ('node1_committed_during');
+COMMIT;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+Performing --wsrep-recover ...
+Starting server ...
+Using --wsrep-start-position when starting mysqld ...
+# restart: --wsrep-start-position=<WSREP_START_POSITION>
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+INSERT INTO t1 VALUES ('node2_committed_after');
+COMMIT;
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 VALUES ('node1_to_be_committed_after');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+INSERT INTO t1 VALUES ('node1_committed_after');
+COMMIT;
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+ROLLBACK;
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+COMMIT;
+SET AUTOCOMMIT=ON;
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+DROP TABLE t1;
+COMMIT;
+SET AUTOCOMMIT=ON;
+Performing State Transfer on a server that has been killed and restarted
+while a DDL was in progress on it
+CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+INSERT INTO t1 VALUES ('node1_committed_before');
+START TRANSACTION;
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+INSERT INTO t1 VALUES ('node2_committed_before');
+COMMIT;
+SET GLOBAL debug = 'd,sync.alter_opened_table';
+ALTER TABLE t1 ADD COLUMN f2 INTEGER;
+SET wsrep_sync_wait = 0;
+Killing server ...
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+COMMIT;
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+Performing --wsrep-recover ...
+Starting server ...
+Using --wsrep-start-position when starting mysqld ...
+# restart: --wsrep-start-position=<WSREP_START_POSITION>
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES ('node2_committed_after');
+INSERT INTO t1 (f1) VALUES ('node2_committed_after');
+INSERT INTO t1 (f1) VALUES ('node2_committed_after');
+INSERT INTO t1 (f1) VALUES ('node2_committed_after');
+INSERT INTO t1 (f1) VALUES ('node2_committed_after');
+COMMIT;
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+COMMIT;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES ('node1_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_committed_after');
+COMMIT;
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
+ROLLBACK;
+SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't1';
+COUNT(*) = 2
+1
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+COMMIT;
+SET AUTOCOMMIT=ON;
+SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't1';
+COUNT(*) = 2
+1
+SELECT COUNT(*) = 35 FROM t1;
+COUNT(*) = 35
+1
+SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
+COUNT(*) = 0
+1
+DROP TABLE t1;
+COMMIT;
+SET AUTOCOMMIT=ON;

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_fifo16.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_fifo16.cnf
@@ -1,0 +1,14 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep_sst_method=xtrabackup-v2
+wsrep_debug=1
+
+[mysqld.1]
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=1;pc.ignore_sb=true;@ENV.WSREP_PROVIDER_TIMEOUTS'
+
+[mysqld.2]
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.size=1;pc.ignore_sb=true;@ENV.WSREP_PROVIDER_TIMEOUTS'
+
+[sst]
+transfer-fifo-streams=16

--- a/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_fifo16.test
+++ b/mysql-test/suite/galera/t/galera_sst_xtrabackup-v2_fifo16.test
@@ -1,0 +1,25 @@
+#
+# Same SST flows as galera_sst_xtrabackup-v2.test, but with
+# [sst] transfer-fifo-streams=16 so the donor uses
+# `xtrabackup --fifo-streams=16` and the joiner runs ONE
+# `xbstream --fifo-streams=16` consuming 16 FIFOs fed by
+# 16 parallel socat sessions (TLS or plain TCP).
+#
+
+--source include/big_test.inc
+--source include/galera_cluster.inc
+
+--disable_query_log
+--connection node_1
+CALL mtr.add_suppression("Failed to remove page file");
+--connection node_2
+CALL mtr.add_suppression("Failed to remove page file");
+--enable_query_log
+
+--source suite/galera/include/galera_st_shutdown_slave.inc
+--source suite/galera/include/galera_st_clean_slave.inc
+
+--source suite/galera/include/galera_st_kill_slave.inc
+--source suite/galera/include/galera_st_kill_slave_ddl.inc
+
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_recover.log

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -58,6 +58,13 @@ sfmt=""
 strmcmd=""
 tfmt=""
 tcmd=""
+# transfer-fifo-streams: number of parallel TCP streams for the main SST
+# data transfer. Default 1 (single TCP, current behaviour). When > 1, uses
+# xtrabackup --fifo-streams on the donor and a single xbstream --fifo-streams
+# on the joiner, with N socat sessions (encrypt=4 mTLS or plain TCP) acting
+# as the wire.
+transfer_fifo_streams=1
+SST_FIFO_DIR=""
 rebuild=0
 rebuildcmd=""
 payload=0
@@ -665,6 +672,7 @@ read_cnf()
 {
     sfmt=$(parse_cnf sst streamfmt "xbstream")
     tfmt=$(parse_cnf sst transferfmt "socat")
+    transfer_fifo_streams=$(parse_cnf sst transfer-fifo-streams 1)
     encrypt=$(parse_cnf sst encrypt 0)
     sockopt=$(parse_cnf sst sockopt "")
     ncsockopt=$(parse_cnf sst ncsockopt "")
@@ -672,6 +680,62 @@ read_cnf()
     ttime=$(parse_cnf sst time 0)
     scomp=$(parse_cnf sst compressor "")
     sdecomp=$(parse_cnf sst decompressor "")
+
+    # transfer-fifo-streams sanity (N>1).
+    #
+    # The multi-FIFO transport uses xtrabackup --fifo-streams + xbstream
+    # --fifo-streams fanned out over N parallel socat sessions. Three knobs
+    # are incompatible with that and we fatal-out rather than silently
+    # downgrade -- the user explicitly opted into parallel transport, so a
+    # silent fall-back to single-stream would mask their intent:
+    #
+    #  * transferfmt != socat:
+    #      netcat (transferfmt=nc) has no address chaining like socat's
+    #      OPEN:$FIFO,wronly. With nc the joiner would have to use a bash
+    #      `> $FIFO` redirection, which open(O_WRONLY)-blocks before nc
+    #      can bind LISTEN -- deadlock against xbstream's pending
+    #      O_RDONLY open. nc also can't terminate TLS, so the encrypt=4
+    #      flow is socat-only anyway.
+    #
+    #  * streamfmt != xbstream:
+    #      xtrabackup --fifo-streams only operates with --stream=xbstream.
+    #      The legacy --stream=tar mode is single-stdout-only and
+    #      xtrabackup itself rejects --fifo-streams=N>1 there.
+    #
+    #  * sst.compressor / sst.decompressor (wire-level compressors like
+    #    pigz, zstd -c):
+    #      Inserting a per-stream decompressor on the joiner side
+    #      (`socat ... stdio | $sdecomp > $FIFO`) is feasible but adds
+    #      bash plumbing we don't need in the first iteration. Users who
+    #      want on-wire compression have a drop-in workaround:
+    #          [sst] inno-backup-opts = --compress=zstd
+    #      That compresses inside xtrabackup before bytes hit the FIFOs,
+    #      so wire size shrinks without an extra filter between each FIFO
+    #      and its socat. Multi-FIFO is fully compatible with xtrabackup's
+    #      own --compress.
+    if [[ $transfer_fifo_streams -gt 1 ]]; then
+        if [[ $tfmt != "socat" ]]; then
+            wsrep_log_error "******************* FATAL ERROR ********************** "
+            wsrep_log_error "transfer-fifo-streams > 1 requires transferfmt=socat"
+            wsrep_log_error "****************************************************** "
+            safe_exit 22
+        fi
+        if [[ $sfmt != "xbstream" ]]; then
+            wsrep_log_error "******************* FATAL ERROR ********************** "
+            wsrep_log_error "transfer-fifo-streams > 1 requires streamfmt=xbstream"
+            wsrep_log_error "****************************************************** "
+            safe_exit 22
+        fi
+        if [[ -n "$scomp" || -n "$sdecomp" ]]; then
+            wsrep_log_error "******************* FATAL ERROR ********************** "
+            wsrep_log_error "transfer-fifo-streams > 1 incompatible with sst compressor/decompressor."
+            wsrep_log_error "Use xtrabackup's own compression instead:"
+            wsrep_log_error "    [sst] inno-backup-opts = --compress=zstd"
+            wsrep_log_error "****************************************************** "
+            safe_exit 22
+        fi
+        wsrep_log_info "transfer-fifo-streams=${transfer_fifo_streams}: parallel TCP transport enabled"
+    fi
 
     # if wsrep_node_address is not set raise a warning
     local wsrep_node_address=$(parse_cnf mysqld wsrep-node-address "")
@@ -862,6 +926,47 @@ adjust_progress()
         wsrep_log_debug "Rate-limiting SST to $rlimit"
         pcmd+=" -L \$rlimit"
     fi
+}
+
+# make_fifo_workdir [make_fifos N]
+#
+# Creates a private tmpdir for SST multi-FIFO transport. Path is printed to
+# stdout; caller is expected to rm -rf on cleanup.
+#
+# Donor side: xtrabackup --fifo-streams creates the N FIFOs itself and refuses
+# to start if any already exist, so the donor calls this with just one arg
+# (mkdir only).
+#
+# Joiner side: xbstream --fifo-streams expects the FIFOs to be present on
+# startup and does not create them, so the joiner calls
+# make_fifo_workdir N "withfifos" to also mkfifo thread_0..thread_(N-1).
+make_fifo_workdir()
+{
+    local n=$1
+    local mode=${2:-}   # empty (mkdir only) | "withfifos" (mkdir + mkfifo*N)
+    local uuid role dir
+    role="${WSREP_SST_OPT_ROLE:-unknown}"
+    if [[ -r /proc/sys/kernel/random/uuid ]]; then
+        uuid=$(< /proc/sys/kernel/random/uuid)
+    else
+        uuid=$(mktemp -u XXXXXXXXXXXX)
+    fi
+    dir="/tmp/pxc-sst-fifo-${role}-${uuid}"
+    if ! mkdir -m 0700 "$dir"; then
+        wsrep_log_error "make_fifo_workdir: failed to create $dir"
+        safe_exit 32
+    fi
+    if [[ "$mode" == "withfifos" ]]; then
+        local i
+        for ((i = 0; i < n; i++)); do
+            if ! mkfifo "$dir/thread_$i"; then
+                rm -rf "$dir"
+                wsrep_log_error "make_fifo_workdir: mkfifo failed for thread_$i"
+                safe_exit 32
+            fi
+        done
+    fi
+    echo "$dir"
 }
 
 #
@@ -2074,6 +2179,72 @@ then
         if [ "$WSREP_SST_OPT_DEBUG" = "wsrep_sst_donor_skip" ]
         then
           RC=0
+        elif [[ $transfer_fifo_streams -gt 1 ]]; then
+          # ---- multi-FIFO transport path (parallel TCP) ----
+          # The cross-host model is identical to the single-stream case, just
+          # x N: N donor socats TCP-connect to N joiner listeners on
+          # consecutive ports starting at TSST_PORT. Local plumbing differs
+          # only because xtrabackup --fifo-streams creates the FIFOs itself
+          # (and refuses to start if they exist), while xbstream on the joiner
+          # does not.
+          wsrep_log_info "Donor: parallel SST transport with $transfer_fifo_streams TCP streams"
+          SST_FIFO_DIR=$(make_fifo_workdir "$transfer_fifo_streams")
+          # Align --parallel with --fifo-streams so xtrabackup spawns N
+          # data-copy threads, one per FIFO. Last --parallel wins on the
+          # command line, overriding anything inherited from
+          # sst.backup-threads / iopts.
+          INNOBACKUP_FIFO="$INNOBACKUP --parallel=$transfer_fifo_streams --fifo-streams=$transfer_fifo_streams --fifo-dir=$SST_FIFO_DIR --fifo-timeout=300"
+
+          # Build socat args. (Top-level body, no `local`.)
+          _socat_T=""
+          _socat_connect_timeout=""
+          if [[ ${WSREP_SST_IDLE_TIMEOUT:-0} -ne 0 ]]; then
+              _socat_T=" -T ${WSREP_SST_IDLE_TIMEOUT}"
+          fi
+          if [[ ${WSREP_SST_DONOR_TIMEOUT:-0} -ne 0 ]]; then
+              _socat_connect_timeout=",connect-timeout=${WSREP_SST_DONOR_TIMEOUT},retry=30,interval=1"
+          else
+              _socat_connect_timeout=",retry=30,interval=1"
+          fi
+
+          # Spawn N socat pipelines BEFORE xtrabackup. Each waits for its own
+          # FIFO to appear (xtrabackup creates them), then cat-pipes into a
+          # TCP-connect socat. No central polling loop; each stream is
+          # self-contained, mirroring the single-stream pipeline shape.
+          _stream_pids=()
+          for ((_i = 0; _i < transfer_fifo_streams; _i++)); do
+              _port=$((TSST_PORT + _i))
+              if [[ $encrypt -eq 4 ]]; then
+                  _stream_tcmd="socat ${_socat_T} -u stdio openssl-connect:${REMOTEIP}:${_port},cert=${ssl_cert},key=${ssl_key},cafile=${ssl_ca},verify=1${donor_extra}${sockopt}${_socat_connect_timeout}"
+              else
+                  _stream_tcmd="socat ${_socat_T} -u stdio TCP:${REMOTEIP}:${_port}${sockopt}${_socat_connect_timeout}"
+              fi
+              (
+                  _fifo="$SST_FIFO_DIR/thread_$_i"
+                  _deadline=$(( SECONDS + 300 ))
+                  while [[ ! -p "$_fifo" ]] && (( SECONDS < _deadline )); do
+                      sleep 0.1
+                  done
+                  if [[ ! -p "$_fifo" ]]; then
+                      wsrep_log_error "FIFO $_fifo did not appear within 300s"
+                      exit 1
+                  fi
+                  cat "$_fifo" | eval "$_stream_tcmd"
+              ) &
+              _stream_pids+=($!)
+          done
+
+          # Now run xtrabackup in the foreground (same shape as the legacy
+          # single-stream code). Its PIPESTATUS becomes our RC[0] just like
+          # the single-stream branch.
+          timeit "${stagemsg}-SST" "eval $INNOBACKUP_FIFO; RC=( \"\${PIPESTATUS[@]}\" )"
+
+          for _p in "${_stream_pids[@]}"; do
+              wait "$_p" || true
+          done
+          rm -rf "$SST_FIFO_DIR"
+          SST_FIFO_DIR=""
+          # ---- end multi-FIFO transport path ----
         else
           timeit "${stagemsg}-SST" "$INNOBACKUP | $tcmd; RC=( "\${PIPESTATUS[@]}" )"
         fi
@@ -2439,8 +2610,54 @@ then
         # work.
         SAFE_EXIT_CODE_OVERRIDE=
 
-        (recv_data_from_donor_to_joiner "$JOINER_SST_DIR" "${stagemsg}-SST" 0 0) &
-        jpid=$!
+        if [[ $transfer_fifo_streams -gt 1 ]]; then
+            # ---- multi-FIFO joiner path (parallel TCP) ----
+            wsrep_log_info "Joiner: parallel SST transport with $transfer_fifo_streams TCP streams"
+            # mkdir + mkfifo*N — xbstream expects existing FIFOs.
+            SST_FIFO_DIR=$(make_fifo_workdir "$transfer_fifo_streams" "withfifos")
+            (
+                cd "$JOINER_SST_DIR"
+                # Spawn N socat listeners. Each socat opens its TCP LISTEN
+                # address first (bind + listen happen immediately, accept
+                # blocks waiting for the donor), then opens OPEN:$FIFO,wronly
+                # *after* accept completes -- so the FIFO open rendezvous
+                # with xbstream's read side happens at a time when the TCP
+                # listener is already reachable. No bash redirection on the
+                # FIFO, no O_RDWR trick.
+                _socat_pids=()
+                for ((_i = 0; _i < transfer_fifo_streams; _i++)); do
+                    _port=$((TSST_PORT + _i))
+                    _fifo="$SST_FIFO_DIR/thread_$_i"
+                    if [[ $encrypt -eq 4 ]]; then
+                        _stream_tcmd="socat -u openssl-listen:${_port},reuseaddr,cert=${ssl_cert},key=${ssl_key},cafile=${ssl_ca},verify=1${joiner_extra}${sockopt} OPEN:${_fifo},wronly"
+                    elif [[ "$WSREP_SST_OPT_HOST" =~ .*:.* ]]; then
+                        _stream_tcmd="socat -u TCP6-LISTEN:${_port},reuseaddr${sockopt} OPEN:${_fifo},wronly"
+                    else
+                        _stream_tcmd="socat -u TCP-LISTEN:${_port},reuseaddr${sockopt} OPEN:${_fifo},wronly"
+                    fi
+                    ( eval "$_stream_tcmd" ) &
+                    _socat_pids+=($!)
+                done
+
+                # Run xbstream in the foreground (same shape as the legacy
+                # single-stream code's `socat | xbstream`). It opens FIFOs
+                # for read; each socat's pending O_WRONLY open rendezvous
+                # with it once the donor connects on the matching port.
+                xbcmd="${XTRABACKUP_80_PATH}/bin/xbstream -x $xbstream_opts --fifo-streams=$transfer_fifo_streams --fifo-dir=$SST_FIFO_DIR --fifo-timeout=300"
+                eval "$xbcmd"
+                rc_xb=$?
+                for _p in "${_socat_pids[@]}"; do
+                    wait "$_p" || true
+                done
+                rm -rf "$SST_FIFO_DIR"
+                exit $rc_xb
+            ) &
+            jpid=$!
+            # ---- end multi-FIFO joiner path ----
+        else
+            (recv_data_from_donor_to_joiner "$JOINER_SST_DIR" "${stagemsg}-SST" 0 0) &
+            jpid=$!
+        fi
         wsrep_log_info "Proceeding with SST........."
 
         wsrep_log_debug "Cleaning the existing datadir and innodb-data/log directories"


### PR DESCRIPTION
…transport

xtrabackup ≥ 8.0.29 exposes --fifo-streams=N which fans out the backup stream to N parallel named pipes (one per data-copy thread). xbstream consumes the matching N pipes back into a single output. PXC SST today wires xtrabackup's stdout into a single TLS-wrapped TCP socket, so even on fast LAN/WAN networks SST throughput is bounded by what one TLS-encrypted TCP stream can carry (~1 Gbps; socat+OpenSSL is single-core-bound for the per-flow crypto), and by xtrabackup's single stdout mutex (all data-copy threads serialize there).

Adds an opt-in [sst] transfer-fifo-streams=N option (default 1 = legacy single-stream behaviour) that:

 - Runs the donor's xtrabackup with --fifo-streams=N --fifo-dir=... so each data-copy thread feeds its own FIFO.
 - Runs the joiner's xbstream with the same flags, consuming N FIFOs.
 - Bridges with N independent socat sessions (encrypt=4 TLS or plain TCP) on TSST_PORT..TSST_PORT+N-1.

Typical impact:
 - 1 GbE LAN: no benefit, leave default 1.
 - 10 GbE LAN with encrypt=4: N=8 → ~8 Gbps.
 - 25 GbE+ LAN, NVMe disks: N=16.
 - Cross-region WAN (high RTT): N=8 for TCP window aggregation.

The legacy single-TCP code path is left completely untouched; takes effect only when N > 1. Includes a new mtr test variant galera_sst_xtrabackup-v2_fifo16 with N=16 covering both enc_off and enc_on combinations. Restrictions when N>1 (documented inline near the validation block in read_cnf): transferfmt must be socat, streamfmt must be xbstream, and sst.compressor/decompressor is not supported (users should use xtrabackup's own --compress=zstd via [sst] inno-backup-opts instead, which compresses inside xtrabackup before bytes hit the FIFOs).

https://perconadev.atlassian.net/browse/PXC-5251