### PR TITLE
(9.7)PXC-5296: PXC upgrade fails when pxc_strict_mode is ENFORCING

### DIFF
--- a/mysql-test/suite/galera/r/galera_pxc_5296_upgrade_strict_mode.result
+++ b/mysql-test/suite/galera/r/galera_pxc_5296_upgrade_strict_mode.result
@@ -1,0 +1,68 @@
+#
+# 1. Baseline.
+#
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+include/assert.inc [pxc_strict_mode is DISABLED]
+include/assert.inc [sql_require_primary_key global is OFF.]
+#
+# 2. Seed node_2 with a legacy primary-key-less system table and user data.
+#
+SET SESSION wsrep_on = OFF;
+CREATE TABLE mysql.firewall_whitelist (USERHOST VARCHAR(80) NOT NULL,
+RULE text NOT NULL) ENGINE=InnoDB;
+SET SESSION wsrep_on = ON;
+include/assert.inc [seeded mysql.firewall_whitelist has no primary key]
+CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(32)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'before'), (2, 'upgrade'), (3, 'data');
+SELECT * FROM t1 ORDER BY id;
+id	val
+1	before
+2	upgrade
+3	data
+#
+# 3. Regression guard: a client SET sql_require_primary_key=OFF is still
+#    blocked under ENFORCING.
+#
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+SET GLOBAL sql_require_primary_key = OFF;
+ERROR 42000: Variable 'sql_require_primary_key' can't be set to the value of 'OFF'
+SET SESSION sql_require_primary_key = OFF;
+ERROR 42000: Variable 'sql_require_primary_key' can't be set to the value of 'OFF'
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SET GLOBAL sql_require_primary_key = OFF;
+#
+# 4. Restart node_2 with --pxc_strict_mode=ENFORCING --upgrade=FORCE.
+#
+# restart:--pxc_strict_mode=ENFORCING --upgrade=FORCE
+#
+# 5. Post-upgrade checks.
+#
+include/assert.inc [node_2 is up and pxc_strict_mode is still ENFORCING]
+include/assert.inc [global sql_require_primary_key is ON under ENFORCING]
+include/assert.inc [mysql.firewall_whitelist gained its ID primary key]
+include/assert.inc [mysql.firewall_membership was created by the upgrade]
+include/assert.inc [mysql.firewall_membership got its composite primary key]
+include/assert.inc [mysql.general_log and mysql.slow_log survived without a primary key]
+SELECT * FROM t1 ORDER BY id;
+id	val
+1	before
+2	upgrade
+3	data
+#
+# 6. Cleanup.
+#
+SET SESSION wsrep_on = OFF;
+DROP TABLE mysql.firewall_whitelist;
+DROP TABLE mysql.firewall_group_allowlist;
+DROP TABLE mysql.firewall_groups;
+DROP TABLE mysql.firewall_membership;
+SET SESSION wsrep_on = ON;
+# restart
+SET GLOBAL pxc_strict_mode = DISABLED;
+SET GLOBAL sql_require_primary_key = OFF;
+DROP TABLE t1;
+SET GLOBAL pxc_strict_mode = DISABLED;
+SET GLOBAL sql_require_primary_key = OFF;

--- a/mysql-test/suite/galera/r/galera_rpl_pxc_strict_mode_mismatch.result
+++ b/mysql-test/suite/galera/r/galera_rpl_pxc_strict_mode_mismatch.result
@@ -14,8 +14,8 @@ include/assert.inc [sql_require_primary_key global is ON.]
 START REPLICA USER = 'root';
 Warnings:
 Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
-include/wait_for_slave_io_to_start.inc
-include/wait_for_slave_sql_to_start.inc
+include/rpl/wait_for_receiver_to_start.inc
+include/rpl/wait_for_applier_to_start.inc
 # Source runs DDL without PK; replica applier uses replicated session metadata
 CREATE TABLE t_rpl_nopk (c1 INT) ENGINE = InnoDB;
 INSERT INTO t_rpl_nopk VALUES (1);

--- a/mysql-test/suite/galera/t/galera_pxc_5296_upgrade_strict_mode.test
+++ b/mysql-test/suite/galera/t/galera_pxc_5296_upgrade_strict_mode.test
@@ -1,0 +1,197 @@
+################################################################################
+# PXC-5296: A PXC server upgrade must succeed when pxc_strict_mode is ENFORCING.
+#
+# pxc_strict_mode=ENFORCING/MASTER forces sql_require_primary_key=ON (PXC-5106)
+# and rejects any attempt to set it back to OFF. The server upgrade thread runs
+# the compiled-in upgrade script (mysql_system_tables_fix.sql), which
+#   a) temporarily sets sql_require_primary_key=OFF to rebuild the CSV log
+#      tables, which have no primary key (upstream bug#92988), and
+#   b) rebuilds the legacy firewall tables, which also have no primary key,
+#      *without* turning the policy off first.
+# Both were rejected, so the upgrade aborted with "Failed to upgrade server"
+# and the node could not start. Since ENFORCING forces the policy ON at
+# startup, this hit every upgrade of a node running in a strict mode.
+#
+# 1. Baseline.
+# 2. Seed node_2 with a legacy primary-key-less system table (the pre-8.0.22
+#    mysql.firewall_whitelist) and with user data that must survive.
+# 3. Regression guard: a normal client SET sql_require_primary_key=OFF is still
+#    blocked under ENFORCING.
+# 4. Restart node_2 with --pxc_strict_mode=ENFORCING --upgrade=FORCE.
+# 5. Post-upgrade checks: node rejoined, still ENFORCING, the primary-key-less
+#    system tables were rebuilt, log tables intact, user data intact.
+# 6. Cleanup.
+################################################################################
+
+--source include/galera_cluster.inc
+# Reference mysql_upgrade.test, due to the upgrade/restart this takes time.
+--source include/big_test.inc
+--source include/not_valgrind.inc
+
+--echo #
+--echo # 1. Baseline.
+--echo #
+
+--connection node_1
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+--let $pxc_saved_1 = `SELECT @@global.pxc_strict_mode`
+
+--connection node_2
+# mtr.test_suppressions has no primary key, so these INSERTs must happen before
+# node_2 is switched to ENFORCING.
+call mtr.add_suppression("Cannot set sql_require_primary_key=OFF while pxc_strict_mode is");
+call mtr.add_suppression("Setting sql_require_primary_key=ON because pxc_strict_mode is ENFORCING or MASTER");
+--let $pxc_saved_2 = `SELECT @@global.pxc_strict_mode`
+
+--let $assert_text = pxc_strict_mode is DISABLED
+--let $assert_cond = "$pxc_saved_2" = "DISABLED"
+--source include/assert.inc
+
+--let $assert_text = sql_require_primary_key global is OFF.
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 0 ]
+--source include/assert.inc
+
+--echo #
+--echo # 2. Seed node_2 with a legacy primary-key-less system table and user data.
+--echo #
+
+--connection node_2
+# mysql.firewall_whitelist as shipped before 8.0.22: no primary key. The
+# upgrade script runs "ALTER TABLE mysql.firewall_whitelist ENGINE=InnoDB" and
+# then adds the ID primary key. The ALTER is rejected while
+# sql_require_primary_key is ON, which is what aborted the upgrade.
+#
+# wsrep_on=OFF keeps the legacy table local to the node being upgraded, which
+# is how it would look in a real datadir, and keeps node_1 untouched.
+SET SESSION wsrep_on = OFF;
+CREATE TABLE mysql.firewall_whitelist (USERHOST VARCHAR(80) NOT NULL,
+                                       RULE text NOT NULL) ENGINE=InnoDB;
+SET SESSION wsrep_on = ON;
+
+--let $assert_text = seeded mysql.firewall_whitelist has no primary key
+--let $assert_cond = [ SELECT COUNT(*) = 0 FROM information_schema.table_constraints WHERE table_schema = "mysql" AND table_name = "firewall_whitelist" AND constraint_type = "PRIMARY KEY" ]
+--source include/assert.inc
+
+--connection node_1
+# Has a primary key, so it is valid under the sql_require_primary_key=ON that
+# pxc_strict_mode=ENFORCING implies.
+CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(32)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'before'), (2, 'upgrade'), (3, 'data');
+SELECT * FROM t1 ORDER BY id;
+
+--echo #
+--echo # 3. Regression guard: a client SET sql_require_primary_key=OFF is still
+--echo #    blocked under ENFORCING.
+--echo #
+
+# The fix must not weaken the user-facing guard. Only the server's own upgrade
+# thread is exempt; a normal session is not.
+--connection node_1
+SET GLOBAL pxc_strict_mode = 'ENFORCING';
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL sql_require_primary_key = OFF;
+--error ER_WRONG_VALUE_FOR_VAR
+SET SESSION sql_require_primary_key = OFF;
+
+# Put node_1 back to the baseline; only node_2 is upgraded below. Degrading
+# pxc_strict_mode does not clear the global sql_require_primary_key that
+# ENFORCING turned ON, so reset it explicitly.
+SET GLOBAL pxc_strict_mode = 'DISABLED';
+SET GLOBAL sql_require_primary_key = OFF;
+
+--echo #
+--echo # 4. Restart node_2 with --pxc_strict_mode=ENFORCING --upgrade=FORCE.
+--echo #
+
+--connection node_2
+--source include/mysql_upgrade_preparation.inc
+
+# Before the fix this restart aborted during "Server upgrade from ... started"
+# with "Cannot set sql_require_primary_key=OFF while pxc_strict_mode is
+# ENFORCING" followed by "Failed to upgrade server", and the node never came
+# back. Reference mysql_upgrade.test: the upgrade takes a while.
+--let $restart_parameters = restart:--pxc_strict_mode=ENFORCING --upgrade=FORCE
+--let $wait_counter = 10000
+--source include/restart_mysqld.inc
+
+--source include/mysql_upgrade_cleanup.inc
+
+--echo #
+--echo # 5. Post-upgrade checks.
+--echo #
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Wait until node_2 is fully synced before reading replicated data below.
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--source include/wait_condition.inc
+
+--let $pxc_mode_upg = `SELECT @@global.pxc_strict_mode`
+--let $assert_text = node_2 is up and pxc_strict_mode is still ENFORCING
+--let $assert_cond = "$pxc_mode_upg" = "ENFORCING"
+--source include/assert.inc
+
+--let $assert_text = global sql_require_primary_key is ON under ENFORCING
+--let $assert_cond = [ SELECT @@global.sql_require_primary_key = 1 ]
+--source include/assert.inc
+
+# The upgrade script actually ran to completion over the primary-key-less
+# tables: firewall_whitelist gained its ID primary key, and the group-profile
+# tables were created -- including mysql.firewall_membership, which the script
+# creates without a primary key.
+--let $assert_text = mysql.firewall_whitelist gained its ID primary key
+--let $assert_cond = [ SELECT COUNT(*) = 1 FROM information_schema.table_constraints WHERE table_schema = "mysql" AND table_name = "firewall_whitelist" AND constraint_type = "PRIMARY KEY" ]
+--source include/assert.inc
+
+# The script creates firewall_membership without a primary key first and adds
+# the composite key later on, so both statements had to get through.
+--let $assert_text = mysql.firewall_membership was created by the upgrade
+--let $assert_cond = [ SELECT COUNT(*) = 1 FROM information_schema.tables WHERE table_schema = "mysql" AND table_name = "firewall_membership" ]
+--source include/assert.inc
+
+--let $assert_text = mysql.firewall_membership got its composite primary key
+--let $assert_cond = [ SELECT COUNT(*) = 1 FROM information_schema.table_constraints WHERE table_schema = "mysql" AND table_name = "firewall_membership" AND constraint_type = "PRIMARY KEY" ]
+--source include/assert.inc
+
+# The CSV log tables are the ones the script wraps in
+# sql_require_primary_key=OFF. They must still be there, and still without a
+# primary key.
+--let $assert_text = mysql.general_log and mysql.slow_log survived without a primary key
+--let $assert_cond = [ SELECT COUNT(*) = 2 FROM information_schema.tables t WHERE t.table_schema = "mysql" AND t.table_name IN ("general_log", "slow_log") AND NOT EXISTS (SELECT 1 FROM information_schema.table_constraints c WHERE c.table_schema = t.table_schema AND c.table_name = t.table_name AND c.constraint_type = "PRIMARY KEY") ]
+--source include/assert.inc
+
+# t1 was created on node_1; it must be present on the upgraded node_2, proving
+# the upgraded node is a working cluster member and the data survived.
+SELECT * FROM t1 ORDER BY id;
+
+--echo #
+--echo # 6. Cleanup.
+--echo #
+
+--connection node_2
+# Drop the node-local firewall tables while still under ENFORCING; DROP is not
+# affected by sql_require_primary_key.
+SET SESSION wsrep_on = OFF;
+DROP TABLE mysql.firewall_whitelist;
+DROP TABLE mysql.firewall_group_allowlist;
+DROP TABLE mysql.firewall_groups;
+DROP TABLE mysql.firewall_membership;
+SET SESSION wsrep_on = ON;
+
+# Restore node_2 to its suite defaults.
+--let $restart_parameters = restart
+--source include/restart_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--eval SET GLOBAL pxc_strict_mode = $pxc_saved_2
+SET GLOBAL sql_require_primary_key = OFF;
+
+--connection node_1
+DROP TABLE t1;
+--eval SET GLOBAL pxc_strict_mode = $pxc_saved_1
+SET GLOBAL sql_require_primary_key = OFF;

--- a/mysql-test/suite/galera/t/galera_rpl_pxc_strict_mode_mismatch.test
+++ b/mysql-test/suite/galera/t/galera_rpl_pxc_strict_mode_mismatch.test
@@ -91,8 +91,8 @@ SET GLOBAL pxc_strict_mode = 'ENFORCING';
 --enable_query_log
 START REPLICA USER = 'root';
 
---source include/wait_for_slave_io_to_start.inc
---source include/wait_for_slave_sql_to_start.inc
+--source include/rpl/wait_for_receiver_to_start.inc
+--source include/rpl/wait_for_applier_to_start.inc
 
 --echo # Source runs DDL without PK; replica applier uses replicated session metadata
 --connection node_1

--- a/scripts/mysql_system_tables.sql
+++ b/scripts/mysql_system_tables.sql
@@ -348,6 +348,16 @@ DROP PREPARE stmt;
 
 -- bug#92988: Temporarily turn off sql_require_primary_key for the
 -- next 2 tables as this is not necessary as they do not replicate.
+--
+-- pxc_strict_mode ENFORCING/MASTER forces sql_require_primary_key ON, so it
+-- has to be relaxed
+SET @old_pxc_strict_mode = @@global.pxc_strict_mode;
+SET @pxc_relax_strict_mode = (@old_pxc_strict_mode <> 'DISABLED');
+SET @cmd = "SET @@global.pxc_strict_mode = DISABLED";
+SET @str = IF(@pxc_relax_strict_mode, @cmd, "SET @dummy = 0");
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
 SET @old_sql_require_primary_key = @@session.sql_require_primary_key;
 SET @@session.sql_require_primary_key = 0;
 
@@ -358,6 +368,12 @@ CREATE TABLE IF NOT EXISTS general_log (event_time TIMESTAMP(6) NOT NULL DEFAULT
 CREATE TABLE IF NOT EXISTS slow_log (start_time TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), user_host MEDIUMTEXT NOT NULL, query_time TIME(6) NOT NULL, lock_time TIME(6) NOT NULL, rows_sent INTEGER NOT NULL, rows_examined INTEGER NOT NULL, db VARCHAR(512) NOT NULL, last_insert_id INTEGER NOT NULL, insert_id INTEGER NOT NULL, server_id INTEGER UNSIGNED NOT NULL, sql_text MEDIUMBLOB NOT NULL, thread_id BIGINT UNSIGNED NOT NULL) engine=CSV CHARACTER SET utf8mb3 comment="Slow log";
 
 SET @@session.sql_require_primary_key = @old_sql_require_primary_key;
+-- Restore pxc_strict_mode saved above, under the same guard.
+SET @cmd = "SET @@global.pxc_strict_mode = @old_pxc_strict_mode";
+SET @str = IF(@pxc_relax_strict_mode, @cmd, "SET @dummy = 0");
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
 
 SET @cmd = "CREATE TABLE IF NOT EXISTS component ( component_id int unsigned NOT NULL AUTO_INCREMENT, component_group_id int unsigned NOT NULL, component_urn text NOT NULL, PRIMARY KEY (component_id)) engine=INNODB DEFAULT CHARSET=utf8mb3 COMMENT 'Components' ROW_FORMAT=DYNAMIC TABLESPACE=mysql";
 SET @str = CONCAT(@cmd, " ENCRYPTION='", @is_mysql_encrypted, "'");

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -238,6 +238,17 @@ ALTER TABLE func
 
 SET @old_log_state = @@global.general_log;
 SET GLOBAL general_log = 'OFF';
+-- The log tables below have no primary key, so relax the primary-key policy
+-- for them (Refer bug#92988 in mysql_system_tables.sql).
+-- pxc_strict_mode ENFORCING/MASTER forces sql_require_primary_key ON, so it
+-- has to be relaxed
+SET @old_pxc_strict_mode = @@global.pxc_strict_mode;
+SET @pxc_relax_strict_mode = (@old_pxc_strict_mode <> 'DISABLED');
+SET @cmd = "SET @@global.pxc_strict_mode = DISABLED";
+SET @str = IF(@pxc_relax_strict_mode, @cmd, "SET @dummy = 0");
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
 SET @old_sql_require_primary_key = @@session.sql_require_primary_key;
 SET @@session.sql_require_primary_key = 0;
 ALTER TABLE general_log
@@ -272,6 +283,12 @@ ALTER TABLE slow_log
 SET GLOBAL slow_query_log = @old_log_state;
 
 SET @@session.sql_require_primary_key = @old_sql_require_primary_key;
+-- Restore pxc_strict_mode saved above, under the same guard.
+SET @cmd = "SET @@global.pxc_strict_mode = @old_pxc_strict_mode";
+SET @str = IF(@pxc_relax_strict_mode, @cmd, "SET @dummy = 0");
+PREPARE stmt FROM @str;
+EXECUTE stmt;
+DROP PREPARE stmt;
 ALTER TABLE plugin
   MODIFY name varchar(64) DEFAULT '' NOT NULL,
   MODIFY dl varchar(128) DEFAULT '' NOT NULL,

--- a/sql/bootstrap.cc
+++ b/sql/bootstrap.cc
@@ -435,6 +435,15 @@ bool run_bootstrap_thread(const char *file_name, MYSQL_FILE *file,
   */
   thd->variables.default_table_encryption = false;
 
+#ifdef WITH_WSREP
+  /*
+    Disable sql_require_primary_key for the server upgrade thread because its
+    internal upgrade script modifies system tables without primary keys.
+    Otherwise, PXC's default ENFORCING mode can abort the upgrade (PXC-5296).
+  */
+  if (thread_type == SYSTEM_THREAD_SERVER_UPGRADE)
+    thd->variables.sql_require_primary_key = false;
+#endif /* WITH_WSREP */
   my_thread_attr_t thr_attr;
   my_thread_attr_init(&thr_attr);
 #ifndef _WIN32

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -8277,6 +8277,13 @@ static bool check_session_admin_and_sql_require_primary_key_on_check(
     sys_var *self, THD *thd, set_var *var) {
   if (check_session_admin(self, thd, var)) return true;
   if (pxc_strict_mode < PXC_STRICT_MODE_ENFORCING) return false;
+  /*
+    Allow the server upgrade thread to bypass pxc_strict_mode when temporarily
+    disabling sql_require_primary_key for system tables without primary keys.
+    These are internal statements compiled into the server; rejecting them can
+    abort upgrades and prevent the node from starting (PXC-5296).
+  */
+  if (thd->is_server_upgrade_thread()) return false;
   if (var->save_result.ulonglong_value == 0) {
     const char *strict_name =
         (pxc_strict_mode == PXC_STRICT_MODE_MASTER) ? "MASTER" : "ENFORCING";


### PR DESCRIPTION
Ports the fix from #2353 (8.4) to **9.7**.

https://perconadev.atlassian.net/browse/PXC-5296
https://perconadev.atlassian.net/browse/PXC-5106

## What this is

Unlike 8.4 and trunk, the `9.7` branch **still carries the original PXC-5106** — the revert in `fe0dac6dbd2` never reached it (verified: `check_session_admin_and_sql_require_primary_key_on_check`, `pxc_strict_mode_update` and the startup forcing are all present at `5dcb2246f13`). This line therefore has the upgrade bug, and this PR applies **only the PXC-5296 fix delta**, not a re-land.

Derived from `PXC-5106_2-8.4` @ `fb8f1d2ed99` (the head of #2353), applying only the PXC-5296 delta on top of the PXC-5106 already present here.

## The bug being fixed

`pxc_strict_mode=ENFORCING/MASTER` forces `sql_require_primary_key=ON` and rejects turning it back off. The server upgrade thread runs the compiled-in upgrade script — `mysql_system_tables.sql` concatenated with `mysql_system_tables_fix.sql` (see `scripts/CMakeLists.txt`) — which must relax that policy to rebuild system tables that have no primary key. Both halves were rejected, so the upgrade aborted and the node could not start:

```
[Server] Server upgrade from '80045' to '80046' started.
[WSREP]  Cannot set sql_require_primary_key=OFF while pxc_strict_mode is ENFORCING.
[Server] Execution of server-side SQL statement
         'SET @@session.sql_require_primary_key = 0; ' failed with error code = 1231
[Server] Failed to upgrade server.
[Server] Aborting
```

Since `pxc_strict_mode` defaults to `ENFORCING`, this hit every upgrade of a node left in a strict mode.

## Changes

* `sql/sys_vars.cc` — exempt the **server upgrade thread** from the strict-mode guard so the script's internal `SET` is accepted. A normal client `SET sql_require_primary_key=OFF` under ENFORCING is still rejected. Deliberately narrow: `is_dd_system_thread()` / `is_initialize_system_thread()` are *not* exempted because they are unreachable here (`--initialize` forces `pxc_strict_mode=DISABLED`, and the DD restart thread only runs the `PXC_SECTION` block, which never touches this variable).
* `sql/bootstrap.cc` — start the upgrade thread with `sql_require_primary_key=false` (under `#ifdef WITH_WSREP`). The script only relaxes the policy around the log tables, so this covers the primary-key-less firewall DDL it does not wrap (`ALTER TABLE mysql.firewall_whitelist ENGINE=InnoDB`, `CREATE TABLE mysql.firewall_membership`).
* `scripts/mysql_system_tables.sql`, `scripts/mysql_system_tables_fix.sql` — relax `pxc_strict_mode` around the log-table blocks, gated on it not already being `DISABLED` so a non-cluster node and `--initialize` are unaffected (`pxc_strict_mode` can only be changed on a cluster node; setting it elsewhere fails with `ER_UNKNOWN_ERROR` and would itself abort the upgrade).

Both C++ changes are required, verified by reverting each in isolation: without `sys_vars.cc` the failure is error **1231** on the internal `SET`; without `bootstrap.cc` it is error **3750** `ER_TABLE_WITHOUT_PK` on the firewall DDL.

## Tests

`mysql-test/suite/galera/t/galera_pxc_5296_upgrade_strict_mode.test` seeds a node with a legacy primary-key-less `mysql.firewall_whitelist`, restarts it with `--pxc_strict_mode=ENFORCING --upgrade=FORCE`, and asserts the node returns, rejoins, stays ENFORCING with `sql_require_primary_key=ON`, that the primary-key-less system tables were rebuilt, and that pre-upgrade data survived. It also guards that a client `SET ... = OFF` remains blocked.

Verified the fix regions are byte-identical across `PXC-5106_2-8.4`, `PXC-5106_2-9.7` and this branch.

## Jenkins

[pxc-8.x-pipeline-parallel-mtr #899](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/899/) — Debug, `ubuntu:noble`, `FULL_MTR=yes`, `MTR_ARGS="--unit-tests-report --big-test --mem --testcase-timeout=120"`, PXB `pxb-9.6`/`pxb-9.5`/`pxb-8.4` per this line's `wsrep_sst_xtrabackup-v2.sh`. **Running — results to follow.**

For reference, the 8.4 equivalent (#2353) ran as [#890](https://pxc.cd.percona.com/job/pxc-8.x-pipeline-parallel-mtr/890/): 5 failures against a matched baseline's 8, with all four affected tests passing in both `enc_off` and `enc_on`.

## Note on the PXB parameters used

`.ai_helper.md`'s "Jenkins 9.7 parameters" specify target dirs `pxb-9.7` (THIS) / `pxb-9.6` (PREV), but that matches `release-9.7.1-1`'s `wsrep_sst_xtrabackup-v2.sh`. The `9.7` branch this PR targets expects `pxb-9.6` / `pxb-9.5` / `pxb-8.4`, so the run above uses those (identical to trunk's mapping) — parameters must match the code under test. Worth reconciling that config block.

Also included here: `galera_rpl_pxc_strict_mode_mismatch.test` on this line still referenced the pre-8.4 include names `include/wait_for_slave_io_to_start.inc` / `wait_for_slave_sql_to_start.inc`, which no longer exist; they are repointed at `include/rpl/wait_for_receiver_to_start.inc` / `wait_for_applier_to_start.inc`. Without that the test fails on every run.
