### PR TITLE
[DISCARDED PXC-5291 will have fix](8.4)PXC-5292: CREATE TRIGGER with nonexistent DEFINER by SET_ANY_DEFINER …

### DIFF
--- a/mysql-test/suite/galera/r/pxc_create_trigger_nonexistent_definer.result
+++ b/mysql-test/suite/galera/r/pxc_create_trigger_nonexistent_definer.result
@@ -1,0 +1,62 @@
+
+# 1. Setup users.
+
+SET @old_trust = @@GLOBAL.log_bin_trust_function_creators;
+Warnings:
+Warning	1287	'@@log_bin_trust_function_creators' is deprecated and will be removed in a future release.
+SET GLOBAL log_bin_trust_function_creators = 1;
+CREATE DATABASE probe;
+CREATE USER 'any_def'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'any_def'@'%';
+GRANT SET_ANY_DEFINER ON *.* TO 'any_def'@'%';
+CREATE USER 'nonexist_ok'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'nonexist_ok'@'%';
+GRANT SET_ANY_DEFINER, ALLOW_NONEXISTENT_DEFINER ON *.* TO 'nonexist_ok'@'%';
+CREATE USER 'sup'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'sup'@'%';
+GRANT SUPER ON *.* TO 'sup'@'%';
+Warnings:
+Warning	1287	The SUPER privilege identifier is deprecated
+CREATE TABLE t (id INT PRIMARY KEY);
+
+# 2. SET_ANY_DEFINER user, nonexistent DEFINER -> rejected pre-TOI, no eviction.
+
+CREATE DEFINER='ghost1'@'localhost' TRIGGER tg_ghost1 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or ALLOW_NONEXISTENT_DEFINER privilege(s) for this operation
+include/assert.inc ['node_1 still in a 2-node cluster after the rejected orphan-definer CREATE TRIGGER (no eviction)']
+include/assert.inc ['node_1 is still Synced (not Inconsistent)']
+include/assert.inc ['No inconsistency seen in node_1']
+include/assert.inc ['Trigger tg_ghost1 not created on node_1']
+include/assert.inc ['node_2 still in a 2-node cluster (no eviction)']
+include/assert.inc ['No inconsistency seen in node_2']
+include/assert.inc ['Trigger tg_ghost1 not created on node_2']
+
+# 2b. SET_ANY_DEFINER , EXISTING different DEFINER -> allowed, replicates.
+
+CREATE DEFINER='sup'@'%' TRIGGER tg_existing AFTER UPDATE ON t FOR EACH ROW SET @u = NEW.id;
+include/assert.inc ['Trigger tg_existing (existing DEFINER) created on node_1 by SET_ANY_DEFINER user']
+'Trigger tg_existing replicated to node_2'
+
+# 3. ALLOW_NONEXISTENT_DEFINER user, nonexistent DEFINER -> allowed, replicates.
+
+CREATE DEFINER='ghost2'@'localhost' TRIGGER tg_ghost2 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+Warnings:
+Note	1449	The user specified as a definer ('ghost2'@'localhost') does not exist
+include/assert.inc ['Trigger tg_ghost2 created on node_1 (ALLOW_NONEXISTENT_DEFINER)']
+'Trigger tg_ghost2 replicated to node_2'
+
+# 4. SUPER user, nonexistent DEFINER -> allowed, replicates.
+
+CREATE DEFINER='ghost3'@'localhost' TRIGGER tg_ghost3 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+Warnings:
+Note	1449	The user specified as a definer ('ghost3'@'localhost') does not exist
+include/assert.inc ['Trigger tg_ghost3 created on node_1 (SUPER)']
+'Trigger tg_ghost3 replicated to node_2'
+
+# 5. Cleanup.
+
+DROP DATABASE probe;
+DROP USER 'any_def'@'%';
+DROP USER 'nonexist_ok'@'%';
+DROP USER 'sup'@'%';
+SET GLOBAL log_bin_trust_function_creators = @old_trust;

--- a/mysql-test/suite/galera/t/pxc_create_trigger_nonexistent_definer.test
+++ b/mysql-test/suite/galera/t/pxc_create_trigger_nonexistent_definer.test
@@ -1,0 +1,167 @@
+################################################################################
+# PXC-5292: CREATE TRIGGER with a nonexistent DEFINER by a user without
+#           SUPER / ALLOW_NONEXISTENT_DEFINER must be rejected on the origin
+#           node BEFORE the statement is replicated (before TOI), so the node
+#           is NOT evicted from the cluster.
+#
+# This guards against the inconsistency via the orphan-definer path
+# (WL#15874 stage 2). Without the fix, the origin accepts the statement and
+# replicates it. Statement is later rejected in check_valid_definer()
+# during creation (post-TOI) while the appliers create it successfully -> the
+# origin is declared inconsistent by consensus and leaves the cluster.
+#
+# Test:
+# 1. Setup users.
+# 2. SET_ANY_DEFINER user, nonexistent DEFINER -> rejected pre-TOI, no eviction.
+# 2b. SET_ANY_DEFINER , EXISTING different DEFINER -> allowed, replicates.
+# 3. ALLOW_NONEXISTENT_DEFINER user, nonexistent DEFINER -> allowed, replicates.
+# 4. SUPER user, nonexistent DEFINER -> allowed, replicates.
+# 5. Cleanup.
+################################################################################
+
+--source include/galera_cluster.inc
+--source include/count_sessions.inc
+
+--echo
+--echo # 1. Setup users.
+--echo
+
+--connection node_1
+SET @old_trust = @@GLOBAL.log_bin_trust_function_creators;
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = 1;
+--enable_warnings
+
+CREATE DATABASE probe;
+
+# SET_ANY_DEFINER, but NOT SUPER and NOT ALLOW_NONEXISTENT_DEFINER.
+CREATE USER 'any_def'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'any_def'@'%';
+GRANT SET_ANY_DEFINER ON *.* TO 'any_def'@'%';
+
+# SET_ANY_DEFINER + ALLOW_NONEXISTENT_DEFINER (allowed to create orphan definer).
+CREATE USER 'nonexist_ok'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'nonexist_ok'@'%';
+GRANT SET_ANY_DEFINER, ALLOW_NONEXISTENT_DEFINER ON *.* TO 'nonexist_ok'@'%';
+
+# SUPER.
+CREATE USER 'sup'@'%' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON probe.* TO 'sup'@'%';
+GRANT SUPER ON *.* TO 'sup'@'%';
+
+--connect (any_def_con,localhost,any_def,,probe,$NODE_MYPORT_1)
+CREATE TABLE t (id INT PRIMARY KEY);
+
+--echo
+--echo # 2. SET_ANY_DEFINER user, nonexistent DEFINER -> rejected pre-TOI, no eviction.
+--echo
+
+# The 'ghost1' definer does not exist, logged in as 'user with SET_ANY_DEFINER'
+--connection any_def_con
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+CREATE DEFINER='ghost1'@'localhost' TRIGGER tg_ghost1 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+# --- Eviction guard: node_1 must still be a healthy member of the 2-node cluster ---
+--connection node_1
+--let $assert_text= 'node_1 still in a 2-node cluster after the rejected orphan-definer CREATE TRIGGER (no eviction)'
+--let $assert_cond= [SELECT VARIABLE_VALUE = 2 AS c FROM performance_schema.global_status WHERE VARIABLE_NAME = "wsrep_cluster_size", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'node_1 is still Synced (not Inconsistent)'
+--let $assert_cond= [SELECT VARIABLE_VALUE = "Synced" AS c FROM performance_schema.global_status WHERE VARIABLE_NAME = "wsrep_local_state_comment", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'No inconsistency seen in node_1'
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.error_log WHERE DATA LIKE "%Inconsistency detected%"] = 0
+--source include/assert.inc
+
+# Rejected before replication: trigger exists on no node.
+--let $assert_text= 'Trigger tg_ghost1 not created on node_1'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost1", c, 1] = 0
+--source include/assert.inc
+
+--connection node_2
+--let $assert_text= 'node_2 still in a 2-node cluster (no eviction)'
+--let $assert_cond= [SELECT VARIABLE_VALUE = 2 AS c FROM performance_schema.global_status WHERE VARIABLE_NAME = "wsrep_cluster_size", c, 1] = 1
+--source include/assert.inc
+
+--let $assert_text= 'No inconsistency seen in node_2'
+--let $assert_cond = [SELECT COUNT(*) FROM performance_schema.error_log WHERE DATA LIKE "%Inconsistency detected%"] = 0
+--source include/assert.inc
+
+--let $assert_text= 'Trigger tg_ghost1 not created on node_2'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost1", c, 1] = 0
+--source include/assert.inc
+
+--echo
+--echo # 2b. SET_ANY_DEFINER , EXISTING different DEFINER -> allowed, replicates.
+--echo
+
+# The 'sup' DEFINER is existing, logged in as 'user with SET_ANY_DEFINER'
+--connection any_def_con
+CREATE DEFINER='sup'@'%' TRIGGER tg_existing AFTER UPDATE ON t FOR EACH ROW SET @u = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_existing (existing DEFINER) created on node_1 by SET_ANY_DEFINER user'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_existing", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger tg_existing replicated to node_2'
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_existing"
+--source include/wait_condition.inc
+
+--echo
+--echo # 3. ALLOW_NONEXISTENT_DEFINER user, nonexistent DEFINER -> allowed, replicates.
+--echo
+
+# The 'ghost2' DEFINER is not existing, logged in as 'user with ALLOW_NONEXISTENT_DEFINER'
+--connect (nonexist_ok_con,localhost,nonexist_ok,,probe,$NODE_MYPORT_1)
+CREATE DEFINER='ghost2'@'localhost' TRIGGER tg_ghost2 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_ghost2 created on node_1 (ALLOW_NONEXISTENT_DEFINER)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost2", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger tg_ghost2 replicated to node_2'
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost2"
+--source include/wait_condition.inc
+
+--echo
+--echo # 4. SUPER user, nonexistent DEFINER -> allowed, replicates.
+--echo
+
+# The 'ghost3' DEFINER is not existing, logged in as 'super user'
+--connect (sup_con,localhost,sup,,probe,$NODE_MYPORT_1)
+CREATE DEFINER='ghost3'@'localhost' TRIGGER tg_ghost3 AFTER INSERT ON t FOR EACH ROW SET @n = NEW.id;
+
+--connection node_1
+--let $assert_text= 'Trigger tg_ghost3 created on node_1 (SUPER)'
+--let $assert_cond= [SELECT COUNT(*) AS c FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost3", c, 1] = 1
+--source include/assert.inc
+
+--connection node_2
+--echo 'Trigger tg_ghost3 replicated to node_2'
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA = "probe" AND TRIGGER_NAME = "tg_ghost3"
+--source include/wait_condition.inc
+
+--echo
+--echo # 5. Cleanup.
+--echo
+
+--disconnect sup_con
+--disconnect nonexist_ok_con
+--disconnect any_def_con
+
+--connection node_1
+DROP DATABASE probe;
+DROP USER 'any_def'@'%';
+DROP USER 'nonexist_ok'@'%';
+DROP USER 'sup'@'%';
+--disable_warnings
+SET GLOBAL log_bin_trust_function_creators = @old_trust;
+--enable_warnings
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -449,6 +449,33 @@ bool Sql_cmd_create_trigger::execute(THD *thd) {
                                              true /* report_error */))
     return true;
 
+  /*
+    A DEFINER referring to a non-existent user (orphan object) requires SUPER or
+    ALLOW_NONEXISTENT_DEFINER. This mirrors stage 2 of check_valid_definer() in
+    sql/auth/sql_authorization.cc. Doing it here, before
+    wsrep_to_isolation_begin(), makes the origin reject the statement before it
+    is replicated; otherwise the origin would reject it only during creation
+    (after TOI) while the appliers create it successfully, leaving this node
+    inconsistent and evicting it from the cluster (PXC-5292, a PXC-4765-class
+    issue). The informational ER_NO_SUCH_USER warning is intentionally left to
+    the authoritative check_valid_definer() call during trigger creation.
+    is_acl_user() self-locks the ACL cache (READ, non-blocking) and returns true
+    when it cannot lock or ACL is not yet initialized; in that rare case this
+    gate is skipped and we simply fall back to the pre-existing post-TOI
+    check_valid_definer() behavior -- no worse than before this fix.
+  */
+  const bool has_super =
+      sctx->check_access(SUPER_ACL);  // This will come from PXC-5291
+  if (lex->definer &&
+      !is_acl_user(thd, lex->definer->host.str, lex->definer->user.str) &&
+      !has_super &&
+      !sctx->has_global_grant(STRING_WITH_LEN("ALLOW_NONEXISTENT_DEFINER"))
+           .first) {
+    my_error(ER_SPECIFIC_ACCESS_DENIED_ERROR, MYF(0),
+             "SUPER or ALLOW_NONEXISTENT_DEFINER");
+    return true;
+  }
+
 #else
   if (!trust_function_creators && mysql_bin_log.is_open() &&
       !(sctx->check_access(SUPER_ACL))) {


### PR DESCRIPTION
…user can cause node inconsistency/eviction

https://perconadev.atlassian.net/browse/PXC-5292

The early privilege gate added by PXC-4765 in Sql_cmd_create_trigger::execute() runs before wsrep_to_isolation_begin() so the origin rejects an invalid DEFINER before replicating it. That gate mirrored only the definer-mismatch stage of check_valid_definer() (WL#15874), not the orphan-definer stage. As a result a user with SET_ANY_DEFINER but without SUPER or ALLOW_NONEXISTENT_DEFINER could create a trigger with a non-existent DEFINER: the early gate passed, the statement replicated, then the origin rejected it during creation (after TOI) while the appliers created it successfully -- leaving the origin inconsistent and evicting it from the cluster.

Add the orphan-definer check (require SUPER or ALLOW_NONEXISTENT_DEFINER when the DEFINER is not an existing ACL user) to the early pre-TOI gate, mirroring stage 2 of check_valid_definer(). The informational ER_NO_SUCH_USER note is left to the authoritative post-TOI check_valid_definer() call to avoid a duplicate warning.