### PR TITLE
[8.4]PXC-5291: User without super can create trigger even without log_bin_…

### DIFF
--- a/mysql-test/suite/galera/r/pxc_create_trigger_binlog_super.result
+++ b/mysql-test/suite/galera/r/pxc_create_trigger_binlog_super.result
@@ -1,0 +1,83 @@
+
+# 1. Setup users.
+
+SET @old_trust = @@GLOBAL.log_bin_trust_function_creators;
+Warnings:
+Warning	1287	'@@log_bin_trust_function_creators' is deprecated and will be removed in a future release.
+SET GLOBAL log_bin_trust_function_creators = 0;
+CREATE DATABASE probe;
+CREATE USER 'any_def'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'any_def'@'%';
+GRANT SET_ANY_DEFINER ON *.* TO 'any_def'@'%';
+CREATE USER 'plain'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'plain'@'%';
+CREATE USER 'sup'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'sup'@'%';
+GRANT SUPER ON *.* TO 'sup'@'%';
+Warnings:
+Warning	1287	The SUPER privilege identifier is deprecated
+CREATE USER 'other'@'%' IDENTIFIED BY '';
+CREATE TABLE t (id BIGINT NOT NULL PRIMARY KEY);
+
+# 2. log_bin_trust_function_creators = 0
+
+# 2a. SET_ANY_DEFINER only
+CREATE TRIGGER t_any_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+ERROR HY000: You do not have the SUPER privilege (you *might* want to use the less safe log_bin_trust_function_creators variable)
+CREATE DEFINER = 'other'@'%' TRIGGER t_any_definer_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+ERROR HY000: You do not have the SUPER privilege (you *might* want to use the less safe log_bin_trust_function_creators variable)
+# 2b. Plain user (no SUPER, no SET_ANY_DEFINER)
+CREATE TRIGGER t_plain_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+ERROR HY000: You do not have the SUPER privilege (you *might* want to use the less safe log_bin_trust_function_creators variable)
+CREATE DEFINER = 'other'@'%' TRIGGER t_plain_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SET_ANY_DEFINER privilege(s) for this operation
+# 2c. SUPER only
+CREATE TRIGGER t_super_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+CREATE DEFINER = 'other'@'%' TRIGGER t_super_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+include/assert.inc ['Trigger t_any_definer_no_trust not created on node_1 (SET_ANY_DEFINER, trust = 0)']
+include/assert.inc ['Trigger t_any_definer_definer_no_trust not created on node_1 (SET_ANY_DEFINER, DEFINER, trust = 0)']
+include/assert.inc ['Trigger t_plain_no_trust not created on node_1 (PLAIN, trust = 0)']
+include/assert.inc ['Trigger t_plain_definer_no_trust not created on node_1 (PLAIN, DEFINER, trust = 0)']
+include/assert.inc ['Trigger t_super_no_trust created on node_1 (SUPER, trust = 0)']
+include/assert.inc ['Trigger t_super_definer_no_trust created on node_1 (SUPER, DEFINER, trust = 0)']
+'Trigger t_sup t_super_no_trust to node_2 (SUPER, trust = 0)'
+'Trigger t_super_definer_no_trust replicated to node_2 (SUPER, DEFINER, trust = 0)'
+include/assert.inc ['Trigger t_any_definer_no_trust not created on node_2 (SET_ANY_DEFINER, trust = 0)']
+include/assert.inc ['Trigger t_any_definer_definer_no_trust not created on node_2 (SET_ANY_DEFINER, DEFINER, trust = 0)']
+include/assert.inc ['Trigger t_plain_no_trust not created on node_2 (PLAIN, trust = 0)']
+include/assert.inc ['Trigger t_plain_definer_no_trust not created on node_2 (PLAIN, DEFINER, trust = 0)']
+
+# 3. log_bin_trust_function_creators = 1
+
+SET GLOBAL log_bin_trust_function_creators = 1;
+# 3a. SET_ANY_DEFINER only
+CREATE TRIGGER t_any_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+CREATE DEFINER = 'other'@'%' TRIGGER t_any_definer_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+# 3b. Plain user (no SUPER, no SET_ANY_DEFINER)
+CREATE TRIGGER t_plain_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+CREATE DEFINER = 'other'@'%' TRIGGER t_plain_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SET_ANY_DEFINER privilege(s) for this operation
+# 3c. SUPER only
+CREATE TRIGGER t_super_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+CREATE DEFINER = 'other'@'%' TRIGGER t_super_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+include/assert.inc ['Trigger t_any_definer_trust created on node_1 (SET_ANY_DEFINER, trust = 1)']
+include/assert.inc ['Trigger t_any_definer_definer_trust created on node_1 (SET_ANY_DEFINER, DEFINER, trust = 1)']
+include/assert.inc ['Trigger t_plain_trust created on node_1 (PLAIN, trust = 1)']
+include/assert.inc ['Trigger t_plain_definer_trust not created on node_1 (PLAIN, DEFINER, trust = 1)']
+include/assert.inc ['Trigger t_super_trust created on node_1 (SUPER, trust = 1)']
+include/assert.inc ['Trigger t_super_definer_trust created on node_1 (SUPER, DEFINER, trust = 1)']
+'Trigger t_any_definer_trust replicated to node_2 (SET_ANY_DEFINER, trust = 1)'
+'Trigger t_any_definer_definer_trust replicated to node_2 (SET_ANY_DEFINER, DEFINER, trust = 1)'
+'Trigger t_super_trust replicated to node_2 (SUPER, trust = 1)'
+'Trigger t_super_definer_trust replicated to node_2 (SUPER, DEFINER, trust = 1)'
+'Trigger t_plain_trust replicated to node_2 (PLAIN, trust = 1)'
+include/assert.inc ['Trigger t_plain_definer_trust not replicated on node_2 (PLAIN, DEFINER, trust = 1)']
+
+# 4. Cleanup.
+
+DROP DATABASE probe;
+DROP USER 'any_def'@'%';
+DROP USER 'plain'@'%';
+DROP USER 'sup'@'%';
+DROP USER 'other'@'%';
+SET GLOBAL log_bin_trust_function_creators = @old_trust;

--- a/mysql-test/suite/galera/r/pxc_create_trigger_nonexistent_definer.result
+++ b/mysql-test/suite/galera/r/pxc_create_trigger_nonexistent_definer.result
@@ -1,0 +1,80 @@
+
+# 1. Setup users.
+
+SET @old_trust = @@GLOBAL.log_bin_trust_function_creators;
+Warnings:
+Warning	1287	'@@log_bin_trust_function_creators' is deprecated and will be removed in a future release.
+SET GLOBAL log_bin_trust_function_creators = 1;
+CREATE DATABASE probe;
+CREATE USER 'any_def'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'any_def'@'%';
+GRANT SET_ANY_DEFINER ON *.* TO 'any_def'@'%';
+CREATE USER 'nonexist_ok'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'nonexist_ok'@'%';
+GRANT SET_ANY_DEFINER, ALLOW_NONEXISTENT_DEFINER ON *.* TO 'nonexist_ok'@'%';
+CREATE USER 'sup'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'sup'@'%';
+GRANT SUPER ON *.* TO 'sup'@'%';
+Warnings:
+Warning	1287	The SUPER privilege identifier is deprecated
+CREATE TABLE t (id INT PRIMARY KEY);
+
+# 2. SET_ANY_DEFINER user, nonexistent DEFINER -> rejected pre-TOI, no eviction.
+
+CREATE DEFINER='ghost1'@'localhost' TRIGGER tg_ghost1 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or ALLOW_NONEXISTENT_DEFINER privilege(s) for this operation
+include/assert.inc ['node_1 still in a 2-node cluster after the rejected orphan-definer CREATE TRIGGER (no eviction)']
+include/assert.inc ['node_1 is still Synced (not Inconsistent)']
+include/assert.inc ['No inconsistency seen in node_1']
+include/assert.inc ['Trigger tg_ghost1 not created on node_1']
+include/assert.inc ['node_2 still in a 2-node cluster (no eviction)']
+include/assert.inc ['No inconsistency seen in node_2']
+include/assert.inc ['Trigger tg_ghost1 not created on node_2']
+
+# 2b. SET_ANY_DEFINER , EXISTING different DEFINER -> allowed, replicates.
+
+CREATE DEFINER='sup'@'%' TRIGGER tg_existing AFTER UPDATE ON t FOR EACH ROW SET @u = NEW.id;
+include/assert.inc ['Trigger tg_existing (existing DEFINER) created on node_1 by SET_ANY_DEFINER user']
+'Trigger tg_existing replicated to node_2'
+
+# 3. ALLOW_NONEXISTENT_DEFINER user, nonexistent DEFINER -> allowed, replicates.
+
+CREATE DEFINER='ghost2'@'localhost' TRIGGER tg_ghost2 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+Warnings:
+Note	1449	The user specified as a definer ('ghost2'@'localhost') does not exist
+include/assert.inc ['Trigger tg_ghost2 created on node_1 (ALLOW_NONEXISTENT_DEFINER)']
+'Trigger tg_ghost2 replicated to node_2'
+
+# 4. SUPER user, nonexistent DEFINER -> allowed, replicates.
+
+CREATE DEFINER='ghost3'@'localhost' TRIGGER tg_ghost3 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+Warnings:
+Note	1449	The user specified as a definer ('ghost3'@'localhost') does not exist
+include/assert.inc ['Trigger tg_ghost3 created on node_1 (SUPER)']
+'Trigger tg_ghost3 replicated to node_2'
+
+# 4b. trust = 0, nonexistent DEFINER: which gate reports, and both enforced.
+
+SET GLOBAL log_bin_trust_function_creators = 0;
+CREATE DEFINER='ghost4'@'localhost' TRIGGER tg_ghost4 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or ALLOW_NONEXISTENT_DEFINER privilege(s) for this operation
+include/assert.inc ['Trigger tg_ghost4 not created on node_1 (trust = 0)']
+include/assert.inc ['node_1 still in a 2-node cluster after the rejected trust = 0 CREATE TRIGGER (no eviction)']
+include/assert.inc ['Trigger tg_ghost4 not created on node_2 (trust = 0)']
+CREATE DEFINER='ghost5'@'localhost' TRIGGER tg_ghost5 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+Warnings:
+Note	1449	The user specified as a definer ('ghost5'@'localhost') does not exist
+include/assert.inc ['Trigger tg_ghost5 created on node_1 (SUPER, trust = 0)']
+'Trigger tg_ghost5 replicated to node_2 (SUPER, trust = 0)'
+CREATE DEFINER='ghost6'@'localhost' TRIGGER tg_ghost6 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+ERROR HY000: You do not have the SUPER privilege (you *might* want to use the less safe log_bin_trust_function_creators variable)
+include/assert.inc ['Trigger tg_ghost6 not created on node_1 (ALLOW_NONEXISTENT_DEFINER, no SUPER, trust = 0)']
+include/assert.inc ['Trigger tg_ghost6 not created on node_2 (ALLOW_NONEXISTENT_DEFINER, no SUPER, trust = 0)']
+
+# 5. Cleanup.
+
+DROP DATABASE probe;
+DROP USER 'any_def'@'%';
+DROP USER 'nonexist_ok'@'%';
+DROP USER 'sup'@'%';
+SET GLOBAL log_bin_trust_function_creators = @old_trust;

--- a/mysql-test/suite/galera/t/pxc_create_trigger_binlog_super.test
+++ b/mysql-test/suite/galera/t/pxc_create_trigger_binlog_super.test
@@ -1,0 +1,239 @@
+################################################################################
+# PXC-5291: User without SUPER can create trigger even without
+#           log_bin_trust_function_creators enabled.
+#
+# Test:
+# 0. Two servers: node_1 and node_2.
+# 1. Setup users.
+# 2. log_bin_trust_function_creators = 0
+# 2a. SET_ANY_DEFINER only
+# 2b. Plain user (no SUPER, no SET_ANY_DEFINER)
+# 2c. SUPER only
+# 3. log_bin_trust_function_creators = 1
+# 3a. SET_ANY_DEFINER only
+# 3b. Plain user (no SUPER, no SET_ANY_DEFINER)
+# 3c. SUPER only
+# 4. Cleanup.
+################################################################################
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--echo
+--echo # 1. Setup users.
+--echo
+
+--connection node_1
+SET @old_trust = @@GLOBAL.log_bin_trust_function_creators;
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = 0;
+--enable_warnings
+
+CREATE DATABASE probe;
+
+# User with SET_ANY_DEFINER(YES), SUPER(NO)
+CREATE USER 'any_def'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'any_def'@'%';
+GRANT SET_ANY_DEFINER ON *.* TO 'any_def'@'%';
+
+# User with SET_ANY_DEFINER(NO), SUPER(NO)
+CREATE USER 'plain'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'plain'@'%';
+
+# User with SET_ANY_DEFINER(NO), SUPER(YES)
+CREATE USER 'sup'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'sup'@'%';
+GRANT SUPER ON *.* TO 'sup'@'%';
+
+# Helper user used as a DEFINER.
+CREATE USER 'other'@'%' IDENTIFIED BY '';
+
+--connect (any_def_con,localhost,any_def,,probe,$NODE_MYPORT_1)
+CREATE TABLE t (id BIGINT NOT NULL PRIMARY KEY);
+
+################################################################################
+--echo
+--echo # 2. log_bin_trust_function_creators = 0
+--echo
+
+--echo # 2a. SET_ANY_DEFINER only
+--connection any_def_con
+
+--error ER_BINLOG_CREATE_ROUTINE_NEED_SUPER
+CREATE TRIGGER t_any_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+--error ER_BINLOG_CREATE_ROUTINE_NEED_SUPER
+CREATE DEFINER = 'other'@'%' TRIGGER t_any_definer_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+
+--echo # 2b. Plain user (no SUPER, no SET_ANY_DEFINER)
+--connect (plain_con,localhost,plain,,probe,$NODE_MYPORT_1)
+
+--error ER_BINLOG_CREATE_ROUTINE_NEED_SUPER
+CREATE TRIGGER t_plain_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+CREATE DEFINER = 'other'@'%' TRIGGER t_plain_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+
+--echo # 2c. SUPER only
+--connect (sup_con,localhost,sup,,probe,$NODE_MYPORT_1)
+
+CREATE TRIGGER t_super_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+CREATE DEFINER = 'other'@'%' TRIGGER t_super_definer_no_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+
+################################################################################
+##### Asserts
+################################################################################
+
+# Rejected triggers exist on no node; the SUPER-created trigger replicates.
+--connection node_1
+--let $assert_text = 'Trigger t_any_definer_no_trust not created on node_1 (SET_ANY_DEFINER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_no_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_any_definer_definer_no_trust not created on node_1 (SET_ANY_DEFINER, DEFINER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_definer_no_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_plain_no_trust not created on node_1 (PLAIN, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_no_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_plain_definer_no_trust not created on node_1 (PLAIN, DEFINER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_definer_no_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_super_no_trust created on node_1 (SUPER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_no_trust", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_super_definer_no_trust created on node_1 (SUPER, DEFINER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_definer_no_trust", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger t_sup t_super_no_trust to node_2 (SUPER, trust = 0)'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_no_trust"
+--source include/wait_condition.inc
+
+--echo 'Trigger t_super_definer_no_trust replicated to node_2 (SUPER, DEFINER, trust = 0)'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_definer_no_trust"
+--source include/wait_condition.inc
+
+--let $assert_text = 'Trigger t_any_definer_no_trust not created on node_2 (SET_ANY_DEFINER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_no_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_any_definer_definer_no_trust not created on node_2 (SET_ANY_DEFINER, DEFINER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_definer_no_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_plain_no_trust not created on node_2 (PLAIN, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_no_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_plain_definer_no_trust not created on node_2 (PLAIN, DEFINER, trust = 0)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_definer_no_trust", c, 1] = 0
+--source include/assert.inc
+
+################################################################################
+--echo
+--echo # 3. log_bin_trust_function_creators = 1
+--echo
+
+--connection node_1
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = 1;
+--enable_warnings
+
+--echo # 3a. SET_ANY_DEFINER only
+--connection any_def_con
+
+CREATE TRIGGER t_any_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+CREATE DEFINER = 'other'@'%' TRIGGER t_any_definer_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+
+--echo # 3b. Plain user (no SUPER, no SET_ANY_DEFINER)
+--connection plain_con
+
+# This passes(even in PS) since definer is not there and log_bin_trust_function_creators is set.
+CREATE TRIGGER t_plain_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+CREATE DEFINER = 'other'@'%' TRIGGER t_plain_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+
+--echo # 3c. SUPER only
+--connection sup_con
+
+CREATE TRIGGER t_super_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+CREATE DEFINER = 'other'@'%' TRIGGER t_super_definer_trust AFTER DELETE ON t FOR EACH ROW SET @x = OLD.id;
+
+################################################################################
+##### Asserts
+################################################################################
+# Rejected triggers exist on no node; the SUPER-created trigger replicates.
+--connection node_1
+--let $assert_text = 'Trigger t_any_definer_trust created on node_1 (SET_ANY_DEFINER, trust = 1)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_trust", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_any_definer_definer_trust created on node_1 (SET_ANY_DEFINER, DEFINER, trust = 1)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_definer_trust", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_plain_trust created on node_1 (PLAIN, trust = 1)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_trust", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_plain_definer_trust not created on node_1 (PLAIN, DEFINER, trust = 1)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_definer_trust", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_super_trust created on node_1 (SUPER, trust = 1)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_trust", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text = 'Trigger t_super_definer_trust created on node_1 (SUPER, DEFINER, trust = 1)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_definer_trust", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger t_any_definer_trust replicated to node_2 (SET_ANY_DEFINER, trust = 1)'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_trust"
+--source include/wait_condition.inc
+
+--echo 'Trigger t_any_definer_definer_trust replicated to node_2 (SET_ANY_DEFINER, DEFINER, trust = 1)'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_any_definer_definer_trust"
+--source include/wait_condition.inc
+
+--echo 'Trigger t_super_trust replicated to node_2 (SUPER, trust = 1)'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_trust"
+--source include/wait_condition.inc
+
+--echo 'Trigger t_super_definer_trust replicated to node_2 (SUPER, DEFINER, trust = 1)'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_super_definer_trust"
+--source include/wait_condition.inc
+
+--echo 'Trigger t_plain_trust replicated to node_2 (PLAIN, trust = 1)'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_trust"
+--source include/wait_condition.inc
+
+--let $assert_text = 'Trigger t_plain_definer_trust not replicated on node_2 (PLAIN, DEFINER, trust = 1)'
+--let $assert_cond = [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "t_plain_definer_trust", c, 1] = 0
+--source include/assert.inc
+
+################################################################################
+--echo
+--echo # 4. Cleanup.
+--echo
+
+--disconnect plain_con
+--disconnect sup_con
+--disconnect any_def_con
+
+--connection node_1
+DROP DATABASE probe;
+DROP USER 'any_def'@'%';
+DROP USER 'plain'@'%';
+DROP USER 'sup'@'%';
+DROP USER 'other'@'%';
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = @old_trust;
+--enable_warnings
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/galera/t/pxc_create_trigger_nonexistent_definer.test
+++ b/mysql-test/suite/galera/t/pxc_create_trigger_nonexistent_definer.test
@@ -1,0 +1,234 @@
+################################################################################
+# PXC-5292: CREATE TRIGGER with a nonexistent DEFINER by a user without
+#           SUPER / ALLOW_NONEXISTENT_DEFINER must be rejected on the origin
+#           node BEFORE the statement is replicated (before TOI), so the node
+#           is NOT evicted from the cluster.
+#
+# This guards against the inconsistency via the orphan-definer path
+# (WL#15874 stage 2). Without the fix, the origin accepts the statement and
+# replicates it. Statement is later rejected in check_valid_definer()
+# during creation (post-TOI) while the appliers create it successfully -> the
+# origin is declared inconsistent by consensus and leaves the cluster.
+#
+# Test:
+# 1. Setup users.
+# 2. SET_ANY_DEFINER user, nonexistent DEFINER -> rejected pre-TOI, no eviction.
+# 2b. SET_ANY_DEFINER , EXISTING different DEFINER -> allowed, replicates.
+# 3. ALLOW_NONEXISTENT_DEFINER user, nonexistent DEFINER -> allowed, replicates.
+# 4. SUPER user, nonexistent DEFINER -> allowed, replicates.
+# 4b. trust = 0, nonexistent DEFINER: which gate reports, and both enforced.
+#     - SET_ANY_DEFINER only -> rejected by the DEFINER check (it runs first).
+#     - SUPER -> satisfies both gates, allowed, replicates.
+#     - ALLOW_NONEXISTENT_DEFINER without SUPER -> clears the DEFINER check,
+#       then rejected by the binlog gate.
+# 5. Cleanup.
+################################################################################
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--echo
+--echo # 1. Setup users.
+--echo
+
+--connection node_1
+SET @old_trust = @@GLOBAL.log_bin_trust_function_creators;
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = 1;
+--enable_warnings
+
+CREATE DATABASE probe;
+
+# SET_ANY_DEFINER, but NOT SUPER and NOT ALLOW_NONEXISTENT_DEFINER.
+CREATE USER 'any_def'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'any_def'@'%';
+GRANT SET_ANY_DEFINER ON *.* TO 'any_def'@'%';
+
+# SET_ANY_DEFINER + ALLOW_NONEXISTENT_DEFINER (allowed to create orphan definer).
+CREATE USER 'nonexist_ok'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'nonexist_ok'@'%';
+GRANT SET_ANY_DEFINER, ALLOW_NONEXISTENT_DEFINER ON *.* TO 'nonexist_ok'@'%';
+
+# SUPER.
+CREATE USER 'sup'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'sup'@'%';
+GRANT SUPER ON *.* TO 'sup'@'%';
+
+--connect (any_def_con,localhost,any_def,,probe,$NODE_MYPORT_1)
+CREATE TABLE t (id INT PRIMARY KEY);
+
+--echo
+--echo # 2. SET_ANY_DEFINER user, nonexistent DEFINER -> rejected pre-TOI, no eviction.
+--echo
+
+# The 'ghost1' definer does not exist, logged in as 'user with SET_ANY_DEFINER'
+--connection any_def_con
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+CREATE DEFINER='ghost1'@'localhost' TRIGGER tg_ghost1 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+# --- Eviction guard: node_1 must still be a healthy member of the 2-node cluster ---
+--connection node_1
+--let $assert_text= 'node_1 still in a 2-node cluster after the rejected orphan-definer CREATE TRIGGER (no eviction)'
+--let $assert_cond= [SELECT VARIABLE_VALUE = 2 AS c FROM performance_schema.global_status WHERE VARIABLE_NAME = "wsrep_cluster_size", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'node_1 is still Synced (not Inconsistent)'
+--let $assert_cond= [SELECT VARIABLE_VALUE = "Synced" AS c FROM performance_schema.global_status WHERE VARIABLE_NAME = "wsrep_local_state_comment", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'No inconsistency seen in node_1'
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.error_log WHERE DATA LIKE "%Inconsistency detected%"] = 0
+--source include/assert.inc
+
+# Rejected before replication: trigger exists on no node.
+--let $assert_text= 'Trigger tg_ghost1 not created on node_1'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost1", c, 1] = 0
+--source include/assert.inc
+
+--connection node_2
+--let $assert_text= 'node_2 still in a 2-node cluster (no eviction)'
+--let $assert_cond= [SELECT VARIABLE_VALUE = 2 AS c FROM performance_schema.global_status WHERE VARIABLE_NAME = "wsrep_cluster_size", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'No inconsistency seen in node_2'
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.error_log WHERE DATA LIKE "%Inconsistency detected%"] = 0
+--source include/assert.inc
+
+--let $assert_text= 'Trigger tg_ghost1 not created on node_2'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost1", c, 1] = 0
+--source include/assert.inc
+
+--echo
+--echo # 2b. SET_ANY_DEFINER , EXISTING different DEFINER -> allowed, replicates.
+--echo
+
+# The 'sup' DEFINER is existing, logged in as 'user with SET_ANY_DEFINER'
+--connection any_def_con
+CREATE DEFINER='sup'@'%' TRIGGER tg_existing AFTER UPDATE ON t FOR EACH ROW SET @u = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_existing (existing DEFINER) created on node_1 by SET_ANY_DEFINER user'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_existing", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger tg_existing replicated to node_2'
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_existing"
+--source include/wait_condition.inc
+
+--echo
+--echo # 3. ALLOW_NONEXISTENT_DEFINER user, nonexistent DEFINER -> allowed, replicates.
+--echo
+
+# The 'ghost2' DEFINER is not existing, logged in as 'user with ALLOW_NONEXISTENT_DEFINER'
+--connect (nonexist_ok_con,localhost,nonexist_ok,,probe,$NODE_MYPORT_1)
+CREATE DEFINER='ghost2'@'localhost' TRIGGER tg_ghost2 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_ghost2 created on node_1 (ALLOW_NONEXISTENT_DEFINER)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost2", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger tg_ghost2 replicated to node_2'
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost2"
+--source include/wait_condition.inc
+
+--echo
+--echo # 4. SUPER user, nonexistent DEFINER -> allowed, replicates.
+--echo
+
+# The 'ghost3' DEFINER is not existing, logged in as 'super user'
+--connect (sup_con,localhost,sup,,probe,$NODE_MYPORT_1)
+CREATE DEFINER='ghost3'@'localhost' TRIGGER tg_ghost3 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_ghost3 created on node_1 (SUPER)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost3", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger tg_ghost3 replicated to node_2'
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost3"
+--source include/wait_condition.inc
+
+--echo
+--echo # 4b. trust = 0, nonexistent DEFINER: which gate reports, and both enforced.
+--echo
+
+# Cases above runs with log_bin_trust_function_creators = 1.
+--connection node_1
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = 0;
+--enable_warnings
+
+# The 'ghost4' definer does not exist, logged in as 'user with SET_ANY_DEFINER'
+--connection any_def_con
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+CREATE DEFINER='ghost4'@'localhost' TRIGGER tg_ghost4 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+# Rejected before replication: trigger exists on no node.
+--connection node_1
+--let $assert_text= 'Trigger tg_ghost4 not created on node_1 (trust = 0)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost4", c, 1] = 0
+--source include/assert.inc
+
+--let $assert_text= 'node_1 still in a 2-node cluster after the rejected trust = 0 CREATE TRIGGER (no eviction)'
+--let $assert_cond= [SELECT VARIABLE_VALUE = 2 AS c FROM performance_schema.global_status WHERE VARIABLE_NAME = "wsrep_cluster_size", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--let $assert_text= 'Trigger tg_ghost4 not created on node_2 (trust = 0)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost4", c, 1] = 0
+--source include/assert.inc
+
+# --- SUPER: satisfies the DEFINER check
+--connection sup_con
+CREATE DEFINER='ghost5'@'localhost' TRIGGER tg_ghost5 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_ghost5 created on node_1 (SUPER, trust = 0)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost5", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger tg_ghost5 replicated to node_2 (SUPER, trust = 0)'
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost5"
+--source include/wait_condition.inc
+
+# --- ALLOW_NONEXISTENT_DEFINER without SUPER: clears the DEFINER check, ---
+# then the binlog gate rejects, because only SUPER (or trust = 1) satisfies it.
+# This pins that the binlog gate is still reached and enforced AFTER the
+# DEFINER check passes -- the complement of the SET_ANY_DEFINER case above.
+--connection nonexist_ok_con
+--error ER_BINLOG_CREATE_ROUTINE_NEED_SUPER
+CREATE DEFINER='ghost6'@'localhost' TRIGGER tg_ghost6 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_ghost6 not created on node_1 (ALLOW_NONEXISTENT_DEFINER, no SUPER, trust = 0)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost6", c, 1] = 0
+--source include/assert.inc
+
+--connection node_2
+--let $assert_text= 'Trigger tg_ghost6 not created on node_2 (ALLOW_NONEXISTENT_DEFINER, no SUPER, trust = 0)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost6", c, 1] = 0
+--source include/assert.inc
+
+--echo
+--echo # 5. Cleanup.
+--echo
+
+--disconnect sup_con
+--disconnect nonexist_ok_con
+--disconnect any_def_con
+
+--connection node_1
+DROP DATABASE probe;
+DROP USER 'any_def'@'%';
+DROP USER 'nonexist_ok'@'%';
+DROP USER 'sup'@'%';
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = @old_trust;
+--enable_warnings
+
+--source include/wait_until_count_sessions.inc

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -7803,7 +7803,12 @@ bool check_system_user_privilege(THD *thd, List<LEX_USER> list) {
   return (false);
 }
 
+#ifdef WITH_WSREP
+bool check_valid_definer(THD *thd, LEX_USER *definer,
+                         bool report_no_such_user_warning) {
+#else
 bool check_valid_definer(THD *thd, LEX_USER *definer) {
+#endif
   DBUG_TRACE;
   Security_context *sctx = thd->security_context();
   if ((strcmp(definer->user.str, sctx->priv_user().str) ||
@@ -7829,6 +7834,9 @@ bool check_valid_definer(THD *thd, LEX_USER *definer) {
                "SUPER or ALLOW_NONEXISTENT_DEFINER");
       return true;
     } else
+#ifdef WITH_WSREP
+        if (report_no_such_user_warning)
+#endif
       push_warning_printf(thd, Sql_condition::SL_NOTE, ER_NO_SUCH_USER,
                           ER_THD(thd, ER_NO_SUCH_USER), definer->user.str,
                           definer->host.str);

--- a/sql/auth/sql_authorization.h
+++ b/sql/auth/sql_authorization.h
@@ -71,9 +71,20 @@ extern mysql_mutex_t LOCK_mandatory_roles;
 
   @param thd the session
   @param definer the definer to check
+  @param report_no_such_user_warning whether the informational ER_NO_SUCH_USER
+         note is pushed when the definer does not exist and the caller is
+         allowed to create an orphan object. Pass false when the check is
+         repeated later on the same statement, so that the client is not given
+         a duplicate note.
   @retval false : success
   @retval true : failure
 */
+
+#ifdef WITH_WSREP
+extern bool check_valid_definer(THD *thd, LEX_USER *definer,
+                                bool report_no_such_user_warning = true);
+#else
 extern bool check_valid_definer(THD *thd, LEX_USER *definer);
+#endif
 
 #endif /* SQL_AUTHORIZATION_INCLUDED */

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -42,7 +42,7 @@
 #include "mysql_com.h"
 #include "mysqld_error.h"
 #include "sql/auth/auth_acls.h"
-#include "sql/auth/auth_common.h"  // check_table_access
+#include "sql/auth/sql_authorization.h"  // check_valid_definer
 #include "sql/auth/sql_security_ctx.h"
 #include "sql/binlog.h"
 #include "sql/dd/cache/dictionary_client.h"
@@ -409,26 +409,20 @@ bool Sql_cmd_create_trigger::execute(THD *thd) {
   Security_context *sctx = thd->security_context();
 #ifdef WITH_WSREP
   LEX *lex = thd->lex;
-  bool definer_is_current_user =
-      !lex->definer || /* If definer is not specified, consider current user */
-      (strcmp(lex->definer->user.str, sctx->priv_user().str) == 0 &&
-       my_strcasecmp(system_charset_info, lex->definer->host.str,
-                     sctx->priv_host().str) == 0);
-  bool binlog_requires_super =
+
+  /*
+    check_valid_definer() is the authorization check introduced in WL#15874.
+  */
+  if (WSREP(thd) && lex->definer &&
+      check_valid_definer(thd, lex->definer,
+                          false /* report_no_such_user_warning */))
+    return true;
+
+  const bool binlog_requires_super =
       !trust_function_creators &&
       (WSREP_EMULATE_BINLOG(thd) || mysql_bin_log.is_open());
-  bool has_super_or_set_user_id =
-      sctx->check_access(SUPER_ACL) ||
-      sctx->has_global_grant(STRING_WITH_LEN("SET_ANY_DEFINER")).first;
-
-  // Definer check: If a definer is specified and is different from the current
-  // user, then we need to check for SUPER or SET_ANY_DEFINER privileges.
-  if ((!definer_is_current_user || binlog_requires_super) &&
-      !has_super_or_set_user_id) {
-    if (!definer_is_current_user) {
-      my_error(ER_SPECIFIC_ACCESS_DENIED_ERROR, MYF(0),
-               "SUPER or SET_ANY_DEFINER");
-    } else if (WSREP(thd)) {
+  if (binlog_requires_super && !sctx->check_access(SUPER_ACL)) {
+    if (WSREP(thd)) {
       /*
         If WSREP is enabled, then we are ALWAYS doing binlog
         replication of some sort, and we always require the SUPER
@@ -444,10 +438,6 @@ bool Sql_cmd_create_trigger::execute(THD *thd) {
     }
     return true;
   }
-
-  if (lex->definer && sctx->can_operate_with(lex->definer, consts::system_user,
-                                             true /* report_error */))
-    return true;
 
 #else
   if (!trust_function_creators && mysql_bin_log.is_open() &&


### PR DESCRIPTION
…trust_function_creators enabled

https://perconadev.atlassian.net/browse/PXC-5291

The PXC-4765 change folded the trigger DEFINER-mismatch check and the binlog-safety (log_bin_trust_function_creators) check into a single privilege test that accepted SUPER or SET_ANY_DEFINER. As a result a user holding only SET_ANY_DEFINER could create a trigger while log_bin_trust_function_creators = 0, diverging from PS and PXC 8.4.7 which reject it with ER_BINLOG_CREATE_ROUTINE_NEED_SUPER.

Split the two checks in Sql_cmd_create_trigger::execute(): the DEFINER-mismatch check keeps SUPER or SET_ANY_DEFINER, while the binlog-safety check now requires SUPER only. SET_ANY_DEFINER no longer bypasses the binlog-safety gate.