### PR TITLE
PXC-5305: Wrong query results when an internal temporary table is converted to on-disk InnoDB

### DIFF
--- a/mysql-test/r/with_recursive_innodb_tmp_table.result
+++ b/mysql-test/r/with_recursive_innodb_tmp_table.result
@@ -366,29 +366,30 @@ drop table t1;
 #
 create table t1 (
 id int primary key,
-col1 varchar(32),
+col1 varchar(300) character set latin1,
 key index_col1(col1)
 );
 create table t2 (
 id int primary key,
-col1 varchar(32)
+col1 varchar(300) character set latin1
 );
 create procedure insert_bug_37308710_data()
 begin
 declare num int;
 set num = 1;
-while num < 100 do
-insert into t1 values (num, lpad(num, 32, '0'));
-insert into t2 values (num, lpad(num, 32, '0'));
+while num <= 4000 do
+insert into t1 values (num, lpad(num, 300, '0'));
+insert into t2 values (num, lpad(num, 300, '0'));
 set num = num + 1;
 end while;
 end//
-call insert_bug_37308710_data();
 set @old_internal_tmp_mem_storage_engine =
 @@session.internal_tmp_mem_storage_engine;
 set session internal_tmp_mem_storage_engine = 'memory';
 set @old_tmp_table_size = @@tmp_table_size;
-set @@tmp_table_size = 102400;
+set @old_max_heap_table_size = @@max_heap_table_size;
+set @@max_heap_table_size = 16*1024*1024;
+set @@tmp_table_size = 16*1024*1024;
 flush status;
 explain select count(distinct d.col1)
 from (
@@ -401,13 +402,13 @@ from t1
 join t2 on d.col1 = t2.col1
 where t2.id = 1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
-1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
-2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	#	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	303	const	#	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	#	NULL	Using temporary
 Warnings:
-Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001'))
 select count(distinct d.col1)
 from (
 select t1.col1
@@ -423,7 +424,7 @@ count(distinct d.col1)
 show status like 'Created_tmp_disk_tables';
 Variable_name	Value
 Created_tmp_disk_tables	0
-set @@tmp_table_size = 1024;
+set @@tmp_table_size = 1024*1024;
 flush status;
 explain select count(distinct d.col1)
 from (
@@ -436,13 +437,13 @@ from t1
 join t2 on d.col1 = t2.col1
 where t2.id = 1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
-1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
-2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
-4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	#	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	303	const	#	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	303	NULL	#	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	#	NULL	Using temporary
 Warnings:
-Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001'))
 select count(distinct d.col1)
 from (
 select t1.col1
@@ -461,6 +462,7 @@ Created_tmp_disk_tables	1
 set session internal_tmp_mem_storage_engine =
 @old_internal_tmp_mem_storage_engine;
 set @@tmp_table_size = @old_tmp_table_size;
+set @@max_heap_table_size = @old_max_heap_table_size;
 drop procedure insert_bug_37308710_data;
 drop table t1, t2;
 # cleanup

--- a/mysql-test/r/with_recursive_innodb_tmp_table.result
+++ b/mysql-test/r/with_recursive_innodb_tmp_table.result
@@ -360,6 +360,108 @@ Warning	1287	Setting user variables within expressions is deprecated and will be
 show status like 'Created_tmp_disk_tables';
 Variable_name	Value
 Created_tmp_disk_tables	0
-# cleanup
 drop table t1;
+#
+# Bug 37308710 - const access after MEMORY to InnoDB temp-table overflow
+#
+create table t1 (
+id int primary key,
+col1 varchar(32),
+key index_col1(col1)
+);
+create table t2 (
+id int primary key,
+col1 varchar(32)
+);
+create procedure insert_bug_37308710_data()
+begin
+declare num int;
+set num = 1;
+while num < 100 do
+insert into t1 values (num, lpad(num, 32, '0'));
+insert into t2 values (num, lpad(num, 32, '0'));
+set num = num + 1;
+end while;
+end//
+call insert_bug_37308710_data();
+set @old_internal_tmp_mem_storage_engine =
+@@session.internal_tmp_mem_storage_engine;
+set session internal_tmp_mem_storage_engine = 'memory';
+set @old_tmp_table_size = @@tmp_table_size;
+set @@tmp_table_size = 102400;
+flush status;
+explain select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+count(distinct d.col1)
+1
+show status like 'Created_tmp_disk_tables';
+Variable_name	Value
+Created_tmp_disk_tables	0
+set @@tmp_table_size = 1024;
+flush status;
+explain select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	NULL	const	PRIMARY	PRIMARY	4	const	1	100.00	NULL
+1	PRIMARY	<derived2>	NULL	const	<auto_distinct_key>	<auto_distinct_key>	131	const	1	100.00	Using index
+2	DERIVED	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+3	UNION	t1	NULL	index	NULL	index_col1	131	NULL	99	100.00	Using index
+4	UNION RESULT	<union2,3>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	NULL	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select count(distinct `d`.`col1`) AS `count(distinct d.col1)` from (/* select#2 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1` union /* select#3 */ select `test`.`t1`.`col1` AS `col1` from `test`.`t1`) `d` join `test`.`t2` where ((`d`.`col1` = '00000000000000000000000000000001'))
+select count(distinct d.col1)
+from (
+select t1.col1
+from t1
+union
+select t1.col1
+from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+count(distinct d.col1)
+1
+show status like 'Created_tmp_disk_tables';
+Variable_name	Value
+Created_tmp_disk_tables	1
+set session internal_tmp_mem_storage_engine =
+@old_internal_tmp_mem_storage_engine;
+set @@tmp_table_size = @old_tmp_table_size;
+drop procedure insert_bug_37308710_data;
+drop table t1, t2;
+# cleanup
 set session internal_tmp_mem_storage_engine=default;

--- a/mysql-test/t/with_recursive_innodb_tmp_table.test
+++ b/mysql-test/t/with_recursive_innodb_tmp_table.test
@@ -74,15 +74,28 @@ drop table t1;
 --echo # Bug 37308710 - const access after MEMORY to InnoDB temp-table overflow
 --echo #
 
+# Note (PXC): the upstream reproducer relied on `tmp_table_size` values below
+# 1 MiB (102400 and 1024 bytes) to keep the small case in memory and force the
+# large case onto disk. Percona's PS-8647 patch in sql/sys_vars.cc silently
+# clamps any tmp_table_size < 1 MiB up to 1 MiB (and emits a warning), so the
+# original values no longer differentiate the two runs and the small case
+# never overflows to disk. To preserve the intent of the test on PXC we widen
+# col1, insert enough rows to make the materialized derived table exceed
+# 1 MiB, and use tmp_table_size values at/above the 1-MiB clamp threshold:
+#   - big case:   tmp_table_size = 16 MiB   -> data fits in MEMORY
+#   - small case: tmp_table_size =  1 MiB   -> data overflows to InnoDB
+#                                              (also exactly at the PS-8647
+#                                               floor, so no clamp warning)
+
 create table t1 (
   id int primary key,
-  col1 varchar(32),
+  col1 varchar(300) character set latin1,
   key index_col1(col1)
 );
 
 create table t2 (
   id int primary key,
-  col1 varchar(32)
+  col1 varchar(300) character set latin1
 );
 
 delimiter //;
@@ -90,21 +103,26 @@ create procedure insert_bug_37308710_data()
 begin
   declare num int;
   set num = 1;
-  while num < 100 do
-    insert into t1 values (num, lpad(num, 32, '0'));
-    insert into t2 values (num, lpad(num, 32, '0'));
+  while num <= 4000 do
+    insert into t1 values (num, lpad(num, 300, '0'));
+    insert into t2 values (num, lpad(num, 300, '0'));
     set num = num + 1;
   end while;
 end//
 delimiter ;//
 
+--disable_query_log
 call insert_bug_37308710_data();
+--enable_query_log
 
 set @old_internal_tmp_mem_storage_engine =
   @@session.internal_tmp_mem_storage_engine;
 set session internal_tmp_mem_storage_engine = 'memory';
 set @old_tmp_table_size = @@tmp_table_size;
-set @@tmp_table_size = 102400;
+set @old_max_heap_table_size = @@max_heap_table_size;
+# Ensure MEMORY-table cap is not the earlier section's 61000-byte value.
+set @@max_heap_table_size = 16*1024*1024;
+set @@tmp_table_size = 16*1024*1024;
 
 let $query =
 select count(distinct d.col1)
@@ -119,13 +137,19 @@ join t2 on d.col1 = t2.col1
 where t2.id = 1;
 
 flush status;
+# InnoDB's live rows-estimate for t1 fluctuates between runs; mask it out
+# so the test only checks the columns we actually care about.
+--replace_column 10 #
 eval explain $query;
 eval $query;
 show status like 'Created_tmp_disk_tables';
 
-set @@tmp_table_size = 1024;
+set @@tmp_table_size = 1024*1024;
 
 flush status;
+# InnoDB's live rows-estimate for t1 fluctuates between runs; mask it out
+# so the test only checks the columns we actually care about.
+--replace_column 10 #
 eval explain $query;
 eval $query;
 show status like 'Created_tmp_disk_tables';
@@ -133,6 +157,7 @@ show status like 'Created_tmp_disk_tables';
 set session internal_tmp_mem_storage_engine =
   @old_internal_tmp_mem_storage_engine;
 set @@tmp_table_size = @old_tmp_table_size;
+set @@max_heap_table_size = @old_max_heap_table_size;
 drop procedure insert_bug_37308710_data;
 drop table t1, t2;
 

--- a/mysql-test/t/with_recursive_innodb_tmp_table.test
+++ b/mysql-test/t/with_recursive_innodb_tmp_table.test
@@ -68,6 +68,73 @@ set @@tmp_table_size=30000,@@max_heap_table_size=30000;
 set @@tmp_table_size=60000,@@max_heap_table_size=61000;
 --source include/with_recursive_wl9248.inc
 
---echo # cleanup
 drop table t1;
+
+--echo #
+--echo # Bug 37308710 - const access after MEMORY to InnoDB temp-table overflow
+--echo #
+
+create table t1 (
+  id int primary key,
+  col1 varchar(32),
+  key index_col1(col1)
+);
+
+create table t2 (
+  id int primary key,
+  col1 varchar(32)
+);
+
+delimiter //;
+create procedure insert_bug_37308710_data()
+begin
+  declare num int;
+  set num = 1;
+  while num < 100 do
+    insert into t1 values (num, lpad(num, 32, '0'));
+    insert into t2 values (num, lpad(num, 32, '0'));
+    set num = num + 1;
+  end while;
+end//
+delimiter ;//
+
+call insert_bug_37308710_data();
+
+set @old_internal_tmp_mem_storage_engine =
+  @@session.internal_tmp_mem_storage_engine;
+set session internal_tmp_mem_storage_engine = 'memory';
+set @old_tmp_table_size = @@tmp_table_size;
+set @@tmp_table_size = 102400;
+
+let $query =
+select count(distinct d.col1)
+from (
+  select t1.col1
+  from t1
+  union
+  select t1.col1
+  from t1
+) d
+join t2 on d.col1 = t2.col1
+where t2.id = 1;
+
+flush status;
+eval explain $query;
+eval $query;
+show status like 'Created_tmp_disk_tables';
+
+set @@tmp_table_size = 1024;
+
+flush status;
+eval explain $query;
+eval $query;
+show status like 'Created_tmp_disk_tables';
+
+set session internal_tmp_mem_storage_engine =
+  @old_internal_tmp_mem_storage_engine;
+set @@tmp_table_size = @old_tmp_table_size;
+drop procedure insert_bug_37308710_data;
+drop table t1, t2;
+
+--echo # cleanup
 set session internal_tmp_mem_storage_engine=default;

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -2887,6 +2887,13 @@ bool create_ondisk_from_heap(THD *thd, TABLE *wtable, int error,
     thd_proc_info(thd, (!strcmp(save_proc_info, "Copying to tmp table")
                             ? "Copying to tmp table on disk"
                             : save_proc_info));
+
+  /*
+    Reading from the in-memory table clears wtable's not-started state, so reset
+    it here.
+  */
+  wtable->set_not_started();
+
   return false;
 
 err_after_open:


### PR DESCRIPTION
## Summary

Backports upstream MySQL fix for [Bug #116741](https://bugs.mysql.com/bug.php?id=116741) (Oracle commit [`cde9f3eaaf9`](https://github.com/mysql/mysql-server/commit/cde9f3eaaf9), ships in MySQL 8.4.11) to the PXC 8.4 series, plus the PXC-specific test adjustment required to make the upstream reproducer actually exercise the fixed path on this branch.

- Jira: https://perconadev.atlassian.net/browse/PXC-5305
- Customer ticket: CUSTOM-258
- Target: `8.4` (branch base is 8.4.10)
- Sibling PR (Percona Server): percona/percona-server#6125

Without the fix, a query can silently return an incorrect result set — no error, no warning — when an internal temporary table is converted from MEMORY to an on-disk InnoDB table mid-execution. Rows that exist are dropped from the result. The only "workaround" is avoiding the conversion, which does not hold in production as data volume grows.

## Commits

| Commit | Scope |
| --- | --- |
| `576f3e2` Bug#37308710 — Innodb tmp table causes incorrect query results | `sql/sql_tmp_table.cc` (+7), `main.with_recursive_innodb_tmp_table` test + result |
| `5d0958d` CUSTOM-258 | `main.with_recursive_innodb_tmp_table` test + result only |

Whole-PR diff is exactly three files:

```
mysql-test/r/with_recursive_innodb_tmp_table.result
mysql-test/t/with_recursive_innodb_tmp_table.test
sql/sql_tmp_table.cc
```

The only source change is one statement in `create_ondisk_from_heap()`:

```c
/*
  Reading from the in-memory table clears wtable's not-started state, so reset
  it here.
*/
wtable->set_not_started();
```

Reading rows from the in-memory temporary table advances table state. After conversion the table kept a *started* state, so subsequent reads from the on-disk temporary table could miss the expected row for CONST access.

## Why the second commit is needed (PXC/PS divergence from upstream)

The upstream subtest reaches the conversion path by running the query at `tmp_table_size = 102400` (in-memory) and then at `tmp_table_size = 1024` (expected to spill to disk).

Percona-only patch **PS-8647** in `sql/sys_vars.cc` silently rewrites any `tmp_table_size` below 1 MiB up to exactly 1 MiB and pushes a warning. The rewrite is unconditional and independent of `internal_tmp_mem_storage_engine`, so it also applies when the session uses the MEMORY engine.

Consequence on this branch: the effective `tmp_table_size` is 1 MiB in *both* runs. The 99-row derived result (~40-byte reclength) fits comfortably in 1 MiB, `create_ondisk_from_heap()` is never entered, and the MEMORY→InnoDB transition the backport is meant to exercise never happens. The upstream test therefore failed with two diff hunks: unexpected `Tmp_table_size is set below 1MiB` warnings on each `SET`, and `Created_tmp_disk_tables` reporting 0 where upstream expects 1.

`5d0958d` is **test-only** — the backported source fix stays as-is. It gives the reproducer enough data to overflow the 1-MiB floor PS-8647 imposes:

- `col1` widened to `VARCHAR(300) CHARACTER SET latin1`, generator grown to 4000 rows → derived table ~1.2 MiB
- `max_heap_table_size` explicitly saved/restored and set to 16 MiB for this section (the preceding `with_recursive_wl9248` block left it at 61000, which would cap MEMORY well below `tmp_table_size` and defeat the size differential)
- `tmp_table_size` values at or above the PS-8647 threshold: 16 MiB in-memory (`Created_tmp_disk_tables = 0`) and exactly 1 MiB on-disk (`Created_tmp_disk_tables = 1`) — both ≥ 1 MiB, so the strict `<` check never fires and no unexpected warnings appear

The `count(distinct d.col1) = 1` assertion — the actual bug being verified — is untouched. A comment block documents the divergence so the next porter does not "fix" the values back to the upstream ones.

## Testing

Full MTR (`FULL_MTR=yes`, `--big-test`, `CI_FS_MTR=yes`) on `pxc-8.x-pipeline-parallel-mtr`, `ubuntu:noble` / x86_64 / Hetzner:

| Config | Build | Result | Failures |
| --- | --- | --- | --- |
| Debug | [#873](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/873/) | UNSTABLE | 4 |
| RelWithDebInfo | [#874](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/874/) | UNSTABLE | 3 |
| RelWithDebInfo + ASAN | [#875](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/875/) | UNSTABLE | 23 |

### The target test now passes in every configuration

| Build | Result |
| --- | --- |
| #873 Debug | `main.with_recursive_innodb_tmp_table  w7  [ pass ]  28730` |
| #874 RelWithDebInfo | `main.with_recursive_innodb_tmp_table  w6  [ pass ]   3645` |
| #875 ASAN | `main.with_recursive_innodb_tmp_table w10  [ pass ]  21654` |

For contrast, on the pre-adjustment branch (`CUSTOM-258-848`, build [#871](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/871/)) the same test failed deterministically:

```
main.with_recursive_innodb_tmp_table  w7  [ fail ]
Retrying test main.with_recursive_innodb_tmp_table, attempt(2/3).
main.with_recursive_innodb_tmp_table  w7  [ retry-fail ]
Test main.with_recursive_innodb_tmp_table has failed 2 times, no more retries.
```

### Baseline diff

Baselines: [#871](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/871/) (Debug) and [#870](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/870/) (RelWithDebInfo), both `CUSTOM-258-848`, same OS/cloud/MTR args.

**Debug — #873 vs #871**

- Resolved: `main.with_recursive_innodb_tmp_table`, `galera.galera_as_slave_gtid_replicate_do_db.enc_on`
- New: `galera.galera_bf_bf_2.enc_on` — a BF-BF certification-conflict test, no interaction with the temp-table path; known intermittent
- Unchanged: 3 × `shutdown_report` (MTR shutdown-check noise, present in every build of this job including release-tag runs)

**RelWithDebInfo — #874 vs #870**

Strict subset of the baseline. Resolved: `main.with_recursive_innodb_tmp_table`, `galera.galera_fc_auto_evict.enc_off`, `galera.galera_as_slave_gtid_replicate_do_db.enc_off`/`.enc_on`. Remaining `innodb.innodb_stats_drop_locked` also fails in the baseline. **No new failures.**

### ASAN run

No sanitizer findings: `ERROR: AddressSanitizer:` and leak-summary greps over #875 return **zero** matches. The only ASAN-related output is a pipeline defect, repeated per worker:

```
AddressSanitizer: failed to read suppressions file '/tmp/pxc/mysql-test/asan.supp'
```

so ASAN ran with no suppressions at all. The 23 failures are ordinary test failures under an instrumented, much slower build (`galera_garbd` — garbd is not instrumented; `gr_recovery_endpoints_*` / `gr_clone_*` clone-and-recovery timing; `innodb.bootstrap`; the `unit_tests` roll-up), not memory errors.

## Caveats / follow-ups

1. **No PXC ASAN baseline exists.** `pxc-8.x-pipeline-asan` has never been built and its config points at a personal fork of `jenkins-pipelines` (`kamil-holubicki`, branch `innovative`), so #875 was run through `pxc-8.x-pipeline-parallel-mtr` with `ANALYZER_OPTS=-DWITH_ASAN=ON -DWITH_ASAN_SCOPE=ON`. Its 23 failures cannot be formally classified as pre-existing without a same-base ASAN run on `8.4`/`Percona-XtraDB-Cluster-8.4.10-10`. Happy to fire one on request.
2. Missing `mysql-test/asan.supp` in the PXC ASAN pipeline is worth a separate ticket.
3. `SLACK_CHANNEL` in the PS/PXC pipeline groovy is interpolated as `"#${SLACK_CHANNEL}"` against a default that already carries `#`, producing `##ps-upstream-merges`; Slack notifications from these jobs never land. Also worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
